### PR TITLE
Build the test net: framework-less harness, LZ4 oracle, conformance and negative scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,21 +43,25 @@ jobs:
         # failing command on the left of a pipe reds the step by itself.
         shell: bash
     steps:
-      - name: Check out the source
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      # The image's CUDA apt repo is unused here and a historic false-red
-      # vector (the 2022 NVIDIA key rotation broke it fleet-wide) - drop it
-      # before updating. CMake comes from the signature-verified Ubuntu LTS
-      # archive, the same source the local gate command in the README uses.
-      - name: Install CMake
+      # Tools BEFORE checkout, and git among them: without git in the
+      # container, actions/checkout silently falls back to a REST-API
+      # tarball download - the flakier path (it red this gate twice with
+      # GitHub-side 5xx pages on 2026-07-16). The image's CUDA apt repo is
+      # unused here and a historic false-red vector (the 2022 NVIDIA key
+      # rotation broke it fleet-wide) - drop it before updating. Packages
+      # come from the signature-verified Ubuntu LTS archive, the same
+      # source the local gate command in the README uses.
+      - name: Install git and CMake
         run: >-
           rm -f /etc/apt/sources.list.d/cuda*.list &&
           apt-get update -q -o Acquire::Retries=3 &&
           apt-get install -yq -o Acquire::Retries=3 --no-install-recommends
-          cmake
+          git cmake
+
+      - name: Check out the source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Configure and build (host-only)
         run: cmake -B build && cmake --build build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 # CI — the fail-closed pull-request gate.
 #
 # Runs only on pull requests to `main`, so the mainline scaffolding push does
-# not trigger it. Every PR must build and pass the format check before it can
-# merge; the CUDA toolchain and the test/bench steps are added by the M0/M1
-# PRs that introduce them and become part of these required checks.
+# not trigger it. Every PR must build both configurations, pass the host-side
+# test subset, and pass the format check before it can merge; the bench step
+# is added by the PR that introduces bench/ and becomes part of these
+# required checks.
 
 name: CI
 
@@ -28,14 +29,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # The exact toolchain the local GPU gate uses - same image, same digest.
-    # The runner has no GPU: this job proves both configurations compile;
-    # the on-device ctest results are pasted into each PR from the local
-    # container run. The host-side ctest step (oracle diffs, negative
-    # tests, conformance tests) arrives with the test harness (#4).
+    # The runner has no GPU: this job proves both configurations compile
+    # and runs the host-side test subset (oracle diffs, negative tests,
+    # conformance tests); the on-device ctest results are pasted into each
+    # PR from the local container run.
     container:
       image: nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8
     permissions:
       contents: read
+    defaults:
+      run:
+        # Explicit bash gets -o pipefail (the default shell does not), so a
+        # failing command on the left of a pipe reds the step by itself.
+        shell: bash
     steps:
       - name: Check out the source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -56,15 +62,37 @@ jobs:
       - name: Configure and build (host-only)
         run: cmake -B build && cmake --build build
 
-      # Unconditional AND self-verifying: the smoke binary exists only if
-      # the CUDA configuration actually built the device TUs, so a renamed
-      # CMake option cannot quietly turn this step into a green host-only
-      # build (-D on an unknown option is a warning, not an error).
+      # Unconditional AND self-verifying: the GPU-test binaries exist only
+      # if the CUDA configuration actually built the device TUs, so a
+      # renamed CMake option cannot quietly turn this step into a green
+      # host-only build (-D on an unknown option is a warning, not an
+      # error).
       - name: Configure and build (CUDA engine)
         run: >-
           cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON &&
           cmake --build build-cuda -j &&
-          test -x build-cuda/cudec_smoke
+          test -x build-cuda/tests/smoke &&
+          test -x build-cuda/tests/gpu_fixture
+
+      # The host-side subset; gpu-labeled tests run in this same container
+      # on the maintainer's machine and their output is pasted into the PR.
+      # Fail-closed plumbing: --no-tests=error reds a vacuous zero-test
+      # selection, and the identity greps pin BOTH sets by name - a known
+      # host test silently dropping out of the CI selection (say, by
+      # gaining a gpu-matching label) reds the gate exactly like a known
+      # GPU test vanishing from the deferred listing.
+      - name: Host-side tests (runner has no GPU)
+        run: >-
+          ctest --test-dir build-cuda -LE gpu --no-tests=error
+          --output-on-failure &&
+          ctest --test-dir build-cuda -LE gpu -N | tee host-selected.txt &&
+          grep -E ': conformance_c$' host-selected.txt &&
+          grep -E ': oracle_lz4$' host-selected.txt &&
+          grep -E ': launch_fail$' host-selected.txt &&
+          echo "Deferred to the local GPU gate:" &&
+          ctest --test-dir build-cuda -L gpu -N | tee gpu-deferred.txt &&
+          grep -E ': smoke$' gpu-deferred.txt &&
+          grep -E ': gpu_fixture$' gpu-deferred.txt
 
   format:
     name: format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,13 @@ if(CUDEC_ENABLE_CUDA)
   enable_language(CUDA)
   enable_testing()
 
+  # Single source of truth for the strict device flags: the raw list also
+  # feeds the configure-time liveness probes in tests/CMakeLists.txt, so an
+  # edit here is probed, not trusted.
+  set(CUDEC_CUDA_STRICT_FLAGS_RAW --Werror=all-warnings
+                                  -Xcompiler=-Wall,-Wextra,-Werror)
   set(CUDEC_CUDA_STRICT_FLAGS
-      $<$<COMPILE_LANGUAGE:CUDA>:--Werror=all-warnings;-Xcompiler=-Wall,-Wextra,-Werror>)
+      $<$<COMPILE_LANGUAGE:CUDA>:${CUDEC_CUDA_STRICT_FLAGS_RAW}>)
 
   target_sources(cudec PRIVATE src/batch.cu)
   # The cudec target predates enable_language(CUDA), so the architecture
@@ -49,11 +54,8 @@ if(CUDEC_ENABLE_CUDA)
                      CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
   target_compile_options(cudec PRIVATE ${CUDEC_CUDA_STRICT_FLAGS})
 
-  add_executable(cudec_smoke tests/smoke.cu)
-  target_link_libraries(cudec_smoke PRIVATE cudec)
-  set_target_properties(
-    cudec_smoke PROPERTIES CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON
-                           CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
-  target_compile_options(cudec_smoke PRIVATE ${CUDEC_CUDA_STRICT_FLAGS})
-  add_test(NAME smoke COMMAND cudec_smoke)
+  # Keep this last in the CUDA block: the conformance checks in tests/
+  # snapshot the cudec target's properties at this point - anything added
+  # to the target below this line would escape them.
+  add_subdirectory(tests)
 endif()

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ cmake -B build && cmake --build build
 ```
 
 With the CUDA engine (CUDA 12.x toolchain; the maintained path is the
-pinned dev container — GPU required only for the tests, not the build):
+pinned dev container — GPU required only for the gpu-labeled tests, not the
+build: without a GPU, drop `--gpus all` and add `-LE gpu` to the ctest line
+to build everything and run the host-side subset):
 
 ```sh
 docker run --rm --gpus all -v "$PWD:/w" -w /w \
@@ -78,7 +80,7 @@ docker run --rm --gpus all -v "$PWD:/w" -w /w \
   sh -c "apt-get update -q && apt-get install -yq cmake >/dev/null && \
          cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && \
          cmake --build build-cuda -j && \
-         ctest --test-dir build-cuda --output-on-failure"
+         ctest --test-dir build-cuda --no-tests=error --output-on-failure"
 ```
 
 ## Contributing

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -100,7 +100,41 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
 
 - Unit + oracle-diff + negative tests run under `ctest`; structural rules
   (fail-closed coverage, C-ABI purity, no-dependency rule) are encoded as
-  conformance tests so every PR is checked mechanically.
+  conformance tests so every PR is checked mechanically. The configure-time
+  conformance checks are **drift detectors, not tamper-proofing**: they
+  snapshot the library target's link surfaces and flags when `tests/` is
+  configured and defend against honest refactoring mistakes; adversarial
+  evasion (and additions made after that snapshot) remain code review's
+  job.
+- **The harness is framework-less; ctest is the runner** (settled in the #4
+  design review): one executable per test group over the small assertion
+  header `tests/require.h`; discovery, labels, parallelism, and rerun come
+  from ctest; buffer diffs report first-mismatch offset plus a hex window —
+  the one assertion domain a framework would not improve. Rationale:
+  near-zero supply-chain surface for the security net itself, and
+  early-abort semantics fit contract-sequence tests. Recorded reassessment
+  trigger: if early-abort measurably masks failure clusters at M5 mutant
+  scale, or an outside contributor base emerges, migrate to Catch2 (pinned)
+  — the REQUIRE-shaped macros survive that move verbatim, and no framework
+  headers are compiled through nvcc-only paths that would complicate it.
+- **A GPU test never self-skips** (banned pattern): no "no device, exit 0"
+  branches — skipping is exclusively the runner's decision via ctest labels
+  (`-LE gpu` on the GPU-less CI runner; the full run on the local gate). A
+  mislabeled GPU test in CI therefore fails loudly instead of passing
+  vacuously; `--no-tests=error` closes the zero-tests-selected route; CI
+  prints the deferred `-L gpu -N` listing and pins the known GPU tests by
+  name.
+- **Oracle pinning policy**: oracles are vendored via FetchContent from
+  maintainer-uploaded release assets, pinned by a self-computed SHA-256
+  cross-checked against a second packaging ecosystem; auto-generated
+  `/archive/` tarballs are avoided (GitHub regenerated them in 2023 and
+  their hashes moved). Where a project publishes no uploaded asset, the
+  archive tarball is pinned and a future hash mismatch is treated as the
+  invariant working, not as noise. FetchContent pins are invisible to
+  Dependabot — oracle bumps are deliberate manual PRs owned by the
+  supply-chain sweep. Third-party oracle code compiles with SYSTEM includes
+  and without the project's strict flags; one translation unit per oracle,
+  never its build system.
 - Fuzzing: mutation-based corpus fuzzing of the host-side parsers, plus
   GPU-vs-oracle diff loops on mutated streams for the kernels.
 - Benchmarks live in `bench/` with recorded methodology; every published
@@ -136,8 +170,13 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
 
 - Exact LZ4 kernel decomposition: single-pass warp-cooperative decode vs.
   two-phase (sequence scan, then parallel copy) — decided with measurements
-  in the M1 design issue.
-- Test framework choice (GoogleTest vs. Catch2) and oracle vendoring
-  mechanism (FetchContent pinned to release hashes) — M0.
-- CUDA dev container image and CI toolchain pinning — M0.
+  in the M1 design issue. The exact batch upper bound is pinned there too:
+  with the kernel geometry settled, the zero-visible-devices technique from
+  the #4 harness distinguishes the boundary through the public API
+  (`CUDEC_ERR_CUDA` = passed validation and reached the launch;
+  `CUDEC_ERR_INVALID_ARGUMENT` = rejected) without publishing the constant.
 - Benchmark corpus set beyond Silesia/enwik (game-asset-like data) — M2.
+
+Settled: test framework and oracle vendoring (section 5, via the #4 design
+review); dev-container image and CI toolchain pinning (issues #1/#3 —
+digest-pinned `nvidia/cuda` 12.6.2 in CI and the local gate).

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -33,6 +33,8 @@ cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
      * for the real decoder. */
     constexpr size_t kMaxChunks =
         static_cast<size_t>(INT32_MAX) * kBlockThreads;
+    static_assert(kMaxChunks < SIZE_MAX,
+                  "the SIZE_MAX over-limit contract test relies on this");
     if (d_src_ptrs == nullptr || d_src_sizes == nullptr ||
         d_dst_ptrs == nullptr || d_dst_capacities == nullptr ||
         d_results == nullptr ||

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,156 @@
+# The test net: ctest is the runner, one executable per test group, the
+# assertion header tests/require.h as the only "framework". Decision record
+# and reassessment trigger: docs/MASTERPLAN.md section 5.
+enable_language(CXX)
+
+# Supply chain: the hash-verified tarball is the only acceptable oracle
+# source - a system copy must never silently substitute for it.
+set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
+
+# liblz4, pinned by the SHA-256 of the maintainer-uploaded release asset
+# (self-computed at pin time and cross-checked against conan-center; the
+# auto-generated /archive/ tarballs are avoided - GitHub regenerated them
+# in 2023 and their hashes moved). Test-only dependency: the link
+# allowlist below keeps it out of the library.
+include(FetchContent)
+FetchContent_Declare(
+  lz4
+  URL https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz
+  URL_HASH
+    SHA256=537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+FetchContent_MakeAvailable(lz4)
+
+# The uploaded tarball has no top-level CMakeLists (lz4's lives in
+# build/cmake), so MakeAvailable only populates the source tree; we compile
+# the one translation unit the block-format oracle needs and depend on
+# nothing of lz4's build system. SYSTEM include + none of our strict flags:
+# third-party code is audited by hash, not reformatted.
+add_library(lz4_oracle STATIC ${lz4_SOURCE_DIR}/lib/lz4.c)
+target_include_directories(lz4_oracle SYSTEM PUBLIC ${lz4_SOURCE_DIR}/lib)
+
+# PRIVATE on purpose: the archive still links through, but the lz4 include
+# path stays out of every consumer's command line - so an accidental
+# #include <lz4.h> in a .cu test is a compile error, and the "nvcc never
+# sees lz4.h" rule is enforced, not just observed.
+add_library(cudec_test_fixtures STATIC fixtures.cpp)
+target_link_libraries(cudec_test_fixtures PRIVATE lz4_oracle)
+target_include_directories(cudec_test_fixtures PUBLIC .)
+set_target_properties(cudec_test_fixtures PROPERTIES CXX_STANDARD 17
+                                                     CXX_STANDARD_REQUIRED ON)
+target_compile_options(
+  cudec_test_fixtures PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror>)
+
+# GPU tests carry the label (the GPU-less CI runner selects -LE gpu) and
+# run serially: one physical device, and deterministic device state is
+# worth more than parallel wall time. A GPU test never self-skips - the
+# banned pattern is recorded in docs/MASTERPLAN.md section 5.
+function(cudec_add_test name)
+  cmake_parse_arguments(T "GPU" "" "SOURCES;LIBS" ${ARGN})
+  add_executable(${name} ${T_SOURCES})
+  target_link_libraries(${name} PRIVATE cudec ${T_LIBS})
+  set_target_properties(
+    ${name} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON
+                       CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON
+                       CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+  target_compile_options(
+    ${name} PRIVATE ${CUDEC_CUDA_STRICT_FLAGS}
+                    $<$<COMPILE_LANGUAGE:C,CXX>:-Wall;-Wextra;-Werror>)
+  add_test(NAME ${name} COMMAND ${name})
+  if(T_GPU)
+    set_tests_properties(${name} PROPERTIES LABELS gpu RUN_SERIAL TRUE)
+  endif()
+endfunction()
+
+cudec_add_test(conformance_c SOURCES conformance_c.c)
+set_target_properties(conformance_c PROPERTIES C_STANDARD 99
+                                               C_STANDARD_REQUIRED ON)
+cudec_add_test(oracle_lz4 SOURCES oracle_lz4.cpp LIBS cudec_test_fixtures)
+cudec_add_test(launch_fail SOURCES launch_fail.cpp)
+# Belt and suspenders with the setenv inside launch_fail.cpp: zero visible
+# devices is the test condition, on the GPU machine too.
+set_tests_properties(launch_fail PROPERTIES ENVIRONMENT
+                                            "CUDA_VISIBLE_DEVICES=")
+cudec_add_test(smoke SOURCES smoke.cu GPU)
+cudec_add_test(gpu_fixture SOURCES gpu_fixture.cu LIBS cudec_test_fixtures
+               GPU)
+
+# ---- Structural conformance, configure time: a violation reds every CI
+# build. These are drift detectors, not tamper-proofing - the honest limits
+# are recorded in docs/MASTERPLAN.md section 5.
+
+# The library must depend on nothing beyond the CUDA runtime - checked on
+# the private AND consumer-facing link surfaces (an INTERFACE dependency of
+# a static library is exactly what its consumers inherit), and on link
+# options, which could smuggle a -l dependency past the target lists.
+foreach(_prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES LINK_OPTIONS
+              INTERFACE_LINK_OPTIONS)
+  get_target_property(_entries cudec ${_prop})
+  if(_entries)
+    foreach(_entry IN LISTS _entries)
+      if(NOT _entry MATCHES "^CUDA::")
+        message(
+          FATAL_ERROR
+            "cudec carries '${_entry}' in ${_prop} - the library must depend "
+            "on nothing beyond the CUDA runtime")
+      endif()
+    endforeach()
+  endif()
+endforeach()
+
+# Warnings-as-errors must be wired on the library...
+get_target_property(_cudec_opts cudec COMPILE_OPTIONS)
+if(NOT _cudec_opts MATCHES "Werror")
+  message(FATAL_ERROR "warnings-as-errors is no longer wired on target cudec")
+endif()
+
+# ...and LIVE: a translation unit with a known warning must FAIL to compile
+# under the exact flag list the targets use, invoked directly (try_compile
+# does not forward per-language flags reliably - verified empirically). The
+# presence check above cannot see a dead gate (an appended -Wno-error still
+# contains the substring); these probes can. Honest scope limit: nvcc's
+# front end diagnoses both probes (#177-D), so this proves the
+# --Werror=all-warnings seam end to end; the -Xcompiler=-Werror suffix has
+# no cheap gcc-only trigger (the front end shadows every candidate tried)
+# and stays covered by the substring check only.
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/probes/host_warning.cu
+     "int main() {\n    int unused_host_variable;\n    return 0;\n}\n")
+file(
+  WRITE ${CMAKE_CURRENT_BINARY_DIR}/probes/device_warning.cu
+  "__global__ void probe() { int unused_device_variable; }\nint main() { return 0; }\n"
+)
+# Positive control first: a warning-free TU must compile with exit 0 under
+# the identical command. Without it, ANY probe breakage (arch renamed in a
+# toolkit bump, unwritable dir, rejected flag) exits nonzero and would
+# masquerade as "gate live" - the probes would go vacuous exactly on the
+# toolchain-drift event they guard against.
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/probes/control_clean.cu
+     "int main() { return 0; }\n")
+execute_process(
+  COMMAND
+    ${CMAKE_CUDA_COMPILER} ${CUDEC_CUDA_STRICT_FLAGS_RAW} -arch=sm_86 -c
+    ${CMAKE_CURRENT_BINARY_DIR}/probes/control_clean.cu -o
+    ${CMAKE_CURRENT_BINARY_DIR}/probes/control_clean.o
+  RESULT_VARIABLE _control_exit
+  OUTPUT_QUIET ERROR_QUIET)
+if(NOT _control_exit EQUAL 0)
+  message(
+    FATAL_ERROR
+      "warnings-gate probe invocation is broken (the warning-free control "
+      "TU failed to compile) - fix the probe before trusting the gate")
+endif()
+foreach(_probe host_warning device_warning)
+  execute_process(
+    COMMAND
+      ${CMAKE_CUDA_COMPILER} ${CUDEC_CUDA_STRICT_FLAGS_RAW} -arch=sm_86 -c
+      ${CMAKE_CURRENT_BINARY_DIR}/probes/${_probe}.cu -o
+      ${CMAKE_CURRENT_BINARY_DIR}/probes/${_probe}.o
+    RESULT_VARIABLE _probe_exit
+    OUTPUT_QUIET ERROR_QUIET)
+  if(_probe_exit EQUAL 0)
+    message(
+      FATAL_ERROR
+        "warnings-as-errors gate is dead: probe '${_probe}' compiled clean "
+        "under the strict flags")
+  endif()
+endforeach()

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -1,0 +1,60 @@
+/* Conformance: the public header is consumable from plain C99 - it
+ * compiles as C, resolves every public symbol with C linkage, and the
+ * documented contract holds for a C caller. C99 deliberately: it routes
+ * the header's layout check through the pre-C11 negative-array-size
+ * fallback, which no other translation unit compiles.
+ *
+ * Every path exercised here is a documented synchronous reject that makes
+ * no CUDA call (see cudec.h), so this test runs green on the GPU-less CI
+ * runner - the pointers below are host memory and are never dereferenced. */
+#include "cudec.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#define REQUIRE(cond)                                                     \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,       \
+                    #cond);                                               \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
+int main(void) {
+    unsigned char raw[2 * sizeof(cudec_chunk_result) + 16];
+    const uintptr_t base = ((uintptr_t)raw + 15) & ~(uintptr_t)15;
+    cudec_chunk_result* aligned = (cudec_chunk_result*)base;
+    cudec_chunk_result* misaligned = (cudec_chunk_result*)(base + 8);
+    const void* srcs[1] = {0};
+    size_t sizes[1] = {0};
+    void* dsts[1] = {0};
+    size_t caps[1] = {0};
+
+    REQUIRE(cudec_version() == CUDEC_VERSION_MAJOR * 10000 +
+                                   CUDEC_VERSION_MINOR * 100 +
+                                   CUDEC_VERSION_PATCH);
+
+    /* Every documented reject class, one call each: null arrays, null
+     * results, misaligned results, empty batch, over-limit batch. */
+    REQUIRE(cudec_lz4_decompress_batch(0, sizes, dsts, caps, 1, aligned, 0) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_batch(srcs, 0, dsts, caps, 1, aligned, 0) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, 0, caps, 1, aligned, 0) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, 0, 1, aligned, 0) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, 1, 0, 0) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, 1, misaligned,
+                                       0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, 0, aligned,
+                                       0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, SIZE_MAX,
+                                       aligned, 0) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+
+    printf("PASS: plain-C caller exercised every public symbol\n");
+    return 0;
+}

--- a/tests/fixtures.cpp
+++ b/tests/fixtures.cpp
@@ -1,0 +1,158 @@
+#include "fixtures.h"
+
+#include <lz4.h>
+
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+/* Own PRNG: rand() and std:: distributions are implementation-defined and
+ * would break bit-identical corpora across platforms. */
+uint64_t SplitMix64(uint64_t& state) {
+    state += 0x9e3779b97f4a7c15ull;
+    uint64_t z = state;
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ull;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111ebull;
+    return z ^ (z >> 31);
+}
+
+std::vector<unsigned char> RandomBytes(size_t size, uint64_t seed) {
+    std::vector<unsigned char> out(size);
+    uint64_t s = seed;
+    for (size_t i = 0; i < size; i++) {
+        out[i] = static_cast<unsigned char>(SplitMix64(s));
+    }
+    return out;
+}
+
+/* Token text with splices copied from exponentially growing distances, so
+ * the compressed streams carry matches across the whole LZ4 offset range
+ * (1..65535), not just the short distances a plain dictionary produces. */
+std::vector<unsigned char> TextLike(size_t size, uint64_t seed) {
+    static const char* const kWords[] = {
+        "the",  "quick",  "brown", "fox",    "jumps", "over",
+        "lazy", "dog",    "gpu",   "decode", "batch", "chunk",
+        "warp", "stream", "block", "lane"};
+    std::vector<unsigned char> out;
+    out.reserve(size + 32);
+    uint64_t s = seed;
+    size_t distance = 1;
+    while (out.size() < size) {
+        const char* word = kWords[SplitMix64(s) % 16];
+        out.insert(out.end(), word, word + std::strlen(word));
+        out.push_back(' ');
+        if (out.size() > distance && SplitMix64(s) % 4 == 0) {
+            const size_t start = out.size() - distance;
+            const size_t len = distance < 16 ? distance : 16;
+            for (size_t i = 0; i < len; i++) {
+                out.push_back(out[start + i]);
+            }
+            distance =
+                distance >= 65535
+                    ? 1
+                    : (distance * 2 < 65535 ? distance * 2 : size_t{65535});
+        }
+    }
+    out.resize(size);
+    return out;
+}
+
+std::vector<unsigned char> Lz4Compress(
+    const std::vector<unsigned char>& original) {
+    const int bound = LZ4_compressBound(static_cast<int>(original.size()));
+    std::vector<unsigned char> compressed(static_cast<size_t>(bound));
+    const int written = LZ4_compress_default(
+        reinterpret_cast<const char*>(original.data()),
+        reinterpret_cast<char*>(compressed.data()),
+        static_cast<int>(original.size()), bound);
+    /* Fixture generation is infrastructure, not a test: a compressor
+     * failure here would silently hollow out every downstream assertion. */
+    if (written <= 0) {
+        std::abort();
+    }
+    compressed.resize(static_cast<size_t>(written));
+    return compressed;
+}
+
+}  // namespace
+
+std::vector<Fixture> MakeLz4BlockFixtures() {
+    std::vector<Fixture> out;
+    const auto add = [&out](std::string name, uint64_t seed,
+                            std::vector<unsigned char> original) {
+        Fixture f;
+        f.name = std::move(name);
+        f.seed = seed;
+        f.original = std::move(original);
+        f.compressed = Lz4Compress(f.original);
+        out.push_back(std::move(f));
+    };
+    add("zeros-65536", 0x01, std::vector<unsigned char>(65536, 0));
+    add("random-65536", 0x11, RandomBytes(65536, 0x11));
+    static const size_t kEdgeSizes[] = {1,   31,  32,   33,   255,
+                                        256, 257, 4095, 4096, 65536};
+    for (const size_t n : kEdgeSizes) {
+        add("text-" + std::to_string(n), 0x22 + n, TextLike(n, 0x22 + n));
+    }
+    return out;
+}
+
+std::vector<Mutant> MutateStream(const std::vector<unsigned char>& stream,
+                                 uint64_t seed) {
+    std::vector<Mutant> out;
+    const size_t n = stream.size();
+    if (n == 0) {
+        /* Nothing to mutate; the flip loop's % n below must never run.
+         * Callers assert non-empty mutant lists, so this stays loud. */
+        return out;
+    }
+    const auto add = [&out](std::string description,
+                            std::vector<unsigned char> s) {
+        out.push_back(Mutant{std::move(description), std::move(s)});
+    };
+    /* Truncations at fixed fractions: a stream ending mid-sequence. */
+    for (const size_t quarters : {size_t{1}, size_t{2}, size_t{3}}) {
+        const size_t keep = n * quarters / 4;
+        if (keep < n) {
+            add("truncate-to-" + std::to_string(keep),
+                {stream.begin(), stream.begin() + static_cast<long>(keep)});
+        }
+    }
+    /* Shave 1..8 bytes off either end. */
+    for (size_t k = 1; k <= 8 && k < n; k++) {
+        add("drop-" + std::to_string(k) + "-tail",
+            {stream.begin(), stream.end() - static_cast<long>(k)});
+        add("drop-" + std::to_string(k) + "-head",
+            {stream.begin() + static_cast<long>(k), stream.end()});
+    }
+    /* Seeded single-bit flips. A flipped stream is NOT necessarily invalid
+     * (the oracle may accept it) - consumers must ask the oracle, never
+     * assume mutated means rejected. */
+    uint64_t s = seed;
+    for (int i = 0; i < 8; i++) {
+        std::vector<unsigned char> flipped = stream;
+        const size_t offset = SplitMix64(s) % n;
+        flipped[offset] ^=
+            static_cast<unsigned char>(1u << (SplitMix64(s) % 8));
+        add("flip-bit-at-" + std::to_string(offset), std::move(flipped));
+    }
+    return out;
+}
+
+bool OracleDecodes(const std::vector<unsigned char>& stream,
+                   size_t original_size, std::vector<unsigned char>* decoded) {
+    if (stream.empty()) {
+        return false; /* never hand liblz4 a null source pointer */
+    }
+    decoded->assign(original_size, 0);
+    const int written = LZ4_decompress_safe(
+        reinterpret_cast<const char*>(stream.data()),
+        reinterpret_cast<char*>(decoded->data()),
+        static_cast<int>(stream.size()), static_cast<int>(original_size));
+    if (written < 0) {
+        return false;
+    }
+    decoded->resize(static_cast<size_t>(written));
+    return true;
+}

--- a/tests/fixtures.h
+++ b/tests/fixtures.h
@@ -1,0 +1,40 @@
+/* Deterministic test corpus: LZ4 block pairs compressed by the CPU oracle,
+ * plus a mutation generator for the negative net. Everything is seeded and
+ * reproducible - a failure's (fixture, mutant) coordinates are a complete
+ * repro key. The oracle (liblz4) is the sole authority on stream validity:
+ * docs/MASTERPLAN.md, "the oracles decide". */
+#ifndef CUDEC_TESTS_FIXTURES_H
+#define CUDEC_TESTS_FIXTURES_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+struct Fixture {
+    std::string name;
+    uint64_t seed;
+    std::vector<unsigned char> original;
+    std::vector<unsigned char> compressed; /* LZ4 block format */
+};
+
+/* Corpus chosen against the future kernel geometry: max-compressible,
+ * incompressible, match-heavy text, and sizes crossing warp/block
+ * boundaries. */
+std::vector<Fixture> MakeLz4BlockFixtures();
+
+struct Mutant {
+    std::string description;
+    std::vector<unsigned char> stream;
+};
+
+/* Deterministic truncations (fixed fractions; 1..8 bytes off either end)
+ * and seeded single-bit flips of one compressed stream. */
+std::vector<Mutant> MutateStream(const std::vector<unsigned char>& stream,
+                                 uint64_t seed);
+
+/* CPU-reference decode verdict (and output when accepted). */
+bool OracleDecodes(const std::vector<unsigned char>& stream,
+                   size_t original_size, std::vector<unsigned char>* decoded);
+
+#endif /* CUDEC_TESTS_FIXTURES_H */

--- a/tests/gpu_fixture.cu
+++ b/tests/gpu_fixture.cu
@@ -1,0 +1,184 @@
+/* The fixture corpus through the real batch plumbing (device pointer
+ * tables, per-chunk sizes/capacities, poisoned destinations) - exactly the
+ * path the M1 decoder lands into. Today it pins the stub contract that
+ * smoke.cu does not cover: every chunk reports NOT_IMPLEMENTED and the
+ * destination buffers stay untouched (the header's "writes no output"
+ * promise). The reject-parity implication for mutants is written and
+ * executing now; M1 flips the pristine-pair expectations to CUDEC_OK plus
+ * byte-equality against the oracle output. */
+#include "cudec.h"
+#include "fixtures.h"
+#include "require.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr unsigned char kDstPoison = 0xA5;
+
+struct Chunk {
+    std::string context;
+    const std::vector<unsigned char>* src;
+    size_t dst_capacity;
+};
+
+/* Uploads a batch, runs it through the entry point on a created stream,
+ * and returns the per-chunk results plus the downloaded (poisoned)
+ * destination buffers. Plain int-returning so REQUIRE can early-abort. */
+int RunBatch(const std::vector<Chunk>& chunks,
+             std::vector<cudec_chunk_result>* results,
+             std::vector<std::vector<unsigned char>>* dst_bytes) {
+    const size_t n = chunks.size();
+    std::vector<const void*> h_srcs(n);
+    std::vector<void*> h_dsts(n);
+    std::vector<size_t> h_sizes(n);
+    std::vector<size_t> h_caps(n);
+    for (size_t i = 0; i < n; i++) {
+        void* d_src = nullptr;
+        void* d_dst = nullptr;
+        const size_t src_size = chunks[i].src->size();
+        REQUIRE_CUDA(cudaMalloc(&d_src, src_size ? src_size : 1));
+        if (src_size) {
+            REQUIRE_CUDA(cudaMemcpy(d_src, chunks[i].src->data(), src_size,
+                                    cudaMemcpyHostToDevice));
+        }
+        REQUIRE_CUDA(cudaMalloc(&d_dst, chunks[i].dst_capacity));
+        REQUIRE_CUDA(cudaMemset(d_dst, kDstPoison, chunks[i].dst_capacity));
+        h_srcs[i] = d_src;
+        h_dsts[i] = d_dst;
+        h_sizes[i] = src_size;
+        h_caps[i] = chunks[i].dst_capacity;
+    }
+
+    const void** d_srcs;
+    void** d_dsts;
+    size_t* d_sizes;
+    size_t* d_caps;
+    cudec_chunk_result* d_results;
+    REQUIRE_CUDA(cudaMalloc(&d_srcs, n * sizeof(*d_srcs)));
+    REQUIRE_CUDA(cudaMalloc(&d_dsts, n * sizeof(*d_dsts)));
+    REQUIRE_CUDA(cudaMalloc(&d_sizes, n * sizeof(*d_sizes)));
+    REQUIRE_CUDA(cudaMalloc(&d_caps, n * sizeof(*d_caps)));
+    REQUIRE_CUDA(cudaMalloc(&d_results, n * sizeof(*d_results)));
+    REQUIRE_CUDA(cudaMemcpy(d_srcs, h_srcs.data(), n * sizeof(*d_srcs),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_dsts, h_dsts.data(), n * sizeof(*d_dsts),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_sizes, h_sizes.data(), n * sizeof(*d_sizes),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_caps, h_caps.data(), n * sizeof(*d_caps),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemset(d_results, 0xFF, n * sizeof(*d_results)));
+
+    cudaStream_t stream;
+    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    REQUIRE(cudec_lz4_decompress_batch(d_srcs, d_sizes, d_dsts, d_caps, n,
+                                       d_results, stream) == CUDEC_OK);
+    REQUIRE_CUDA(cudaStreamSynchronize(stream));
+    REQUIRE_CUDA(cudaStreamDestroy(stream));
+
+    results->assign(n, cudec_chunk_result{});
+    REQUIRE_CUDA(cudaMemcpy(results->data(), d_results,
+                            n * sizeof(*d_results), cudaMemcpyDeviceToHost));
+    dst_bytes->assign(n, {});
+    for (size_t i = 0; i < n; i++) {
+        (*dst_bytes)[i].assign(h_caps[i], 0);
+        REQUIRE_CUDA(cudaMemcpy((*dst_bytes)[i].data(), h_dsts[i], h_caps[i],
+                                cudaMemcpyDeviceToHost));
+    }
+    /* Process teardown reclaims the device allocations; the harness keeps
+     * no device state across tests (RUN_SERIAL on the gpu label). */
+    return 0;
+}
+
+int CheckStubContract(const std::vector<Chunk>& chunks,
+                      const std::vector<cudec_chunk_result>& results,
+                      const std::vector<std::vector<unsigned char>>& dsts) {
+    const std::vector<unsigned char> poison_row(65536, kDstPoison);
+    for (size_t i = 0; i < chunks.size(); i++) {
+        const char* ctx = chunks[i].context.c_str();
+        REQUIRE_CTX(results[i].status == CUDEC_ERR_NOT_IMPLEMENTED, "%s", ctx);
+        REQUIRE_CTX(results[i].reserved == 0, "%s", ctx);
+        REQUIRE_CTX(results[i].bytes_written == 0, "%s", ctx);
+        /* "Writes no output": the poison must survive verbatim. */
+        REQUIRE_CTX(dsts[i].size() <= poison_row.size(), "%s", ctx);
+        REQUIRE_CTX(equal_bytes(dsts[i].data(), poison_row.data(),
+                                dsts[i].size()),
+                    "%s", ctx);
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    /* Self-sufficiently non-vacuous: this test must bite on its own, not
+     * by courtesy of oracle_lz4 running in the same suite. */
+    const auto fixtures = MakeLz4BlockFixtures();
+    REQUIRE(!fixtures.empty());
+
+    /* Batch 1: the pristine pairs - the exact plumbing the M1 decoder
+     * inherits; at M1 these expectations flip to CUDEC_OK + bytes_written
+     * + byte-equality against the oracle output. */
+    std::vector<Chunk> pairs;
+    for (const auto& f : fixtures) {
+        pairs.push_back(Chunk{f.name, &f.compressed, f.original.size()});
+    }
+    std::vector<cudec_chunk_result> results;
+    std::vector<std::vector<unsigned char>> dsts;
+    REQUIRE(RunBatch(pairs, &results, &dsts) == 0);
+    REQUIRE(CheckStubContract(pairs, results, dsts) == 0);
+
+    /* Batch 2: the mutant corpus with oracle verdicts. The reject-parity
+     * implication (oracle rejects => cudec must not report success) is
+     * armed and executing today - trivially satisfied by the stub, load-
+     * bearing from M1 on. */
+    std::vector<std::vector<unsigned char>> mutant_streams;
+    std::vector<std::string> mutant_contexts;
+    std::vector<size_t> mutant_capacities;
+    std::vector<bool> oracle_rejected;
+    for (const auto& f : fixtures) {
+        for (auto& m : MutateStream(f.compressed, f.seed)) {
+            std::vector<unsigned char> decoded;
+            oracle_rejected.push_back(
+                !OracleDecodes(m.stream, f.original.size(), &decoded));
+            mutant_streams.push_back(std::move(m.stream));
+            mutant_contexts.push_back(f.name + "/" + m.description);
+            mutant_capacities.push_back(f.original.size());
+        }
+    }
+    /* Chunk keeps pointers into mutant_streams, so it is built only after
+     * the vector stopped growing (reallocation would dangle them). */
+    std::vector<Chunk> mutant_chunks;
+    for (size_t i = 0; i < mutant_streams.size(); i++) {
+        mutant_chunks.push_back(Chunk{mutant_contexts[i], &mutant_streams[i],
+                                      mutant_capacities[i]});
+    }
+    REQUIRE(RunBatch(mutant_chunks, &results, &dsts) == 0);
+    REQUIRE(CheckStubContract(mutant_chunks, results, dsts) == 0);
+    size_t rejected_count = 0;
+    for (size_t i = 0; i < mutant_chunks.size(); i++) {
+        if (!oracle_rejected[i]) {
+            continue;
+        }
+        rejected_count++;
+        /* M1 note: for mutants the oracle ACCEPTS, the flip must compare
+         * against the oracle's own output and size (a truncation can land
+         * on a valid, shorter stream) - never against f.original. */
+        REQUIRE_CTX(results[i].status != CUDEC_OK,
+                    "reject parity (armed for M1): %s",
+                    mutant_chunks[i].context.c_str());
+    }
+    /* The parity arm must have teeth: at least one mutant per corpus is
+     * oracle-rejected, or this whole loop was vacuous. */
+    REQUIRE(rejected_count > 0);
+
+    std::printf("PASS: %zu pairs + %zu mutants (%zu oracle-rejected) through "
+                "the batch plumbing; stub contract and poison intact\n",
+                pairs.size(), mutant_chunks.size(), rejected_count);
+    return 0;
+}

--- a/tests/launch_fail.cpp
+++ b/tests/launch_fail.cpp
@@ -1,0 +1,42 @@
+/* The launch-failure branch of cudec_lz4_decompress_batch, exercised with
+ * defined behavior (deferred gap 1 from the #2 review): a process with
+ * zero visible CUDA devices makes every launch submission fail
+ * deterministically, so CI's GPU-lessness becomes the test condition and
+ * the same test runs on the GPU machine via the environment override. No
+ * destroyed-stream UB anywhere: the fake device pointers below pass
+ * validation and are never dereferenced because the launch dies at
+ * submission. */
+#include "cudec.h"
+#include "require.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+int main() {
+    /* First statement, before any CUDA runtime touch; belt-and-suspenders
+     * with the ENVIRONMENT property on the ctest entry. */
+    REQUIRE(setenv("CUDA_VISIBLE_DEVICES", "", 1) == 0);
+
+    alignas(16) static cudec_chunk_result results[1];
+    static const void* srcs[1];
+    static size_t sizes[1];
+    static void* dsts[1];
+    static size_t caps[1];
+
+    /* Validation is pure host logic: it rejects without a CUDA call even
+     * when no device exists. */
+    REQUIRE(cudec_lz4_decompress_batch(nullptr, sizes, dsts, caps, 1, results,
+                                       nullptr) == CUDEC_ERR_INVALID_ARGUMENT);
+
+    /* A validation-passing call must reach the launch and report its
+     * submission failure - the branch under test. Twice: the branch is
+     * stable, not a one-shot artifact of first-touch context init. */
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, 1, results,
+                                       nullptr) == CUDEC_ERR_CUDA);
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, 1, results,
+                                       nullptr) == CUDEC_ERR_CUDA);
+
+    std::printf("PASS: launch-failure branch reports CUDEC_ERR_CUDA with "
+                "zero visible devices\n");
+    return 0;
+}

--- a/tests/oracle_lz4.cpp
+++ b/tests/oracle_lz4.cpp
@@ -1,0 +1,91 @@
+/* The oracle net proves itself before any kernel exists: the fixture
+ * pairs are real (oracle self-round-trip), the mutation machinery is
+ * deterministic (two generation passes agree, verdicts agree), and the
+ * mutations actually bite (at least one rejected mutant per fixture -
+ * "all rejected" would be false: some bit flips yield valid streams). */
+#include "fixtures.h"
+#include "require.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+/* Corpus drift tripwire: the determinism invariant ("bit-identical corpora
+ * across platforms and runs") must be executable, not argued. The pinned
+ * digest moves whenever an oracle bump shifts LZ4_compress_default output
+ * (and with it the whole mutant corpus and its verdicts) - the bump PR
+ * then updates the pin consciously instead of the corpus drifting green.
+ * FNV-1a, not crypto: a tripwire against drift, not a defense. */
+constexpr uint64_t kExpectedCorpusDigest = 0x04e2fb5078db9e2bull;
+
+uint64_t Fnv1a64(uint64_t hash, const void* data, size_t size) {
+    const unsigned char* bytes = static_cast<const unsigned char*>(data);
+    for (size_t i = 0; i < size; i++) {
+        hash ^= bytes[i];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+}  // namespace
+
+int main() {
+    const auto fixtures = MakeLz4BlockFixtures();
+    REQUIRE(!fixtures.empty());
+
+    uint64_t digest = 14695981039346656037ull;
+    for (const auto& f : fixtures) {
+        digest = Fnv1a64(digest, f.name.data(), f.name.size());
+        digest = Fnv1a64(digest, f.compressed.data(), f.compressed.size());
+    }
+    REQUIRE_CTX(digest == kExpectedCorpusDigest,
+                "corpus digest is 0x%016llx - an oracle or generator change "
+                "moved the fixtures; verify deliberately, then update the pin",
+                static_cast<unsigned long long>(digest));
+
+    size_t mutant_total = 0;
+    for (const auto& f : fixtures) {
+        std::vector<unsigned char> decoded;
+        REQUIRE_CTX(OracleDecodes(f.compressed, f.original.size(), &decoded),
+                    "fixture %s", f.name.c_str());
+        REQUIRE_CTX(decoded.size() == f.original.size(), "fixture %s",
+                    f.name.c_str());
+        REQUIRE_CTX(equal_bytes(decoded.data(), f.original.data(),
+                                decoded.size()),
+                    "fixture %s", f.name.c_str());
+
+        const auto mutants = MutateStream(f.compressed, f.seed);
+        const auto mutants_again = MutateStream(f.compressed, f.seed);
+        REQUIRE_CTX(mutants.size() == mutants_again.size(), "fixture %s",
+                    f.name.c_str());
+        REQUIRE_CTX(!mutants.empty(), "fixture %s", f.name.c_str());
+        size_t rejected = 0;
+        for (size_t i = 0; i < mutants.size(); i++) {
+            REQUIRE_CTX(mutants[i].stream == mutants_again[i].stream,
+                        "generation determinism: fixture %s mutant %zu (%s)",
+                        f.name.c_str(), i, mutants[i].description.c_str());
+            std::vector<unsigned char> first_out;
+            std::vector<unsigned char> second_out;
+            const bool first = OracleDecodes(mutants[i].stream,
+                                             f.original.size(), &first_out);
+            const bool second = OracleDecodes(mutants[i].stream,
+                                              f.original.size(), &second_out);
+            REQUIRE_CTX(first == second,
+                        "verdict determinism: fixture %s mutant %zu (%s)",
+                        f.name.c_str(), i, mutants[i].description.c_str());
+            if (!first) {
+                rejected++;
+            }
+        }
+        REQUIRE_CTX(rejected > 0,
+                    "no mutant rejected for fixture %s - mutations do not "
+                    "bite",
+                    f.name.c_str());
+        mutant_total += mutants.size();
+    }
+    std::printf("PASS: %zu fixtures round-trip; %zu mutants, machinery "
+                "deterministic and biting\n",
+                fixtures.size(), mutant_total);
+    return 0;
+}

--- a/tests/require.h
+++ b/tests/require.h
@@ -1,0 +1,57 @@
+/* The harness's entire assertion layer. ctest is the runner; each test
+ * group is one executable that aborts on its first failed check (a later
+ * check is meaningless once earlier state diverged). The framework
+ * decision and its reassessment trigger: docs/MASTERPLAN.md section 5. */
+#ifndef CUDEC_TESTS_REQUIRE_H
+#define CUDEC_TESTS_REQUIRE_H
+
+#include <cstddef>
+#include <cstdio>
+
+#define REQUIRE(cond)                                                      \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,   \
+                         #cond);                                           \
+            return 1;                                                      \
+        }                                                                  \
+    } while (0)
+
+/* Same, with a printf-style context suffix: the (fixture, mutant, index)
+ * coordinates that make a deterministic failure directly reproducible. */
+#define REQUIRE_CTX(cond, ...)                                             \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            std::fprintf(stderr, "FAIL %s:%d: %s | ", __FILE__, __LINE__,  \
+                         #cond);                                           \
+            std::fprintf(stderr, __VA_ARGS__);                             \
+            std::fputc('\n', stderr);                                      \
+            return 1;                                                      \
+        }                                                                  \
+    } while (0)
+
+#define REQUIRE_CUDA(call) REQUIRE((call) == cudaSuccess)
+
+/* Byte-diff for the buffer-shaped assertion domain: reports the first
+ * mismatch offset plus a small hex window instead of a bare boolean. */
+inline bool equal_bytes(const void* actual_p, const void* expected_p,
+                        size_t size) {
+    const unsigned char* actual = static_cast<const unsigned char*>(actual_p);
+    const unsigned char* expected =
+        static_cast<const unsigned char*>(expected_p);
+    for (size_t i = 0; i < size; i++) {
+        if (actual[i] == expected[i]) {
+            continue;
+        }
+        std::fprintf(stderr, "first byte mismatch at offset %zu:\n", i);
+        const size_t from = i < 8 ? 0 : i - 8;
+        for (size_t j = from; j < from + 16 && j < size; j++) {
+            std::fprintf(stderr, "  [%zu] have %02x want %02x%s\n", j,
+                         actual[j], expected[j], j == i ? "  <--" : "");
+        }
+        return false;
+    }
+    return true;
+}
+
+#endif /* CUDEC_TESTS_REQUIRE_H */

--- a/tests/smoke.cu
+++ b/tests/smoke.cu
@@ -3,21 +3,11 @@
  * device - fail-closed argument validation, asynchronous submission, and
  * per-chunk device-side reporting. */
 #include "cudec.h"
+#include "require.h"
 
 #include <cuda_runtime.h>
 
 #include <cstdio>
-
-#define REQUIRE(cond)                                                      \
-    do {                                                                   \
-        if (!(cond)) {                                                     \
-            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,   \
-                         #cond);                                           \
-            return 1;                                                      \
-        }                                                                  \
-    } while (0)
-
-#define REQUIRE_CUDA(call) REQUIRE((call) == cudaSuccess)
 
 int main() {
     REQUIRE(cudec_version() == CUDEC_VERSION_MAJOR * 10000 +


### PR DESCRIPTION
# What & why

The test net comes before the kernels. This builds the harness the M1 LZ4 decoder lands into, per the design settled in a three-candidate design review (framework-less / GoogleTest / Catch2; two independent judgments, unanimous for framework-less over ctest): one executable per test group, a small assertion header, near-zero supply-chain surface for the security net itself, and a recorded Catch2 migration trigger if M5 mutant scale ever defeats early-abort semantics. Closes #4.

Delivered: `tests/require.h` (assertion layer, byte-diff with first-mismatch hex window), deterministic fixture corpus + mutation generator (own splitmix64; match distances across the whole LZ4 offset range; sizes crossing warp/block geometry), the liblz4 1.10.0 oracle vendored via FetchContent, the oracle self-proof test with a pinned FNV-1a corpus-drift tripwire, the plain-C99 conformance caller, the launch-failure test with defined behavior (zero visible devices - closes the gap deferred from the #2 review), the GPU fixture test through the real batch plumbing (stub contract incl. untouched poisoned outputs; reject-parity armed for M1), configure-time conformance checks (four-surface link allowlist; warnings-gate presence check + live nvcc probes with a warning-free positive control), and the CI host-side test step with fail-closed plumbing.

Supply-chain provenance for the oracle pin: SHA-256 `537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b` self-computed from the downloaded release asset `lz4-1.10.0.tar.gz` and cross-checked against conan-center's recipe pin (identical). `FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER` blocks any silent system-copy substitution.

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: no new decode paths; every documented reject path now carries an explicit negative test (C99 conformance TU one call each; launch-failure branch tested with defined behavior; the harness itself has no self-skip route - a GPU test in CI dies loudly, never greens).
- [x] Oracle coverage: this PR introduces the oracle net (liblz4 self-round-trip, mutant verdict machinery, reject-parity implication armed against the stub; full GPU-vs-oracle byte diff flips on at M1).
- [x] Determinism preserved: corpus bit-identity is now executable, not argued - pinned FNV-1a digest over every fixture's name and compressed bytes; generation and verdict determinism asserted per fixture.
- [x] Every CUDA API call's error is checked (REQUIRE_CUDA throughout the tests); no exceptions cross the C ABI (unchanged, now locked by the C99 conformance test).
- [x] An adversarial review was run - see Notes.

## Performance checklist

Not a hot-path change (harness and CI only); gate cost measured anyway: in-container configure including the liveness probes and FetchContent 8.6 s, full ctest 0.69 s on the RTX 3080, CI job re-uses the digest-pinned container from #8.

- [ ] The claim is measured, not reasoned: n/a
- [ ] No regression against the recorded baseline: n/a (no baseline exists yet; bench/ arrives with #5)

## Quality checklist

- [x] Minimal: framework-less by decision, not omission - the whole assertion layer is one header; the only helper function (`cudec_add_test`) has five users; the oracle-vendoring helper is deliberately deferred to the third oracle.
- [x] Self-documenting: every non-obvious decision carries its why at the point of use (probe positive control, PRIVATE include containment, poison checks, banned self-skip pattern).
- [x] Conformance tests pass, and the new structural properties this change establishes are locked in as new conformance checks: four-surface link allowlist, warnings-gate liveness probes with positive control, C-ABI C99 consumption, corpus digest tripwire.

## Verification

- [x] `cmake --build` - builds clean, both configurations, warnings-as-errors on host and device.
- [x] `ctest` - green: full gate on the RTX 3080 in the pinned container (5/5: conformance_c, oracle_lz4, launch_fail, smoke, gpu_fixture; gpu label serialized), and a GPU-less CI-parity run (host-only build, CUDA build, `test -x` self-checks, 3/3 host subset with `--no-tests=error`, all five identity greps, pipefail active).
- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.
- [x] Docs synced: MASTERPLAN section 5 records the framework decision + reassessment trigger, the banned self-skip pattern, the oracle-pinning policy, and the drift-detector limits; section 8 closes the settled M0 questions; README documents the no-GPU variant and carries `--no-tests=error`.

## Notes

Adversarial review protocol (five refute-by-default lenses on the full diff + touched files):

- correctness: PASS (flagged the probe positive-control gap, the corpus-digest gap, and a latent MutateStream division-by-zero - all fixed below).
- performance: PASS (configure/test cost priced; per-chunk cudaMalloc pattern acceptable at current scale, revisit with M1 corpus growth).
- CUDA domain: PASS.
- integration: NEEDS_IMPROVEMENT -> fixed: probe positive control; host-side CI test set pinned by identity (symmetric to the GPU set); lz4 include path made PRIVATE so `#include <lz4.h>` in a .cu is a compile error, not a convention; stale ci.yml comment updated; link-allowlist snapshot-ordering comment added.
- robustness: NEEDS_IMPROVEMENT -> fixed: link allowlist widened to all four link surfaces (INTERFACE_LINK_LIBRARIES / LINK_OPTIONS / INTERFACE_LINK_OPTIONS); gpu_fixture made self-sufficiently non-vacuous (`!fixtures.empty()`, `rejected_count > 0`); explicit bash for pipefail in CI; MutateStream empty-input guard.
- Closure re-run of integration and robustness on the fixed tree: both PASS. Declined findings: none. Accepted, documented limits: the liveness probes prove the `--Werror=all-warnings` seam end to end while the `-Xcompiler=-Werror` suffix stays substring-checked (no cheap gcc-only warning exists - the nvcc front end shadows every candidate tried); the configure-time conformance checks are drift detectors, not tamper-proofing (recorded in MASTERPLAN section 5).

M1 hand-off notes recorded in code: accepted-mutant comparisons must diff against the oracle's own output and size (a truncation can land on a valid, shorter stream), never against the original fixture; the exact batch-bound probe technique is recorded in MASTERPLAN section 8.

CodeRabbit is not installed on this repository (verified on #7 - no response to an explicit review request); this PR merges on CI plus the adversarial review protocol above, per the precedent documented there. Installing the app remains an open account-level decision.