### PR TITLE
Add the warp-per-chunk LZ4 decode kernel

### DIFF
--- a/include/cudec.h
+++ b/include/cudec.h
@@ -66,8 +66,12 @@ typedef char cudec_chunk_result_layout_check
          : -1];
 #endif
 
-/* Batch LZ4 block decode. M1 lands the decoder; until then every chunk
- * reports CUDEC_ERR_NOT_IMPLEMENTED and writes no output.
+/* Batch LZ4 block decode. Each chunk is an independent LZ4 block; on
+ * success the chunk's result reports CUDEC_OK and bytes_written, and the
+ * destination holds exactly bytes_written decoded bytes. A malformed
+ * chunk reports a defined error (CUDEC_ERR_CORRUPT_INPUT /
+ * CUDEC_ERR_OUTPUT_TOO_SMALL) with bytes_written == 0; its destination
+ * contents are then unspecified but never presented as a valid decode.
  *
  * All array arguments are device memory holding chunk_count entries, and
  * the pointers those arrays contain are device pointers; d_results must be

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -1,20 +1,84 @@
 #include "cudec.h"
+#include "lz4_block.h"
 
 #include <cuda_runtime.h>
 
 namespace {
 
-constexpr unsigned kBlockThreads = 256;
+constexpr unsigned kWarpSize = 32;
+constexpr unsigned kBlockWarps = 4;
+constexpr unsigned kBlockThreads = kWarpSize * kBlockWarps;  /* 128 */
 
-/* M1 replaces this with the LZ4 decoder; the stub proves the batch
- * contract end to end (validation, launch, per-chunk device reporting). */
-__global__ void report_not_implemented(cudec_chunk_result* results,
-                                       size_t chunk_count) {
-    size_t i = blockIdx.x * static_cast<size_t>(blockDim.x) + threadIdx.x;
-    if (i < chunk_count) {
-        results[i].status = CUDEC_ERR_NOT_IMPLEMENTED;
-        results[i].reserved = 0;
-        results[i].bytes_written = 0;
+/* Warp-per-chunk LZ4 block decode (masterplan section 9). All 32 lanes run
+ * the validated parser redundantly in lockstep - identical bytes, identical
+ * arithmetic, identical registers, so no leader lane and no shuffles - and
+ * fan out by lane for every copy. Overlapping matches use the closed-form
+ * modular gather dst[m+i] = dst[m-off + (i mod off)], which reads only from
+ * the region finalized before this match; off >= 1 is guaranteed by the
+ * parser's offset==0 rejection, so the modulo never divides by zero. */
+__global__ void __launch_bounds__(kBlockThreads)
+    lz4_decode_batch(const void* const* src_ptrs, const size_t* src_sizes,
+                     void* const* dst_ptrs, const size_t* dst_caps,
+                     size_t chunk_count, cudec_chunk_result* results) {
+    const unsigned lane = threadIdx.x % kWarpSize;
+    /* The global thread id fits in 32 bits because the host caps the grid
+     * at kMaxBlocks (8192) x kBlockThreads (128) ~ 1.05M threads; if that
+     * cap were ever raised past ~33M blocks (~4.3B threads), widen this
+     * to size_t. */
+    const size_t warp_in_grid =
+        (blockIdx.x * blockDim.x + threadIdx.x) / kWarpSize;
+    const size_t total_warps =
+        (static_cast<size_t>(gridDim.x) * blockDim.x) / kWarpSize;
+
+    for (size_t chunk = warp_in_grid; chunk < chunk_count;
+         chunk += total_warps) {
+        const unsigned char* src =
+            static_cast<const unsigned char*>(src_ptrs[chunk]);
+        /* dst must NOT be __restrict__-qualified: the cross-lane read after
+         * write below relies on __syncwarp() forcing a reload from global
+         * memory, and __restrict__ could legally let the compiler cache a
+         * dst[] value across the barrier, silently breaking lane-to-lane
+         * visibility. */
+        unsigned char* dst = static_cast<unsigned char*>(dst_ptrs[chunk]);
+
+        cudec_detail::Lz4Parser parser{src, src_sizes[chunk], dst_caps[chunk]};
+        cudec_detail::Lz4Sequence seq;
+        cudec_status status = CUDEC_OK;
+        bool done = false;
+        while (true) {
+            status = parser.Next(&seq, &done);
+            if (status != CUDEC_OK) {
+                break;
+            }
+            for (uint64_t i = lane; i < seq.literals_len; i += kWarpSize) {
+                dst[seq.literals_dst + i] = src[seq.literals_src + i];
+            }
+            /* The match may read literal bytes just written above. */
+            __syncwarp();
+            if (seq.match_len != 0) {
+                const uint64_t offset = seq.match_dst - seq.match_src;
+                for (uint64_t i = lane; i < seq.match_len; i += kWarpSize) {
+                    dst[seq.match_dst + i] =
+                        dst[seq.match_src + (i % offset)];
+                }
+                /* The next sequence may read bytes this match wrote. */
+                __syncwarp();
+            }
+            if (done) {
+                break;
+            }
+        }
+
+        /* All lanes agree on status and dst_pos (redundant parse); one lane
+         * writes the 16-byte result. bytes_written is set on full success
+         * only - a rejected chunk reports zero and never presents its
+         * partial output as valid. */
+        if (lane == 0) {
+            results[chunk].status = status;
+            results[chunk].reserved = 0;
+            results[chunk].bytes_written =
+                (status == CUDEC_OK) ? parser.dst_pos : 0;
+        }
     }
 }
 
@@ -28,11 +92,11 @@ cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
                                         cudec_chunk_result* d_results,
                                         cudec_stream_t stream) {
     /* Fail closed: reject the whole call rather than guess at intent. The
-     * grid bound keeps the block count inside gridDim.x's int32 range; the
-     * alignment bound keeps a single 16-byte result store per chunk open
-     * for the real decoder. */
-    constexpr size_t kMaxChunks =
-        static_cast<size_t>(INT32_MAX) * kBlockThreads;
+     * bound rejects absurd counts while staying well under SIZE_MAX (the
+     * grid is capped independently, so the launch geometry never
+     * overflows); d_results is 16-byte aligned so each per-chunk result
+     * record lands in a single aligned 16-byte slot. */
+    constexpr size_t kMaxChunks = static_cast<size_t>(INT32_MAX) * kWarpSize;
     static_assert(kMaxChunks < SIZE_MAX,
                   "the SIZE_MAX over-limit contract test relies on this");
     if (d_src_ptrs == nullptr || d_src_sizes == nullptr ||
@@ -48,9 +112,16 @@ cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
      * call consumes the pending error state. */
     (void)cudaGetLastError();
 
-    const unsigned grid_blocks =
-        static_cast<unsigned>((chunk_count + kBlockThreads - 1) / kBlockThreads);
-    report_not_implemented<<<grid_blocks, kBlockThreads, 0, stream>>>(
-        d_results, chunk_count);
+    /* One warp per chunk; the grid is sized to cover the batch in a single
+     * wave up to a cap that already fills the target GPU, and the kernel's
+     * grid-stride loop handles any remainder. */
+    constexpr size_t kMaxBlocks = 8192;
+    size_t blocks = (chunk_count + kBlockWarps - 1) / kBlockWarps;
+    if (blocks > kMaxBlocks) {
+        blocks = kMaxBlocks;
+    }
+    lz4_decode_batch<<<static_cast<unsigned>(blocks), kBlockThreads, 0,
+                       stream>>>(d_src_ptrs, d_src_sizes, d_dst_ptrs,
+                                 d_dst_capacities, chunk_count, d_results);
     return cudaGetLastError() == cudaSuccess ? CUDEC_OK : CUDEC_ERR_CUDA;
 }

--- a/tests/gpu_fixture.cu
+++ b/tests/gpu_fixture.cu
@@ -1,11 +1,11 @@
 /* The fixture corpus through the real batch plumbing (device pointer
- * tables, per-chunk sizes/capacities, poisoned destinations) - exactly the
- * path the M1 decoder lands into. Today it pins the stub contract that
- * smoke.cu does not cover: every chunk reports NOT_IMPLEMENTED and the
- * destination buffers stay untouched (the header's "writes no output"
- * promise). The reject-parity implication for mutants is written and
- * executing now; M1 flips the pristine-pair expectations to CUDEC_OK plus
- * byte-equality against the oracle output. */
+ * tables, per-chunk sizes/capacities, poisoned destinations) on the GPU
+ * decoder. Pristine pairs must decode to the original with byte-equality;
+ * the mutant corpus is held to the same two-direction oracle-parity
+ * contract as the CPU twin (where cudec accepts, liblz4 accepts and the
+ * bytes match; where liblz4 rejects, cudec rejects), with the documented
+ * offset==0 stricter case allowed. On success the decoder writes exactly
+ * bytes_written, so the poison beyond it must survive. */
 #include "cudec.h"
 #include "fixtures.h"
 #include "require.h"
@@ -95,20 +95,20 @@ int RunBatch(const std::vector<Chunk>& chunks,
     return 0;
 }
 
-int CheckStubContract(const std::vector<Chunk>& chunks,
-                      const std::vector<cudec_chunk_result>& results,
-                      const std::vector<std::vector<unsigned char>>& dsts) {
-    const std::vector<unsigned char> poison_row(65536, kDstPoison);
-    for (size_t i = 0; i < chunks.size(); i++) {
-        const char* ctx = chunks[i].context.c_str();
-        REQUIRE_CTX(results[i].status == CUDEC_ERR_NOT_IMPLEMENTED, "%s", ctx);
-        REQUIRE_CTX(results[i].reserved == 0, "%s", ctx);
-        REQUIRE_CTX(results[i].bytes_written == 0, "%s", ctx);
-        /* "Writes no output": the poison must survive verbatim. */
-        REQUIRE_CTX(dsts[i].size() <= poison_row.size(), "%s", ctx);
-        REQUIRE_CTX(equal_bytes(dsts[i].data(), poison_row.data(),
-                                dsts[i].size()),
-                    "%s", ctx);
+/* On a successful decode the output is exactly the expected bytes and the
+ * poison beyond bytes_written is untouched. */
+int CheckDecodedOk(const char* ctx, const cudec_chunk_result& result,
+                   const std::vector<unsigned char>& expected,
+                   const std::vector<unsigned char>& dst) {
+    REQUIRE_CTX(result.status == CUDEC_OK, "%s status=%d", ctx,
+                static_cast<int>(result.status));
+    REQUIRE_CTX(result.reserved == 0, "%s", ctx);
+    REQUIRE_CTX(result.bytes_written == expected.size(), "%s", ctx);
+    REQUIRE_CTX(dst.size() >= expected.size(), "%s", ctx);
+    REQUIRE_CTX(equal_bytes(dst.data(), expected.data(), expected.size()),
+                "%s", ctx);
+    for (size_t j = expected.size(); j < dst.size(); j++) {
+        REQUIRE_CTX(dst[j] == kDstPoison, "%s poison at %zu", ctx, j);
     }
     return 0;
 }
@@ -124,28 +124,38 @@ int main() {
     /* Batch 1: the pristine pairs - the exact plumbing the M1 decoder
      * inherits; at M1 these expectations flip to CUDEC_OK + bytes_written
      * + byte-equality against the oracle output. */
+    /* Slack capacity so the "writes exactly bytes_written, poison beyond
+     * survives" guarantee is exercised on the primary success path (not
+     * only via short-decoding mutants). A larger capacity is still parity-
+     * faithful for a valid stream: the terminal/LASTLITERALS checks only
+     * grow more lenient, and the decode still yields original.size() bytes. */
     std::vector<Chunk> pairs;
     for (const auto& f : fixtures) {
-        pairs.push_back(Chunk{f.name, &f.compressed, f.original.size()});
+        pairs.push_back(Chunk{f.name, &f.compressed, f.original.size() + 8});
     }
     std::vector<cudec_chunk_result> results;
     std::vector<std::vector<unsigned char>> dsts;
     REQUIRE(RunBatch(pairs, &results, &dsts) == 0);
-    REQUIRE(CheckStubContract(pairs, results, dsts) == 0);
+    for (size_t i = 0; i < fixtures.size(); i++) {
+        REQUIRE(CheckDecodedOk(pairs[i].context.c_str(), results[i],
+                               fixtures[i].original, dsts[i]) == 0);
+    }
 
-    /* Batch 2: the mutant corpus with oracle verdicts. The reject-parity
-     * implication (oracle rejects => cudec must not report success) is
-     * armed and executing today - trivially satisfied by the stub, load-
-     * bearing from M1 on. */
+    /* Batch 2: the mutant corpus, held to the two-direction oracle-parity
+     * contract - the same as the CPU twin, now on the GPU decoder. */
     std::vector<std::vector<unsigned char>> mutant_streams;
     std::vector<std::string> mutant_contexts;
     std::vector<size_t> mutant_capacities;
-    std::vector<bool> oracle_rejected;
+    std::vector<bool> oracle_accepts;
+    std::vector<std::vector<unsigned char>> oracle_outputs;
     for (const auto& f : fixtures) {
         for (auto& m : MutateStream(f.compressed, f.seed)) {
             std::vector<unsigned char> decoded;
-            oracle_rejected.push_back(
-                !OracleDecodes(m.stream, f.original.size(), &decoded));
+            const bool ok =
+                OracleDecodes(m.stream, f.original.size(), &decoded);
+            oracle_accepts.push_back(ok);
+            oracle_outputs.push_back(ok ? decoded
+                                        : std::vector<unsigned char>{});
             mutant_streams.push_back(std::move(m.stream));
             mutant_contexts.push_back(f.name + "/" + m.description);
             mutant_capacities.push_back(f.original.size());
@@ -159,26 +169,96 @@ int main() {
                                       mutant_capacities[i]});
     }
     REQUIRE(RunBatch(mutant_chunks, &results, &dsts) == 0);
-    REQUIRE(CheckStubContract(mutant_chunks, results, dsts) == 0);
     size_t rejected_count = 0;
+    size_t stricter_count = 0;
+    std::string stricter_ctx;
     for (size_t i = 0; i < mutant_chunks.size(); i++) {
-        if (!oracle_rejected[i]) {
-            continue;
+        const char* ctx = mutant_chunks[i].context.c_str();
+        if (results[i].status == CUDEC_OK) {
+            /* cudec accepts => liblz4 accepts and the bytes match its own
+             * output and size (a truncation can decode to a valid, shorter
+             * stream - compare against the oracle output, never
+             * f.original). */
+            REQUIRE_CTX(oracle_accepts[i], "cudec accepts, liblz4 rejects: %s",
+                        ctx);
+            REQUIRE(CheckDecodedOk(ctx, results[i], oracle_outputs[i],
+                                   dsts[i]) == 0);
+        } else {
+            /* Failure contract: a rejected chunk reports no output, never
+             * presenting its partial dst as a valid decode. */
+            REQUIRE_CTX(results[i].bytes_written == 0, "reject bw: %s", ctx);
+            REQUIRE_CTX(results[i].reserved == 0, "reject reserved: %s", ctx);
+            if (oracle_accepts[i]) {
+                stricter_count++;
+                stricter_ctx = mutant_chunks[i].context;
+            } else {
+                rejected_count++;
+            }
         }
-        rejected_count++;
-        /* M1 note: for mutants the oracle ACCEPTS, the flip must compare
-         * against the oracle's own output and size (a truncation can land
-         * on a valid, shorter stream) - never against f.original. */
-        REQUIRE_CTX(results[i].status != CUDEC_OK,
-                    "reject parity (armed for M1): %s",
-                    mutant_chunks[i].context.c_str());
     }
-    /* The parity arm must have teeth: at least one mutant per corpus is
-     * oracle-rejected, or this whole loop was vacuous. */
+    /* The parity arm must have teeth: at least one mutant is oracle-
+     * rejected. The stricter set is pinned by IDENTITY, not just count: it
+     * is exactly the one offset==0 mutant (matching the CPU twin). */
     REQUIRE(rejected_count > 0);
+    REQUIRE(stricter_count == 1);
+    REQUIRE(stricter_ctx == "text-256/flip-bit-at-88");
 
-    std::printf("PASS: %zu pairs + %zu mutants (%zu oracle-rejected) through "
-                "the batch plumbing; stub contract and poison intact\n",
-                pairs.size(), mutant_chunks.size(), rejected_count);
+    /* Batch 3: the grid-stride re-entry path (a warp decoding more than one
+     * chunk). The host caps the grid at 8192 blocks = 32768 warps, so a
+     * batch beyond that forces the `chunk += total_warps` wraparound - the
+     * exactly-once distribution that no other gate exercises. All chunks
+     * share one empty-block src and one dst (an empty block writes nothing),
+     * so 40000 chunks cost two device buffers, not 80000 allocations. A
+     * skipped chunk keeps its 0xFF-poisoned result (status != OK); a
+     * double-decode is idempotent - so requiring every result CUDEC_OK with
+     * bytes_written 0 proves each chunk was decoded exactly once. */
+    {
+        const size_t wrap_n = 40000;
+        unsigned char* d_src_one;
+        unsigned char* d_dst_one;
+        REQUIRE_CUDA(cudaMalloc(&d_src_one, 1));
+        REQUIRE_CUDA(cudaMemset(d_src_one, 0, 1)); /* empty-block token */
+        REQUIRE_CUDA(cudaMalloc(&d_dst_one, 1));
+        std::vector<const void*> h_s(wrap_n, d_src_one);
+        std::vector<void*> h_d(wrap_n, d_dst_one);
+        std::vector<size_t> h_sz(wrap_n, 1);
+        std::vector<size_t> h_cp(wrap_n, 1);
+        const void** d_s;
+        void** d_d;
+        size_t* d_sz;
+        size_t* d_cp;
+        cudec_chunk_result* d_r;
+        REQUIRE_CUDA(cudaMalloc(&d_s, wrap_n * sizeof(*d_s)));
+        REQUIRE_CUDA(cudaMalloc(&d_d, wrap_n * sizeof(*d_d)));
+        REQUIRE_CUDA(cudaMalloc(&d_sz, wrap_n * sizeof(*d_sz)));
+        REQUIRE_CUDA(cudaMalloc(&d_cp, wrap_n * sizeof(*d_cp)));
+        REQUIRE_CUDA(cudaMalloc(&d_r, wrap_n * sizeof(*d_r)));
+        REQUIRE_CUDA(cudaMemcpy(d_s, h_s.data(), wrap_n * sizeof(*d_s),
+                                cudaMemcpyHostToDevice));
+        REQUIRE_CUDA(cudaMemcpy(d_d, h_d.data(), wrap_n * sizeof(*d_d),
+                                cudaMemcpyHostToDevice));
+        REQUIRE_CUDA(cudaMemcpy(d_sz, h_sz.data(), wrap_n * sizeof(*d_sz),
+                                cudaMemcpyHostToDevice));
+        REQUIRE_CUDA(cudaMemcpy(d_cp, h_cp.data(), wrap_n * sizeof(*d_cp),
+                                cudaMemcpyHostToDevice));
+        REQUIRE_CUDA(cudaMemset(d_r, 0xFF, wrap_n * sizeof(*d_r)));
+        REQUIRE(cudec_lz4_decompress_batch(d_s, d_sz, d_d, d_cp, wrap_n, d_r,
+                                           nullptr) == CUDEC_OK);
+        REQUIRE_CUDA(cudaDeviceSynchronize());
+        std::vector<cudec_chunk_result> wrap_res(wrap_n);
+        REQUIRE_CUDA(cudaMemcpy(wrap_res.data(), d_r, wrap_n * sizeof(*d_r),
+                                cudaMemcpyDeviceToHost));
+        for (size_t i = 0; i < wrap_n; i++) {
+            REQUIRE_CTX(wrap_res[i].status == CUDEC_OK, "wrap chunk %zu", i);
+            REQUIRE_CTX(wrap_res[i].bytes_written == 0, "wrap chunk %zu", i);
+        }
+    }
+
+    std::printf("PASS: %zu pairs decoded byte-exact + %zu mutants in oracle "
+                "parity (%zu oracle-rejected, %zu offset==0 stricter) + 40000 "
+                "grid-stride wraparound chunks on the GPU decoder; failure "
+                "contract and poison beyond bytes_written intact\n",
+                pairs.size(), mutant_chunks.size(), rejected_count,
+                stricter_count);
     return 0;
 }

--- a/tests/smoke.cu
+++ b/tests/smoke.cu
@@ -1,7 +1,7 @@
 /* M0 smoke test: the library links, the version matches the header, and
- * the stubbed batch entry point honors its documented contract on a real
- * device - fail-closed argument validation, asynchronous submission, and
- * per-chunk device-side reporting. */
+ * the batch entry point honors its documented contract on a real device -
+ * fail-closed argument validation, asynchronous submission, per-chunk
+ * device-side reporting, and a real empty-block decode. */
 #include "cudec.h"
 #include "require.h"
 
@@ -25,8 +25,9 @@ int main() {
                                        no_results, nullptr) ==
             CUDEC_ERR_INVALID_ARGUMENT);
 
-    /* 257 chunks spans two blocks of the 256-thread launch, so the
-     * multi-block index arithmetic actually executes on device. */
+    /* 257 chunks span many blocks of the warp-per-chunk launch (128
+     * threads = 4 chunks per block), so the multi-block index arithmetic
+     * actually executes on device. */
     const size_t chunk_count = 257;
     const size_t chunk_bytes = 64;
 
@@ -34,12 +35,16 @@ int main() {
     const void* h_src_ptrs[chunk_count];
     void* h_dst_ptrs[chunk_count];
     size_t h_sizes[chunk_count];
+    /* Each chunk is a valid empty LZ4 block (a lone 0x00 token) so the
+     * batch exercises a real successful decode end to end at the ABI
+     * boundary; the fixture test covers content-bearing streams. */
     for (size_t i = 0; i < chunk_count; i++) {
         REQUIRE_CUDA(cudaMalloc(&buffers[i], chunk_bytes));
+        REQUIRE_CUDA(cudaMemset(buffers[i], 0, 1));
         REQUIRE_CUDA(cudaMalloc(&buffers[chunk_count + i], chunk_bytes));
         h_src_ptrs[i] = buffers[i];
         h_dst_ptrs[i] = buffers[chunk_count + i];
-        h_sizes[i] = chunk_bytes;
+        h_sizes[i] = 1;
     }
 
     const void** d_src_ptrs;
@@ -123,14 +128,14 @@ int main() {
     REQUIRE_CUDA(cudaMemcpy(h_results, d_results, sizeof(h_results),
                             cudaMemcpyDeviceToHost));
     for (size_t i = 0; i < chunk_count; i++) {
-        REQUIRE(h_results[i].status == CUDEC_ERR_NOT_IMPLEMENTED);
+        REQUIRE(h_results[i].status == CUDEC_OK);
         REQUIRE(h_results[i].reserved == 0);
         REQUIRE(h_results[i].bytes_written == 0);
     }
 
     REQUIRE_CUDA(cudaStreamDestroy(stream));
-    std::printf("PASS: version + fail-closed validation + %zu-chunk stub "
-                "batch on device\n",
+    std::printf("PASS: version + fail-closed validation + %zu-chunk "
+                "empty-block decode on device\n",
                 chunk_count);
     return 0;
 }


### PR DESCRIPTION
# What & why

M1 ladder step 3 (masterplan section 9): the LZ4 block decoder behind the frozen batch ABI, replacing the stub. This is the fail-closed heart on the GPU - the project's login path. Closes #14.

One warp per chunk over a grid-stride loop; all 32 lanes run the merged validation ladder (`src/lz4_block.h`, merged in #17) redundantly in lockstep and fan out by lane for every copy; overlapping matches use the closed-form modular gather that reads only the region finalized before the match; `__syncwarp()` carries the intra-warp memory ordering at the two copy boundaries; zero shared memory, no table, no dispatch heuristic.

## Type of change

- [x] Decode kernel / device code
- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: the kernel runs the already-hardened parser ladder; every device read/write is bounded by what the parser guarantees; a rejected chunk reports bytes_written 0 and never presents its partial dst as valid (now asserted in the test).
- [x] Oracle coverage: pristine pairs decode byte-exact; the mutant corpus is held to the two-direction oracle-parity contract on the GPU decoder, matching the CPU twin including the single offset==0 stricter case.
- [x] Determinism preserved: same-batch-twice bit-identical across the whole Silesia corpus and the fixture batch.
- [x] Every CUDA API call's error is checked (host launch: drain + post-launch check); no exceptions cross the ABI.
- [x] Adversarial review was run (security-review gated) - see Notes.

## Performance checklist

Minimal-correct kernel; numbers are #15's job (the bench GPU path). Recorded here per the masterplan occupancy plan: 46 registers/thread, so >= 32 warps/SM is achievable on sm_86. The per-element 64-bit modulo in the match gather is a known perf-pass (#16) target, not a correctness issue.

- [ ] The claim is measured: deferred to #15.
- [ ] No regression against baseline: n/a (first GPU decode; baseline is the CPU oracle in docs/BENCHMARKS.md).

## Quality checklist

- [x] Minimal: no shared memory, no sequence table, no dispatch heuristic - the least kernel that is correct and fail-closed.
- [x] Self-documenting: the closed-form gather, the two syncwarp barriers, the offset==0/modulo-by-zero link, the no-__restrict__ invariant on dst, and the cap-tied index math each carry their why.
- [x] Conformance tests pass; the new structural properties (real decode, failure contract, grid-stride coverage) are locked into gpu_fixture.

## Verification

- [x] `cmake --build` - both configurations clean under warnings-as-errors.
- [x] `ctest` - 7/7 on the RTX 3080.
- [x] **Whole-Silesia GPU-vs-oracle diff: 3239 chunks, 211.94 MB, 0 byte mismatches, 0 nondeterministic** across a second run.
- [x] gpu_fixture: 12 pairs byte-exact + 310 mutants two-direction parity (248 oracle-rejected, 1 offset==0 stricter, identity-pinned) + 40000-chunk grid-stride wraparound; failure contract + poison intact.
- [x] CI-parity run without a GPU: green, all identity pins.
- [x] Prettier - clean.
- [x] Docs: cudec.h result-contract comment updated; masterplan section 9 already specifies this kernel.

## Notes

Security-review gated (decoder validation is the login path). Three lenses:

- **CUDA domain: PASS.** Confirmed the central question - `__syncwarp()` is sufficient for the cross-lane global-memory ordering the kernel relies on (both the documented CUDA memory model and the on-target gates agree; a `__threadfence_block` is not needed). Verified the two barriers are necessary and sufficient, the warp-uniform indexing eliminates partial-warp `__syncwarp` UB by construction, the closed-form gather equals sequential LZ4 for every offset >= 1, and no OOB / div-by-zero / result-store race exists.
- **Correctness + robustness: NEEDS_IMPROVEMENT -> all fixed.** The kernel was ruled analytically sound; the five findings were verification-net gaps (per the project's "verify empirically, not by reasoning" invariant): (1) the failure-contract `bytes_written==0` on a kernel reject was untested - a broken kernel setting it unconditionally would have passed; (2) the grid-stride multi-chunk-per-warp path had zero empirical coverage (needs > 32768 chunks); (3) `stricter_count==1` pinned the count but not the identity; (4) the poison check was vacuous on pristine pairs; (5) stale comments. All five closed - the failure contract is now asserted, a 40000-chunk test forces the wraparound and proves exactly-once, the stricter case is pinned by identity to the offset==0 mutant, pristine pairs carry slack capacity, comments corrected. A closure pass re-verified all five PASS. No declined findings.

**Toolchain constraint (documented):** compute-sanitizer memcheck/racecheck cannot run in the container - the WSL2/WDDM GPU passthrough aborts the tool at init ("Device not supported"), an environment block rather than a code result. The whole-corpus GPU-vs-oracle byte diff (an OOB corrupts output) plus same-batch-twice determinism (a race breaks it) are the standing substitute gates; run the real sanitizer when a Linux-native GPU or the debugger interface is available.

Follow-up (out of scope): bench_lz4's "stub era" report line becomes accurate when #15 adds the GPU bench path and re-records docs/BENCHMARKS.md.

CodeRabbit remains uninstalled on this repository (see #7); merging on CI + the review protocol above.