### PR TITLE
Build the benchmark harness: honest numbers or none

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
           grep -E ': conformance_c$' host-selected.txt &&
           grep -E ': oracle_lz4$' host-selected.txt &&
           grep -E ': launch_fail$' host-selected.txt &&
+          grep -E ': bench_selfcheck$' host-selected.txt &&
           echo "Deferred to the local GPU gate:" &&
           ctest --test-dir build-cuda -L gpu -N | tee gpu-deferred.txt &&
           grep -E ': smoke$' gpu-deferred.txt &&

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 build/
 build-cuda/
 
+# Downloaded benchmark corpora - hash-pinned by bench/get-corpora.sh,
+# never committed.
+bench/corpora/
+
 # Local maintainer tooling and working notes - never in the public tree.
 .claude/
 CLAUDE.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ if(CUDEC_ENABLE_CUDA)
     set(CMAKE_CUDA_ARCHITECTURES 80 86-real)
   endif()
   enable_language(CUDA)
+  # The project language is C; the test net and the bench harness add .cpp
+  # translation units, so CXX is enabled here where both subdirectories
+  # can see it (a language enabled inside one subdirectory is invisible to
+  # its siblings).
+  enable_language(CXX)
   enable_testing()
 
   # Single source of truth for the strict device flags: the raw list also
@@ -54,8 +59,11 @@ if(CUDEC_ENABLE_CUDA)
                      CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
   target_compile_options(cudec PRIVATE ${CUDEC_CUDA_STRICT_FLAGS})
 
-  # Keep this last in the CUDA block: the conformance checks in tests/
-  # snapshot the cudec target's properties at this point - anything added
-  # to the target below this line would escape them.
+  # Keep tests/ after everything that may touch the cudec target: its
+  # conformance checks snapshot the target's properties at this point -
+  # anything added to the target below this line would escape them. bench/
+  # follows because it consumes targets defined in tests/ and is
+  # consumer-only by rule (it links project targets, never modifies them).
   add_subdirectory(tests)
+  add_subdirectory(bench)
 endif()

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ and milestones:
   never an out-of-bounds access and never a guess. Every reject path has a
   negative test.
 - **Deterministic.** Same input, same output — bit-exact on every code path.
-- **Honest numbers.** Every performance claim ships with GPU model, driver,
-  CUDA version, corpus, and chunk-size distribution. Benchmarks live in the
-  repo.
+- **Honest numbers.** Recorded baselines: [docs/BENCHMARKS.md](docs/BENCHMARKS.md)
+  (`bench/bench_lz4`; corpora via `bench/get-corpora.sh`, hash-pinned).
+  Every performance claim ships with GPU model, driver,
+  CUDA version, corpus, and chunk-size distribution.
 - **Minimal.** The least code that does the job; structural rules are locked
   in by conformance tests.
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,21 @@
+# The benchmark harness: honest numbers or none - every report emits its
+# methodology block (docs/MASTERPLAN.md section 5). CPU-oracle only until
+# M1 lands a kernel to time. Consumer-only by rule: this directory links
+# project targets and never modifies them (the conformance snapshot in
+# tests/ runs before it).
+find_package(CUDAToolkit REQUIRED)
+
+add_executable(bench_lz4 bench_lz4.cpp)
+target_link_libraries(bench_lz4 PRIVATE cudec cudec_test_fixtures lz4_oracle
+                                        CUDA::cudart)
+set_target_properties(bench_lz4 PROPERTIES CXX_STANDARD 17
+                                           CXX_STANDARD_REQUIRED ON)
+# -O2 unconditionally: an empty CMAKE_BUILD_TYPE (the documented container
+# command) would otherwise time -O0 marshaling around the decoder.
+target_compile_options(
+  bench_lz4 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror;-O2>)
+
+# Rot protection: one short self-checked run on the built-in corpus as a
+# host-side ctest entry, so the harness cannot silently break between
+# milestones.
+add_test(NAME bench_selfcheck COMMAND bench_lz4 --selfcheck)

--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -1,0 +1,311 @@
+/* The benchmark harness (M0 skeleton): times batch LZ4 block decode
+ * through the CPU oracle - the only decoder that exists until M1, which
+ * plugs in as a second timed path in this same harness. A report cannot
+ * be produced without its methodology block; that is the point
+ * (docs/MASTERPLAN.md section 5, honest numbers). */
+#include "cudec.h"
+#include "fixtures.h"
+
+#include <cuda_runtime.h>
+#include <lz4.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+/* The LZ4 block-format ceiling used across the project. */
+constexpr size_t kChunkBytes = 65536;
+
+constexpr size_t kMaxRuns = 1000000;
+
+struct Corpus {
+    std::string name;
+    std::vector<std::vector<unsigned char>> originals;
+    std::vector<std::vector<unsigned char>> compressed;
+    size_t original_bytes = 0;
+    size_t compressed_bytes = 0;
+};
+
+bool AppendFileChunked(const std::string& path, Corpus* corpus) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        std::fprintf(stderr, "cannot open corpus file: %s\n", path.c_str());
+        return false;
+    }
+    const size_t chunks_before = corpus->originals.size();
+    while (true) {
+        std::vector<unsigned char> chunk(kChunkBytes);
+        in.read(reinterpret_cast<char*>(chunk.data()),
+                static_cast<std::streamsize>(kChunkBytes));
+        const std::streamsize got = in.gcount();
+        if (got <= 0) {
+            break;
+        }
+        chunk.resize(static_cast<size_t>(got));
+        corpus->originals.push_back(std::move(chunk));
+    }
+    /* Fail closed on I/O trouble and on zero contribution: a file that
+     * adds no chunks (empty, unreadable, a directory) must never end up
+     * attested in the methodology block. Per-FILE contribution, not the
+     * accumulated corpus - the accumulated check goes vacuous from the
+     * second argument on. */
+    if (in.bad()) {
+        std::fprintf(stderr, "read error in corpus file: %s\n", path.c_str());
+        return false;
+    }
+    if (corpus->originals.size() == chunks_before) {
+        std::fprintf(stderr, "corpus file contributed no data: %s\n",
+                     path.c_str());
+        return false;
+    }
+    return true;
+}
+
+void CompressAll(Corpus* corpus) {
+    for (const auto& original : corpus->originals) {
+        corpus->compressed.push_back(Lz4CompressBlock(original));
+        corpus->original_bytes += original.size();
+        corpus->compressed_bytes += corpus->compressed.back().size();
+    }
+}
+
+/* One measured repetition: decode the whole batch, wall clock. The timed
+ * region contains ONLY LZ4_decompress_safe calls into a pre-sized scratch
+ * buffer - no buffer clears, no allocation - so the label on the number
+ * is the number (OracleDecodes zero-fills its output and is therefore
+ * used on the untimed verify pass only). Exits on any decode failure:
+ * numbers for a broken decoder are not numbers. */
+double DecodeAllSeconds(const Corpus& corpus, unsigned char* scratch) {
+    const auto start = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        const int written = LZ4_decompress_safe(
+            reinterpret_cast<const char*>(corpus.compressed[i].data()),
+            reinterpret_cast<char*>(scratch),
+            static_cast<int>(corpus.compressed[i].size()),
+            static_cast<int>(corpus.originals[i].size()));
+        if (written < 0 ||
+            static_cast<size_t>(written) != corpus.originals[i].size()) {
+            std::fprintf(stderr, "chunk %zu failed to decode - refusing to "
+                                 "time a broken decoder\n",
+                         i);
+            std::exit(1);
+        }
+    }
+    const auto end = std::chrono::steady_clock::now();
+    return std::chrono::duration<double>(end - start).count();
+}
+
+std::string HostCpuName() {
+    std::ifstream in("/proc/cpuinfo");
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.rfind("model name", 0) == 0) {
+            const size_t colon = line.find(':');
+            if (colon != std::string::npos) {
+                return line.substr(colon + 2);
+            }
+        }
+    }
+    return "unknown host CPU";
+}
+
+std::string CudaDeviceLine() {
+    int count = 0;
+    if (cudaGetDeviceCount(&count) != cudaSuccess || count == 0) {
+        return "none visible to this process (the GPU decode path arrives "
+               "with M1)";
+    }
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, 0) != cudaSuccess) {
+        return "device query failed";
+    }
+    int driver = 0;
+    int runtime = 0;
+    (void)cudaDriverGetVersion(&driver);
+    (void)cudaRuntimeGetVersion(&runtime);
+    return std::string(prop.name) + " (sm_" + std::to_string(prop.major) +
+           std::to_string(prop.minor) + "), driver " +
+           std::to_string(driver / 1000) + "." +
+           std::to_string((driver % 100) / 10) + ", runtime " +
+           std::to_string(runtime / 1000) + "." +
+           std::to_string((runtime % 100) / 10);
+}
+
+/* Strict count parsing: whole-string decimal in [min, max] - rejects
+ * strtoul's silent garbage-to-0 and negative wraparound alike. */
+bool ParseCount(const char* text, size_t min, size_t max, size_t* out) {
+    char* end = nullptr;
+    const unsigned long value = std::strtoul(text, &end, 10);
+    if (end == text || *end != '\0' || value < min || value > max) {
+        return false;
+    }
+    *out = value;
+    return true;
+}
+
+/* Nearest-rank with ceiling: never flatters - at 30 runs, p99 is the
+ * slowest run, not the second-slowest a floor index would pick. */
+double Percentile(const std::vector<double>& sorted, int pct) {
+    const size_t rank =
+        (sorted.size() * static_cast<size_t>(pct) + 99) / 100;
+    return sorted[(rank == 0 ? 1 : rank) - 1];
+}
+
+void PrintReport(const Corpus& corpus, const std::vector<double>& sorted,
+                 size_t warmup, size_t runs) {
+    std::vector<size_t> sizes;
+    for (const auto& original : corpus.originals) {
+        sizes.push_back(original.size());
+    }
+    std::sort(sizes.begin(), sizes.end());
+    const double to_gbps = static_cast<double>(corpus.original_bytes) / 1e9;
+
+    std::printf("## bench_lz4 report\n");
+    std::printf("- decoder: CPU oracle, LZ4_decompress_safe (liblz4 %s), "
+                "single thread\n",
+                LZ4_versionString());
+    std::printf("- host CPU: %s\n", HostCpuName().c_str());
+    std::printf("- CUDA device: %s\n", CudaDeviceLine().c_str());
+    std::printf("- cudec: %d (stub era - the library decodes nothing yet)\n",
+                cudec_version());
+    std::printf("- corpus: %s, %zu chunks, %.2f MB original, %.2f MB "
+                "compressed (ratio %.3f), compressed in-harness via "
+                "LZ4_compress_default\n",
+                corpus.name.c_str(), corpus.originals.size(),
+                static_cast<double>(corpus.original_bytes) / 1e6,
+                static_cast<double>(corpus.compressed_bytes) / 1e6,
+                static_cast<double>(corpus.compressed_bytes) /
+                    static_cast<double>(corpus.original_bytes));
+    std::printf("- chunk sizes: min %zu / median %zu / max %zu bytes\n",
+                sizes.front(), sizes[sizes.size() / 2], sizes.back());
+    std::printf("- method: %zu warmup + %zu measured runs, wall clock per "
+                "whole-batch decode; the timed region is "
+                "LZ4_decompress_safe only (no clears, no allocation); "
+                "output byte-verified once before timing; percentiles are "
+                "nearest-rank\n",
+                warmup, runs);
+    std::printf("- wall per run: p50 %.3f ms / p90 %.3f ms / p99 %.3f ms\n",
+                Percentile(sorted, 50) * 1e3, Percentile(sorted, 90) * 1e3,
+                Percentile(sorted, 99) * 1e3);
+    std::printf("- decode throughput: p50 %.3f GB/s / p90 %.3f GB/s / p99 "
+                "%.3f GB/s\n",
+                to_gbps / Percentile(sorted, 50),
+                to_gbps / Percentile(sorted, 90),
+                to_gbps / Percentile(sorted, 99));
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    size_t runs = 30;
+    size_t warmup = 3;
+    bool selfcheck = false;
+    std::vector<std::string> files;
+    for (int i = 1; i < argc; i++) {
+        const std::string arg = argv[i];
+        if (arg == "--selfcheck") {
+            selfcheck = true;
+        } else if (arg == "--runs" && i + 1 < argc) {
+            if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
+                std::fprintf(stderr, "--runs must be in [1, %zu]\n",
+                             kMaxRuns);
+                return 2;
+            }
+        } else if (arg == "--warmup" && i + 1 < argc) {
+            if (!ParseCount(argv[++i], 0, kMaxRuns, &warmup)) {
+                std::fprintf(stderr, "--warmup must be in [0, %zu]\n",
+                             kMaxRuns);
+                return 2;
+            }
+        } else if (arg == "--runs" || arg == "--warmup") {
+            std::fprintf(stderr, "%s needs a value\n", arg.c_str());
+            return 2;
+        } else if (!arg.empty() && arg[0] == '-') {
+            std::fprintf(stderr, "usage: bench_lz4 [--runs N] [--warmup N] "
+                                 "[--selfcheck] [corpus files...]\n");
+            return 2;
+        } else {
+            files.push_back(arg);
+        }
+    }
+    if (selfcheck) {
+        warmup = 1;
+        runs = 3;
+    }
+
+    Corpus corpus;
+    if (files.empty()) {
+        corpus.name = "builtin";
+        for (auto& fixture : MakeLz4BlockFixtures()) {
+            corpus.originals.push_back(std::move(fixture.original));
+        }
+    } else {
+        for (const auto& path : files) {
+            if (!AppendFileChunked(path, &corpus)) {
+                return 1;
+            }
+            const size_t slash = path.find_last_of("/\\");
+            corpus.name += (corpus.name.empty() ? "" : "+") +
+                           path.substr(slash == std::string::npos
+                                           ? 0
+                                           : slash + 1);
+        }
+    }
+    /* An empty corpus has nothing to attest: refuse instead of emitting a
+     * report over zero bytes (and indexing empty vectors). */
+    if (corpus.originals.empty()) {
+        std::fprintf(stderr, "corpus is empty - nothing to benchmark\n");
+        return 1;
+    }
+    /* The timed scratch buffer is sized to kChunkBytes; enforce the
+     * chunking invariant here instead of trusting fixture growth in
+     * another directory to keep it (a larger chunk would otherwise hand
+     * LZ4_decompress_safe an overstated capacity). */
+    for (const auto& original : corpus.originals) {
+        if (original.size() > kChunkBytes) {
+            std::fprintf(stderr, "chunk of %zu bytes exceeds the %zu-byte "
+                                 "scratch invariant\n",
+                         original.size(), kChunkBytes);
+            return 1;
+        }
+    }
+    CompressAll(&corpus);
+
+    /* Byte-verify every chunk once, outside the timed region. */
+    std::vector<unsigned char> scratch;
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        if (!OracleDecodes(corpus.compressed[i], corpus.originals[i].size(),
+                           &scratch) ||
+            scratch.size() != corpus.originals[i].size() ||
+            std::memcmp(scratch.data(), corpus.originals[i].data(),
+                        scratch.size()) != 0) {
+            std::fprintf(stderr, "verification failed at chunk %zu\n", i);
+            return 1;
+        }
+    }
+
+    /* One pre-sized buffer for the timed loops; every chunk fits by the
+     * kChunkBytes chunking invariant. */
+    std::vector<unsigned char> timed_scratch(kChunkBytes);
+    for (size_t i = 0; i < warmup; i++) {
+        (void)DecodeAllSeconds(corpus, timed_scratch.data());
+    }
+    std::vector<double> times;
+    for (size_t i = 0; i < runs; i++) {
+        times.push_back(DecodeAllSeconds(corpus, timed_scratch.data()));
+    }
+    std::sort(times.begin(), times.end());
+
+    PrintReport(corpus, times, warmup, runs);
+    if (selfcheck) {
+        std::printf("PASS: selfcheck complete\n");
+    }
+    return 0;
+}

--- a/bench/get-corpora.sh
+++ b/bench/get-corpora.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Fetches the benchmark corpora into bench/corpora/ (git-ignored; the
+# supply-chain rule applied to data): SHA-256-pinned, fail-closed on any
+# mismatch, never committed. Needs curl and unzip.
+#
+# Two mirrors per corpus. The Silesia mirrors ship differently-packaged
+# zips, so each mirror carries its own zip hash; the twelve contained
+# corpus files were verified byte-identical across both packagings at pin
+# time (2026-07-17). enwik8 is byte-identical on both mirrors.
+set -eu
+
+dir="$(dirname "$0")/corpora"
+mkdir -p "$dir"
+
+fetch() {
+    name="$1"
+    sum="$2"
+    url="$3"
+    out="$dir/$name"
+    if [ -f "$out" ] && echo "$sum  $out" | sha256sum -c --status; then
+        echo "$name: present and verified"
+        return 0
+    fi
+    echo "$name: fetching $url"
+    curl -fSL --retry 3 -o "$out.tmp" "$url" || return 1
+    if ! echo "$sum  $out.tmp" | sha256sum -c --status; then
+        rm -f "$out.tmp"
+        echo "$name: SHA-256 mismatch from $url - refusing the file" >&2
+        return 1
+    fi
+    mv "$out.tmp" "$out"
+}
+
+fetch enwik8.zip \
+    547994d9980ebed1288380d652999f38a14fe291a6247c157c3d33d4932534bc \
+    "http://mattmahoney.net/dc/enwik8.zip" ||
+    fetch enwik8.zip \
+        547994d9980ebed1288380d652999f38a14fe291a6247c157c3d33d4932534bc \
+        "https://data.deepai.org/enwik8.zip"
+
+fetch silesia.zip \
+    0626e25f45c0ffb5dc801f13b7c82a3b75743ba07e3a71835a41e3d9f63c77af \
+    "http://sun.aei.polsl.pl/~sdeor/corpus/silesia.zip" ||
+    fetch silesia.zip \
+        7d1dd71bfecda66a0ca30d863ed031809f67ecf12717a60fe72c1cc39e28434e \
+        "http://mattmahoney.net/dc/silesia.zip"
+
+unzip -oq "$dir/enwik8.zip" -d "$dir"
+unzip -oq "$dir/silesia.zip" -d "$dir/silesia"
+
+# The zip pins guarantee the archives; this manifest pins the FILES the
+# harness actually reads - packaging-independent (the mirrors' archives
+# differ), and it catches a half-extracted tree left by an interrupt.
+cat >"$dir/manifest.sha256" <<'EOF'
+2b49720ec4d78c3c9fabaee6e4179a5e997302b3a70029f30f2d582218c024a8  enwik8
+b24c37886142e11d0ee687db6ab06f936207aa7f2ea1fd1d9a36763c7a507e6a  silesia/dickens
+657fc3764b0c75ac9de9623125705831ebbfbe08fed248df73bc2dc66e2a963b  silesia/mozilla
+68637ed52e3e4860174ed2dc0840ac77d5f1a60abbcb13770d5754e3774d53e6  silesia/mr
+fc63a31770947b8c2062d3b19ca94c00485a232bb91b502021948fee983e1635  silesia/nci
+e7ee013880d34dd5208283d0d3d91b07f442e067454276095ded14f322a656eb  silesia/ooffice
+60f027179302ca3ad87c58ac90b6be72ec23588aaa7a3b7fe8ecc0f11def3fa3  silesia/osdb
+0eac0114a3dfe6e2ee1f345a0f79d653cb26c3bc9f0ed79238af4933422b7578  silesia/reymont
+93ba07bc44d8267789c1d911992f40b089ffa2140b4a160fac11ccae9a40e7b2  silesia/samba
+c2d0ea2cc59d4c21b7fe43a71499342a00cbe530a1d5548770e91ecd6214adcc  silesia/sao
+6a68f69b26daf09f9dd84f7470368553194a0b294fcfa80f1604efb11143a383  silesia/webster
+7de9fce1405dc44ae5e6813ed21cd5751e761bd4265655a005d39b9685d1c9ad  silesia/x-ray
+0e82e54e695c1938e4193448022543845b33020c8be6bf3bf3ead2224903e08c  silesia/xml
+EOF
+(cd "$dir" && sha256sum -c --quiet manifest.sha256)
+echo "corpora ready under $dir"

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,42 @@
+# Benchmarks
+
+The baseline record. Every entry carries the full methodology block as
+emitted by the harness (`bench/bench_lz4`) — a number without its
+methodology cannot be produced, by construction. Regressions against the
+recorded baselines block merges unless explicitly justified
+([MASTERPLAN](MASTERPLAN.md) section 5). Corpora are fetched hash-pinned
+via `bench/get-corpora.sh` and never committed.
+
+## Baseline: CPU oracle (M0, pre-kernel)
+
+The reference the M1 GPU decoder is measured against: the single-threaded
+CPU oracle on the development machine, recorded 2026-07-17 inside the
+digest-pinned dev container (`nvidia/cuda:12.6.2-devel-ubuntu24.04`).
+For context, the sm_86 output-bandwidth ceiling on this machine is
+~760 GB/s.
+
+```
+## bench_lz4 report
+- decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
+- cudec: 1 (stub era - the library decodes nothing yet)
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3239 chunks, 211.94 MB original, 102.44 MB compressed (ratio 0.483), compressed in-harness via LZ4_compress_default
+- chunk sizes: min 8066 / median 65536 / max 65536 bytes
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
+- wall per run: p50 60.082 ms / p90 60.406 ms / p99 60.816 ms
+- decode throughput: p50 3.528 GB/s / p90 3.509 GB/s / p99 3.485 GB/s
+```
+
+```
+## bench_lz4 report
+- decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
+- cudec: 1 (stub era - the library decodes nothing yet)
+- corpus: builtin, 12 chunks, 0.21 MB original, 0.10 MB compressed (ratio 0.511), compressed in-harness via LZ4_compress_default
+- chunk sizes: min 1 / median 257 / max 65536 bytes
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
+- wall per run: p50 0.046 ms / p90 0.049 ms / p99 0.064 ms
+- decode throughput: p50 4.480 GB/s / p90 4.221 GB/s / p99 3.206 GB/s
+```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
 # The test net: ctest is the runner, one executable per test group, the
 # assertion header tests/require.h as the only "framework". Decision record
 # and reassessment trigger: docs/MASTERPLAN.md section 5.
-enable_language(CXX)
 
 # Supply chain: the hash-verified tarball is the only acceptable oracle
 # source - a system copy must never silently substitute for it.
@@ -28,6 +27,11 @@ FetchContent_MakeAvailable(lz4)
 # third-party code is audited by hash, not reformatted.
 add_library(lz4_oracle STATIC ${lz4_SOURCE_DIR}/lib/lz4.c)
 target_include_directories(lz4_oracle SYSTEM PUBLIC ${lz4_SOURCE_DIR}/lib)
+# -O2 unconditionally: the oracle is also the bench harness's timed
+# decoder, and an empty CMAKE_BUILD_TYPE (the documented container
+# command) would otherwise time -O0 reference code. Correctness is
+# optimization-independent; honest numbers are not.
+target_compile_options(lz4_oracle PRIVATE -O2)
 
 # PRIVATE on purpose: the archive still links through, but the lz4 include
 # path stays out of every consumer's command line - so an accidental
@@ -38,8 +42,14 @@ target_link_libraries(cudec_test_fixtures PRIVATE lz4_oracle)
 target_include_directories(cudec_test_fixtures PUBLIC .)
 set_target_properties(cudec_test_fixtures PROPERTIES CXX_STANDARD 17
                                                      CXX_STANDARD_REQUIRED ON)
+# -O2 for the harness's UNTIMED bulk work: corpus prep and the byte-verify
+# pass run through this code over 200+ MB corpora (the timed region itself
+# calls LZ4_decompress_safe in lz4_oracle directly and never enters
+# fixtures code). Keeps setup time negligible under the build-type-less
+# documented container command.
 target_compile_options(
-  cudec_test_fixtures PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror>)
+  cudec_test_fixtures
+  PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror;-O2>)
 
 # GPU tests carry the label (the GPU-less CI runner selects -LE gpu) and
 # run serially: one physical device, and deterministic device state is

--- a/tests/fixtures.cpp
+++ b/tests/fixtures.cpp
@@ -58,7 +58,9 @@ std::vector<unsigned char> TextLike(size_t size, uint64_t seed) {
     return out;
 }
 
-std::vector<unsigned char> Lz4Compress(
+}  // namespace
+
+std::vector<unsigned char> Lz4CompressBlock(
     const std::vector<unsigned char>& original) {
     const int bound = LZ4_compressBound(static_cast<int>(original.size()));
     std::vector<unsigned char> compressed(static_cast<size_t>(bound));
@@ -66,16 +68,14 @@ std::vector<unsigned char> Lz4Compress(
         reinterpret_cast<const char*>(original.data()),
         reinterpret_cast<char*>(compressed.data()),
         static_cast<int>(original.size()), bound);
-    /* Fixture generation is infrastructure, not a test: a compressor
-     * failure here would silently hollow out every downstream assertion. */
+    /* Corpus generation is infrastructure, not a test: a compressor
+     * failure here would silently hollow out every downstream consumer. */
     if (written <= 0) {
         std::abort();
     }
     compressed.resize(static_cast<size_t>(written));
     return compressed;
 }
-
-}  // namespace
 
 std::vector<Fixture> MakeLz4BlockFixtures() {
     std::vector<Fixture> out;
@@ -85,7 +85,7 @@ std::vector<Fixture> MakeLz4BlockFixtures() {
         f.name = std::move(name);
         f.seed = seed;
         f.original = std::move(original);
-        f.compressed = Lz4Compress(f.original);
+        f.compressed = Lz4CompressBlock(f.original);
         out.push_back(std::move(f));
     };
     add("zeros-65536", 0x01, std::vector<unsigned char>(65536, 0));

--- a/tests/fixtures.h
+++ b/tests/fixtures.h
@@ -37,4 +37,10 @@ std::vector<Mutant> MutateStream(const std::vector<unsigned char>& stream,
 bool OracleDecodes(const std::vector<unsigned char>& stream,
                    size_t original_size, std::vector<unsigned char>* decoded);
 
+/* CPU-reference block compression. Fixture generation and the bench
+ * harness share it so every compressed stream in the project has a single
+ * provenance; aborts on compressor failure (infrastructure, not a test). */
+std::vector<unsigned char> Lz4CompressBlock(
+    const std::vector<unsigned char>& original);
+
 #endif /* CUDEC_TESTS_FIXTURES_H */


### PR DESCRIPTION
# What & why

The benchmark skeleton the M1 kernel plugs into as a second timed path. The design center: **the methodology is inseparable from the numbers** - a report cannot be produced without its block naming the decoder, host CPU, CUDA device and versions, the corpus with in-harness compressor provenance, the chunk-size distribution, and the exact timed region. Closes #5, per the plan posted on the issue.

Delivered: `bench/bench_lz4` (warmup + measured runs, nearest-rank percentiles, timed region = `LZ4_decompress_safe` only into a pre-sized scratch - no clears, no allocation; fail-closed CLI/input handling), `bench/get-corpora.sh` (hash-pinned Silesia + enwik8, two mirrors each, plus a 13-file SHA-256 manifest over the extracted files the harness actually reads), `bench_selfcheck` as host-side ctest entry + CI identity pin, unconditional `-O2` across the whole timed path (the documented container command sets no build type), and `docs/BENCHMARKS.md` with the first recorded baselines.

**The recorded denominator for every future GPU number: Silesia, 3239 chunks, 211.94 MB, CPU oracle single-threaded - p50 3.528 GB/s** (output-bandwidth ceiling on this machine: ~760 GB/s).

Corpus pin provenance: enwik8 zip byte-identical from two independent hosts (self-computed `547994d9…`); the two Silesia mirrors ship differently-packaged zips (per-mirror pins `0626e25f…` / `7d1dd71b…`), verified content-identical across all twelve contained files at pin time - which is why the extraction manifest pins the files themselves, packaging-independent.

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [x] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: strict count parsing (whole-string, ranged - no strtoul garbage-to-0 or negative wraparound), per-file corpus contribution checks, mid-file I/O error detection, empty-corpus and chunk-size-invariant rejection - all verified empirically (each degenerate input exits nonzero with a named reason).
- [x] Oracle coverage: unchanged - the harness reuses the test net's fixtures/oracle; the corpus digest tripwire stayed green throughout (the relocated `Lz4CompressBlock` is byte-identical code).
- [x] Determinism preserved: corpora are hash-pinned down to the extracted files; the built-in corpus is the seeded fixture set.
- [x] Every CUDA API call's error is checked (device identification degrades to a "none visible" methodology line, never a failure); no exceptions cross the C ABI (untouched).
- [x] An adversarial review was run - see Notes.

## Performance checklist

- [x] The claim is measured, not reasoned: docs/BENCHMARKS.md carries the full methodology blocks; reproducibility across independent runs is within 0.3% on the Silesia corpus.
- [x] No regression against the recorded baseline: this PR CREATES the baseline record.

## Quality checklist

- [x] Minimal: one executable, one script, one doc; the harness reuses the test net's corpus/oracle infrastructure instead of duplicating it.
- [x] Self-documenting: the timed region, the percentile semantics, the -O2 pins, and the supply-chain decisions each carry their why at the point of use.
- [x] Conformance tests pass; the new structural property (bench must keep working) is locked in as the `bench_selfcheck` ctest entry + CI identity pin.

## Verification

- [x] `cmake --build` - both configurations clean under warnings-as-errors (the gate caught a real format-truncation warning during development).
- [x] `ctest` - 6/6 on the RTX 3080 in the pinned container; GPU-less CI-parity run green end to end (host subset 4/4, all six identity greps, pipefail).
- [x] Prettier - clean.
- [x] Docs synced: docs/BENCHMARKS.md established; README links it and names both commands; masterplan needed no change (section 5 already specified this harness).

## Notes

Adversarial review protocol: four refute-by-default lenses (correctness, robustness, integration, performance; no kernel/ABI surface touched, so the CUDA domain lens was not required). All four returned NEEDS_IMPROVEMENT in round one; every finding was fixed, none declined:

- performance (the heaviest): the timed region contained an undisclosed per-chunk output-buffer zero-fill - the recorded baseline understated CPU throughput and would have flattered every future GPU-vs-CPU ratio. Fixed by timing `LZ4_decompress_safe` directly; the method line now states the region exactly; BENCHMARKS.md re-recorded (3.405 -> 3.528 GB/s p50).
- correctness/robustness: per-file corpus contribution check (the accumulated check went vacuous from the second file), mid-file I/O error detection, empty-corpus guard, nearest-rank percentiles (floor indexing systematically excluded the slowest run), strict arg parsing, a latent scratch-size invariant now enforced rather than observed.
- integration: the script's executable bit (staged via `git add --chmod=+x`, index verified 100755), .gitignore grouping, README discoverability, a stale -O2 rationale comment.
- Closure re-runs of all four lenses verified the fixes; a final verification pass confirmed the three convergent residuals (comment truthfulness, warmup parsing spec, scratch invariant) and caught one misplaced comment from the fix wave itself - also fixed.

Accepted, documented limits: a sub-resolution corpus (single tiny file) can print absurd throughput - visibly absurd, never silently flattering; the bench "consumer-only" rule for the CMake conformance snapshot remains review-enforced (pre-accepted in masterplan section 5).

CodeRabbit remains uninstalled on this repository (see #7); merging on CI plus the review protocol above. Installing the app remains an open account-level decision.