### PR TITLE
Add LZ4 frame format decode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,8 @@ jobs:
           cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON &&
           cmake --build build-cuda -j &&
           test -x build-cuda/tests/smoke &&
-          test -x build-cuda/tests/gpu_fixture
+          test -x build-cuda/tests/gpu_fixture &&
+          test -x build-cuda/tests/frame_twin
 
       # The host-side subset; gpu-labeled tests run in this same container
       # on the maintainer's machine and their output is pasted into the PR.
@@ -98,7 +99,8 @@ jobs:
           echo "Deferred to the local GPU gate:" &&
           ctest --test-dir build-cuda -L gpu -N | tee gpu-deferred.txt &&
           grep -E ': smoke$' gpu-deferred.txt &&
-          grep -E ': gpu_fixture$' gpu-deferred.txt
+          grep -E ': gpu_fixture$' gpu-deferred.txt &&
+          grep -E ': frame_twin$' gpu-deferred.txt
 
   format:
     name: format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,20 @@ if(CUDEC_ENABLE_CUDA)
   set(CUDEC_CUDA_STRICT_FLAGS
       $<$<COMPILE_LANGUAGE:CUDA>:${CUDEC_CUDA_STRICT_FLAGS_RAW}>)
 
-  target_sources(cudec PRIVATE src/batch.cu)
+  # frame.cpp (the LZ4 frame orchestrator) is host C++ that drives the
+  # device batch decoder, so it needs the CUDA runtime.
+  find_package(CUDAToolkit REQUIRED)
+  target_sources(cudec PRIVATE src/batch.cu src/frame.cpp)
+  target_link_libraries(cudec PRIVATE CUDA::cudart)
   # The cudec target predates enable_language(CUDA), so the architecture
   # list must be applied as an explicit target property.
   set_target_properties(
     cudec PROPERTIES CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON
+                     CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON
                      CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
-  target_compile_options(cudec PRIVATE ${CUDEC_CUDA_STRICT_FLAGS})
+  target_compile_options(
+    cudec PRIVATE ${CUDEC_CUDA_STRICT_FLAGS}
+                  $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror>)
 
   # Keep tests/ after everything that may touch the cudec target: its
   # conformance checks snapshot the target's properties at this point -

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -28,7 +28,11 @@ typedef enum cudec_status {
     CUDEC_ERR_CORRUPT_INPUT = 2,
     CUDEC_ERR_OUTPUT_TOO_SMALL = 3,
     CUDEC_ERR_CUDA = 4,
-    CUDEC_ERR_NOT_IMPLEMENTED = 5
+    CUDEC_ERR_NOT_IMPLEMENTED = 5,
+    /* A well-formed frame that uses a feature cudec does not decode
+     * (block-linked mode, a dictionary id). Distinct from CORRUPT_INPUT:
+     * the input is valid, just outside cudec's supported subset. */
+    CUDEC_ERR_UNSUPPORTED = 6
 } cudec_status;
 
 /* Binary-compatible with cudaStream_t without pulling in the CUDA headers:
@@ -95,6 +99,30 @@ cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
                                         size_t chunk_count,
                                         cudec_chunk_result* d_results,
                                         cudec_stream_t stream);
+
+/* Decode a single LZ4 frame (the .lz4 container: magic, frame descriptor,
+ * data blocks, end mark, optional checksums) from host memory into host
+ * memory, using the GPU batch decoder internally. Synchronous.
+ *
+ * `frame`/`frame_size` is the whole frame in host memory; the decoded
+ * output is written to `dst` (host, `dst_capacity` bytes) and the produced
+ * size is returned in `*bytes_written`.
+ *
+ * Supported subset: block-INDEPENDENT frames (compress with
+ * LZ4F_blockIndependent). The header, block, and content checksums and the
+ * optional declared content size, when present, are verified fail-closed.
+ * Returns CUDEC_ERR_UNSUPPORTED for a valid frame cudec does not decode
+ * (block-linked mode - the default of liblz4's frame compressor - or a
+ * dictionary id), CUDEC_ERR_CORRUPT_INPUT for a malformed frame, a checksum
+ * mismatch, or a declared content size that does not match the decoded
+ * size, CUDEC_ERR_OUTPUT_TOO_SMALL when `dst_capacity` is too small, and
+ * CUDEC_ERR_CUDA on a device or host resource failure. A NULL `frame` or
+ * `bytes_written`, or a NULL `dst` with a non-zero `dst_capacity`, returns
+ * CUDEC_ERR_INVALID_ARGUMENT. On any error `*bytes_written` is 0 and no
+ * partial output is presented as a valid decode. */
+cudec_status cudec_lz4f_decompress(const void* frame, size_t frame_size,
+                                   void* dst, size_t dst_capacity,
+                                   size_t* bytes_written);
 
 #ifdef __cplusplus
 }

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -1,0 +1,340 @@
+/* LZ4 frame (.lz4 container) decode: host-side frame parse + the GPU block
+ * batch decoder (cudec_lz4_decompress_batch) for the compressed blocks,
+ * then assembly and checksum verification. Host orchestration on top of
+ * the device engine - masterplan section 3 (M2). Supported subset:
+ * block-independent frames; the header/block/content checksums and the
+ * optional declared content size are verified fail-closed. Frame spec
+ * (public): lz4_Frame_format.md. */
+#include "cudec.h"
+#include "xxhash32.h"
+
+#include <cuda_runtime.h>
+
+#include <cstring>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kLz4FrameMagic = 0x184D2204u;
+
+uint32_t Read32LE(const unsigned char* p) {
+    uint32_t v;
+    std::memcpy(&v, p, 4);
+    return v; /* the frame format and the target hosts are little-endian */
+}
+
+uint64_t Read64LE(const unsigned char* p) {
+    uint64_t v;
+    std::memcpy(&v, p, 8);
+    return v;
+}
+
+/* A parsed data block: an offset/length into the frame, and whether it is
+ * stored uncompressed (a straight copy) or LZ4-compressed (GPU-decoded). */
+struct FrameBlock {
+    size_t src_off;
+    size_t src_len;
+    bool uncompressed;
+};
+
+/* Owns one cudaMalloc allocation and frees it on every scope exit - so the
+ * device buffers are reclaimed on ALL return paths, including the hostile-
+ * input reject paths, not just on success. A leak on the expected corrupt-
+ * frame path is a GPU-memory-exhaustion DoS in a library entry point. */
+struct DevPtr {
+    void* p = nullptr;
+    DevPtr() = default;
+    DevPtr(const DevPtr&) = delete;
+    DevPtr& operator=(const DevPtr&) = delete;
+    ~DevPtr() {
+        /* Cleanup errors are not actionable and must not mask the real
+         * status; the discard is deliberate. */
+        if (p != nullptr) {
+            (void)cudaFree(p);
+        }
+    }
+    cudaError_t alloc(size_t bytes) { return cudaMalloc(&p, bytes); }
+};
+
+/* Decodes the compressed blocks in one device batch and assembles the whole
+ * frame output (compressed decoded bytes + uncompressed blocks copied
+ * verbatim) into `out`, bounded by dst_capacity, writing the produced size
+ * to *total_out. Every CUDA failure maps to a defined status; a block the
+ * decoder rejects makes the whole frame CORRUPT_INPUT.
+ *
+ * Staging is a single source buffer and a single destination buffer (not a
+ * cudaMalloc per block): device memory stays bounded, an oversized hostile
+ * frame fails fast and cleanly on one allocation instead of a per-block
+ * allocation storm, and the shape is closer to what the pinned-host
+ * streaming path (issue #24) needs. #24 still supersedes it (overlap,
+ * pinned memory, per-block dst sizing). */
+cudec_status DecodeAndAssemble(const unsigned char* frame,
+                               const std::vector<FrameBlock>& blocks,
+                               size_t block_max, unsigned char* out,
+                               size_t dst_capacity, size_t* total_out) {
+#define FRAME_CUDA(call)                        \
+    do {                                        \
+        if ((call) != cudaSuccess) {            \
+            return CUDEC_ERR_CUDA;              \
+        }                                       \
+    } while (0)
+
+    std::vector<size_t> cidx;
+    size_t total_src = 0;
+    for (size_t i = 0; i < blocks.size(); i++) {
+        if (!blocks[i].uncompressed) {
+            cidx.push_back(i);
+            total_src += blocks[i].src_len;
+        }
+    }
+    const size_t n = cidx.size();
+
+    /* Decoded output size per block; uncompressed blocks use src_len. */
+    std::vector<size_t> decoded_len(blocks.size(), 0);
+
+    DevPtr d_src, d_dst, dd_src, dd_dst, dd_ssz, dd_dcp, dd_res;
+    if (n != 0) {
+        /* One destination slot of block_max per compressed block. Guard the
+         * product against size_t overflow before asking the driver. */
+        if (block_max != 0 && n > SIZE_MAX / block_max) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        FRAME_CUDA(d_src.alloc(total_src));
+        FRAME_CUDA(d_dst.alloc(n * block_max));
+
+        std::vector<const void*> h_src(n);
+        std::vector<void*> h_dst(n);
+        std::vector<size_t> h_ssz(n), h_dcp(n);
+        {
+            /* Gather the (non-contiguous) compressed block sources into one
+             * host staging buffer and copy them up in a single transfer. */
+            std::vector<unsigned char> stage(total_src);
+            size_t so = 0;
+            for (size_t k = 0; k < n; k++) {
+                const FrameBlock& b = blocks[cidx[k]];
+                std::memcpy(stage.data() + so, frame + b.src_off, b.src_len);
+                h_src[k] = static_cast<unsigned char*>(d_src.p) + so;
+                h_ssz[k] = b.src_len;
+                h_dst[k] = static_cast<unsigned char*>(d_dst.p) + k * block_max;
+                h_dcp[k] = block_max;
+                so += b.src_len;
+            }
+            FRAME_CUDA(cudaMemcpy(d_src.p, stage.data(), total_src,
+                                  cudaMemcpyHostToDevice));
+        }
+
+        FRAME_CUDA(dd_src.alloc(n * sizeof(void*)));
+        FRAME_CUDA(dd_dst.alloc(n * sizeof(void*)));
+        FRAME_CUDA(dd_ssz.alloc(n * sizeof(size_t)));
+        FRAME_CUDA(dd_dcp.alloc(n * sizeof(size_t)));
+        FRAME_CUDA(dd_res.alloc(n * sizeof(cudec_chunk_result)));
+        FRAME_CUDA(cudaMemcpy(dd_src.p, h_src.data(), n * sizeof(void*),
+                              cudaMemcpyHostToDevice));
+        FRAME_CUDA(cudaMemcpy(dd_dst.p, h_dst.data(), n * sizeof(void*),
+                              cudaMemcpyHostToDevice));
+        FRAME_CUDA(cudaMemcpy(dd_ssz.p, h_ssz.data(), n * sizeof(size_t),
+                              cudaMemcpyHostToDevice));
+        FRAME_CUDA(cudaMemcpy(dd_dcp.p, h_dcp.data(), n * sizeof(size_t),
+                              cudaMemcpyHostToDevice));
+
+        const cudec_status launched = cudec_lz4_decompress_batch(
+            static_cast<const void* const*>(dd_src.p),
+            static_cast<const size_t*>(dd_ssz.p),
+            static_cast<void* const*>(dd_dst.p),
+            static_cast<const size_t*>(dd_dcp.p), n,
+            static_cast<cudec_chunk_result*>(dd_res.p), nullptr);
+        if (launched != CUDEC_OK) {
+            return launched;
+        }
+        FRAME_CUDA(cudaDeviceSynchronize());
+
+        std::vector<cudec_chunk_result> res(n);
+        FRAME_CUDA(cudaMemcpy(res.data(), dd_res.p,
+                              n * sizeof(cudec_chunk_result),
+                              cudaMemcpyDeviceToHost));
+        for (size_t k = 0; k < n; k++) {
+            /* Any per-block failure means the frame's block data is corrupt.
+             * The per-block dst capacity is our internal block_max, never the
+             * caller's dst, so a block-level OUTPUT_TOO_SMALL is an over-long
+             * corrupt block - map every non-OK block to CORRUPT_INPUT rather
+             * than leaking the internal capacity as the caller's status. */
+            if (res[k].status != CUDEC_OK ||
+                res[k].bytes_written > block_max) {
+                return CUDEC_ERR_CORRUPT_INPUT;
+            }
+            decoded_len[cidx[k]] = res[k].bytes_written;
+        }
+    }
+
+    /* Compute the assembled layout and total size, and check the caller's
+     * capacity BEFORE writing a single byte - so a too-small buffer yields
+     * OUTPUT_TOO_SMALL with no partial output left in `out`. */
+    size_t total = 0;
+    for (size_t i = 0; i < blocks.size(); i++) {
+        const size_t len =
+            blocks[i].uncompressed ? blocks[i].src_len : decoded_len[i];
+        if (len > dst_capacity - total) {
+            return CUDEC_ERR_OUTPUT_TOO_SMALL;
+        }
+        total += len;
+    }
+
+    /* Place each block at its prefix offset: uncompressed blocks copied from
+     * the frame, compressed blocks copied straight from device to `out` (no
+     * intermediate host buffer, no second copy). */
+    size_t off = 0;
+    size_t k = 0;
+    for (size_t i = 0; i < blocks.size(); i++) {
+        if (blocks[i].uncompressed) {
+            if (blocks[i].src_len != 0) {
+                std::memcpy(out + off, frame + blocks[i].src_off,
+                            blocks[i].src_len);
+            }
+            off += blocks[i].src_len;
+        } else {
+            const size_t len = decoded_len[i];
+            if (len != 0) {
+                const unsigned char* dsrc =
+                    static_cast<unsigned char*>(d_dst.p) + k * block_max;
+                FRAME_CUDA(cudaMemcpy(out + off, dsrc, len,
+                                      cudaMemcpyDeviceToHost));
+            }
+            off += len;
+            k++;
+        }
+    }
+
+    *total_out = total;
+    return CUDEC_OK;
+#undef FRAME_CUDA
+}
+
+/* The frame decode proper; wrapped by the extern "C" entry point in a
+ * try/catch so a host allocation failure can never cross the C ABI. */
+cudec_status DecodeFrame(const unsigned char* f, size_t frame_size,
+                         unsigned char* out, size_t dst_capacity,
+                         size_t* bytes_written) {
+    /* Magic (4) + FLG (1) + BD (1) + HC (1) is the minimum header. */
+    if (frame_size < 7 || Read32LE(f) != kLz4FrameMagic) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+    const unsigned flg = f[4];
+    const unsigned bd = f[5];
+    if (((flg >> 6) & 3) != 1 || (flg & 2) != 0) {
+        return CUDEC_ERR_CORRUPT_INPUT; /* version / reserved bit */
+    }
+    const bool block_independent = (flg >> 5) & 1;
+    const bool block_checksum = (flg >> 4) & 1;
+    const bool content_size = (flg >> 3) & 1;
+    const bool content_checksum = (flg >> 2) & 1;
+    const bool dict_id = flg & 1;
+    if ((bd & 0x8F) != 0) {
+        return CUDEC_ERR_CORRUPT_INPUT; /* BD reserved bits */
+    }
+    const unsigned bmax = (bd >> 4) & 7;
+    if (bmax < 4 || bmax > 7) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+    const size_t block_max = (size_t{64} << 10) << ((bmax - 4) * 2);
+    if (!block_independent || dict_id) {
+        return CUDEC_ERR_UNSUPPORTED; /* linked blocks / dictionaries */
+    }
+
+    /* Header checksum covers FLG..end-of-descriptor. */
+    size_t pos = 6;
+    uint64_t declared_content_size = 0;
+    if (content_size) {
+        if (frame_size < pos + 8) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        declared_content_size = Read64LE(f + pos);
+        pos += 8;
+    }
+    if (frame_size < pos + 1) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+    const unsigned hc = f[pos];
+    if (((cudec_detail::xxhash32(f + 4, pos - 4) >> 8) & 0xFF) != hc) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+    pos += 1;
+
+    std::vector<FrameBlock> blocks;
+    while (true) {
+        if (frame_size < pos + 4) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        const uint32_t bs = Read32LE(f + pos);
+        pos += 4;
+        if (bs == 0) {
+            break; /* end mark */
+        }
+        const bool uncompressed = (bs >> 31) & 1;
+        const size_t blen = bs & 0x7FFFFFFFu;
+        if (blen == 0 || blen > block_max || frame_size < pos + blen) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        if (block_checksum) {
+            if (frame_size < pos + blen + 4) {
+                return CUDEC_ERR_CORRUPT_INPUT;
+            }
+            if (cudec_detail::xxhash32(f + pos, blen) !=
+                Read32LE(f + pos + blen)) {
+                return CUDEC_ERR_CORRUPT_INPUT;
+            }
+        }
+        blocks.push_back({pos, blen, uncompressed});
+        pos += blen + (block_checksum ? 4 : 0);
+    }
+
+    size_t total = 0;
+    const cudec_status decode_status =
+        DecodeAndAssemble(f, blocks, block_max, out, dst_capacity, &total);
+    if (decode_status != CUDEC_OK) {
+        return decode_status;
+    }
+
+    /* A declared content size (FLG bit 3) must equal the produced size -
+     * liblz4 rejects a frame whose declared size does not match (too large
+     * or too small); cudec rejects it too (oracle parity). */
+    if (content_size && declared_content_size != total) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+
+    if (content_checksum) {
+        if (frame_size < pos + 4) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        if (cudec_detail::xxhash32(out, total) != Read32LE(f + pos)) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+    }
+
+    *bytes_written = total;
+    return CUDEC_OK;
+}
+
+}  // namespace
+
+cudec_status cudec_lz4f_decompress(const void* frame_v, size_t frame_size,
+                                   void* dst_v, size_t dst_capacity,
+                                   size_t* bytes_written) {
+    if (bytes_written != nullptr) {
+        *bytes_written = 0;
+    }
+    if (frame_v == nullptr || bytes_written == nullptr ||
+        (dst_v == nullptr && dst_capacity != 0)) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+    try {
+        return DecodeFrame(static_cast<const unsigned char*>(frame_v),
+                           frame_size, static_cast<unsigned char*>(dst_v),
+                           dst_capacity, bytes_written);
+    } catch (...) {
+        /* A host allocation failed (e.g. std::bad_alloc driven by a hostile
+         * block count). Never let an exception cross the C ABI: report a
+         * defined resource error, no output presented as success. */
+        *bytes_written = 0;
+        return CUDEC_ERR_CUDA;
+    }
+}

--- a/src/xxhash32.h
+++ b/src/xxhash32.h
@@ -1,0 +1,86 @@
+/* Minimal XXH32 (Yann Collet's xxHash, 32-bit, seed 0) - the checksum the
+ * LZ4 frame format uses for its header, block, and content integrity
+ * fields. Implemented here because the library depends on nothing beyond
+ * the CUDA toolkit; verified byte-for-byte against liblz4's XXH32 in the
+ * frame twin test. Host-only, internal. */
+#ifndef CUDEC_XXHASH32_H
+#define CUDEC_XXHASH32_H
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace cudec_detail {
+
+inline uint32_t xxh_read32(const unsigned char* p) {
+    uint32_t v;
+    std::memcpy(&v, p, 4); /* little-endian hosts; the frame format is LE */
+    return v;
+}
+
+inline uint32_t xxh_rotl(uint32_t x, int r) {
+    return (x << r) | (x >> (32 - r));
+}
+
+inline uint32_t xxh_round(uint32_t acc, uint32_t input) {
+    constexpr uint32_t kPrime2 = 2246822519u;
+    constexpr uint32_t kPrime1 = 2654435761u;
+    return xxh_rotl(acc + input * kPrime2, 13) * kPrime1;
+}
+
+inline uint32_t xxhash32(const void* data, size_t len) {
+    constexpr uint32_t kPrime1 = 2654435761u;
+    constexpr uint32_t kPrime2 = 2246822519u;
+    constexpr uint32_t kPrime3 = 3266489917u;
+    constexpr uint32_t kPrime4 = 668265263u;
+    constexpr uint32_t kPrime5 = 374761393u;
+
+    const unsigned char* p = static_cast<const unsigned char*>(data);
+    const unsigned char* const end = p + len;
+    uint32_t h;
+
+    if (len >= 16) {
+        const unsigned char* const limit = end - 16;
+        uint32_t v1 = kPrime1 + kPrime2;
+        uint32_t v2 = kPrime2;
+        uint32_t v3 = 0;
+        uint32_t v4 = static_cast<uint32_t>(0u - kPrime1);
+        do {
+            v1 = xxh_round(v1, xxh_read32(p));
+            p += 4;
+            v2 = xxh_round(v2, xxh_read32(p));
+            p += 4;
+            v3 = xxh_round(v3, xxh_read32(p));
+            p += 4;
+            v4 = xxh_round(v4, xxh_read32(p));
+            p += 4;
+        } while (p <= limit);
+        h = xxh_rotl(v1, 1) + xxh_rotl(v2, 7) + xxh_rotl(v3, 12) +
+            xxh_rotl(v4, 18);
+    } else {
+        h = kPrime5;
+    }
+
+    h += static_cast<uint32_t>(len);
+    while (p + 4 <= end) {
+        h += xxh_read32(p) * kPrime3;
+        h = xxh_rotl(h, 17) * kPrime4;
+        p += 4;
+    }
+    while (p < end) {
+        h += (*p) * kPrime5;
+        h = xxh_rotl(h, 11) * kPrime1;
+        p++;
+    }
+
+    h ^= h >> 15;
+    h *= kPrime2;
+    h ^= h >> 13;
+    h *= kPrime3;
+    h ^= h >> 16;
+    return h;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_XXHASH32_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,15 @@ FetchContent_MakeAvailable(lz4)
 # third-party code is audited by hash, not reformatted.
 add_library(lz4_oracle STATIC ${lz4_SOURCE_DIR}/lib/lz4.c)
 target_include_directories(lz4_oracle SYSTEM PUBLIC ${lz4_SOURCE_DIR}/lib)
+
+# The frame oracle adds liblz4's frame API and xxHash (the checksum the
+# frame format uses) - the reference the cudec frame decoder is held to.
+add_library(
+  lz4_frame_oracle STATIC
+  ${lz4_SOURCE_DIR}/lib/lz4.c ${lz4_SOURCE_DIR}/lib/lz4hc.c
+  ${lz4_SOURCE_DIR}/lib/lz4frame.c ${lz4_SOURCE_DIR}/lib/xxhash.c)
+target_include_directories(lz4_frame_oracle SYSTEM PUBLIC
+                           ${lz4_SOURCE_DIR}/lib)
 # -O2 unconditionally: the oracle is also the bench harness's timed
 # decoder, and an empty CMAKE_BUILD_TYPE (the documented container
 # command) would otherwise time -O0 reference code. Correctness is
@@ -90,6 +99,10 @@ set_tests_properties(launch_fail PROPERTIES ENVIRONMENT
 cudec_add_test(smoke SOURCES smoke.cu GPU)
 cudec_add_test(gpu_fixture SOURCES gpu_fixture.cu LIBS cudec_test_fixtures
                GPU)
+cudec_add_test(frame_twin SOURCES frame_twin.cu LIBS lz4_frame_oracle GPU)
+# frame_twin verifies the library's own xxhash32.h against liblz4's XXH32.
+target_include_directories(frame_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
 # ---- Structural conformance, configure time: a violation reds every CI
 # build. These are drift detectors, not tamper-proofing - the honest limits
@@ -104,7 +117,12 @@ foreach(_prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES LINK_OPTIONS
   get_target_property(_entries cudec ${_prop})
   if(_entries)
     foreach(_entry IN LISTS _entries)
-      if(NOT _entry MATCHES "^CUDA::")
+      # A PRIVATE link of an imported target lands in the interface list
+      # wrapped as $<LINK_ONLY:CUDA::cudart>; strip that wrapper before
+      # matching so CUDA::cudart (the CUDA runtime the rule permits) is not
+      # a false positive.
+      string(REGEX REPLACE "^\\$<LINK_ONLY:(.+)>$" "\\1" _bare "${_entry}")
+      if(NOT _bare MATCHES "^CUDA::")
         message(
           FATAL_ERROR
             "cudec carries '${_entry}' in ${_prop} - the library must depend "

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -55,6 +55,23 @@ int main(void) {
                                        aligned, 0) ==
             CUDEC_ERR_INVALID_ARGUMENT);
 
+    /* The frame entry point resolves its own C linkage here. Every call
+     * below is a documented argument reject that returns before any CUDA
+     * call, so it runs on the GPU-less runner and never dereferences the
+     * host pointers. */
+    {
+        size_t written = 123;
+        unsigned char byte = 0;
+        REQUIRE(cudec_lz4f_decompress(0, 0, &byte, 1, &written) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* null frame */
+        REQUIRE(written == 0);
+        REQUIRE(cudec_lz4f_decompress(&byte, 1, &byte, 1, 0) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* null bytes_written */
+        REQUIRE(cudec_lz4f_decompress(&byte, 1, 0, 1, &written) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* null dst, nonzero capacity */
+        REQUIRE(written == 0);
+    }
+
     printf("PASS: plain-C caller exercised every public symbol\n");
     return 0;
 }

--- a/tests/frame_twin.cu
+++ b/tests/frame_twin.cu
@@ -1,0 +1,351 @@
+/* The LZ4 frame decoder held to liblz4's frame API (#23). Frames are
+ * generated with LZ4F_compressFrame in block-independent mode (cudec's
+ * supported subset), decoded on the GPU via cudec_lz4f_decompress, and
+ * compared byte-exact to the original and to LZ4F_decompress. Also pins:
+ * the library's XXH32 against liblz4's, the uncompressed-block path
+ * (random data), and every reject branch (linked frame, dictionary,
+ * corrupt magic/checksum, truncation, undersized output). */
+#include "cudec.h"
+#include "require.h"
+#include "xxhash32.h"
+
+extern "C" {
+#include "lz4frame.h"
+#include "xxhash.h"
+}
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+/* Deterministic corpus generator (own PRNG - reproducible across runs). */
+std::vector<unsigned char> MakeData(size_t n, uint64_t seed, int mode) {
+    std::vector<unsigned char> out(n);
+    uint64_t s = seed;
+    for (size_t i = 0; i < n; i++) {
+        s = s * 6364136223846793005ull + 1442695040888963407ull;
+        if (mode == 0) {
+            out[i] = static_cast<unsigned char>('A' + (i / 37) % 26);
+        } else if (mode == 1) {
+            out[i] = static_cast<unsigned char>(s >> 56); /* incompressible */
+        } else {
+            out[i] = static_cast<unsigned char>((i / 8) % 2 ? (s >> 56) : 0);
+        }
+    }
+    return out;
+}
+
+std::vector<unsigned char> CompressFrame(const std::vector<unsigned char>& in,
+                                         bool independent, bool content_ck,
+                                         bool block_ck,
+                                         bool content_size = false) {
+    LZ4F_preferences_t prefs;
+    std::memset(&prefs, 0, sizeof(prefs));
+    prefs.frameInfo.blockMode =
+        independent ? LZ4F_blockIndependent : LZ4F_blockLinked;
+    prefs.frameInfo.contentChecksumFlag =
+        content_ck ? LZ4F_contentChecksumEnabled : LZ4F_noContentChecksum;
+    prefs.frameInfo.blockChecksumFlag =
+        block_ck ? LZ4F_blockChecksumEnabled : LZ4F_noBlockChecksum;
+    /* Setting contentSize makes LZ4F emit the 8-byte declared-size field
+     * (FLG bit 3), which the decoder must validate against the real size. */
+    prefs.frameInfo.contentSize = content_size ? in.size() : 0;
+    const size_t bound = LZ4F_compressFrameBound(in.size(), &prefs);
+    std::vector<unsigned char> frame(bound);
+    const size_t r = LZ4F_compressFrame(frame.data(), bound, in.data(),
+                                        in.size(), &prefs);
+    if (LZ4F_isError(r)) {
+        std::fprintf(stderr, "LZ4F_compressFrame failed\n");
+        std::abort();
+    }
+    frame.resize(r);
+    return frame;
+}
+
+/* Decode a whole frame through liblz4's frame API (the oracle). Returns
+ * true and fills *out with the decoded bytes on success; false if liblz4
+ * rejects the frame. */
+bool Lz4fDecode(const std::vector<unsigned char>& frame,
+                std::vector<unsigned char>* out) {
+    LZ4F_dctx* dctx = nullptr;
+    if (LZ4F_isError(LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION))) {
+        return false;
+    }
+    size_t src_off = 0, dst_off = 0;
+    bool ok = true;
+    size_t hint = 1;
+    while (src_off < frame.size()) {
+        size_t src_left = frame.size() - src_off;
+        size_t dst_left = out->size() - dst_off;
+        hint = LZ4F_decompress(dctx, out->data() + dst_off, &dst_left,
+                               frame.data() + src_off, &src_left, nullptr);
+        if (LZ4F_isError(hint)) {
+            ok = false;
+            break;
+        }
+        src_off += src_left;
+        dst_off += dst_left;
+        if (hint == 0) {
+            break; /* frame complete */
+        }
+        if (src_left == 0 && dst_left == 0) {
+            ok = false; /* no progress: truncated / undersized out */
+            break;
+        }
+    }
+    LZ4F_freeDecompressionContext(dctx);
+    if (ok && hint != 0) {
+        ok = false; /* input exhausted mid-frame */
+    }
+    if (ok) {
+        out->resize(dst_off);
+    }
+    return ok;
+}
+
+/* Decodes a frame through cudec and requires byte-exact equality with the
+ * original. */
+int CheckFrameOk(const char* ctx, const std::vector<unsigned char>& frame,
+                 const std::vector<unsigned char>& original) {
+    std::vector<unsigned char> out(original.size() + 16, 0xEE);
+    size_t written = 12345;
+    REQUIRE_CTX(cudec_lz4f_decompress(frame.data(), frame.size(), out.data(),
+                                      out.size(), &written) == CUDEC_OK,
+                "%s", ctx);
+    REQUIRE_CTX(written == original.size(), "%s size", ctx);
+    REQUIRE_CTX(equal_bytes(out.data(), original.data(), original.size()),
+                "%s bytes", ctx);
+    return 0;
+}
+
+int CheckReject(const char* ctx, const std::vector<unsigned char>& frame,
+                cudec_status expected) {
+    std::vector<unsigned char> out(1 << 20, 0);
+    size_t written = 999;
+    REQUIRE_CTX(cudec_lz4f_decompress(frame.data(), frame.size(), out.data(),
+                                      out.size(), &written) == expected,
+                "%s", ctx);
+    REQUIRE_CTX(written == 0, "%s bytes_written must be 0", ctx);
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    /* 1. The library's XXH32 must match liblz4's, byte for byte. */
+    for (size_t n : {size_t{0}, size_t{1}, size_t{15}, size_t{16},
+                     size_t{17}, size_t{1000}, size_t{65537}}) {
+        const auto d = MakeData(n, 0x51 + n, 1);
+        REQUIRE_CTX(cudec_detail::xxhash32(d.data(), n) ==
+                        XXH32(d.data(), n, 0),
+                    "xxhash32 parity at n=%zu", n);
+    }
+
+    /* 2. Independent frames of every flag combination and size class decode
+     * byte-exact. Sizes span single-block, multi-block, and the block
+     * boundary; modes span compressible, incompressible (uncompressed
+     * blocks), and mixed. */
+    const size_t sizes[] = {0, 1, 100, 65535, 65536, 65537, 200000};
+    for (size_t n : sizes) {
+        for (int mode = 0; mode < 3; mode++) {
+            const auto data = MakeData(n, 0x100 + n + mode, mode);
+            for (int flags = 0; flags < 4; flags++) {
+                const bool content_ck = flags & 1;
+                const bool block_ck = flags & 2;
+                const auto frame =
+                    CompressFrame(data, true, content_ck, block_ck);
+                char ctx[64];
+                std::snprintf(ctx, sizeof(ctx), "n=%zu mode=%d flags=%d", n,
+                              mode, flags);
+                REQUIRE(CheckFrameOk(ctx, frame, data) == 0);
+            }
+        }
+    }
+
+    /* 2b. Content-size frames (FLG bit 3): the 8-byte declared size is
+     * emitted and must be validated. A correct frame decodes byte-exact; a
+     * frame whose declared size is corrupted must reject in parity with
+     * liblz4 (which returns frameSize_wrong). */
+    for (size_t n : {size_t{0}, size_t{100}, size_t{65537}, size_t{200000}}) {
+        const auto data = MakeData(n, 0x777 + n, 0);
+        const auto frame = CompressFrame(data, true, false, false, true);
+        char ctx[48];
+        std::snprintf(ctx, sizeof(ctx), "content-size n=%zu", n);
+        REQUIRE(CheckFrameOk(ctx, frame, data) == 0);
+    }
+    {
+        const auto data = MakeData(100000, 0x778, 0);
+        auto frame = CompressFrame(data, true, false, false, true);
+        /* Descriptor: FLG(4) BD(5) ContentSize(6..13) HC(14). Corrupt the
+         * declared size and repair HC so the size-mismatch path (not the
+         * header-checksum path) is what fires. liblz4 must also reject. */
+        frame[6] ^= 0xFF;
+        frame[14] =
+            static_cast<unsigned char>((XXH32(frame.data() + 4, 10, 0) >> 8) &
+                                       0xFF);
+        std::vector<unsigned char> oout(data.size() + 4096);
+        REQUIRE(Lz4fDecode(frame, &oout) == false);
+        REQUIRE(CheckReject("content-size-mismatch", frame,
+                            CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+
+    /* 2c. On-device block reject - the frame.cpp<->kernel status seam. Use a
+     * single-block compressed frame and mutate ONLY bytes inside the block
+     * payload, never the 4-byte block-size field or the header. The host
+     * parser validates block size and checksums but not block content, so a
+     * payload-only mutation always reaches the GPU decoder: any cudec reject
+     * here is a kernel-status-seam reject by construction, not a host-side
+     * one. Also held to the oracle direction: whenever liblz4 rejects, cudec
+     * rejects; when both accept, the bytes match (cudec may be stricter). */
+    {
+        const auto data = MakeData(40000, 0x321, 0); /* fits one 64 KiB block */
+        const auto base = CompressFrame(data, true, false, false);
+        /* Layout with no checksums / no content size: magic(4) FLG(5) BD(6)
+         * HC(7) | block size(4) | block data(blen) | end mark(4). */
+        const uint32_t bs = static_cast<uint32_t>(base[7]) |
+                            (static_cast<uint32_t>(base[8]) << 8) |
+                            (static_cast<uint32_t>(base[9]) << 16) |
+                            (static_cast<uint32_t>(base[10]) << 24);
+        REQUIRE((bs >> 31) == 0); /* compressible input -> a compressed block */
+        const size_t blen = bs & 0x7FFFFFFFu;
+        const size_t data_begin = 11;
+        const size_t data_end = data_begin + blen;
+        REQUIRE(data_end + 4 == base.size()); /* exactly one block + end mark */
+
+        /* Output capacity >= the 64 KiB block max, so a mutation that still
+         * decodes cleanly (to at most block_max bytes) can never trip the
+         * assembly-stage OUTPUT_TOO_SMALL. Every cudec reject in this sweep
+         * is then a kernel-status-seam reject, with nothing host-side left
+         * to count. */
+        const size_t kSeamCap = (size_t{64} << 10) + 4096;
+        const size_t step = blen > 96 ? blen / 96 : 1;
+        size_t seam_rejects = 0;
+        for (size_t p = data_begin; p < data_end; p += step) {
+            auto frame = base;
+            frame[p] ^= 0x5A;
+
+            std::vector<unsigned char> oout(kSeamCap);
+            const bool oracle_ok = Lz4fDecode(frame, &oout);
+
+            std::vector<unsigned char> cout(kSeamCap, 0xCC);
+            size_t w = 1;
+            const cudec_status s = cudec_lz4f_decompress(
+                frame.data(), frame.size(), cout.data(), cout.size(), &w);
+
+            if (s != CUDEC_OK) {
+                /* Payload-only mutation, so this reject came from the GPU. */
+                REQUIRE_CTX(w == 0, "seam mut@%zu: reject wrote", p);
+                seam_rejects++;
+            }
+            if (!oracle_ok) {
+                REQUIRE_CTX(s != CUDEC_OK, "seam mut@%zu: oracle rejects, "
+                                           "cudec accepted",
+                            p);
+            } else if (s == CUDEC_OK) {
+                REQUIRE_CTX(w == oout.size(), "seam mut@%zu: size vs oracle", p);
+                REQUIRE_CTX(equal_bytes(cout.data(), oout.data(), w),
+                            "seam mut@%zu: bytes vs oracle", p);
+            }
+        }
+        REQUIRE(seam_rejects > 0); /* the kernel-status seam is actually hit */
+    }
+
+    /* 3. Reject branches. */
+    const auto data = MakeData(200000, 0x999, 2);
+
+    /* Block-linked (liblz4's default) is unsupported, not corrupt. */
+    REQUIRE(CheckReject("linked", CompressFrame(data, false, false, false),
+                        CUDEC_ERR_UNSUPPORTED) == 0);
+
+    /* A dictionary-id frame is unsupported: set the DictID FLG bit on an
+     * otherwise valid independent frame and repair the header checksum so
+     * the UNSUPPORTED path (not the checksum path) is what fires. */
+    {
+        auto frame = CompressFrame(data, true, false, false);
+        frame[4] |= 0x01; /* FLG DictID bit */
+        /* HC covers FLG..end-of-descriptor; no content size here, so the
+         * descriptor is FLG,BD and HC is at offset 6. Recompute it. */
+        frame[6] = static_cast<unsigned char>(
+            (XXH32(frame.data() + 4, 2, 0) >> 8) & 0xFF);
+        /* The DictID bit implies 4 more header bytes liblz4 would read, but
+         * cudec rejects on the bit before parsing them - which is the
+         * point. */
+        REQUIRE(CheckReject("dictid", frame, CUDEC_ERR_UNSUPPORTED) == 0);
+    }
+
+    /* Corrupt magic. */
+    {
+        auto frame = CompressFrame(data, true, false, false);
+        frame[0] ^= 0xFF;
+        REQUIRE(CheckReject("bad-magic", frame, CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+
+    /* Corrupt header checksum. */
+    {
+        auto frame = CompressFrame(data, true, false, false);
+        frame[6] ^= 0xFF;
+        REQUIRE(CheckReject("bad-hc", frame, CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+
+    /* Corrupt content checksum (last 4 bytes of a content-checksummed
+     * frame). */
+    {
+        auto frame = CompressFrame(data, true, true, false);
+        frame[frame.size() - 1] ^= 0xFF;
+        REQUIRE(CheckReject("bad-content-ck", frame,
+                            CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+
+    /* Corrupt block checksum. */
+    {
+        auto frame = CompressFrame(data, true, false, true);
+        /* first block checksum sits after the header + first block data;
+         * flip a byte late in the frame that is not the end mark / content
+         * checksum - the middle of the frame is block data or a block
+         * checksum, both of which must fail closed. */
+        frame[frame.size() / 2] ^= 0xFF;
+        std::vector<unsigned char> out(1 << 20, 0);
+        size_t w = 1;
+        const cudec_status s = cudec_lz4f_decompress(
+            frame.data(), frame.size(), out.data(), out.size(), &w);
+        REQUIRE(s == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(w == 0);
+    }
+
+    /* Truncation: any prefix of a valid frame must reject, never over-read
+     * or falsely succeed. */
+    {
+        const auto frame = CompressFrame(data, true, true, true);
+        for (size_t cut : {size_t{3}, size_t{6}, size_t{10}, frame.size() / 2,
+                           frame.size() - 1}) {
+            std::vector<unsigned char> t(frame.begin(),
+                                         frame.begin() +
+                                             static_cast<long>(cut));
+            std::vector<unsigned char> out(1 << 20, 0);
+            size_t w = 1;
+            const cudec_status s = cudec_lz4f_decompress(
+                t.data(), t.size(), out.data(), out.size(), &w);
+            REQUIRE_CTX(s != CUDEC_OK, "truncation to %zu accepted", cut);
+            REQUIRE_CTX(w == 0, "truncation to %zu wrote", cut);
+        }
+    }
+
+    /* Undersized output buffer. */
+    {
+        const auto frame = CompressFrame(data, true, false, false);
+        std::vector<unsigned char> out(data.size() / 2, 0);
+        size_t w = 1;
+        REQUIRE(cudec_lz4f_decompress(frame.data(), frame.size(), out.data(),
+                                      out.size(), &w) ==
+                CUDEC_ERR_OUTPUT_TOO_SMALL);
+        REQUIRE(w == 0);
+    }
+
+    std::printf("PASS: frame decode in liblz4 parity across sizes/flags/"
+                "modes; xxhash32 verified; linked/dictid/corrupt/truncation/"
+                "undersized all reject fail-closed\n");
+    return 0;
+}


### PR DESCRIPTION
# What & why

Decode the LZ4 **frame** format (the `.lz4` container), building on the M1
block decoder. Closes #23.

`cudec_lz4f_decompress` parses the frame on the host, magic, FLG/BD frame
descriptor, header checksum, block table, end mark, content checksum, and
hands the compressed blocks to the existing device batch decoder
(`cudec_lz4_decompress_batch`) in one batch; uncompressed blocks are
straight host copies; the output is assembled in block order under the
caller's capacity. The host split reuses the M1 engine unchanged and keeps
the device code free of container logic.

- **Supported subset:** block-independent frames. Block-linked frames
  (liblz4's frame-compressor default) and dictionary-id frames are rejected
  fail-closed with the new `CUDEC_ERR_UNSUPPORTED`, a valid frame outside
  cudec's subset, distinct from `CUDEC_ERR_CORRUPT_INPUT` (a malformed
  frame or a checksum mismatch).
- **Checksums verified fail-closed:** header, optional per-block, and
  optional content (xxHash32). xxHash32 is implemented internally
  (`src/xxhash32.h`) to keep the no-dependency-beyond-CUDA invariant, and
  pinned bit-for-bit to liblz4's `XXH32` in the twin test.
- **ABI:** new status `CUDEC_ERR_UNSUPPORTED = 6`; new synchronous entry
  point `cudec_lz4f_decompress(frame, frame_size, dst, dst_capacity,
  bytes_written)`. On any error `*bytes_written` is 0.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] API surface

## Engineering checklist

- [x] Fail-closed preserved: every malformed/truncated/checksum-mismatch
      branch rejects with a defined status and `bytes_written == 0`; each
      reject branch has a negative test.
- [x] Oracle coverage: byte-exact against `LZ4F_decompress` and the
      original over size classes, flag combinations, and content modes;
      xxHash32 pinned bit-for-bit to liblz4's `XXH32`.
- [x] Determinism preserved (host assembly is deterministic; the device
      batch is the M1 kernel, already determinism-gated).
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [x] Adversarial review run (`/security-review`), see Notes.

## Performance checklist

Host orchestrator, not the hot path; no performance claims. The
per-block staging shape is the M2 choice (frames decoded one at a time);
the overlap/pinned-streaming lever is issue #24.

## Quality checklist

- [x] Minimal, self-documenting; the load-bearing bounds/ABI "why"
      comments are kept.
- [x] Conformance: the no-dependency allowlist and fail-closed coverage
      rules extend to the frame path; the internal xxHash32 stays
      bit-identical to the reference (twin-tested).

## Verification

Pinned dev container (`nvidia/cuda:12.6.2-devel-ubuntu24.04`, RTX 3080,
nvcc 12.6.77), clean rebuild, host C/CXX/CUDA all `-Werror`:

```
100% tests passed, 0 tests failed out of 8
    Start 7: frame_twin
7/8 Test #7: frame_twin .......................   Passed    0.40 sec
```

- [x] `cmake --build`, clean.
- [x] `ctest`, 8/8 green (frame_twin incl.).
- [x] Prettier, clean.

## Notes

Adversarial review: three rounds of the refute-by-default panel
(correctness / robustness / integration / performance + cuda-reviewer),
converging to PASS on every lens against the final tree.

Round 1 (2× FAIL, 3× NEEDS_IMPROVEMENT), the first cut built and passed
its twin test but the panel found real defects the twin was structurally
blind to, all fixed:

- **Declared content size never validated** (correctness FAIL, oracle-parity
  break): FLG bit 3 carries an 8-byte uncompressed length that liblz4
  enforces (`frameSize_wrong`) but cudec ignored, a mismatched frame
  decoded to success. Now captured during the header parse and rejected
  `CORRUPT_INPUT` when it does not equal the produced size; the whole
  content-size path was untested and now is (decode-OK plus a
  mismatch-rejects case cross-checked against liblz4).
- **Device-memory leak on every error path** (robustness FAIL, cuda-reviewer
  HIGH): the per-block `cudaMalloc`s were freed only on the success path, so
  a corrupt compressed block, the expected hostile input, leaked all
  device buffers, a repeatable GPU-exhaustion DoS in a library entry point.
  `DecodeBlocksOnGpu` is replaced by `DecodeAndAssemble` with an RAII device
  pointer that frees on every scope exit, including the exception path.
- **`std::bad_alloc` could cross the `extern "C"` boundary** (cuda-reviewer
  HIGH): the body is now wrapped so any host allocation failure returns a
  defined `CUDEC_ERR_CUDA` with no output, never an exception across the ABI.
- **Allocation amplification + per-block malloc storm + double host copy**
  (robustness/perf MEDIUM): staging is now a single source and single
  destination allocation (overflow-guarded), so an oversized hostile frame
  fails fast on one allocation instead of a per-block storm, and decoded
  blocks are copied straight device-to-host into the caller's buffer at
  prefix offsets (capacity checked before any write), no intermediate
  vectors, no second copy, no partial output on the too-small path.
- **On-device block-reject seam untested + wrong status** (integration
  MEDIUM): a per-block failure now maps to `CORRUPT_INPUT` (not the internal
  `OUTPUT_TOO_SMALL` leaked as the caller's status), and a payload-confined
  mutation-parity sweep exercises the frame↔kernel seam by construction and
  holds cudec to the oracle direction.

Rounds 2–3 closed the remainder: the new public symbol
`cudec_lz4f_decompress` is now referenced from the plain-C conformance test
(its `extern "C"` linkage resolved from a pure-C TU), the seam sweep's
output capacity is sized ≥ the block max so every reject it counts is a true
kernel-seam reject, and the header documents the `INVALID_ARGUMENT`
null-argument contract.

The staging shape is provisional for M2 (one frame at a time, correctness
first); the overlap/pinned-host streaming lever is issue #24, noted in the
code. CodeRabbit remains inactive on the repo (see the earlier PR notes);
the app installation is a decision of mine.
