### PR TITLE
Add the LZ4 parser core and validation ladder, twin-tested under CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           ctest --test-dir build-cuda -LE gpu -N | tee host-selected.txt &&
           grep -E ': conformance_c$' host-selected.txt &&
           grep -E ': oracle_lz4$' host-selected.txt &&
+          grep -E ': parser_twin$' host-selected.txt &&
           grep -E ': launch_fail$' host-selected.txt &&
           grep -E ': bench_selfcheck$' host-selected.txt &&
           echo "Deferred to the local GPU gate:" &&

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -232,8 +232,9 @@ the check, so the accumulator cannot wrap for any caller-supplied sizes);
 literal presence vs. remaining src; literal fit vs. remaining dst
 capacity; offset-field presence; `offset == 0` rejected;
 `offset > bytes written so far` rejected; match-length fit vs. remaining
-capacity; success ONLY at exact stream consumption after a literals-only
-tail. Edge semantics (end-of-block rules, empty-block tokens) are settled
+capacity; the LZ4 parsing restriction that a match may not end within the
+last `LASTLITERALS` (5) output bytes; success ONLY at exact stream
+consumption after a literals-only tail. Edge semantics (end-of-block rules, empty-block tokens) are settled
 empirically by oracle parity — whenever liblz4 rejects, cudec rejects; for
 accepted mutants the comparison is against the oracle's own output and
 size. One crafted negative fixture per ladder branch, its oracle verdict
@@ -245,6 +246,18 @@ presented as success. On success, writes touch exactly
 `dst[0, bytes_written)`. Check-before-load is batch isolation, not just
 parity: on a GPU an out-of-bounds read is not a per-chunk failure — it can
 fault the launch and poison the whole batch.
+
+**One deliberate divergence from liblz4 (settled empirically at ladder
+step 2):** a match offset of 0 is invalid per the LZ4 block spec, but
+liblz4 tolerates it as a defined self-referential copy (its decoder
+silences an msan warning there rather than erroring). cudec rejects it —
+fail-closed on spec-invalid input (prime directive 1) outranks bug-for-bug
+parity with the reference. This makes cudec's accept set a strict subset
+of liblz4's: the twin test asserts the two security-critical directions
+(where cudec accepts, liblz4 accepts and the bytes match; where liblz4
+rejects, cudec rejects) and reports the count of stricter-than-liblz4
+cases so the divergence stays visible rather than silent. It is the only
+such point.
 
 **Anti-pattern rule (from the two-phase candidate's disproof):** no packed
 or narrowed field anywhere in the decoder unless its bound derives from an

--- a/src/lz4_block.h
+++ b/src/lz4_block.h
@@ -1,0 +1,221 @@
+/* The LZ4 block sequence parser and its validation ladder - the
+ * fail-closed core of the decoder, single-sourced for host and device
+ * (masterplan section 9). The parser owns every check; callers own the
+ * copies: the CPU twin test executes them sequentially, the M1 kernel
+ * fans them out across a warp. Internal header, not part of the ABI.
+ *
+ * Ladder contract: every value decoded from the stream is validated
+ * before first use as an address, length, or offset; lengths accumulate
+ * in 64-bit with the remaining-capacity bound re-checked inside every
+ * 255-continuation step (each step adds at most 255 after the check;
+ * reaching a wrapping accumulator would need more continuation bytes than
+ * the src buffer can hold, so under the decoder contract that the
+ * src_size bytes are readable, no accumulator wraps for any caller sizes);
+ * success is reported ONLY at exact stream consumption after a
+ * literals-only tail.
+ * Edge semantics are settled empirically by oracle parity - whenever
+ * liblz4 rejects, this parser must reject (tests/parser_twin.cpp). */
+#ifndef CUDEC_LZ4_BLOCK_H
+#define CUDEC_LZ4_BLOCK_H
+
+#include "cudec.h"
+
+#include <stdint.h>
+
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+
+namespace cudec_detail {
+
+/* LZ4 block end-of-block parsing restrictions, from the reference decoder
+ * (lz4.c, LZ4_decompress_safe non-partial path): a literal run whose end
+ * lands within MFLIMIT bytes of the output capacity, OR within
+ * (2 offset + 1 token + LASTLITERALS) bytes of the input end, must be the
+ * terminal run and must consume the input exactly. Replicating this is
+ * what gives bit-exact accept/reject parity with liblz4. */
+constexpr uint64_t kLz4MinTrailingSlackDst = 12;  /* MFLIMIT */
+constexpr uint64_t kLz4MinTrailingSlackSrc = 8;   /* 2 + 1 + LASTLITERALS */
+constexpr uint64_t kLz4LastLiterals = 5;          /* LASTLITERALS */
+constexpr uint64_t kLz4RunMask = 15;              /* RUN_MASK */
+/* liblz4 caps a length extension's byte reads at a margin before the input
+ * end (read_variable_length's ilimit): iend - RUN_MASK for literals,
+ * iend - (LASTLITERALS - 1) for matches. A decoder reading extension bytes
+ * up to iend instead would ACCEPT streams liblz4 rejects (fail-open). */
+constexpr uint64_t kLz4LiteralReadMargin = kLz4RunMask;         /* 15 */
+constexpr uint64_t kLz4MatchReadMargin = kLz4LastLiterals - 1;  /* 4 */
+
+/* One parsed sequence, in absolute offsets. The literals live in src;
+ * the match gathers from the already-written region of dst (match_len is
+ * zero only for the literals-only tail). Executing a sequence means:
+ * copy literals_len bytes src[literals_src..] -> dst[literals_dst..],
+ * then match_len bytes dst[match_src + (i mod offset)] -> dst[match_dst + i]
+ * (equivalently a sequential chasing copy; offset = match_dst - match_src). */
+struct Lz4Sequence {
+    uint64_t literals_src;
+    uint64_t literals_dst;
+    uint64_t literals_len;
+    uint64_t match_src;
+    uint64_t match_dst;
+    uint64_t match_len;
+};
+
+struct Lz4Parser {
+    const unsigned char* src;
+    uint64_t src_size;
+    uint64_t dst_capacity;
+    uint64_t src_pos = 0;
+    uint64_t dst_pos = 0;
+
+    /* Accumulates an LZ4 255-terminated length extension onto *length.
+     * Replicates liblz4's read_variable_length exactly for accept/reject
+     * parity: `read_margin` is liblz4's ilimit margin before the input end
+     * (each byte read must leave src_pos <= src_size - read_margin), and
+     * `initial_check` mirrors its pre-read guard on the literal path. The
+     * margin comparisons add the margin to the left side so they never
+     * underflow, even for src_size < read_margin. cudec adds one bound of
+     * its own - the remaining dst capacity, checked before each add of at
+     * most 255 - so no continuation sequence can wrap the 64-bit
+     * accumulator or pass a length the destination cannot hold; this only
+     * makes cudec reject sooner, never accept where liblz4 rejects. */
+    CUDEC_HOST_DEVICE cudec_status AccumulateLength(uint64_t* length,
+                                                    uint64_t read_margin,
+                                                    bool initial_check) {
+        if (initial_check && src_pos + read_margin >= src_size) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        unsigned char byte;
+        do {
+            if (src_pos >= src_size) {
+                return CUDEC_ERR_CORRUPT_INPUT; /* extension byte missing */
+            }
+            if (*length > dst_capacity - dst_pos) {
+                return CUDEC_ERR_OUTPUT_TOO_SMALL;
+            }
+            byte = src[src_pos++];
+            *length += byte;
+            if (src_pos + read_margin > src_size) {
+                return CUDEC_ERR_CORRUPT_INPUT; /* read past liblz4's ilimit */
+            }
+        } while (byte == 255);
+        return CUDEC_OK;
+    }
+
+    /* Parses the next sequence and advances both cursors past it. Exactly
+     * one of three outcomes: CUDEC_OK with *sequence filled (execute it,
+     * then call again); CUDEC_OK with *done set (exact-consumption
+     * success - the ONLY success exit, after a literals-only tail); or a
+     * reject status. Liveness: every call consumes at least the token
+     * byte, so decode loops terminate on every input. */
+    CUDEC_HOST_DEVICE cudec_status Next(Lz4Sequence* sequence, bool* done) {
+        *done = false;
+        if (src_pos >= src_size) {
+            return CUDEC_ERR_CORRUPT_INPUT; /* a token must exist */
+        }
+        const unsigned char token = src[src_pos++];
+
+        uint64_t literals_len = token >> 4;
+        if (literals_len == 15) {
+            const cudec_status status = AccumulateLength(
+                &literals_len, kLz4LiteralReadMargin, /*initial_check=*/true);
+            if (status != CUDEC_OK) {
+                return status;
+            }
+        }
+        if (literals_len > src_size - src_pos) {
+            return CUDEC_ERR_CORRUPT_INPUT; /* literals must exist */
+        }
+        if (literals_len > dst_capacity - dst_pos) {
+            return CUDEC_ERR_OUTPUT_TOO_SMALL;
+        }
+
+        /* End-of-block rule (both slacks are non-negative given the two
+         * checks above, so no subtraction underflows even for a
+         * caller-supplied SIZE_MAX capacity). A terminal run must consume
+         * the input exactly - a match cannot follow this close to either
+         * end. */
+        const uint64_t dst_slack = dst_capacity - dst_pos - literals_len;
+        const uint64_t src_slack = src_size - src_pos - literals_len;
+        const bool terminal = dst_slack < kLz4MinTrailingSlackDst ||
+                              src_slack < kLz4MinTrailingSlackSrc;
+        if (terminal) {
+            if (src_pos + literals_len != src_size) {
+                return CUDEC_ERR_CORRUPT_INPUT;
+            }
+            sequence->literals_src = src_pos;
+            sequence->literals_dst = dst_pos;
+            sequence->literals_len = literals_len;
+            src_pos += literals_len;
+            dst_pos += literals_len;
+            sequence->match_src = 0;
+            sequence->match_dst = dst_pos;
+            sequence->match_len = 0;
+            *done = true;
+            return CUDEC_OK;
+        }
+
+        sequence->literals_src = src_pos;
+        sequence->literals_dst = dst_pos;
+        sequence->literals_len = literals_len;
+        src_pos += literals_len;
+        dst_pos += literals_len;
+
+        /* Non-terminal: src_slack >= kLz4MinTrailingSlackSrc (8) here, so
+         * the 2-byte offset and the match token are present. */
+        const uint64_t offset = static_cast<uint64_t>(src[src_pos]) |
+                                (static_cast<uint64_t>(src[src_pos + 1]) << 8);
+        src_pos += 2;
+        /* offset == 0 is invalid per the LZ4 block spec. liblz4 TOLERATES
+         * it (a defined self-referential copy - lz4.c silences an msan
+         * warning there rather than erroring), but cudec is deliberately
+         * stricter: fail-closed on spec-invalid input outranks bug-for-bug
+         * parity with the reference (prime directive 1). This is the one
+         * point where cudec's accept set is a strict subset of liblz4's;
+         * the twin test documents and bounds it. It is also load-bearing
+         * for the M1 kernel: the closed-form gather reduces by
+         * offset (i mod offset), so offset == 0 reaching the device copy
+         * engine would be a modulo-by-zero. Never relax this to regain
+         * bug-for-bug liblz4 parity. */
+        if (offset == 0) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        if (offset > dst_pos) {
+            return CUDEC_ERR_CORRUPT_INPUT; /* match source underflow */
+        }
+
+        uint64_t match_len = (token & 0xF) + uint64_t{4};
+        if ((token & 0xF) == 15) {
+            /* The +4 minmatch is already in match_len; the extension
+             * accumulates on top with the same in-loop bound. */
+            const cudec_status status = AccumulateLength(
+                &match_len, kLz4MatchReadMargin, /*initial_check=*/false);
+            if (status != CUDEC_OK) {
+                return status;
+            }
+        }
+        if (match_len > dst_capacity - dst_pos) {
+            return CUDEC_ERR_OUTPUT_TOO_SMALL;
+        }
+        /* LZ4 parsing restriction: the last LASTLITERALS bytes of a block
+         * are always literals, so a match may not end within them. liblz4
+         * enforces this (cpy > oend - LASTLITERALS is _output_error); a
+         * decoder that skipped it would ACCEPT streams liblz4 rejects -
+         * the fail-open direction. No underflow: the non-terminal path
+         * guarantees dst_capacity - dst_pos >= kLz4MinTrailingSlackDst
+         * (12) > kLz4LastLiterals. */
+        if (match_len > dst_capacity - dst_pos - kLz4LastLiterals) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        sequence->match_src = dst_pos - offset;
+        sequence->match_dst = dst_pos;
+        sequence->match_len = match_len;
+        dst_pos += match_len;
+        return CUDEC_OK;
+    }
+};
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_LZ4_BLOCK_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,12 @@ cudec_add_test(conformance_c SOURCES conformance_c.c)
 set_target_properties(conformance_c PROPERTIES C_STANDARD 99
                                                C_STANDARD_REQUIRED ON)
 cudec_add_test(oracle_lz4 SOURCES oracle_lz4.cpp LIBS cudec_test_fixtures)
+cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
+# The twin compiles the decoder core from src/ on the host - the
+# fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,
+# ladder step 2).
+target_include_directories(parser_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 cudec_add_test(launch_fail SOURCES launch_fail.cpp)
 # Belt and suspenders with the setenv inside launch_fail.cpp: zero visible
 # devices is the test condition, on the GPU machine too.

--- a/tests/parser_twin.cpp
+++ b/tests/parser_twin.cpp
@@ -1,0 +1,399 @@
+/* The CPU twin of the decoder core (masterplan section 9, ladder step 2):
+ * the single-source parser + validation ladder from src/lz4_block.h,
+ * executed sequentially on the host, held to oracle parity on the
+ * GPU-less CI runner - the fail-closed heart of M1 lands under CI before
+ * any kernel exists. Parity is the authority: whenever liblz4 rejects,
+ * the twin must reject; where both accept, the bytes must match the
+ * oracle's own output and size. */
+#include "cudec.h"
+#include "fixtures.h"
+#include "lz4_block.h"
+#include "require.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+/* Sequential reference execution of the parsed sequences. The match copy
+ * is the chasing byte copy - reads may land on just-written bytes, which
+ * is exactly LZ4's replication semantics for overlapping matches (and
+ * equivalent to the kernel's closed-form modular gather). */
+cudec_status TwinDecode(const std::vector<unsigned char>& stream,
+                        size_t capacity, std::vector<unsigned char>* out) {
+    out->assign(capacity, 0);
+    cudec_detail::Lz4Parser parser{stream.data(), stream.size(), capacity};
+    cudec_detail::Lz4Sequence seq;
+    bool done = false;
+    while (true) {
+        const cudec_status status = parser.Next(&seq, &done);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+        for (uint64_t i = 0; i < seq.literals_len; i++) {
+            (*out)[seq.literals_dst + i] = stream[seq.literals_src + i];
+        }
+        for (uint64_t i = 0; i < seq.match_len; i++) {
+            (*out)[seq.match_dst + i] = (*out)[seq.match_src + i];
+        }
+        if (done) {
+            break;
+        }
+    }
+    out->resize(parser.dst_pos);
+    return CUDEC_OK;
+}
+
+struct CraftedNegative {
+    const char* name;
+    std::vector<unsigned char> stream;
+    size_t capacity;
+    cudec_status expected;
+};
+
+/* One crafted stream per validation-ladder branch that liblz4 ALSO
+ * rejects (offset==0 is the deliberate divergence and is tested
+ * separately). Each case pins the twin's specific status and asserts the
+ * oracle rejects too, so the crafted stream is demonstrably malformed and
+ * the branch is demonstrably in parity. Byte layouts verified by trace. */
+std::vector<CraftedNegative> MakeCraftedNegatives() {
+    return {
+        /* token needed, none present */
+        {"empty-src", {}, 16, CUDEC_ERR_CORRUPT_INPUT},
+        /* literal-length extension byte missing */
+        {"literal-extension-truncated", {0xF0}, 1024,
+         CUDEC_ERR_CORRUPT_INPUT},
+        /* literal length accumulates past the destination capacity - the
+         * stream is long enough that the extension read stays within
+         * liblz4's iend-RUN_MASK bound, so the capacity check fires, not
+         * the read-bound check */
+        {"literal-length-past-capacity",
+         {0xF0, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+         40, CUDEC_ERR_OUTPUT_TOO_SMALL},
+        /* terminal run (close to the end) that does not consume the input
+         * exactly - a match cannot follow this near the end */
+        {"terminal-inexact-consumption", {0x10, 0x41, 0x01, 0x00}, 16,
+         CUDEC_ERR_CORRUPT_INPUT},
+        /* non-terminal match whose offset points before the output start */
+        {"offset-beyond-written",
+         {0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 16,
+         CUDEC_ERR_CORRUPT_INPUT},
+        /* non-terminal match whose length accumulates past capacity */
+        {"match-length-past-capacity",
+         {0x1F, 0x41, 0x01, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00}, 100,
+         CUDEC_ERR_OUTPUT_TOO_SMALL},
+    };
+}
+
+/* A match may not end within the last LASTLITERALS(5) output bytes (LZ4
+ * parsing restriction). The mutation corpus never reaches this class (it
+ * only truncates/drops/flips - it never grows a length), so it is swept
+ * explicitly here, deriving the family from the REFERENCE restriction
+ * rather than from cudec's own branches. Each stream: L literals, offset
+ * 1, a length-extended match, then a T-literal terminal tail; the match
+ * ends at cap - T, so T < 5 must reject on both sides and T >= 5 accept.
+ * Verifies the fix that closed the fail-open divergence found in the #13
+ * review. */
+int SweepLastLiterals(size_t* accepts, size_t* rejects) {
+    for (int L : {4, 8, 12}) {
+        for (int ext : {0, 10, 100}) {
+            for (int T : {4, 5, 6, 10}) {
+                std::vector<unsigned char> s;
+                s.push_back(static_cast<unsigned char>((L << 4) | 15));
+                for (int i = 0; i < L; i++) {
+                    s.push_back(static_cast<unsigned char>('A' + i % 26));
+                }
+                s.push_back(1); /* offset low  */
+                s.push_back(0); /* offset high => offset 1 */
+                s.push_back(static_cast<unsigned char>(ext));
+                s.push_back(static_cast<unsigned char>(T << 4));
+                for (int i = 0; i < T; i++) {
+                    s.push_back(static_cast<unsigned char>('a' + i % 26));
+                }
+                const size_t match_len = 19 + static_cast<size_t>(ext);
+                const size_t cap = static_cast<size_t>(L) + match_len +
+                                   static_cast<size_t>(T);
+                std::vector<unsigned char> twin_out;
+                std::vector<unsigned char> oracle_out;
+                const bool twin_ok =
+                    TwinDecode(s, cap, &twin_out) == CUDEC_OK;
+                const bool oracle_ok = OracleDecodes(s, cap, &oracle_out);
+                REQUIRE_CTX(twin_ok == oracle_ok,
+                            "last-5 parity: L=%d ext=%d T=%d", L, ext, T);
+                REQUIRE_CTX(twin_ok == (T >= 5),
+                            "last-5 expectation: L=%d ext=%d T=%d", L, ext, T);
+                if (twin_ok) {
+                    REQUIRE_CTX(twin_out.size() == oracle_out.size() &&
+                                    equal_bytes(twin_out.data(),
+                                                oracle_out.data(),
+                                                twin_out.size()),
+                                "last-5 bytes: L=%d ext=%d T=%d", L, ext, T);
+                    (*accepts)++;
+                } else {
+                    (*rejects)++;
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+/* liblz4 caps a length-extension's byte reads at a margin before the input
+ * end (iend - RUN_MASK for literals, iend - (LASTLITERALS-1) for matches);
+ * a decoder reading up to the input end instead ACCEPTS streams liblz4
+ * rejects. Neither the mutation corpus nor the last-5 sweep grows an
+ * extension near end-of-source, so this class is swept here in both
+ * directions - the second fail-open family found in the #13 review. */
+int SweepExtensionReadBound(size_t* accepts, size_t* rejects) {
+    /* Match-extension family: 1 literal, offset 1, a match extension of
+     * `ff255s` 0xFF bytes plus a terminator, then a T-literal tail. As T
+     * shrinks, the extension end crosses liblz4's iend-4 bound. */
+    for (int ff255s : {0, 1, 2}) {
+        for (int last : {0, 30, 200}) {
+            for (int T : {0, 1, 2, 3, 4, 6}) {
+                std::vector<unsigned char> s = {0x1F, 0x41, 0x01, 0x00};
+                for (int i = 0; i < ff255s; i++) {
+                    s.push_back(0xFF);
+                }
+                s.push_back(static_cast<unsigned char>(last));
+                s.push_back(static_cast<unsigned char>(T << 4));
+                for (int i = 0; i < T; i++) {
+                    s.push_back(static_cast<unsigned char>('a' + i));
+                }
+                const size_t match_len = 4 + 15 +
+                                         static_cast<size_t>(ff255s) * 255 +
+                                         static_cast<size_t>(last);
+                const size_t cap = 1 + match_len + static_cast<size_t>(T);
+                std::vector<unsigned char> t_out;
+                std::vector<unsigned char> o_out;
+                const bool t_ok = TwinDecode(s, cap, &t_out) == CUDEC_OK;
+                const bool o_ok = OracleDecodes(s, cap, &o_out);
+                REQUIRE_CTX(t_ok == o_ok,
+                            "match-ext parity: ff=%d last=%d T=%d", ff255s,
+                            last, T);
+                if (t_ok) {
+                    REQUIRE_CTX(t_out.size() == o_out.size() &&
+                                    equal_bytes(t_out.data(), o_out.data(),
+                                                t_out.size()),
+                                "match-ext bytes: ff=%d last=%d T=%d", ff255s,
+                                last, T);
+                    (*accepts)++;
+                } else {
+                    (*rejects)++;
+                }
+            }
+        }
+    }
+    /* Literal-extension family: an extension of `ff255s` 0xFF plus a
+     * terminator, its literals, and a capacity sweep across iend-15. */
+    for (int ff255s : {0, 1}) {
+        for (int last : {0, 30, 200}) {
+            std::vector<unsigned char> base = {0xF0};
+            for (int i = 0; i < ff255s; i++) {
+                base.push_back(0xFF);
+            }
+            base.push_back(static_cast<unsigned char>(last));
+            const size_t lit_len = 15 + static_cast<size_t>(ff255s) * 255 +
+                                   static_cast<size_t>(last);
+            for (size_t i = 0; i < lit_len; i++) {
+                base.push_back(static_cast<unsigned char>('A' + i % 26));
+            }
+            for (size_t cap = lit_len; cap <= lit_len + 18; cap++) {
+                std::vector<unsigned char> t_out;
+                std::vector<unsigned char> o_out;
+                const bool t_ok = TwinDecode(base, cap, &t_out) == CUDEC_OK;
+                const bool o_ok = OracleDecodes(base, cap, &o_out);
+                REQUIRE_CTX(t_ok == o_ok,
+                            "literal-ext parity: ff=%d last=%d cap=%zu",
+                            ff255s, last, cap);
+                if (t_ok) {
+                    (*accepts)++;
+                } else {
+                    (*rejects)++;
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    const auto fixtures = MakeLz4BlockFixtures();
+    REQUIRE(!fixtures.empty());
+
+    /* Every fixture decodes to its original through the twin. */
+    for (const auto& f : fixtures) {
+        std::vector<unsigned char> out;
+        REQUIRE_CTX(TwinDecode(f.compressed, f.original.size(), &out) ==
+                        CUDEC_OK,
+                    "fixture %s", f.name.c_str());
+        REQUIRE_CTX(out.size() == f.original.size(), "fixture %s",
+                    f.name.c_str());
+        REQUIRE_CTX(equal_bytes(out.data(), f.original.data(), out.size()),
+                    "fixture %s", f.name.c_str());
+    }
+
+    /* Full mutant parity, as the two security-critical directions of a
+     * fail-closed decoder:
+     *   1. where the twin ACCEPTS, liblz4 must accept and the bytes and
+     *      size must match - the twin never invents an acceptance;
+     *   2. where liblz4 REJECTS, the twin must reject - never more lenient.
+     * Together these make the twin's accept set a subset of liblz4's, with
+     * bit-exact output on it. The one allowed gap (twin rejects a stream
+     * liblz4 accepts) is the deliberate offset==0 strictness; every such
+     * case must still be a DEFINED reject status, and their count is
+     * reported so the divergence stays visible, never silent. */
+    size_t mutant_total = 0;
+    size_t rejected_total = 0;
+    size_t stricter_than_oracle = 0;
+    for (const auto& f : fixtures) {
+        for (const auto& m : MutateStream(f.compressed, f.seed)) {
+            std::vector<unsigned char> oracle_out;
+            const bool oracle_accepts =
+                OracleDecodes(m.stream, f.original.size(), &oracle_out);
+            std::vector<unsigned char> twin_out;
+            const cudec_status twin_status =
+                TwinDecode(m.stream, f.original.size(), &twin_out);
+            mutant_total++;
+            if (twin_status == CUDEC_OK) {
+                /* Direction 1: an acceptance is never invented. */
+                REQUIRE_CTX(oracle_accepts,
+                            "twin accepts what liblz4 rejects: %s/%s",
+                            f.name.c_str(), m.description.c_str());
+                REQUIRE_CTX(twin_out.size() == oracle_out.size(),
+                            "size parity: %s/%s", f.name.c_str(),
+                            m.description.c_str());
+                REQUIRE_CTX(equal_bytes(twin_out.data(), oracle_out.data(),
+                                        twin_out.size()),
+                            "byte parity: %s/%s", f.name.c_str(),
+                            m.description.c_str());
+            } else {
+                /* A reject is always a defined status. */
+                REQUIRE_CTX(twin_status == CUDEC_ERR_CORRUPT_INPUT ||
+                                twin_status == CUDEC_ERR_OUTPUT_TOO_SMALL,
+                            "undefined reject status %d: %s/%s",
+                            static_cast<int>(twin_status), f.name.c_str(),
+                            m.description.c_str());
+                if (oracle_accepts) {
+                    stricter_than_oracle++;
+                } else {
+                    rejected_total++;
+                }
+            }
+        }
+    }
+    REQUIRE(mutant_total > 0);
+    REQUIRE(rejected_total > 0);
+    /* Golden bound over the deterministic corpus: the ONLY streams the
+     * twin rejects while liblz4 accepts are the offset==0 family. This one
+     * value (like the fixture digest in oracle_lz4) turns "offset==0 is the
+     * sole divergence" from a printed number into an enforced invariant -
+     * a regression that over-rejects a class of valid streams changes it
+     * and reds the gate. Re-derive the divergence before touching it. */
+    REQUIRE(stricter_than_oracle == 1);
+
+    /* The last-LASTLITERALS match restriction, swept in both directions
+     * (the mutation corpus cannot reach this class). */
+    size_t last5_accepts = 0;
+    size_t last5_rejects = 0;
+    REQUIRE(SweepLastLiterals(&last5_accepts, &last5_rejects) == 0);
+    REQUIRE(last5_accepts > 0);
+    REQUIRE(last5_rejects > 0);
+
+    /* The length-extension read-bound restriction, swept in both
+     * directions (also unreachable by the mutation corpus). */
+    size_t ext_accepts = 0;
+    size_t ext_rejects = 0;
+    REQUIRE(SweepExtensionReadBound(&ext_accepts, &ext_rejects) == 0);
+    REQUIRE(ext_accepts > 0);
+    REQUIRE(ext_rejects > 0);
+
+    /* One crafted negative per ladder branch that liblz4 also rejects:
+     * pins the twin's specific status AND that the stream is malformed. */
+    const auto crafted = MakeCraftedNegatives();
+    for (const auto& c : crafted) {
+        std::vector<unsigned char> twin_out;
+        REQUIRE_CTX(TwinDecode(c.stream, c.capacity, &twin_out) == c.expected,
+                    "crafted %s", c.name);
+        std::vector<unsigned char> oracle_out;
+        REQUIRE_CTX(!OracleDecodes(c.stream, c.capacity, &oracle_out),
+                    "crafted %s: oracle unexpectedly accepts", c.name);
+    }
+
+    /* The deliberate divergence, pinned explicitly: a non-terminal match
+     * with offset==0 is spec-invalid; the twin rejects it fail-closed
+     * even though liblz4 tolerates it (src/lz4_block.h). Oracle behavior
+     * is intentionally NOT asserted here - liblz4 accepting it is the
+     * whole reason this case is documented. */
+    {
+        const std::vector<unsigned char> zero_offset = {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        std::vector<unsigned char> twin_out;
+        REQUIRE(TwinDecode(zero_offset, 16, &twin_out) ==
+                CUDEC_ERR_CORRUPT_INPUT);
+    }
+
+    /* The empty block (a lone zero token) is valid LZ4: both sides must
+     * accept it with zero output bytes. */
+    {
+        std::vector<unsigned char> twin_out;
+        REQUIRE(TwinDecode({0x00}, 16, &twin_out) == CUDEC_OK);
+        REQUIRE(twin_out.empty());
+        std::vector<unsigned char> oracle_out;
+        REQUIRE(OracleDecodes({0x00}, 16, &oracle_out));
+        REQUIRE(oracle_out.empty());
+    }
+
+    /* Capacity beyond the 64 KiB project convention: the frozen ABI
+     * allows any size_t capacity, and the ladder must stay correct there
+     * (the anti-pattern rule from masterplan section 9 - no field may be
+     * narrowed to a convention the ABI does not enforce). */
+    {
+        const auto& f = fixtures.front();
+        const size_t big_capacity = size_t{1} << 20;
+        std::vector<unsigned char> twin_out;
+        REQUIRE(TwinDecode(f.compressed, big_capacity, &twin_out) ==
+                CUDEC_OK);
+        std::vector<unsigned char> oracle_out;
+        REQUIRE(OracleDecodes(f.compressed, big_capacity, &oracle_out));
+        REQUIRE(twin_out.size() == oracle_out.size());
+        REQUIRE(equal_bytes(twin_out.data(), oracle_out.data(),
+                            twin_out.size()));
+    }
+
+    /* SIZE_MAX capacity, parser only (the twin cannot allocate that much
+     * output, and the oracle casts capacity to int): drive the ladder
+     * directly to prove the slack subtractions and the length accumulator
+     * stay correct at the boundary the header comment names. A valid
+     * stream must still decode to exactly its content size. */
+    {
+        const auto& f = fixtures.back();
+        cudec_detail::Lz4Parser parser{f.compressed.data(),
+                                       f.compressed.size(), SIZE_MAX};
+        cudec_detail::Lz4Sequence seq;
+        bool done = false;
+        while (true) {
+            const cudec_status status = parser.Next(&seq, &done);
+            REQUIRE(status == CUDEC_OK);
+            if (done) {
+                break;
+            }
+        }
+        REQUIRE(parser.dst_pos == f.original.size());
+    }
+
+    std::printf("PASS: %zu fixtures + %zu mutants in oracle parity "
+                "(%zu oracle-rejected, %zu stricter-than-liblz4 on "
+                "spec-invalid input); %zu crafted negatives; last-5 sweep "
+                "%zu accept / %zu reject; empty block, offset==0 "
+                "divergence, SIZE_MAX and beyond-convention capacity "
+                "pinned; ext-read sweep %zu accept / %zu reject\n",
+                fixtures.size(), mutant_total, rejected_total,
+                stricter_than_oracle, crafted.size(), last5_accepts,
+                last5_rejects, ext_accepts, ext_rejects);
+    return 0;
+}


### PR DESCRIPTION
# What & why

M1 ladder step 2 (masterplan section 9): the LZ4 block sequence parser and its fail-closed validation ladder as a single-source `__host__ __device__` header, with a CPU twin held to bit-exact liblz4 parity on the GPU-less CI runner. This is the security heart of the decoder - the project's login-path equivalent. It lands under CI before any kernel, and the M1 kernel (next) runs this exact parse across 32 lanes in lockstep, so a bug here would poison the kernel too. Closes #13.

The end-of-block logic was derived by reading the pinned lz4-1.10.0 reference source, not from the format prose, then verified empirically against the vendored liblz4.

## Type of change

- [ ] Decode kernel / device code
- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: every stream value validated before first use as address/length/offset; 64-bit accumulation with the capacity bound re-checked inside every continuation step; the end-of-block parsing restrictions (terminal-run detection, exact-consumption success, last-LASTLITERALS match restriction, extension-read ilimit bounds) replicated from the reference. Every reject path has coverage.
- [x] Oracle coverage: the twin is held to liblz4 parity - fixtures round-trip, 310 mutants in two-direction parity, plus two reference-derived sweeps for the classes the mutation corpus cannot reach.
- [x] Determinism: the closed-form overlap semantics are a pure function of lower addresses; a 5M-stream fuzz shows zero byte mismatches on shared accepts.
- [x] Every CUDA API call's error is checked: n/a (host/device parser, no CUDA calls); no exceptions cross the C ABI.
- [x] Adversarial review run - see Notes (it found and I fixed two fail-open bugs).

## Performance checklist

Not a hot-path change; the parser is written for the kernel to inline (no allocation, no exceptions, register-only cursors). Numbers arrive with the kernel (#14) and bench (#15).

## Quality checklist

- [x] Minimal: one header, one twin; the ladder is the least code that is fail-closed and parity-faithful.
- [x] Self-documenting: each restriction cites the reference behavior it replicates and the failure direction it prevents; the offset==0 divergence and its kernel-modulo rationale are documented in place.
- [x] Conformance tests pass; the new structural property (parser under CI) is locked in as the parser_twin identity pin.

## Verification

- [x] `cmake --build` - both configurations clean under warnings-as-errors.
- [x] `ctest` - 7/7 on the RTX 3080; the twin passes with 310 mutants (248 oracle-rejected, 1 stricter = offset==0), 6 crafted negatives, last-5 sweep 27/9, ext-read sweep 123/45, SIZE_MAX + beyond-convention pins.
- [x] CI-parity run without a GPU: green, all identity pins.
- [x] Prettier - clean.
- [x] Docs: masterplan section 9 gains the last-5 restriction in the ladder and the offset==0 divergence (now a true, bounded strict-subset claim post-fix).

## Notes

Security-review gated (decoder validation is the login path). The panel earned its keep - it found two genuine, empirically-reproduced fail-open divergences that the bit-flip/truncation mutation corpus was structurally blind to (both need a length extension to construct):

1. **Last-LASTLITERALS match restriction** (HIGH): liblz4 rejects any within-block match ending in the last 5 output bytes; the parser accepted them - 656/656 fail-open in a crafted family before the fix. Fixed by the `match_len > dst_capacity - dst_pos - 5` check; covered by a both-directional sweep.
2. **Extension-read ilimit** (HIGH): liblz4 caps a length extension's byte reads at iend-RUN_MASK (literals) / iend-(LASTLITERALS-1) (matches); the parser read to iend, accepting streams liblz4 rejects. Fixed by replicating read_variable_length's bound (underflow-safe); covered by a both-directional sweep.

Both are the fail-open direction - the dangerous one for a fail-closed decoder. The offset==0 case (the stricter direction, spec-justified) was reframed into a documented, golden-bounded divergence rather than reproducing liblz4's bug-for-bug tolerance. A 5,000,000-stream differential fuzz against the vendored liblz4 closes with zero fail-opens and zero byte mismatches; the only remaining divergence is the two documented offset==0 cases (fail-closed, safe).

Process adaptation (mandatory-process-adaptation): crafted negatives and corpus mutations must be derived from the REFERENCE's branch set, not the implementation's own branches - a check the implementation lacks is invisible to a corpus shaped by the implementation. The two new sweeps encode this; future format work adds reference-derived negatives up front.

CodeRabbit remains uninstalled on this repository (see #7); merging on CI + the review protocol above.