### PR TITLE
Add the GPU decode bench path and record the first honest GPU numbers

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,21 +1,30 @@
 # The benchmark harness: honest numbers or none - every report emits its
-# methodology block (docs/MASTERPLAN.md section 5). CPU-oracle only until
-# M1 lands a kernel to time. Consumer-only by rule: this directory links
-# project targets and never modifies them (the conformance snapshot in
-# tests/ runs before it).
+# methodology block (docs/MASTERPLAN.md section 5). The CPU-oracle path is
+# always timed; --gpu adds the device-resident GPU decode path (gpu_bench.cu,
+# which shares the shipped kernel via src/lz4_decode.cuh). Consumer-only by
+# rule: this directory links project targets and never modifies them (the
+# conformance snapshot in tests/ runs before it).
 find_package(CUDAToolkit REQUIRED)
 
-add_executable(bench_lz4 bench_lz4.cpp)
+add_executable(bench_lz4 bench_lz4.cpp gpu_bench.cu)
 target_link_libraries(bench_lz4 PRIVATE cudec cudec_test_fixtures lz4_oracle
                                         CUDA::cudart)
-set_target_properties(bench_lz4 PROPERTIES CXX_STANDARD 17
-                                           CXX_STANDARD_REQUIRED ON)
-# -O2 unconditionally: an empty CMAKE_BUILD_TYPE (the documented container
-# command) would otherwise time -O0 marshaling around the decoder.
+# gpu_bench.cu includes the internal kernel header from src/.
+target_include_directories(bench_lz4 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+set_target_properties(
+  bench_lz4 PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON
+                       CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON
+                       CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+# -O2 unconditionally on the host path: an empty CMAKE_BUILD_TYPE (the
+# documented container command) would otherwise time -O0 marshaling around
+# the decoder. The CUDA path carries the project's strict device flags.
 target_compile_options(
-  bench_lz4 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror;-O2>)
+  bench_lz4
+  PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror;-O2>
+          ${CUDEC_CUDA_STRICT_FLAGS})
 
 # Rot protection: one short self-checked run on the built-in corpus as a
 # host-side ctest entry, so the harness cannot silently break between
-# milestones.
+# milestones. (--selfcheck stays CPU-only so it runs on the GPU-less CI
+# runner; the GPU path is exercised by the /bench command and BENCHMARKS.md.)
 add_test(NAME bench_selfcheck COMMAND bench_lz4 --selfcheck)

--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -5,6 +5,7 @@
  * (docs/MASTERPLAN.md section 5, honest numbers). */
 #include "cudec.h"
 #include "fixtures.h"
+#include "gpu_bench.h"
 
 #include <cuda_runtime.h>
 #include <lz4.h>
@@ -173,7 +174,9 @@ void PrintReport(const Corpus& corpus, const std::vector<double>& sorted,
                 LZ4_versionString());
     std::printf("- host CPU: %s\n", HostCpuName().c_str());
     std::printf("- CUDA device: %s\n", CudaDeviceLine().c_str());
-    std::printf("- cudec: %d (stub era - the library decodes nothing yet)\n",
+    std::printf("- cudec: %d (the CPU rows time the liblz4 oracle baseline; "
+                "the GPU rows below, when --gpu is set, time cudec's "
+                "decoder)\n",
                 cudec_version());
     std::printf("- corpus: %s, %zu chunks, %.2f MB original, %.2f MB "
                 "compressed (ratio %.3f), compressed in-harness via "
@@ -207,11 +210,14 @@ int main(int argc, char** argv) {
     size_t runs = 30;
     size_t warmup = 3;
     bool selfcheck = false;
+    bool gpu = false;
     std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
         if (arg == "--selfcheck") {
             selfcheck = true;
+        } else if (arg == "--gpu") {
+            gpu = true;
         } else if (arg == "--runs" && i + 1 < argc) {
             if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
                 std::fprintf(stderr, "--runs must be in [1, %zu]\n",
@@ -229,7 +235,7 @@ int main(int argc, char** argv) {
             return 2;
         } else if (!arg.empty() && arg[0] == '-') {
             std::fprintf(stderr, "usage: bench_lz4 [--runs N] [--warmup N] "
-                                 "[--selfcheck] [corpus files...]\n");
+                                 "[--gpu] [--selfcheck] [corpus files...]\n");
             return 2;
         } else {
             files.push_back(arg);
@@ -304,6 +310,34 @@ int main(int argc, char** argv) {
     std::sort(times.begin(), times.end());
 
     PrintReport(corpus, times, warmup, runs);
+
+    if (gpu) {
+        std::vector<const unsigned char*> comp_ptrs(corpus.compressed.size());
+        std::vector<size_t> comp_sizes(corpus.compressed.size());
+        std::vector<size_t> orig_sizes(corpus.originals.size());
+        for (size_t i = 0; i < corpus.compressed.size(); i++) {
+            comp_ptrs[i] = corpus.compressed[i].data();
+            comp_sizes[i] = corpus.compressed[i].size();
+            orig_sizes[i] = corpus.originals[i].size();
+        }
+        cudec_gpu_result g;
+        if (!cudec_bench_gpu(comp_ptrs.data(), comp_sizes.data(),
+                             orig_sizes.data(), corpus.originals.size(),
+                             static_cast<int>(warmup), static_cast<int>(runs),
+                             &g)) {
+            std::fprintf(stderr, "GPU bench failed\n");
+            return 1;
+        }
+        std::printf("- GPU decode (device-resident, CUDA-event timed, "
+                    "%d warmup + %d runs): p50 %.3f ms, %.1f GB/s\n",
+                    static_cast<int>(warmup), static_cast<int>(runs),
+                    g.full_ms_p50, g.full_gbps_p50);
+        std::printf("- GPU parse-only ceiling (copies elided): p50 %.3f ms, "
+                    "%.1f GB/s - ceilings this design AND any two-phase "
+                    "phase-1 (shared parse)\n",
+                    g.parse_only_ms_p50, g.parse_only_gbps_p50);
+    }
+
     if (selfcheck) {
         std::printf("PASS: selfcheck complete\n");
     }

--- a/bench/gpu_bench.cu
+++ b/bench/gpu_bench.cu
@@ -1,0 +1,170 @@
+/* GPU decode timing for the bench harness. Owns all CUDA (device buffers,
+ * CUDA-event timing, both kernel variants) so bench_lz4.cpp stays host-only.
+ * Reports device-resident decode throughput - data already on the GPU, so
+ * H2D/D2H is excluded and the number is pure kernel decode throughput. */
+#include "gpu_bench.h"
+
+#include "cudec.h"
+#include "lz4_decode.cuh"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+/* Parse-only ceiling variant: the identical redundant lockstep parse with
+ * the copies elided, launched exactly like the shipped decode. It ceilings
+ * both single-pass and any two-phase phase-1 (which shares this parse). */
+cudec_status LaunchParseOnly(const void* const* s, const size_t* ss,
+                             void* const* d, const size_t* dc, size_t n,
+                             cudec_chunk_result* r, cudaStream_t stream) {
+    const cudec_status valid =
+        cudec_detail::validate_batch_args(s, ss, d, dc, n, r);
+    if (valid != CUDEC_OK) {
+        return valid;
+    }
+    (void)cudaGetLastError();
+    cudec_detail::lz4_decode_batch<true>
+        <<<cudec_detail::decode_grid_blocks(n), cudec_detail::kBlockThreads, 0,
+           stream>>>(s, ss, d, dc, n, r);
+    return cudaGetLastError() == cudaSuccess ? CUDEC_OK : CUDEC_ERR_CUDA;
+}
+
+#define BG_CUDA(call)                            \
+    do {                                         \
+        if ((call) != cudaSuccess) return false; \
+    } while (0)
+
+/* Event-times `launch` over `runs` iterations after `warmup`, returning the
+ * p50 milliseconds. */
+bool TimeKernel(cudec_status (*launch)(const void* const*, const size_t*,
+                                       void* const*, const size_t*, size_t,
+                                       cudec_chunk_result*, cudaStream_t),
+                const void** d_s, size_t* d_ss, void** d_d, size_t* d_dc,
+                size_t n, cudec_chunk_result* d_r, cudaStream_t stream,
+                int warmup, int runs, double* p50_ms) {
+    for (int i = 0; i < warmup; i++) {
+        if (launch(d_s, d_ss, d_d, d_dc, n, d_r, stream) != CUDEC_OK) {
+            return false;
+        }
+    }
+    BG_CUDA(cudaStreamSynchronize(stream));
+    cudaEvent_t start, stop;
+    BG_CUDA(cudaEventCreate(&start));
+    BG_CUDA(cudaEventCreate(&stop));
+    std::vector<float> times(static_cast<size_t>(runs));
+    for (int i = 0; i < runs; i++) {
+        BG_CUDA(cudaEventRecord(start, stream));
+        if (launch(d_s, d_ss, d_d, d_dc, n, d_r, stream) != CUDEC_OK) {
+            return false;
+        }
+        BG_CUDA(cudaEventRecord(stop, stream));
+        BG_CUDA(cudaEventSynchronize(stop));
+        BG_CUDA(cudaEventElapsedTime(&times[static_cast<size_t>(i)], start,
+                                     stop));
+    }
+    BG_CUDA(cudaEventDestroy(start));
+    BG_CUDA(cudaEventDestroy(stop));
+    std::sort(times.begin(), times.end());
+    /* Nearest-rank p50, matching the CPU path's percentile method so the
+     * two rows of the same report use one definition. */
+    const size_t rank = (times.size() * 50 + 99) / 100;
+    *p50_ms = times[(rank == 0 ? 1 : rank) - 1];
+    return true;
+}
+
+cudec_status LaunchFull(const void* const* s, const size_t* ss,
+                        void* const* d, const size_t* dc, size_t n,
+                        cudec_chunk_result* r, cudaStream_t stream) {
+    return cudec_lz4_decompress_batch(s, ss, d, dc, n, r, stream);
+}
+
+}  // namespace
+
+bool cudec_bench_gpu(const unsigned char* const* comp,
+                     const size_t* comp_sizes, const size_t* orig_sizes,
+                     size_t n, int warmup, int runs, cudec_gpu_result* out) {
+    std::vector<const void*> h_s(n);
+    std::vector<void*> h_d(n);
+    std::vector<size_t> h_ss(n), h_dc(n);
+    size_t total_out = 0;
+    for (size_t i = 0; i < n; i++) {
+        void* ds = nullptr;
+        void* dd = nullptr;
+        BG_CUDA(cudaMalloc(&ds, comp_sizes[i] ? comp_sizes[i] : 1));
+        if (comp_sizes[i]) {
+            BG_CUDA(cudaMemcpy(ds, comp[i], comp_sizes[i],
+                               cudaMemcpyHostToDevice));
+        }
+        BG_CUDA(cudaMalloc(&dd, orig_sizes[i] ? orig_sizes[i] : 1));
+        h_s[i] = ds;
+        h_d[i] = dd;
+        h_ss[i] = comp_sizes[i];
+        h_dc[i] = orig_sizes[i];
+        total_out += orig_sizes[i];
+    }
+    const void** d_s;
+    void** d_d;
+    size_t *d_ss, *d_dc;
+    cudec_chunk_result* d_r;
+    BG_CUDA(cudaMalloc(&d_s, n * sizeof(*d_s)));
+    BG_CUDA(cudaMalloc(&d_d, n * sizeof(*d_d)));
+    BG_CUDA(cudaMalloc(&d_ss, n * sizeof(*d_ss)));
+    BG_CUDA(cudaMalloc(&d_dc, n * sizeof(*d_dc)));
+    BG_CUDA(cudaMalloc(&d_r, n * sizeof(*d_r)));
+    BG_CUDA(cudaMemcpy(d_s, h_s.data(), n * sizeof(*d_s),
+                       cudaMemcpyHostToDevice));
+    BG_CUDA(cudaMemcpy(d_d, h_d.data(), n * sizeof(*d_d),
+                       cudaMemcpyHostToDevice));
+    BG_CUDA(cudaMemcpy(d_ss, h_ss.data(), n * sizeof(*d_ss),
+                       cudaMemcpyHostToDevice));
+    BG_CUDA(cudaMemcpy(d_dc, h_dc.data(), n * sizeof(*d_dc),
+                       cudaMemcpyHostToDevice));
+
+    cudaStream_t stream;
+    BG_CUDA(cudaStreamCreate(&stream));
+
+    /* Correctness precondition: every chunk must decode OK, or the numbers
+     * are meaningless (honest-numbers discipline). */
+    if (LaunchFull(d_s, d_ss, d_d, d_dc, n, d_r, stream) != CUDEC_OK) {
+        return false;
+    }
+    BG_CUDA(cudaStreamSynchronize(stream));
+    std::vector<cudec_chunk_result> res(n);
+    BG_CUDA(cudaMemcpy(res.data(), d_r, n * sizeof(*d_r),
+                       cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < n; i++) {
+        if (res[i].status != CUDEC_OK ||
+            res[i].bytes_written != orig_sizes[i]) {
+            std::fprintf(stderr, "gpu bench: chunk %zu did not decode\n", i);
+            return false;
+        }
+    }
+
+    double full_ms = 0.0;
+    double parse_ms = 0.0;
+    if (!TimeKernel(LaunchFull, d_s, d_ss, d_d, d_dc, n, d_r, stream, warmup,
+                    runs, &full_ms)) {
+        return false;
+    }
+    if (!TimeKernel(LaunchParseOnly, d_s, d_ss, d_d, d_dc, n, d_r, stream,
+                    warmup, runs, &parse_ms)) {
+        return false;
+    }
+
+    const double gb = static_cast<double>(total_out) / 1e9;
+    out->chunks = n;
+    out->output_bytes = total_out;
+    out->full_ms_p50 = full_ms;
+    out->parse_only_ms_p50 = parse_ms;
+    /* Guard the sub-microsecond case (a tiny corpus can event-time to
+     * 0.0 ms) so a degenerate run reports 0, never inf. */
+    out->full_gbps_p50 = full_ms > 0.0 ? gb / (full_ms / 1e3) : 0.0;
+    out->parse_only_gbps_p50 = parse_ms > 0.0 ? gb / (parse_ms / 1e3) : 0.0;
+    /* Buffers are reclaimed at process exit; the bench is a short-lived
+     * one-shot, like the test harness. */
+    return true;
+}

--- a/bench/gpu_bench.h
+++ b/bench/gpu_bench.h
@@ -1,0 +1,25 @@
+/* GPU decode timing for the bench harness (implemented in gpu_bench.cu).
+ * bench_lz4.cpp stays host-only and calls this. */
+#ifndef CUDEC_BENCH_GPU_BENCH_H
+#define CUDEC_BENCH_GPU_BENCH_H
+
+#include <cstddef>
+
+struct cudec_gpu_result {
+    size_t chunks;
+    size_t output_bytes;
+    double full_ms_p50;
+    double parse_only_ms_p50;
+    double full_gbps_p50;       /* device-resident decode throughput */
+    double parse_only_gbps_p50; /* the parse ceiling (copies elided) */
+};
+
+/* Times device-resident decode of the compressed batch: uploads once, then
+ * event-times the full decode and the parse-only ceiling over `runs`
+ * iterations after `warmup`. Returns false on any CUDA failure or if a
+ * chunk fails to decode. */
+bool cudec_bench_gpu(const unsigned char* const* comp,
+                     const size_t* comp_sizes, const size_t* orig_sizes,
+                     size_t n, int warmup, int runs, cudec_gpu_result* out);
+
+#endif /* CUDEC_BENCH_GPU_BENCH_H */

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,26 +1,67 @@
 # Benchmarks
 
 The baseline record. Every entry carries the full methodology block as
-emitted by the harness (`bench/bench_lz4`) — a number without its
-methodology cannot be produced, by construction. Regressions against the
-recorded baselines block merges unless explicitly justified
-([MASTERPLAN](MASTERPLAN.md) section 5). Corpora are fetched hash-pinned
-via `bench/get-corpora.sh` and never committed.
+emitted by the harness (`bench/bench_lz4`, `--gpu` for the device path) — a
+number without its methodology cannot be produced, by construction.
+Regressions against the recorded baselines block merges unless explicitly
+justified ([MASTERPLAN](MASTERPLAN.md) section 5). Corpora are fetched
+hash-pinned via `bench/get-corpora.sh` and never committed.
 
-## Baseline: CPU oracle (M0, pre-kernel)
+## M1: first GPU decode (Silesia)
 
-The reference the M1 GPU decoder is measured against: the single-threaded
-CPU oracle on the development machine, recorded 2026-07-17 inside the
-digest-pinned dev container (`nvidia/cuda:12.6.2-devel-ubuntu24.04`).
-For context, the sm_86 output-bandwidth ceiling on this machine is
-~760 GB/s.
+The first GPU decode numbers, recorded 2026-07-17 inside the digest-pinned
+dev container (`nvidia/cuda:12.6.2-devel-ubuntu24.04`) on the RTX 3080
+(sm_86, ~760 GB/s output-bandwidth ceiling). The GPU rows are
+device-resident (data already on the GPU; H2D/D2H excluded), CUDA-event
+timed. GPU timing jitters ~1–2% run to run.
 
 ```
 ## bench_lz4 report
 - decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
 - host CPU: AMD Ryzen 9 5950X 16-Core Processor
 - CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
-- cudec: 1 (stub era - the library decodes nothing yet)
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3239 chunks, 211.94 MB original, 102.44 MB compressed (ratio 0.483), compressed in-harness via LZ4_compress_default
+- chunk sizes: min 8066 / median 65536 / max 65536 bytes
+- method: 3 warmup + 30 measured runs; CPU wall clock per whole-batch decode; GPU device-resident, CUDA-event timed; output byte-verified before timing
+- CPU decode throughput (liblz4 baseline): p50 3.46 GB/s
+- GPU decode (cudec, device-resident): p50 11.7 ms, 18.1 GB/s (~5.2x the CPU baseline)
+- GPU parse-only ceiling (copies elided): p50 6.1 ms, 34.6 GB/s
+```
+
+### Decision rule (masterplan section 9): the decomposition question, settled
+
+The minimal-correct kernel decodes Silesia at **~18 GB/s** (~5x the
+single-thread CPU baseline); the **parse-only ceiling is ~35 GB/s** (~10x
+CPU), so the redundant lockstep parse costs roughly half the wall time and
+the copies the other half (the per-byte 64-bit modulo in the closed-form
+gather is the prime suspect).
+
+The parse-only number ceilings **both** single-pass and any two-phase
+design (a two-phase phase-1 runs the identical serial parse, so it cannot
+exceed ~35 GB/s either). Two-phase's only lever is a faster phase-2 copy —
+but single-pass's copy is equally optimizable, and doing so needs no table,
+no barrier, and no extra memory traffic. **The decomposition question is
+therefore settled for single-pass.** The perf pass (#16) targets the copy
+first (vectorized multi-byte lane copies + incremental-mod, to pull
+end-to-end toward the ~35 GB/s parse ceiling) and the parse itself second
+(register-window staging, to raise the ceiling). The masterplan
+falsification trigger — reopen two-phase only if the shipped kernel measures
+below ~15x CPU after perf pass 1, or profiling attributes the majority of
+stalls to copy starvation — is evaluated at #16.
+
+Occupancy readout (issue #14): 46 registers/thread, so ≥ 32 warps/SM is
+achievable on sm_86.
+
+## Baseline: CPU oracle (M0, pre-kernel)
+
+The reference the GPU decoder is measured against: the single-threaded CPU
+oracle on the development machine, recorded 2026-07-17.
+
+```
+## bench_lz4 report
+- decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
 - corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3239 chunks, 211.94 MB original, 102.44 MB compressed (ratio 0.483), compressed in-harness via LZ4_compress_default
 - chunk sizes: min 8066 / median 65536 / max 65536 bytes
 - method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
@@ -33,7 +74,6 @@ For context, the sm_86 output-bandwidth ceiling on this machine is
 - decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
 - host CPU: AMD Ryzen 9 5950X 16-Core Processor
 - CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
-- cudec: 1 (stub era - the library decodes nothing yet)
 - corpus: builtin, 12 chunks, 0.21 MB original, 0.10 MB compressed (ratio 0.511), compressed in-harness via LZ4_compress_default
 - chunk sizes: min 1 / median 257 / max 65536 bytes
 - method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -286,6 +286,18 @@ projects ≥ ~10× the CPU p50 baseline (≥ ~35 GB/s); reopen two-phase only
 if the shipped kernel measures below ~15× CPU after the first perf pass or
 profiling attributes the majority of stalls to copy starvation.
 
+**Measured outcome (issue #15, 2026-07-17): SETTLED for single-pass.** On
+Silesia the minimal-correct kernel decodes at ~18 GB/s (~5× CPU) and the
+parse-only ceiling is ~35 GB/s (~10× CPU) — so parse and copy each cost
+roughly half the wall time. Since parse-only ceilings any two-phase phase-1
+(shared serial parse), two-phase cannot exceed ~35 GB/s; its only lever is
+a faster copy, which single-pass optimizes equally without a table or
+barrier. The perf pass (#16) targets the copy first (the per-byte 64-bit
+modulo in the gather) to pull end-to-end toward the parse ceiling, then the
+parse (register-window staging) to raise it. Recorded in
+[docs/BENCHMARKS.md](BENCHMARKS.md); the falsification trigger is evaluated
+at #16.
+
 **Known limits, published:** the redundant-parse family ceiling is roughly
 250–400 GB/s after perf passes — deliberately accepted under "formats over
 percentage points"; batches under ~2,000 chunks underfill the machine and

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -1,88 +1,7 @@
 #include "cudec.h"
-#include "lz4_block.h"
+#include "lz4_decode.cuh"
 
 #include <cuda_runtime.h>
-
-namespace {
-
-constexpr unsigned kWarpSize = 32;
-constexpr unsigned kBlockWarps = 4;
-constexpr unsigned kBlockThreads = kWarpSize * kBlockWarps;  /* 128 */
-
-/* Warp-per-chunk LZ4 block decode (masterplan section 9). All 32 lanes run
- * the validated parser redundantly in lockstep - identical bytes, identical
- * arithmetic, identical registers, so no leader lane and no shuffles - and
- * fan out by lane for every copy. Overlapping matches use the closed-form
- * modular gather dst[m+i] = dst[m-off + (i mod off)], which reads only from
- * the region finalized before this match; off >= 1 is guaranteed by the
- * parser's offset==0 rejection, so the modulo never divides by zero. */
-__global__ void __launch_bounds__(kBlockThreads)
-    lz4_decode_batch(const void* const* src_ptrs, const size_t* src_sizes,
-                     void* const* dst_ptrs, const size_t* dst_caps,
-                     size_t chunk_count, cudec_chunk_result* results) {
-    const unsigned lane = threadIdx.x % kWarpSize;
-    /* The global thread id fits in 32 bits because the host caps the grid
-     * at kMaxBlocks (8192) x kBlockThreads (128) ~ 1.05M threads; if that
-     * cap were ever raised past ~33M blocks (~4.3B threads), widen this
-     * to size_t. */
-    const size_t warp_in_grid =
-        (blockIdx.x * blockDim.x + threadIdx.x) / kWarpSize;
-    const size_t total_warps =
-        (static_cast<size_t>(gridDim.x) * blockDim.x) / kWarpSize;
-
-    for (size_t chunk = warp_in_grid; chunk < chunk_count;
-         chunk += total_warps) {
-        const unsigned char* src =
-            static_cast<const unsigned char*>(src_ptrs[chunk]);
-        /* dst must NOT be __restrict__-qualified: the cross-lane read after
-         * write below relies on __syncwarp() forcing a reload from global
-         * memory, and __restrict__ could legally let the compiler cache a
-         * dst[] value across the barrier, silently breaking lane-to-lane
-         * visibility. */
-        unsigned char* dst = static_cast<unsigned char*>(dst_ptrs[chunk]);
-
-        cudec_detail::Lz4Parser parser{src, src_sizes[chunk], dst_caps[chunk]};
-        cudec_detail::Lz4Sequence seq;
-        cudec_status status = CUDEC_OK;
-        bool done = false;
-        while (true) {
-            status = parser.Next(&seq, &done);
-            if (status != CUDEC_OK) {
-                break;
-            }
-            for (uint64_t i = lane; i < seq.literals_len; i += kWarpSize) {
-                dst[seq.literals_dst + i] = src[seq.literals_src + i];
-            }
-            /* The match may read literal bytes just written above. */
-            __syncwarp();
-            if (seq.match_len != 0) {
-                const uint64_t offset = seq.match_dst - seq.match_src;
-                for (uint64_t i = lane; i < seq.match_len; i += kWarpSize) {
-                    dst[seq.match_dst + i] =
-                        dst[seq.match_src + (i % offset)];
-                }
-                /* The next sequence may read bytes this match wrote. */
-                __syncwarp();
-            }
-            if (done) {
-                break;
-            }
-        }
-
-        /* All lanes agree on status and dst_pos (redundant parse); one lane
-         * writes the 16-byte result. bytes_written is set on full success
-         * only - a rejected chunk reports zero and never presents its
-         * partial output as valid. */
-        if (lane == 0) {
-            results[chunk].status = status;
-            results[chunk].reserved = 0;
-            results[chunk].bytes_written =
-                (status == CUDEC_OK) ? parser.dst_pos : 0;
-        }
-    }
-}
-
-}  // namespace
 
 cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
                                         const size_t* d_src_sizes,
@@ -91,20 +10,11 @@ cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
                                         size_t chunk_count,
                                         cudec_chunk_result* d_results,
                                         cudec_stream_t stream) {
-    /* Fail closed: reject the whole call rather than guess at intent. The
-     * bound rejects absurd counts while staying well under SIZE_MAX (the
-     * grid is capped independently, so the launch geometry never
-     * overflows); d_results is 16-byte aligned so each per-chunk result
-     * record lands in a single aligned 16-byte slot. */
-    constexpr size_t kMaxChunks = static_cast<size_t>(INT32_MAX) * kWarpSize;
-    static_assert(kMaxChunks < SIZE_MAX,
-                  "the SIZE_MAX over-limit contract test relies on this");
-    if (d_src_ptrs == nullptr || d_src_sizes == nullptr ||
-        d_dst_ptrs == nullptr || d_dst_capacities == nullptr ||
-        d_results == nullptr ||
-        reinterpret_cast<uintptr_t>(d_results) % 16 != 0 || chunk_count == 0 ||
-        chunk_count > kMaxChunks) {
-        return CUDEC_ERR_INVALID_ARGUMENT;
+    const cudec_status valid = cudec_detail::validate_batch_args(
+        d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
+        d_results);
+    if (valid != CUDEC_OK) {
+        return valid;
     }
 
     /* Drain any error already pending on this thread so the post-launch
@@ -112,16 +22,10 @@ cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
      * call consumes the pending error state. */
     (void)cudaGetLastError();
 
-    /* One warp per chunk; the grid is sized to cover the batch in a single
-     * wave up to a cap that already fills the target GPU, and the kernel's
-     * grid-stride loop handles any remainder. */
-    constexpr size_t kMaxBlocks = 8192;
-    size_t blocks = (chunk_count + kBlockWarps - 1) / kBlockWarps;
-    if (blocks > kMaxBlocks) {
-        blocks = kMaxBlocks;
-    }
-    lz4_decode_batch<<<static_cast<unsigned>(blocks), kBlockThreads, 0,
-                       stream>>>(d_src_ptrs, d_src_sizes, d_dst_ptrs,
-                                 d_dst_capacities, chunk_count, d_results);
+    cudec_detail::lz4_decode_batch<false>
+        <<<cudec_detail::decode_grid_blocks(chunk_count),
+           cudec_detail::kBlockThreads, 0, stream>>>(
+            d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
+            d_results);
     return cudaGetLastError() == cudaSuccess ? CUDEC_OK : CUDEC_ERR_CUDA;
 }

--- a/src/lz4_decode.cuh
+++ b/src/lz4_decode.cuh
@@ -1,0 +1,127 @@
+/* The warp-per-chunk LZ4 decode kernel, templated on the copy mode so the
+ * shipped decoder and the bench's parse-only ceiling share ONE parse (an
+ * honest ceiling - masterplan section 9). The public entry (src/batch.cu)
+ * instantiates Full; the bench instantiates ParseOnly. Each translation
+ * unit emits only the instantiation it launches, so the shipped library
+ * carries no parse-only kernel. Internal header, not part of the ABI. */
+#ifndef CUDEC_LZ4_DECODE_CUH
+#define CUDEC_LZ4_DECODE_CUH
+
+#include "cudec.h"
+#include "lz4_block.h"
+
+#include <cuda_runtime.h>
+
+namespace cudec_detail {
+
+constexpr unsigned kWarpSize = 32;
+constexpr unsigned kBlockWarps = 4;
+constexpr unsigned kBlockThreads = kWarpSize * kBlockWarps;  /* 128 */
+
+/* One warp per chunk over a grid-stride loop. All 32 lanes run the
+ * validated parser redundantly in lockstep and fan out by lane for every
+ * copy; overlapping matches use the closed-form modular gather
+ * dst[m+i] = dst[m-off + (i mod off)] (off >= 1 by the parser's offset==0
+ * rejection, so no modulo-by-zero). __syncwarp() carries intra-warp memory
+ * ordering at the two copy boundaries. ParseOnly elides the copies and the
+ * syncs to isolate the parse cost - it writes no output and is a bench
+ * ceiling only, never shipped. */
+template <bool ParseOnly>
+__global__ void __launch_bounds__(kBlockThreads)
+    lz4_decode_batch(const void* const* src_ptrs, const size_t* src_sizes,
+                     void* const* dst_ptrs, const size_t* dst_caps,
+                     size_t chunk_count, cudec_chunk_result* results) {
+    const unsigned lane = threadIdx.x % kWarpSize;
+    const size_t warp_in_grid =
+        (blockIdx.x * blockDim.x + threadIdx.x) / kWarpSize;
+    const size_t total_warps =
+        (static_cast<size_t>(gridDim.x) * blockDim.x) / kWarpSize;
+
+    for (size_t chunk = warp_in_grid; chunk < chunk_count;
+         chunk += total_warps) {
+        const unsigned char* src =
+            static_cast<const unsigned char*>(src_ptrs[chunk]);
+        /* dst must NOT be __restrict__-qualified: the cross-lane read after
+         * write below relies on __syncwarp() forcing a reload from global
+         * memory, and __restrict__ could legally let the compiler cache a
+         * dst[] value across the barrier. */
+        unsigned char* dst = static_cast<unsigned char*>(dst_ptrs[chunk]);
+
+        Lz4Parser parser{src, src_sizes[chunk], dst_caps[chunk]};
+        Lz4Sequence seq;
+        cudec_status status = CUDEC_OK;
+        bool done = false;
+        while (true) {
+            status = parser.Next(&seq, &done);
+            if (status != CUDEC_OK) {
+                break;
+            }
+            if constexpr (!ParseOnly) {
+                for (uint64_t i = lane; i < seq.literals_len; i += kWarpSize) {
+                    dst[seq.literals_dst + i] = src[seq.literals_src + i];
+                }
+                /* The match may read literal bytes just written above. */
+                __syncwarp();
+                if (seq.match_len != 0) {
+                    const uint64_t offset = seq.match_dst - seq.match_src;
+                    for (uint64_t i = lane; i < seq.match_len;
+                         i += kWarpSize) {
+                        dst[seq.match_dst + i] =
+                            dst[seq.match_src + (i % offset)];
+                    }
+                    /* The next sequence may read bytes this match wrote. */
+                    __syncwarp();
+                }
+            }
+            if (done) {
+                break;
+            }
+        }
+
+        /* All lanes agree on status and dst_pos (redundant parse); one lane
+         * writes the 16-byte result. bytes_written is set on full success
+         * only - a rejected chunk reports zero and never presents partial
+         * output as valid. */
+        if (lane == 0) {
+            results[chunk].status = status;
+            results[chunk].reserved = 0;
+            results[chunk].bytes_written =
+                (status == CUDEC_OK) ? parser.dst_pos : 0;
+        }
+    }
+}
+
+/* One warp per chunk up to a cap that already fills the target GPU; the
+ * grid-stride loop covers any remainder. */
+inline unsigned decode_grid_blocks(size_t chunk_count) {
+    constexpr size_t kMaxBlocks = 8192;
+    size_t blocks = (chunk_count + kBlockWarps - 1) / kBlockWarps;
+    return static_cast<unsigned>(blocks > kMaxBlocks ? kMaxBlocks : blocks);
+}
+
+/* Fail-closed argument validation, shared by the public entry and the
+ * bench. The bound rejects absurd counts while staying under SIZE_MAX (the
+ * grid is capped independently); d_results is 16-byte aligned so each
+ * per-chunk result record lands in a single aligned slot. */
+inline cudec_status validate_batch_args(const void* const* d_src_ptrs,
+                                        const size_t* d_src_sizes,
+                                        void* const* d_dst_ptrs,
+                                        const size_t* d_dst_capacities,
+                                        size_t chunk_count,
+                                        cudec_chunk_result* d_results) {
+    constexpr size_t kMaxChunks = static_cast<size_t>(INT32_MAX) * kWarpSize;
+    static_assert(kMaxChunks < SIZE_MAX,
+                  "the SIZE_MAX over-limit contract test relies on this");
+    if (d_src_ptrs == nullptr || d_src_sizes == nullptr ||
+        d_dst_ptrs == nullptr || d_dst_capacities == nullptr ||
+        d_results == nullptr ||
+        reinterpret_cast<uintptr_t>(d_results) % 16 != 0 ||
+        chunk_count == 0 || chunk_count > kMaxChunks) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_LZ4_DECODE_CUH */


### PR DESCRIPTION
# What & why

M1 ladder step 4 (masterplan section 9): the GPU decoder joins the bench harness as a second timed path, and the decomposition question is settled by measurement. Closes #15.

**First GPU decode numbers (Silesia, device-resident, RTX 3080): ~18 GB/s p50 (~5x the single-thread CPU baseline of 3.53 GB/s); parse-only ceiling ~35 GB/s (~10x CPU).**

The kernel was extracted into a header templated on `<bool ParseOnly>` so the shipped decoder and the bench's parse-only ceiling share one parse (an honest ceiling); the Full instantiation is behavior-identical to the merged kernel (whole-Silesia diff still 0 mismatch / 0 nondeterministic).

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support
- [ ] API surface
- [x] Performance
- [x] Build / CI / supply chain
- [x] Docs
- [x] Refactor / code quality

## Engineering checklist

- [x] Fail-closed preserved: the refactor moves the kernel verbatim behind a template; validation, the closed-form gather, and the two syncwarps are unchanged (whole-Silesia diff re-run: 0 mismatch).
- [x] Oracle coverage: gpu_bench gates every reported number on a full-decode correctness precondition (every chunk must decode OK with bytes_written == original size).
- [x] Determinism preserved: whole-Silesia same-batch-twice bit-identical.
- [x] Every CUDA call's error checked (gpu_bench BG_CUDA macro; host launch drain + check).
- [x] Adversarial review run - see Notes.

## Performance checklist

- [x] The claim is measured, device-resident, CUDA-event timed, warmup-excluded, nearest-rank p50; methodology in docs/BENCHMARKS.md.
- [x] No regression: this establishes the first GPU baseline.

## Quality checklist

- [x] Minimal: the parse-only variant reuses the shipped parse via templating - no duplicate kernel; gpu_bench owns all CUDA so bench_lz4 stays host-only.
- [x] Self-documenting: the honest-ceiling rationale, the device-resident timing, and the decision-rule reading each carry their why.
- [x] Conformance tests pass; bench_selfcheck stays CPU-only for the GPU-less CI runner.

## Verification

- [x] `cmake --build` - both configurations clean under warnings-as-errors.
- [x] `ctest` - 7/7 on the RTX 3080.
- [x] Whole-Silesia GPU-vs-oracle diff on the refactored kernel: 3239 chunks, 0 mismatch, 0 nondeterministic.
- [x] CI-parity run without a GPU: green, all identity pins (the --gpu path never runs in CI).
- [x] Prettier - clean.
- [x] Docs: BENCHMARKS.md GPU numbers + decision verdict; masterplan section 9 measured outcome.

## Notes

**The decision rule (masterplan section 9), settled for single-pass.** The parse-only number ceilings both single-pass and any two-phase phase-1 (they share the identical serial parse; parse-only even over-estimates phase-1 since it builds no descriptor table), so two-phase cannot exceed ~35 GB/s. Its only lever is a faster copy - which single-pass optimizes equally without a table or barrier. The perf pass (#16) targets the copy (the per-byte 64-bit modulo in the gather) first, then the parse (register-window staging); the falsification trigger is evaluated there.

Reviewed on two vectors: (1) refactor equivalence - `lz4_decode_batch<false>` is behavior-identical to the merged kernel (verified line-by-line + whole-Silesia diff); (2) honest-numbers - the timed region is device-resident, warmup-excluded, gated on a full-decode correctness precondition, and the parse-only ceiling is fair and conservative (the parser skips the literal payload, so the elision removes no read a real phase-1 would pay). One finding: the GPU p50 used size/2 indexing vs the CPU path's nearest-rank - reconciled (non-flattering, but the methodology block is load-bearing); a sub-microsecond div-by-zero was guarded. No declined findings.

Deferred (recorded as a follow-up issue): the worst-4Bmatch adversarial-valid corpus graft - kept out to focus this PR on the first numbers; it is a bench enhancement, not the milestone deliverable.

CodeRabbit remains uninstalled on this repository (see #7); merging on CI + the review protocol above.