### PR TITLE
Add the CUDA build to the CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# CI — fast, fail-closed pull-request gate.
+# CI — the fail-closed pull-request gate.
 #
 # Runs only on pull requests to `main`, so the mainline scaffolding push does
 # not trigger it. Every PR must build and pass the format check before it can
@@ -26,6 +26,14 @@ jobs:
     # it stable.
     name: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # The exact toolchain the local GPU gate uses - same image, same digest.
+    # The runner has no GPU: this job proves both configurations compile;
+    # the on-device ctest results are pasted into each PR from the local
+    # container run. The host-side ctest step (oracle diffs, negative
+    # tests, conformance tests) arrives with the test harness (#4).
+    container:
+      image: nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8
     permissions:
       contents: read
     steps:
@@ -34,17 +42,29 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure
-        run: cmake -B build
+      # The image's CUDA apt repo is unused here and a historic false-red
+      # vector (the 2022 NVIDIA key rotation broke it fleet-wide) - drop it
+      # before updating. CMake comes from the signature-verified Ubuntu LTS
+      # archive, the same source the local gate command in the README uses.
+      - name: Install CMake
+        run: >-
+          rm -f /etc/apt/sources.list.d/cuda*.list &&
+          apt-get update -q -o Acquire::Retries=3 &&
+          apt-get install -yq -o Acquire::Retries=3 --no-install-recommends
+          cmake
 
-      - name: Build
-        run: cmake --build build
+      - name: Configure and build (host-only)
+        run: cmake -B build && cmake --build build
 
-      # tests/ holds the GPU smoke test, which needs a CUDA toolchain and a
-      # device this runner does not have; GPU results are pasted into each
-      # PR instead. The CUDA build joins this check with #3, and the
-      # host-side ctest step (oracle diffs, negative tests, conformance
-      # tests) with the test harness (#4).
+      # Unconditional AND self-verifying: the smoke binary exists only if
+      # the CUDA configuration actually built the device TUs, so a renamed
+      # CMake option cannot quietly turn this step into a green host-only
+      # build (-D on an unknown option is a warning, not an error).
+      - name: Configure and build (CUDA engine)
+        run: >-
+          cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON &&
+          cmake --build build-cuda -j &&
+          test -x build-cuda/cudec_smoke
 
   format:
     name: format


### PR DESCRIPTION
# What & why

Adds the CUDA build to the `build` required check, per the plan on the
issue. Closes #3.

The job now runs inside the digest-pinned dev container - the exact image
the local GPU gate uses (`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0f…`)
 - so CI and the maintained path share one toolchain. It builds both
configurations unconditionally: host-only (`build/`, the
header-compiles-as-C gate via `src/version.c`) and the CUDA engine
(`build-cuda/`, `-DCUDEC_ENABLE_CUDA=ON`, compile-only, runners have no
GPU; on-device ctest results keep landing in PR bodies from the local
container run). Job name `build` (the ruleset's required-check context),
fail-closed permissions, and the SHA-pinned checkout are unchanged; no new
actions. Design alternatives and the reasoning are recorded on the issue.

## Type of change

- [x] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved: the CUDA compile step is unconditional - the
      gate cannot silently skip. `-DCUDEC_ENABLE_CUDA=ON` without a
      toolchain is a hard configure error by #2's CMake contract.
- [ ] Oracle coverage, n/a (no decode path touched).
- [x] Determinism, n/a (no code path touched).
- [x] CUDA error checking / ABI, n/a (no code touched).
- [x] Adversarial review run (`/security-review`) - workflows surface, four
      lenses; see Notes.

## Performance checklist

Not on the hot path. The devel-image pull adds CI latency per run; measured
on this PR's own runs (see Verification). A slim derived image stays a
later optimization if it starts to matter.

## Quality checklist

- [x] Minimal: one job modified, nothing else.
- [x] Self-documenting; the comment explains why the container and why the
      unconditional step.
- [x] Conformance: extends the supply-chain rule - every CI toolchain
      source pinned to an immutable digest (swept by `/supply-chain`).

## Verification

- [x] Acceptance 1 (a device-code compile error fails the required check):
      proven — probe PR #9 (this change + a deliberate `batch.cu` syntax
      error) went red exactly on the CUDA step, host-only step green:
      https://github.com/iderex/cudec/actions/runs/29537441429/job/87751991634
      (closed unmerged, branch deleted).
- [x] Acceptance 2: this PR's own `build` run compiles the device TUs and
      passes the `test -x` guard:
      https://github.com/iderex/cudec/actions/runs/29537413320/job/87751901001
- [x] Measured baseline (recorded on the issue): image pull 56 s, whole
      `build` job 1 m 11 s — vs 21 s pre-change; the derived-image deferral
      stands on these numbers.
- [x] Job name/context, permissions, action pins unchanged (diff).
- [x] Local container gate on this branch: smoke 1/1 Passed (RTX 3080,
      nvcc 12.6.77).
- [x] Prettier, clean.

## Notes

(review findings / declines)
