### PR TITLE
Add the CMake+CUDA skeleton behind the C ABI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,11 @@ jobs:
       - name: Build
         run: cmake --build build
 
-      # Placeholder until the M0 test net lands: the ctest step is added by
-      # the PR that introduces tests/ (oracle diffs, negative tests,
-      # conformance tests) and becomes part of this required check
-      # automatically.
+      # tests/ holds the GPU smoke test, which needs a CUDA toolchain and a
+      # device this runner does not have; GPU results are pasted into each
+      # PR instead. The CUDA build joins this check with #3, and the
+      # host-side ctest step (oracle diffs, negative tests, conformance
+      # tests) with the test harness (#4).
 
   format:
     name: format

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output - reproducible from the sources via CMake.
 build/
+build-cuda/
 
 # Local maintainer tooling and working notes - never in the public tree.
 .claude/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,58 @@ cmake_minimum_required(VERSION 3.24)
 
 project(cudec VERSION 0.0.1 LANGUAGES C)
 
-# Host-only stub for now: it gives CI a real build gate from day one. The
-# CUDA language, the kernels, and the toolchain requirements arrive with M1.
+# The CUDA engine is opt-in and fail-closed: asking for it without a CUDA
+# toolchain is a hard configure error, never a silent host-only fallback (a
+# CI job that passed without compiling the kernels would be a fail-open
+# gate). CI flips this on together with the CUDA toolchain (issue #3).
+option(CUDEC_ENABLE_CUDA "Build the CUDA decode engine and its tests" OFF)
+
 add_library(cudec src/version.c)
 target_include_directories(cudec PUBLIC include)
 
 if(NOT MSVC)
-  target_compile_options(cudec PRIVATE -Wall -Wextra -Werror)
+  target_compile_options(cudec
+                         PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wall;-Wextra;-Werror>)
+endif()
+
+if(CUDEC_ENABLE_CUDA)
+  if(MSVC)
+    # cl.exe ignores the GCC-style strict-warning flags below with a
+    # warning, not an error - the warnings gate would silently drop.
+    message(
+      FATAL_ERROR
+        "CUDEC_ENABLE_CUDA requires a GCC/Clang host toolchain (the pinned "
+        "Linux container is the maintained path); MSVC-host CUDA builds are "
+        "unsupported.")
+  endif()
+
+  # sm_80 is the baseline the kernels are written against; sm_86 is the
+  # tuned primary target (RTX 3080). SASS for both, PTX only for the
+  # baseline - sm_80 PTX already JIT-covers every newer device, so a second
+  # PTX copy would be dead weight in the fatbin. Overridable from the
+  # command line.
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES 80 86-real)
+  endif()
+  enable_language(CUDA)
+  enable_testing()
+
+  set(CUDEC_CUDA_STRICT_FLAGS
+      $<$<COMPILE_LANGUAGE:CUDA>:--Werror=all-warnings;-Xcompiler=-Wall,-Wextra,-Werror>)
+
+  target_sources(cudec PRIVATE src/batch.cu)
+  # The cudec target predates enable_language(CUDA), so the architecture
+  # list must be applied as an explicit target property.
+  set_target_properties(
+    cudec PROPERTIES CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON
+                     CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+  target_compile_options(cudec PRIVATE ${CUDEC_CUDA_STRICT_FLAGS})
+
+  add_executable(cudec_smoke tests/smoke.cu)
+  target_link_libraries(cudec_smoke PRIVATE cudec)
+  set_target_properties(
+    cudec_smoke PROPERTIES CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON
+                           CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+  target_compile_options(cudec_smoke PRIVATE ${CUDEC_CUDA_STRICT_FLAGS})
+  add_test(NAME smoke COMMAND cudec_smoke)
 endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,13 @@ Issue-driven, gate-driven:
 ## Building & testing
 
 ```sh
-cmake -B build && cmake --build build   # host stub today; CUDA arrives with M1
-ctest --test-dir build                  # once tests/ exists
+cmake -B build && cmake --build build   # host-only; needs just a C compiler
 ```
+
+The CUDA engine and its on-device tests are opt-in (`-DCUDEC_ENABLE_CUDA=ON`)
+and need a CUDA 12.x toolchain plus a GPU for the tests — see the README's
+container command for the maintained path (build directory `build-cuda`,
+`ctest --test-dir build-cuda`).
 
 All repo artifacts — code, comments, commits, PRs, issues — are written in
 English.

--- a/README.md
+++ b/README.md
@@ -63,11 +63,22 @@ and milestones:
 
 ## Building
 
-Requires CMake ≥ 3.24 and a C compiler; the CUDA kernels and their toolchain
-requirements arrive with M1.
+Host-only stub (CMake ≥ 3.24 and a C compiler, no CUDA toolchain needed):
 
 ```sh
 cmake -B build && cmake --build build
+```
+
+With the CUDA engine (CUDA 12.x toolchain; the maintained path is the
+pinned dev container — GPU required only for the tests, not the build):
+
+```sh
+docker run --rm --gpus all -v "$PWD:/w" -w /w \
+  nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8 \
+  sh -c "apt-get update -q && apt-get install -yq cmake >/dev/null && \
+         cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && \
+         cmake --build build-cuda -j && \
+         ctest --test-dir build-cuda --output-on-failure"
 ```
 
 ## Contributing

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -1,11 +1,14 @@
 /* cudec - open-source GPU decompression for the standard formats.
  *
- * Public C ABI. Everything in this header is C-compatible; the library
- * never throws across this boundary and never writes output it did not
- * fully validate.
+ * Public C ABI. Everything in this header is C-compatible and requires no
+ * CUDA headers; the library never throws across this boundary and never
+ * reports output it did not fully validate.
  */
 #ifndef CUDEC_H
 #define CUDEC_H
+
+#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,6 +21,76 @@ extern "C" {
 /* Returns the runtime library version as (major * 10000 +
  * minor * 100 + patch), for ABI sanity checks against these macros. */
 int cudec_version(void);
+
+typedef enum cudec_status {
+    CUDEC_OK = 0,
+    CUDEC_ERR_INVALID_ARGUMENT = 1,
+    CUDEC_ERR_CORRUPT_INPUT = 2,
+    CUDEC_ERR_OUTPUT_TOO_SMALL = 3,
+    CUDEC_ERR_CUDA = 4,
+    CUDEC_ERR_NOT_IMPLEMENTED = 5
+} cudec_status;
+
+/* Binary-compatible with cudaStream_t without pulling in the CUDA headers:
+ * both are pointers to the driver's CUstream_st. Pass a cudaStream_t
+ * directly; NULL means the legacy default stream (callers built with
+ * per-thread default streams pass cudaStreamPerThread explicitly). */
+typedef struct CUstream_st* cudec_stream_t;
+
+/* Per-chunk outcome, written by the device into a caller-provided device
+ * buffer. Fixed 16-byte layout on both sides of the ABI. */
+typedef struct cudec_chunk_result {
+    int32_t status;         /* a cudec_status value */
+    uint32_t reserved;      /* written as zero */
+    uint64_t bytes_written; /* valid output bytes when status is CUDEC_OK */
+} cudec_chunk_result;
+
+/* The device writes these records straight into caller memory, so every
+ * compiler on either side of the ABI must agree on the layout. The first
+ * member is at offset 0 by definition; with the total size and the last
+ * member's offset pinned, no other layout is possible. */
+#if defined(__cplusplus) && __cplusplus >= 201103L
+static_assert(sizeof(cudec_chunk_result) == 16 &&
+                  offsetof(cudec_chunk_result, bytes_written) == 8,
+              "cudec_chunk_result must keep its fixed 16-byte ABI layout");
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert(sizeof(cudec_chunk_result) == 16 &&
+                   offsetof(cudec_chunk_result, bytes_written) == 8,
+               "cudec_chunk_result must keep its fixed 16-byte ABI layout");
+#else
+/* Pre-C11 / pre-C++11: a negative array size fails compilation on drift. */
+typedef char cudec_chunk_result_layout_check
+    [(sizeof(cudec_chunk_result) == 16 &&
+      offsetof(cudec_chunk_result, bytes_written) == 8)
+         ? 1
+         : -1];
+#endif
+
+/* Batch LZ4 block decode. M1 lands the decoder; until then every chunk
+ * reports CUDEC_ERR_NOT_IMPLEMENTED and writes no output.
+ *
+ * All array arguments are device memory holding chunk_count entries, and
+ * the pointers those arrays contain are device pointers; d_results must be
+ * 16-byte aligned (any cudaMalloc allocation is). The call is asynchronous
+ * on `stream`: the synchronous return value covers argument validation and
+ * launch submission only; per-chunk outcomes land in d_results and are
+ * valid once the stream reaches the end of this launch.
+ *
+ * Validation rejects the whole call synchronously with
+ * CUDEC_ERR_INVALID_ARGUMENT and launches nothing: any NULL array
+ * argument, a misaligned d_results, an empty batch (chunk_count == 0), and
+ * a batch beyond the implementation's launch limit (rejected, never
+ * truncated). A rejected call makes no CUDA call and leaves the thread's
+ * pending CUDA error state untouched; a call that passes validation
+ * consumes that pending state (cudaGetLastError semantics), so the
+ * returned status reflects this submission alone. */
+cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
+                                        const size_t* d_src_sizes,
+                                        void* const* d_dst_ptrs,
+                                        const size_t* d_dst_capacities,
+                                        size_t chunk_count,
+                                        cudec_chunk_result* d_results,
+                                        cudec_stream_t stream);
 
 #ifdef __cplusplus
 }

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -1,0 +1,54 @@
+#include "cudec.h"
+
+#include <cuda_runtime.h>
+
+namespace {
+
+constexpr unsigned kBlockThreads = 256;
+
+/* M1 replaces this with the LZ4 decoder; the stub proves the batch
+ * contract end to end (validation, launch, per-chunk device reporting). */
+__global__ void report_not_implemented(cudec_chunk_result* results,
+                                       size_t chunk_count) {
+    size_t i = blockIdx.x * static_cast<size_t>(blockDim.x) + threadIdx.x;
+    if (i < chunk_count) {
+        results[i].status = CUDEC_ERR_NOT_IMPLEMENTED;
+        results[i].reserved = 0;
+        results[i].bytes_written = 0;
+    }
+}
+
+}  // namespace
+
+cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
+                                        const size_t* d_src_sizes,
+                                        void* const* d_dst_ptrs,
+                                        const size_t* d_dst_capacities,
+                                        size_t chunk_count,
+                                        cudec_chunk_result* d_results,
+                                        cudec_stream_t stream) {
+    /* Fail closed: reject the whole call rather than guess at intent. The
+     * grid bound keeps the block count inside gridDim.x's int32 range; the
+     * alignment bound keeps a single 16-byte result store per chunk open
+     * for the real decoder. */
+    constexpr size_t kMaxChunks =
+        static_cast<size_t>(INT32_MAX) * kBlockThreads;
+    if (d_src_ptrs == nullptr || d_src_sizes == nullptr ||
+        d_dst_ptrs == nullptr || d_dst_capacities == nullptr ||
+        d_results == nullptr ||
+        reinterpret_cast<uintptr_t>(d_results) % 16 != 0 || chunk_count == 0 ||
+        chunk_count > kMaxChunks) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+
+    /* Drain any error already pending on this thread so the post-launch
+     * check reports this submission alone; the header documents that the
+     * call consumes the pending error state. */
+    (void)cudaGetLastError();
+
+    const unsigned grid_blocks =
+        static_cast<unsigned>((chunk_count + kBlockThreads - 1) / kBlockThreads);
+    report_not_implemented<<<grid_blocks, kBlockThreads, 0, stream>>>(
+        d_results, chunk_count);
+    return cudaGetLastError() == cudaSuccess ? CUDEC_OK : CUDEC_ERR_CUDA;
+}

--- a/tests/smoke.cu
+++ b/tests/smoke.cu
@@ -1,0 +1,146 @@
+/* M0 smoke test: the library links, the version matches the header, and
+ * the stubbed batch entry point honors its documented contract on a real
+ * device - fail-closed argument validation, asynchronous submission, and
+ * per-chunk device-side reporting. */
+#include "cudec.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+
+#define REQUIRE(cond)                                                      \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,   \
+                         #cond);                                           \
+            return 1;                                                      \
+        }                                                                  \
+    } while (0)
+
+#define REQUIRE_CUDA(call) REQUIRE((call) == cudaSuccess)
+
+int main() {
+    REQUIRE(cudec_version() == CUDEC_VERSION_MAJOR * 10000 +
+                                   CUDEC_VERSION_MINOR * 100 +
+                                   CUDEC_VERSION_PATCH);
+
+    /* Validation needs no CUDA context: this rejects before the process
+     * has made a single CUDA call. */
+    const void* const* no_srcs = nullptr;
+    const size_t* no_sizes = nullptr;
+    void* const* no_dsts = nullptr;
+    const size_t* no_caps = nullptr;
+    cudec_chunk_result* no_results = nullptr;
+    REQUIRE(cudec_lz4_decompress_batch(no_srcs, no_sizes, no_dsts, no_caps, 1,
+                                       no_results, nullptr) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+
+    /* 257 chunks spans two blocks of the 256-thread launch, so the
+     * multi-block index arithmetic actually executes on device. */
+    const size_t chunk_count = 257;
+    const size_t chunk_bytes = 64;
+
+    unsigned char* buffers[2 * chunk_count];
+    const void* h_src_ptrs[chunk_count];
+    void* h_dst_ptrs[chunk_count];
+    size_t h_sizes[chunk_count];
+    for (size_t i = 0; i < chunk_count; i++) {
+        REQUIRE_CUDA(cudaMalloc(&buffers[i], chunk_bytes));
+        REQUIRE_CUDA(cudaMalloc(&buffers[chunk_count + i], chunk_bytes));
+        h_src_ptrs[i] = buffers[i];
+        h_dst_ptrs[i] = buffers[chunk_count + i];
+        h_sizes[i] = chunk_bytes;
+    }
+
+    const void** d_src_ptrs;
+    void** d_dst_ptrs;
+    size_t* d_src_sizes;
+    size_t* d_dst_caps;
+    cudec_chunk_result* d_results;
+    REQUIRE_CUDA(cudaMalloc(&d_src_ptrs, sizeof(h_src_ptrs)));
+    REQUIRE_CUDA(cudaMalloc(&d_dst_ptrs, sizeof(h_dst_ptrs)));
+    REQUIRE_CUDA(cudaMalloc(&d_src_sizes, sizeof(h_sizes)));
+    REQUIRE_CUDA(cudaMalloc(&d_dst_caps, sizeof(h_sizes)));
+    REQUIRE_CUDA(cudaMalloc(&d_results, chunk_count * sizeof(*d_results)));
+    REQUIRE_CUDA(cudaMemcpy(d_src_ptrs, h_src_ptrs, sizeof(h_src_ptrs),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_dst_ptrs, h_dst_ptrs, sizeof(h_dst_ptrs),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_src_sizes, h_sizes, sizeof(h_sizes),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_dst_caps, h_sizes, sizeof(h_sizes),
+                            cudaMemcpyHostToDevice));
+
+    /* cudaStream_t converts to cudec_stream_t with no cast: the public
+     * header's stream type is verified binary-compatible right here. */
+    cudaStream_t stream;
+    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    cudec_stream_t api_stream = stream;
+
+    /* Every reject path, one at a time, so dropping any single validation
+     * check fails the test: each missing array, a misaligned result
+     * buffer, an empty batch, and a batch no launch can cover. Rejection
+     * happens before anything is dereferenced or launched. */
+    cudec_chunk_result* misaligned = reinterpret_cast<cudec_chunk_result*>(
+        reinterpret_cast<char*>(d_results) + 8);
+#define REQUIRE_REJECTED(srcs, sizes, dsts, caps, count, results)          \
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, count,     \
+                                       results, api_stream) ==             \
+            CUDEC_ERR_INVALID_ARGUMENT)
+    REQUIRE_REJECTED(nullptr, d_src_sizes, d_dst_ptrs, d_dst_caps,
+                     chunk_count, d_results);
+    REQUIRE_REJECTED(d_src_ptrs, nullptr, d_dst_ptrs, d_dst_caps,
+                     chunk_count, d_results);
+    REQUIRE_REJECTED(d_src_ptrs, d_src_sizes, nullptr, d_dst_caps,
+                     chunk_count, d_results);
+    REQUIRE_REJECTED(d_src_ptrs, d_src_sizes, d_dst_ptrs, nullptr,
+                     chunk_count, d_results);
+    REQUIRE_REJECTED(d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_caps,
+                     chunk_count, nullptr);
+    REQUIRE_REJECTED(d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_caps,
+                     chunk_count, misaligned);
+    REQUIRE_REJECTED(d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_caps, 0,
+                     d_results);
+    REQUIRE_REJECTED(d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_caps,
+                     SIZE_MAX, d_results);
+#undef REQUIRE_REJECTED
+
+    /* Poison the result buffer so the per-field checks below prove the
+     * kernel wrote every field, not that the allocation happened to be
+     * zero-filled. */
+    REQUIRE_CUDA(cudaMemset(d_results, 0xFF, chunk_count * sizeof(*d_results)));
+
+    /* A stale caller-side error must not be misreported as this call's
+     * failure: plant one, verify it is actually pending, then expect a
+     * clean submission. */
+    REQUIRE(cudaSetDevice(12345) != cudaSuccess);
+    REQUIRE(cudaPeekAtLastError() != cudaSuccess);
+
+    /* A rejected call makes no CUDA call, so the planted error must still
+     * be pending afterwards - only the passing call below consumes it. */
+    REQUIRE(cudec_lz4_decompress_batch(d_src_ptrs, d_src_sizes, d_dst_ptrs,
+                                       d_dst_caps, 0, d_results,
+                                       api_stream) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudaPeekAtLastError() != cudaSuccess);
+
+    REQUIRE(cudec_lz4_decompress_batch(d_src_ptrs, d_src_sizes, d_dst_ptrs,
+                                       d_dst_caps, chunk_count, d_results,
+                                       api_stream) == CUDEC_OK);
+    REQUIRE_CUDA(cudaStreamSynchronize(stream));
+
+    cudec_chunk_result h_results[chunk_count];
+    REQUIRE_CUDA(cudaMemcpy(h_results, d_results, sizeof(h_results),
+                            cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < chunk_count; i++) {
+        REQUIRE(h_results[i].status == CUDEC_ERR_NOT_IMPLEMENTED);
+        REQUIRE(h_results[i].reserved == 0);
+        REQUIRE(h_results[i].bytes_written == 0);
+    }
+
+    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    std::printf("PASS: version + fail-closed validation + %zu-chunk stub "
+                "batch on device\n",
+                chunk_count);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Extends the host-only stub into the real project skeleton behind the C ABI.
Closes #2.

- CMake: the CUDA engine is opt-in (`CUDEC_ENABLE_CUDA`, default OFF) and
  fail-closed, enabling it without a CUDA toolchain is a hard configure
  error, never a silent host-only fallback, and combining it with an MSVC
  host toolchain is an explicit `FATAL_ERROR` (cl.exe would silently drop
  the GCC-style strict-warning flags instead of failing). The default
  configuration keeps building anywhere with just a C compiler, which is
  exactly what the CI `build` check runs. Architectures: `80;86-real` - 
  SASS for the sm_80 baseline and the tuned sm_86 target, PTX only for the
  baseline since sm_80 PTX already JIT-covers every newer device;
  overridable via `CMAKE_CUDA_ARCHITECTURES`.
- Warnings-as-errors on both sides: `-Wall -Wextra -Werror` for host C,
  `--Werror=all-warnings` plus the same host flags through `-Xcompiler` for
  device code.
- First real ABI surface in `include/cudec.h`: `cudec_status`,
  `cudec_stream_t` (binary-compatible with `cudaStream_t` without pulling
  CUDA headers into the public header; NULL documented as the legacy
  default stream), and the 16-byte `cudec_chunk_result` whose layout is
  locked in the header itself for every consumer, `static_assert` in C++,
  `_Static_assert` in C11, a negative-array-size fallback for older C, so
  a layout drift fails compilation rather than silently corrupting caller
  memory. `cudec_lz4_decompress_batch` carries the batch-decode shape from
  the masterplan (device-side descriptor arrays, caller-provided stream,
  per-chunk status); the contract enumerates every reject condition, the
  16-byte alignment requirement on `d_results`, and the error-state
  semantics. The decoder itself is M1; until then every chunk reports
  `CUDEC_ERR_NOT_IMPLEMENTED` and writes no output.
- `src/batch.cu`: fail-closed argument validation (null arrays, misaligned
  result buffer, empty batch, grid-bound overflow) rejecting the whole call
  synchronously before any CUDA call; a drain of the thread's pending CUDA
  error before the launch so the returned status reflects this submission
  alone; a stub kernel that writes the per-chunk result records on device.
- `tests/smoke.cu` (ctest `smoke`): version/header consistency; one
  negative test per reject path (each array null individually, misaligned
  `d_results`, empty batch, `SIZE_MAX`), the first of them before any CUDA
  call to prove validation needs no context; stream-type compatibility
  verified by a cast-free assignment; the result buffer poisoned with
  `0xFF` so the per-field checks are decisive; a planted stale CUDA error
  (verified pending via `cudaPeekAtLastError`) immediately before the
  positive call to pin the error-drain behavior; a 257-chunk batch spanning
  two blocks so the multi-block index arithmetic executes on device,
  checked result-by-result.
- CI: the placeholder comment in `ci.yml` is updated, `tests/` now exists
  but holds a GPU test the runner cannot execute; the CUDA build joins the
  check with #3, host-side ctest with #4.
- README: build instructions for both configurations; the container image
  pinned by digest; the container flow uses a separate `build-cuda`
  directory so the two documented flows cannot collide in one checkout.

## Type of change

- [x] API surface
- [x] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved: validation rejects before anything launches,
      and every reject path has a negative test in the smoke test.
- [ ] Oracle coverage, n/a: no decode path exists yet (arrives with #4).
- [x] Determinism preserved (the stub writes constants).
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [x] Adversarial review run (`/security-review`), four rounds, see Notes.

## Performance checklist

Not on the hot path, scaffolding only; no performance claims made.

## Quality checklist

- [x] Minimal: the change adds no more code than the skeleton requires.
- [x] Self-documenting; comments carry the bounds/ABI "why"s.
- [x] Conformance tests: the harness arrives with #4; until then the header
      asserts lock the `cudec_chunk_result` ABI layout on every compile of
      every consumer, and the smoke test locks stream-type compatibility
      and the batch contract.

## Verification

Pinned dev container (`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0f…`,
RTX 3080, driver 560.94, nvcc 12.6.77, `CMAKE_CUDA_ARCHITECTURES="80;86-real"`),
clean rebuild of the final revision:

```
[ 40%] Building CUDA object CMakeFiles/cudec.dir/src/batch.cu.o
[ 60%] Linking CUDA static library libcudec.a
[ 80%] Building CUDA object CMakeFiles/cudec_smoke.dir/tests/smoke.cu.o
[100%] Linking CUDA executable cudec_smoke
    Start 1: smoke
1/1 Test #1: smoke ............................   Passed    0.28 sec
100% tests passed, 0 tests failed out of 1
```

- [x] `cmake --build`, builds clean (host and device, `-Werror` both).
- [x] `ctest`, green (1/1).
- [x] Prettier, clean.
- [x] Docs synced, README covers both build configurations.

## Notes

Adversarial review: four rounds of the refute-by-default panel
(correctness / performance / robustness / integration + cuda-reviewer),
converging to PASS on every lens against the final tree.

Round 1 (4× NEEDS_IMPROVEMENT, 1× PASS), all fixed: stale-CUDA-error
misattribution in the entry point (drain before launch, documented,
regression-tested); missing negative tests plus an overclaiming test
comment (every reject path now tested individually); the unenforced
16-byte-layout ABI claim (header asserts); the under-specified contract
(reject conditions and `d_results` alignment now documented, the alignment
also validated and negative-tested); non-decisive zero-field assertions
(result buffer poisoned); a `ci.yml` comment that would have gone stale on
merge; a redundant second PTX copy in the arch list; the README image now
digest-pinned.

Round 2 (2× PASS, 2× NEEDS_IMPROVEMENT) - fixed: the error-consumption
sentence overclaimed (rejected calls make no CUDA call and leave the error
state untouched; now scoped precisely); the MSVC decline from round 1
rested on a wrong "fails loudly" premise (cl.exe ignores unknown `-W`
options with a warning, replaced by an explicit `FATAL_ERROR` guard); the
stale-error test now verifies the planted error is actually pending; the
batch spans two blocks; the layout assert no longer silently compiles out
for pre-C11 C consumers; the README build directories no longer collide.

Round 2's remaining MEDIUM asked to lock the drain-before-launch placement
with a launch-failure negative test (destroyed stream → `CUDEC_ERR_CUDA`).
Implemented as suggested, it segfaulted in the container run: using a
stream handle after `cudaStreamDestroy` is undefined behavior in the CUDA
runtime, not a defined error path, the runtime dereferences the handle. A
test built on UB is flakier than the property it guards, so it was removed
after empirical verification (the suite is green without it and segfaulted
with it, same revision otherwise). What remains pinned: the drain's
existence and its placement before the status check (planted-stale-error
test). The launch-failure branch itself stays untested until the harness
(#4) can express it without UB; noted there.

Rounds 3–4 closed the remainder: the error-consumption clause is now
regression-tested in both directions (a rejected call leaves the planted
error pending, the passing call consumes it); the layout check falls back
to a negative-array-size typedef for pre-C11 C *and* pre-C++11 C++, so no
consumer dialect silently skips it; CONTRIBUTING's build section no longer
documents a ctest invocation the host build cannot run.

Declined, with reasons: pinning the exact `kMaxChunks` boundary in the
over-limit test would duplicate a private implementation constant - 
`SIZE_MAX` keeps the branch covered and the boundary moves to the
conformance harness (#4); the host-only build intentionally ships the
batch declaration without a definition (link-time failure is the defined,
loud outcome for an opt-in engine); a pure-C caller linkage test is #4
scope.
