### PR TITLE
Record the perf pass 1 findings: the designed micro-optimizations are rejected

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -41,16 +41,42 @@ design (a two-phase phase-1 runs the identical serial parse, so it cannot
 exceed ~35 GB/s either). Two-phase's only lever is a faster phase-2 copy —
 but single-pass's copy is equally optimizable, and doing so needs no table,
 no barrier, and no extra memory traffic. **The decomposition question is
-therefore settled for single-pass.** The perf pass (#16) targets the copy
-first (vectorized multi-byte lane copies + incremental-mod, to pull
-end-to-end toward the ~35 GB/s parse ceiling) and the parse itself second
-(register-window staging, to raise the ceiling). The masterplan
-falsification trigger — reopen two-phase only if the shipped kernel measures
-below ~15x CPU after perf pass 1, or profiling attributes the majority of
-stalls to copy starvation — is evaluated at #16.
+therefore settled for single-pass.** Perf pass 1 (#16) then measured the
+two designed copy/parse micro-optimizations; both were rejected on hardware
+(see "Perf pass 1" below), and the falsification trigger is evaluated there.
 
 Occupancy readout (issue #14): 46 registers/thread, so ≥ 32 warps/SM is
 achievable on sm_86.
+
+### Perf pass 1 (issue #16): the designed micro-optimizations do not help
+
+Both optimizations the #6 design panel grafted for perf pass 1 were
+implemented and measured on Silesia against the ~18 GB/s baseline; **both
+were rejected by measurement** (masterplan rule: accepted only on recorded
+improvement):
+
+| Attempt                                        | Result          | Why                                                                                                                                  |
+| ---------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Incremental-mod match gather                   | ~15 GB/s (−16%) | the loop-carried `r += step` dependency pipelines worse than the independent per-iteration `i % offset`, which the compiler overlaps |
+| Vectorized (16-byte) literal copy              | ~17 GB/s (−6%)  | Silesia's literal runs are mostly < 16 bytes, so the wide path rarely triggers and only adds setup/branch overhead                   |
+| `__syncwarp` elision on zero-literal sequences | neutral         | the barriers are not the bottleneck                                                                                                  |
+
+The empirical conclusion: the minimal-correct byte-per-lane kernel is at a
+local optimum for this workload. The bottleneck is **structural** — the
+redundant 32-lane parse sets the ~34 GB/s ceiling, and the copies are
+latency-bound on the short literal/match runs typical of real data, where
+neither a cheaper modulo nor wider copies help. Meaningful gains require
+raising the parse ceiling itself (higher occupancy via register reduction,
+or warp-specialization), which is larger than a micro-op pass — tracked as
+a follow-up (issue #21).
+
+**Falsification-trigger verdict (masterplan section 9).** The shipped
+kernel is ~5× CPU (below the ~15× reopen threshold), but two-phase stays
+**ruled out**: the parse-only ceiling (~10× CPU) bounds any two-phase
+phase-1, which shares the identical serial parse, so two-phase cannot reach
+~15× either. The trigger's numeric condition is met while its purpose — does
+two-phase help? — is answered NO by the arithmetic. The path to higher
+throughput is structural single-pass work, not a decomposition change.
 
 ## Baseline: CPU oracle (M0, pre-kernel)
 

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -292,11 +292,20 @@ parse-only ceiling is ~35 GB/s (~10× CPU) — so parse and copy each cost
 roughly half the wall time. Since parse-only ceilings any two-phase phase-1
 (shared serial parse), two-phase cannot exceed ~35 GB/s; its only lever is
 a faster copy, which single-pass optimizes equally without a table or
-barrier. The perf pass (#16) targets the copy first (the per-byte 64-bit
-modulo in the gather) to pull end-to-end toward the parse ceiling, then the
-parse (register-window staging) to raise it. Recorded in
-[docs/BENCHMARKS.md](BENCHMARKS.md); the falsification trigger is evaluated
-at #16.
+barrier. Recorded in [docs/BENCHMARKS.md](BENCHMARKS.md).
+
+**Perf pass 1 outcome (issue #16): the designed micro-optimizations were
+rejected by measurement** — the incremental-mod gather regressed 16% (its
+loop-carried dependency pipelines worse than the independent modulo the
+compiler overlaps) and the vectorized literal copy regressed 6% (real
+literal runs are too short for the wide path); a `__syncwarp` elision was
+neutral. The kernel is at a local optimum for its structure; the bottleneck
+is structural (the redundant 32-lane parse ceiling and latency-bound
+short-run copies), so raising throughput needs higher occupancy or
+warp-specialization — larger than a micro-op pass, tracked as issue #21. The
+falsification trigger does NOT reopen two-phase: it stays ruled out by the
+shared parse ceiling regardless of the numeric condition (see
+BENCHMARKS.md).
 
 **Known limits, published:** the redundant-parse family ceiling is roughly
 250–400 GB/s after perf passes — deliberately accepted under "formats over


### PR DESCRIPTION
# What & why

M1 ladder step 5 (masterplan section 9), perf pass 1, a documented negative result. The two optimizations the #6 design panel grafted were implemented and measured on Silesia against the ~18 GB/s baseline; **both regressed and are not shipped** (masterplan rule: accepted only on recorded improvement). Docs-only; the kernel is unchanged (working tree is byte-identical to the merged baseline). Closes #16.

| Attempt | Result | Why |
|---|---|---|
| Incremental-mod match gather | ~15 GB/s (−16%) | the loop-carried `r += step` dependency pipelines worse than the independent per-iteration `i % offset` the compiler overlaps |
| Vectorized 16-byte literal copy | ~17 GB/s (−6%) | real literal runs are mostly < 16 bytes, so the wide path rarely triggers and adds overhead |
| `__syncwarp` elision on zero-literal sequences | neutral | the barriers are not the bottleneck |

This is the exact "verify empirically, not by authoritative-sounding reasoning" case the project's invariants call out: grafts that looked good on paper lose on hardware. The kernel is at a local optimum for its byte-per-lane structure; the bottleneck is structural (the redundant 32-lane parse ceiling and latency-bound short-run copies), so meaningful gains need higher occupancy or warp-specialization, larger than a micro-op pass, tracked as #21 (M2).

**Falsification-trigger verdict.** The shipped kernel is ~5x CPU (below the ~15x reopen threshold), but two-phase stays **ruled out**: the parse-only ceiling (~10x) bounds any two-phase phase-1 (shared serial parse), so it cannot reach ~15x either. The trigger's numeric condition is met while its purpose, does two-phase help?, is answered NO by the arithmetic.

## Type of change

- [x] Performance
- [x] Docs

## Verification

- [x] Working tree is byte-identical to the merged kernel (no code change); the three attempts were measured on branches and reverted.
- [x] Each attempt built clean and passed all 7 tests before being measured and rejected (correctness held; only throughput was the question).
- [x] Prettier - clean.
- [x] Docs: BENCHMARKS.md gains the perf-pass-1 table + trigger verdict; masterplan section 9 records the outcome and reconciles the earlier forward-looking prose.

## Notes

No code change means no adversarial-review gate (docs only). The follow-up (#21) carries the structural levers (occupancy/register reduction, warp-specialization, two-sequence pipelining) into M2, deferred under "formats over percentage points", the next format outranks the next throughput percent.

CodeRabbit remains uninstalled (see #7); merging on CI.