### PR TITLE
Add the pinned-host streaming decode entry point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
           cmake --build build-cuda -j &&
           test -x build-cuda/tests/smoke &&
           test -x build-cuda/tests/gpu_fixture &&
-          test -x build-cuda/tests/frame_twin
+          test -x build-cuda/tests/frame_twin &&
+          test -x build-cuda/tests/stream_twin
 
       # The host-side subset; gpu-labeled tests run in this same container
       # on the maintainer's machine and their output is pasted into the PR.
@@ -100,7 +101,8 @@ jobs:
           ctest --test-dir build-cuda -L gpu -N | tee gpu-deferred.txt &&
           grep -E ': smoke$' gpu-deferred.txt &&
           grep -E ': gpu_fixture$' gpu-deferred.txt &&
-          grep -E ': frame_twin$' gpu-deferred.txt
+          grep -E ': frame_twin$' gpu-deferred.txt &&
+          grep -E ': stream_twin$' gpu-deferred.txt
 
   format:
     name: format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(CUDEC_ENABLE_CUDA)
   # frame.cpp (the LZ4 frame orchestrator) is host C++ that drives the
   # device batch decoder, so it needs the CUDA runtime.
   find_package(CUDAToolkit REQUIRED)
-  target_sources(cudec PRIVATE src/batch.cu src/frame.cpp)
+  target_sources(cudec PRIVATE src/batch.cu src/frame.cpp src/stream.cpp)
   target_link_libraries(cudec PRIVATE CUDA::cudart)
   # The cudec target predates enable_language(CUDA), so the architecture
   # list must be applied as an explicit target property.

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -124,6 +124,53 @@ cudec_status cudec_lz4f_decompress(const void* frame, size_t frame_size,
                                    void* dst, size_t dst_capacity,
                                    size_t* bytes_written);
 
+/* Memory space of the streaming decoder's per-chunk destinations. */
+typedef enum cudec_mem_space {
+    CUDEC_MEM_HOST = 0,   /* dst_ptrs are host pointers; output is copied D2H */
+    CUDEC_MEM_DEVICE = 1  /* dst_ptrs are device pointers; output stays in VRAM */
+} cudec_mem_space;
+
+/* Streaming batch LZ4 block decode from HOST-resident compressed chunks. The
+ * H2D copy is pipelined against decode across CUDA streams the call manages
+ * internally. Synchronous: the pipeline is fully drained before return, so
+ * every dst[k] and h_results[k] is valid on a CUDEC_OK return.
+ *
+ * All array arguments are HOST arrays of chunk_count entries. h_src_ptrs[k] /
+ * h_src_sizes[k] is the k-th compressed block in host memory; all input is
+ * staged through the library's own pinned ring, so the H2D copy does not
+ * depend on the caller pinning its input. dst_ptrs[k] / dst_caps[k] is the
+ * k-th output slot, in the space named by dst_space: for CUDEC_MEM_DEVICE the
+ * decode writes device memory directly and the copy/decode pipeline overlaps;
+ * for CUDEC_MEM_HOST the decoded bytes are read back to host memory, and that
+ * readback is synchronous in this release (the copy/decode overlap applies to
+ * the device-output path). On a successful chunk the caller's destination
+ * holds exactly bytes_written bytes and the space beyond is left untouched,
+ * in both spaces. h_results[k] receives the k-th outcome.
+ *
+ * `streams` is the overlap depth for the device-output pipeline: 0 selects a
+ * library default; 1 serializes copy and decode; N>=2 round-robins the work
+ * so the copy of later chunks can overlap the decode of earlier ones. The
+ * decoded output is BIT-IDENTICAL for every `streams` value.
+ *
+ * Fail-closed: a NULL array, a NULL h_src_ptrs[k] with a non-zero
+ * h_src_sizes[k], a NULL dst[k] with a non-zero dst_caps[k], an unknown
+ * dst_space, chunk_count == 0, or a batch beyond the launch limit returns
+ * CUDEC_ERR_INVALID_ARGUMENT and decodes nothing. A rejected chunk
+ * reports its defined error in h_results[k] with bytes_written 0; neighbours
+ * are unaffected and its destination is unspecified but never presented as a
+ * valid decode. The aggregate return is CUDEC_OK iff every chunk decoded OK;
+ * otherwise a host/device resource failure (CUDEC_ERR_CUDA) takes precedence,
+ * then the first non-OK chunk's status in index order. Never throws across
+ * this boundary. */
+cudec_status cudec_lz4_decompress_stream(const void* const* h_src_ptrs,
+                                         const size_t* h_src_sizes,
+                                         void* const* dst_ptrs,
+                                         const size_t* dst_caps,
+                                         size_t chunk_count,
+                                         cudec_mem_space dst_space,
+                                         unsigned streams,
+                                         cudec_chunk_result* h_results);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1,0 +1,420 @@
+/* Pinned-host streaming LZ4 block decode: host-resident compressed chunks
+ * decoded on the GPU with the H2D copy overlapped against decode across N
+ * CUDA streams (masterplan section 4, the asset-streaming memory path, M2).
+ *
+ * This adds NO kernel and NO parser code: it is host-side copy/stream
+ * choreography around the unchanged, already-fuzzed cudec_lz4_decompress_batch,
+ * which is reused verbatim per wave. Per-chunk output and result indices are
+ * disjoint, so stream interleaving cannot change the bytes - the output is
+ * bit-identical for every stream count (determinism by construction). The
+ * per-frame staging in frame.cpp is the future consumer of this path (#24's
+ * note in frame.cpp); wiring frame.cpp onto it is a separate change. */
+#include "cudec.h"
+
+#include <cuda_runtime.h>
+
+#include <cstring>
+#include <vector>
+
+namespace {
+
+constexpr unsigned kDefaultStreams = 4;
+constexpr unsigned kMaxStreams = 32;
+constexpr size_t kWaveChunks = 64; /* chunks per wave: amortizes launch cost */
+constexpr size_t kRingDepth = 2;   /* ring slots per stream (double-buffer) */
+
+/* The batch entry's own launch limit; a stream batch cannot exceed it
+ * either. Kept in sync with validate_batch_args in lz4_decode.cuh. */
+constexpr size_t kMaxChunks = static_cast<size_t>(INT32_MAX) * 32;
+
+bool MulOverflows(size_t a, size_t b) { return a != 0 && b > SIZE_MAX / a; }
+
+/* RAII owners so every device/pinned/stream/event allocation is freed on
+ * every return path, including the reject and exception paths. */
+struct DevPtr {
+    void* p = nullptr;
+    DevPtr() = default;
+    DevPtr(const DevPtr&) = delete;
+    DevPtr& operator=(const DevPtr&) = delete;
+    ~DevPtr() {
+        if (p != nullptr) {
+            (void)cudaFree(p);
+        }
+    }
+    cudaError_t alloc(size_t bytes) { return cudaMalloc(&p, bytes); }
+};
+
+struct PinnedPtr {
+    void* p = nullptr;
+    PinnedPtr() = default;
+    PinnedPtr(const PinnedPtr&) = delete;
+    PinnedPtr& operator=(const PinnedPtr&) = delete;
+    ~PinnedPtr() {
+        if (p != nullptr) {
+            (void)cudaFreeHost(p);
+        }
+    }
+    cudaError_t alloc(size_t bytes) {
+        return cudaHostAlloc(&p, bytes, cudaHostAllocDefault);
+    }
+};
+
+struct StreamPtr {
+    cudaStream_t s = nullptr;
+    StreamPtr() = default;
+    StreamPtr(const StreamPtr&) = delete;
+    StreamPtr& operator=(const StreamPtr&) = delete;
+    ~StreamPtr() {
+        if (s != nullptr) {
+            (void)cudaStreamDestroy(s);
+        }
+    }
+    cudaError_t create() {
+        /* Non-blocking so the overlap does not depend on the legacy default
+         * stream staying idle (a caller with default-stream work in the same
+         * context would otherwise serialize every wave). */
+        return cudaStreamCreateWithFlags(&s, cudaStreamNonBlocking);
+    }
+};
+
+struct EventPtr {
+    cudaEvent_t e = nullptr;
+    EventPtr() = default;
+    EventPtr(const EventPtr&) = delete;
+    EventPtr& operator=(const EventPtr&) = delete;
+    ~EventPtr() {
+        if (e != nullptr) {
+            (void)cudaEventDestroy(e);
+        }
+    }
+    cudaError_t create() { return cudaEventCreate(&e); }
+};
+
+/* Per ring slot: one pinned staging buffer + one device buffer for the
+ * wave's compressed sources, a pinned+device metadata buffer for the batch
+ * entry's per-chunk pointer/size arrays, an optional device destination
+ * staging buffer (host-output only), and a completion event. Slots are
+ * reused round-robin; a slot's event gates its reuse. */
+struct Slot {
+    PinnedPtr p_src;
+    DevPtr d_src;
+    PinnedPtr p_meta;
+    DevPtr d_meta;
+    DevPtr d_dst; /* host-output staging only */
+    EventPtr ev;
+};
+
+/* Metadata layout inside p_meta/d_meta for a wave of up to kWaveChunks
+ * chunks: [src_ptrs][src_sizes][dst_ptrs][dst_caps], each kWaveChunks wide,
+ * 8-byte elements. */
+constexpr size_t kMetaStride = kWaveChunks * sizeof(void*);
+constexpr size_t kMetaBytes = 4 * kMetaStride;
+
+cudec_status DecodeStream(const void* const* h_src_ptrs,
+                          const size_t* h_src_sizes, void* const* dst_ptrs,
+                          const size_t* dst_caps, size_t chunk_count,
+                          cudec_mem_space dst_space, unsigned streams,
+                          cudec_chunk_result* h_results) {
+#define STREAM_CUDA(call)                       \
+    do {                                        \
+        if ((call) != cudaSuccess) {            \
+            return CUDEC_ERR_CUDA;              \
+        }                                       \
+    } while (0)
+
+    const bool host_out = (dst_space == CUDEC_MEM_HOST);
+    const size_t wave_count = (chunk_count + kWaveChunks - 1) / kWaveChunks;
+
+    unsigned n_streams = (streams == 0) ? kDefaultStreams : streams;
+    if (n_streams > kMaxStreams) {
+        n_streams = kMaxStreams;
+    }
+    if (static_cast<size_t>(n_streams) > wave_count) {
+        n_streams = static_cast<unsigned>(wave_count);
+    }
+    /* Host output drains each wave before issuing the next (the readback to
+     * pageable caller memory is synchronous), so extra streams and ring slots
+     * buy no overlap - collapse to a single stream and avoid provisioning a
+     * fan-out that never engages. */
+    if (host_out) {
+        n_streams = 1;
+    }
+    const size_t n_slots = static_cast<size_t>(n_streams) * kRingDepth;
+
+    /* Largest single wave's compressed bytes and destination bytes decide
+     * the per-slot buffer sizes (fixed for the whole call, so a hostile
+     * chunk_count cannot drive per-wave growth). */
+    size_t max_wave_src = 0;
+    size_t max_wave_dst = 0;
+    for (size_t w = 0; w < wave_count; w++) {
+        const size_t begin = w * kWaveChunks;
+        const size_t end =
+            (begin + kWaveChunks < chunk_count) ? begin + kWaveChunks
+                                                : chunk_count;
+        size_t wsrc = 0, wdst = 0;
+        for (size_t i = begin; i < end; i++) {
+            if (SIZE_MAX - wsrc < h_src_sizes[i]) {
+                return CUDEC_ERR_CORRUPT_INPUT;
+            }
+            wsrc += h_src_sizes[i];
+            if (host_out) {
+                if (SIZE_MAX - wdst < dst_caps[i]) {
+                    return CUDEC_ERR_CORRUPT_INPUT;
+                }
+                wdst += dst_caps[i];
+            }
+        }
+        if (wsrc > max_wave_src) {
+            max_wave_src = wsrc;
+        }
+        if (wdst > max_wave_dst) {
+            max_wave_dst = wdst;
+        }
+    }
+    if (max_wave_src == 0) {
+        max_wave_src = 1; /* cudaMalloc(0) is legal but avoid the corner */
+    }
+    if (host_out && max_wave_dst == 0) {
+        max_wave_dst = 1;
+    }
+
+    /* Shared results: one device buffer + a pinned mirror so the per-wave
+     * result readback stays async (a device->pageable copy would sync and
+     * serialize the pipeline). */
+    if (MulOverflows(chunk_count, sizeof(cudec_chunk_result))) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+    const size_t results_bytes = chunk_count * sizeof(cudec_chunk_result);
+    DevPtr d_results;
+    PinnedPtr p_results;
+    STREAM_CUDA(d_results.alloc(results_bytes));
+    STREAM_CUDA(p_results.alloc(results_bytes));
+    /* 0xFF is a non-OK status sentinel: any wave that fails to complete
+     * before an error return leaves its result records reading not-OK rather
+     * than stale caller memory. */
+    std::memset(p_results.p, 0xFF, results_bytes);
+
+    std::vector<StreamPtr> stream_pool(n_streams);
+    for (unsigned s = 0; s < n_streams; s++) {
+        STREAM_CUDA(stream_pool[s].create());
+    }
+    std::vector<Slot> slots(n_slots);
+    for (size_t s = 0; s < n_slots; s++) {
+        STREAM_CUDA(slots[s].p_src.alloc(max_wave_src));
+        STREAM_CUDA(slots[s].d_src.alloc(max_wave_src));
+        STREAM_CUDA(slots[s].p_meta.alloc(kMetaBytes));
+        STREAM_CUDA(slots[s].d_meta.alloc(kMetaBytes));
+        if (host_out) {
+            STREAM_CUDA(slots[s].d_dst.alloc(max_wave_dst));
+        }
+        STREAM_CUDA(slots[s].ev.create());
+    }
+
+    /* On an error inside the wave loop we break rather than return, so the
+     * unconditional drain below completes every in-flight stream before the
+     * RAII owners free the buffers those streams are still reading/writing
+     * (not relying on cudaFree's implicit device sync). WAVE_FAIL records the
+     * failure and stops the loop. */
+    cudec_status wave_status = CUDEC_OK;
+    /* Used only inside braced if-blocks in the wave loop; the break exits the
+     * wave loop (not a do-while) so control reaches the unconditional drain. */
+#define WAVE_FAIL(st)       \
+    {                       \
+        wave_status = (st); \
+        break;              \
+    }
+
+    for (size_t w = 0; w < wave_count; w++) {
+        const size_t begin = w * kWaveChunks;
+        const size_t end =
+            (begin + kWaveChunks < chunk_count) ? begin + kWaveChunks
+                                                : chunk_count;
+        const size_t wn = end - begin;
+        const unsigned si = static_cast<unsigned>(w % n_streams);
+        Slot& slot = slots[w % n_slots];
+        cudaStream_t stream = stream_pool[si].s;
+
+        /* Reuse gate: wait for the slot's previous wave to complete before
+         * overwriting its buffers. A never-recorded event returns at once. */
+        if (cudaEventSynchronize(slot.ev.e) != cudaSuccess) {
+            WAVE_FAIL(CUDEC_ERR_CUDA);
+        }
+
+        /* Stage the wave's compressed sources contiguously and build the
+         * per-chunk device pointer/size arrays into the pinned metadata. */
+        unsigned char* p_src = static_cast<unsigned char*>(slot.p_src.p);
+        unsigned char* d_src = static_cast<unsigned char*>(slot.d_src.p);
+        unsigned char* d_dst = static_cast<unsigned char*>(slot.d_dst.p);
+        const void** m_src =
+            reinterpret_cast<const void**>(static_cast<unsigned char*>(
+                slot.p_meta.p));
+        size_t* m_ssz = reinterpret_cast<size_t*>(
+            static_cast<unsigned char*>(slot.p_meta.p) + kMetaStride);
+        void** m_dst = reinterpret_cast<void**>(
+            static_cast<unsigned char*>(slot.p_meta.p) + 2 * kMetaStride);
+        size_t* m_cap = reinterpret_cast<size_t*>(
+            static_cast<unsigned char*>(slot.p_meta.p) + 3 * kMetaStride);
+
+        size_t src_off = 0;
+        size_t dst_off = 0;
+        for (size_t j = 0; j < wn; j++) {
+            const size_t i = begin + j;
+            const size_t ssz = h_src_sizes[i];
+            if (ssz != 0) {
+                std::memcpy(p_src + src_off, h_src_ptrs[i], ssz);
+            }
+            m_src[j] = d_src + src_off;
+            m_ssz[j] = ssz;
+            m_cap[j] = dst_caps[i];
+            if (host_out) {
+                m_dst[j] = d_dst + dst_off;
+                dst_off += dst_caps[i];
+            } else {
+                m_dst[j] = dst_ptrs[i]; /* decode straight into caller VRAM */
+            }
+            src_off += ssz;
+        }
+
+        /* Device metadata pointers into d_meta (same layout as p_meta). */
+        unsigned char* dm = static_cast<unsigned char*>(slot.d_meta.p);
+        const void* const* dd_src =
+            reinterpret_cast<const void* const*>(dm);
+        const size_t* dd_ssz =
+            reinterpret_cast<const size_t*>(dm + kMetaStride);
+        void* const* dd_dst =
+            reinterpret_cast<void* const*>(dm + 2 * kMetaStride);
+        const size_t* dd_cap =
+            reinterpret_cast<const size_t*>(dm + 3 * kMetaStride);
+
+        if (src_off != 0 &&
+            cudaMemcpyAsync(d_src, p_src, src_off, cudaMemcpyHostToDevice,
+                            stream) != cudaSuccess) {
+            WAVE_FAIL(CUDEC_ERR_CUDA);
+        }
+        if (cudaMemcpyAsync(slot.d_meta.p, slot.p_meta.p, kMetaBytes,
+                            cudaMemcpyHostToDevice, stream) != cudaSuccess) {
+            WAVE_FAIL(CUDEC_ERR_CUDA);
+        }
+
+        /* The per-wave result slice is offset*16 into a cudaMalloc base, so
+         * it satisfies the batch entry's 16-byte-alignment requirement. */
+        cudec_chunk_result* d_res =
+            static_cast<cudec_chunk_result*>(d_results.p) + begin;
+        const cudec_status launched = cudec_lz4_decompress_batch(
+            dd_src, dd_ssz, dd_dst, dd_cap, wn, d_res, stream);
+        if (launched != CUDEC_OK) {
+            WAVE_FAIL(launched);
+        }
+
+        /* Result readback into the pinned mirror (async). */
+        if (cudaMemcpyAsync(
+                static_cast<cudec_chunk_result*>(p_results.p) + begin, d_res,
+                wn * sizeof(cudec_chunk_result), cudaMemcpyDeviceToHost,
+                stream) != cudaSuccess) {
+            WAVE_FAIL(CUDEC_ERR_CUDA);
+        }
+
+        if (host_out) {
+            /* Copy exactly bytes_written per chunk into the caller's host
+             * buffer, leaving the tail beyond it untouched - the same
+             * contract as the device-output path, and no cross-chunk residue.
+             * The exact length needs the per-chunk result, so this wave is
+             * drained first; the D2H targets pageable caller memory and is
+             * therefore synchronous, so host-output does not overlap in this
+             * cut (device-output is the overlapped path). Overlapping the
+             * host readback needs a pinned output ring - a later change. */
+            if (cudaStreamSynchronize(stream) != cudaSuccess) {
+                WAVE_FAIL(CUDEC_ERR_CUDA);
+            }
+            const cudec_chunk_result* wr =
+                static_cast<cudec_chunk_result*>(p_results.p) + begin;
+            size_t off = 0;
+            bool copy_failed = false;
+            for (size_t j = 0; j < wn; j++) {
+                const size_t i = begin + j;
+                const size_t bw = static_cast<size_t>(wr[j].bytes_written);
+                if (bw != 0 && dst_ptrs[i] != nullptr &&
+                    cudaMemcpy(dst_ptrs[i], d_dst + off, bw,
+                               cudaMemcpyDeviceToHost) != cudaSuccess) {
+                    copy_failed = true;
+                    break;
+                }
+                off += dst_caps[i];
+            }
+            if (copy_failed) {
+                WAVE_FAIL(CUDEC_ERR_CUDA);
+            }
+        }
+
+        /* Gate slot reuse on the whole wave's completion. */
+        if (cudaEventRecord(slot.ev.e, stream) != cudaSuccess) {
+            WAVE_FAIL(CUDEC_ERR_CUDA);
+        }
+    }
+#undef WAVE_FAIL
+
+    /* Drain every stream unconditionally so no async work outlives the RAII
+     * teardown, and surface any async fault as a defined error. */
+    cudec_status drain = wave_status;
+    for (unsigned s = 0; s < n_streams; s++) {
+        if (cudaStreamSynchronize(stream_pool[s].s) != cudaSuccess &&
+            drain == CUDEC_OK) {
+            drain = CUDEC_ERR_CUDA;
+        }
+    }
+    if (cudaGetLastError() != cudaSuccess && drain == CUDEC_OK) {
+        drain = CUDEC_ERR_CUDA;
+    }
+
+    /* Publish whatever per-chunk results completed (0xFF non-OK sentinel for
+     * any wave that did not), then decide the aggregate. */
+    std::memcpy(h_results, p_results.p, results_bytes);
+    if (drain != CUDEC_OK) {
+        return drain;
+    }
+
+    /* Aggregate: OK iff every chunk decoded OK, else the first non-OK in
+     * index order - a lazy caller checking only the return still fails
+     * closed. */
+    for (size_t i = 0; i < chunk_count; i++) {
+        if (h_results[i].status != CUDEC_OK) {
+            return static_cast<cudec_status>(h_results[i].status);
+        }
+    }
+    return CUDEC_OK;
+#undef STREAM_CUDA
+}
+
+}  // namespace
+
+cudec_status cudec_lz4_decompress_stream(const void* const* h_src_ptrs,
+                                         const size_t* h_src_sizes,
+                                         void* const* dst_ptrs,
+                                         const size_t* dst_caps,
+                                         size_t chunk_count,
+                                         cudec_mem_space dst_space,
+                                         unsigned streams,
+                                         cudec_chunk_result* h_results) {
+    if (h_src_ptrs == nullptr || h_src_sizes == nullptr ||
+        dst_ptrs == nullptr || dst_caps == nullptr || h_results == nullptr ||
+        chunk_count == 0 || chunk_count > kMaxChunks ||
+        (dst_space != CUDEC_MEM_HOST && dst_space != CUDEC_MEM_DEVICE)) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+    /* A NULL source with a non-zero size (a host read that would segfault) or
+     * a NULL destination for a chunk that claims capacity is a caller error;
+     * reject the whole call before touching the device. */
+    for (size_t i = 0; i < chunk_count; i++) {
+        if ((h_src_ptrs[i] == nullptr && h_src_sizes[i] != 0) ||
+            (dst_ptrs[i] == nullptr && dst_caps[i] != 0)) {
+            return CUDEC_ERR_INVALID_ARGUMENT;
+        }
+    }
+    try {
+        return DecodeStream(h_src_ptrs, h_src_sizes, dst_ptrs, dst_caps,
+                            chunk_count, dst_space, streams, h_results);
+    } catch (...) {
+        /* A host allocation failed; never let it cross the C ABI. */
+        return CUDEC_ERR_CUDA;
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,7 @@ cudec_add_test(frame_twin SOURCES frame_twin.cu LIBS lz4_frame_oracle GPU)
 # frame_twin verifies the library's own xxhash32.h against liblz4's XXH32.
 target_include_directories(frame_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+cudec_add_test(stream_twin SOURCES stream_twin.cu LIBS cudec_test_fixtures GPU)
 
 # ---- Structural conformance, configure time: a violation reds every CI
 # build. These are drift detectors, not tamper-proofing - the honest limits

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -72,6 +72,25 @@ int main(void) {
         REQUIRE(written == 0);
     }
 
+    /* The streaming entry and its enum resolve their C linkage here. Every
+     * call is an argument reject that returns before any CUDA call. */
+    {
+        const void* one_src[1] = {0};
+        size_t one_size[1] = {0};
+        void* one_dst[1] = {0};
+        size_t one_cap[1] = {0};
+        cudec_chunk_result sres[1];
+        REQUIRE(cudec_lz4_decompress_stream(0, one_size, one_dst, one_cap, 1,
+                                            CUDEC_MEM_DEVICE, 4, sres) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* null array */
+        REQUIRE(cudec_lz4_decompress_stream(one_src, one_size, one_dst, one_cap,
+                                            0, CUDEC_MEM_DEVICE, 4, sres) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* zero chunks */
+        REQUIRE(cudec_lz4_decompress_stream(one_src, one_size, one_dst, one_cap,
+                                            1, (cudec_mem_space)7, 4, sres) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* unknown dst_space */
+    }
+
     printf("PASS: plain-C caller exercised every public symbol\n");
     return 0;
 }

--- a/tests/stream_twin.cu
+++ b/tests/stream_twin.cu
@@ -1,0 +1,242 @@
+/* The streaming decode entry (cudec_lz4_decompress_stream) held to the
+ * substitute-for-compute-sanitizer gate, extended to the new concurrency
+ * axis: the SAME input decoded at every stream count and in both memory
+ * spaces must be BIT-IDENTICAL (determinism under interleaving), and equal
+ * to the CPU oracle's decode (correctness). Plus the fail-closed ladder: a
+ * corrupt chunk mid-batch reports its error while neighbours decode OK and
+ * the aggregate carries it; zero chunks / a NULL dst reject synchronously;
+ * an undersized dst[k] fails only that chunk. #24. */
+#include "cudec.h"
+#include "fixtures.h"
+#include "require.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr unsigned char kPoison = 0xA5;
+
+struct SChunk {
+    const std::vector<unsigned char>* src;
+    size_t cap;
+};
+
+/* Runs one batch through the streaming entry for a given memory space and
+ * stream count. Returns the per-chunk results, the host-visible destination
+ * bytes (downloaded for device space), and the aggregate status. Device
+ * allocations are reclaimed at process exit (the gpu label is RUN_SERIAL and
+ * no state is kept across tests) - the same convention as gpu_fixture. */
+int RunStream(const std::vector<SChunk>& chunks, cudec_mem_space space,
+              unsigned streams, std::vector<cudec_chunk_result>* results,
+              std::vector<std::vector<unsigned char>>* dst_bytes,
+              cudec_status* aggregate) {
+    const size_t n = chunks.size();
+    std::vector<const void*> h_src(n);
+    std::vector<size_t> h_ssz(n);
+    std::vector<void*> h_dst(n);
+    std::vector<size_t> h_cap(n);
+    std::vector<std::vector<unsigned char>> host_dst;
+    if (space == CUDEC_MEM_HOST) {
+        host_dst.resize(n);
+    }
+    for (size_t i = 0; i < n; i++) {
+        h_src[i] = chunks[i].src->data();
+        h_ssz[i] = chunks[i].src->size();
+        h_cap[i] = chunks[i].cap;
+        if (space == CUDEC_MEM_HOST) {
+            host_dst[i].assign(chunks[i].cap, kPoison);
+            h_dst[i] = host_dst[i].data();
+        } else {
+            void* d = nullptr;
+            REQUIRE_CUDA(cudaMalloc(&d, chunks[i].cap ? chunks[i].cap : 1));
+            if (chunks[i].cap) {
+                REQUIRE_CUDA(cudaMemset(d, kPoison, chunks[i].cap));
+            }
+            h_dst[i] = d;
+        }
+    }
+
+    results->assign(n, cudec_chunk_result{});
+    *aggregate = cudec_lz4_decompress_stream(
+        h_src.data(), h_ssz.data(), h_dst.data(), h_cap.data(), n, space,
+        streams, results->data());
+
+    dst_bytes->assign(n, {});
+    for (size_t i = 0; i < n; i++) {
+        (*dst_bytes)[i].assign(chunks[i].cap, 0);
+        if (chunks[i].cap == 0) {
+            continue;
+        }
+        if (space == CUDEC_MEM_HOST) {
+            std::memcpy((*dst_bytes)[i].data(), host_dst[i].data(),
+                        chunks[i].cap);
+        } else {
+            REQUIRE_CUDA(cudaMemcpy((*dst_bytes)[i].data(), h_dst[i],
+                                    chunks[i].cap, cudaMemcpyDeviceToHost));
+        }
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    const auto fixtures = MakeLz4BlockFixtures();
+    REQUIRE(!fixtures.empty());
+
+    /* A batch spanning several 64-chunk waves so the multi-stream
+     * round-robin actually engages (single-wave batches never interleave). */
+    std::vector<SChunk> batch;
+    std::vector<const std::vector<unsigned char>*> expect;
+    for (int rep = 0; rep < 40; rep++) {
+        for (const auto& f : fixtures) {
+            batch.push_back(SChunk{&f.compressed, f.original.size() + 8});
+            expect.push_back(&f.original);
+        }
+    }
+    const size_t n = batch.size();
+    REQUIRE(n > 128); /* > 2 waves */
+
+    /* Reference: device space, one stream (no overlap). Every other run must
+     * match its decoded bytes exactly. */
+    std::vector<cudec_chunk_result> ref_res;
+    std::vector<std::vector<unsigned char>> ref_dst;
+    cudec_status ref_agg;
+    REQUIRE(RunStream(batch, CUDEC_MEM_DEVICE, 1, &ref_res, &ref_dst,
+                      &ref_agg) == 0);
+    REQUIRE(ref_agg == CUDEC_OK);
+    for (size_t i = 0; i < n; i++) {
+        REQUIRE_CTX(ref_res[i].status == CUDEC_OK, "ref chunk %zu", i);
+        REQUIRE_CTX(ref_res[i].bytes_written == expect[i]->size(),
+                    "ref bw %zu", i);
+        REQUIRE_CTX(equal_bytes(ref_dst[i].data(), expect[i]->data(),
+                                expect[i]->size()),
+                    "ref bytes %zu", i);
+        /* Device space: the kernel writes exactly bytes_written and leaves
+         * the poison beyond it untouched. */
+        for (size_t j = expect[i]->size(); j < ref_dst[i].size(); j++) {
+            REQUIRE_CTX(ref_dst[i][j] == kPoison, "ref poison %zu@%zu", i, j);
+        }
+    }
+
+    /* Determinism + oracle parity across both spaces and stream counts: the
+     * WHOLE caller buffer (decoded prefix + the untouched poison tail) is
+     * bit-identical to the reference for every (space, streams). Comparing
+     * the full buffer, not just the prefix, also locks the no-clobber
+     * property - both spaces must leave the space beyond bytes_written as the
+     * caller left it. This is the masterplan's substitute gate extended to
+     * the concurrency axis. */
+    const cudec_mem_space spaces[] = {CUDEC_MEM_DEVICE, CUDEC_MEM_HOST};
+    const unsigned stream_counts[] = {1, 2, 4, 7};
+    for (cudec_mem_space space : spaces) {
+        for (unsigned s : stream_counts) {
+            std::vector<cudec_chunk_result> res;
+            std::vector<std::vector<unsigned char>> dst;
+            cudec_status agg;
+            REQUIRE(RunStream(batch, space, s, &res, &dst, &agg) == 0);
+            REQUIRE_CTX(agg == CUDEC_OK, "agg space=%d streams=%u",
+                        static_cast<int>(space), s);
+            for (size_t i = 0; i < n; i++) {
+                REQUIRE_CTX(res[i].status == CUDEC_OK, "ok space=%d s=%u c=%zu",
+                            static_cast<int>(space), s, i);
+                REQUIRE_CTX(res[i].bytes_written == ref_res[i].bytes_written,
+                            "bw space=%d s=%u c=%zu", static_cast<int>(space),
+                            s, i);
+                REQUIRE_CTX(dst[i].size() == ref_dst[i].size(),
+                            "cap space=%d s=%u c=%zu", static_cast<int>(space),
+                            s, i);
+                REQUIRE_CTX(equal_bytes(dst[i].data(), ref_dst[i].data(),
+                                        dst[i].size()),
+                            "determinism space=%d s=%u c=%zu",
+                            static_cast<int>(space), s, i);
+            }
+        }
+    }
+
+    /* Fail-closed ladder. */
+
+    /* A corrupt chunk between two valid ones: it reports its defined error
+     * with no output, the neighbours decode OK, and the aggregate carries
+     * the corrupt chunk's status. The corrupt stream is the first
+     * oracle-rejected mutant (cudec rejects everything the oracle rejects). */
+    std::vector<unsigned char> corrupt;
+    for (const auto& f : fixtures) {
+        for (auto& m : MutateStream(f.compressed, f.seed)) {
+            std::vector<unsigned char> decoded;
+            if (!OracleDecodes(m.stream, f.original.size(), &decoded)) {
+                corrupt = std::move(m.stream);
+                break;
+            }
+        }
+        if (!corrupt.empty()) {
+            break;
+        }
+    }
+    REQUIRE(!corrupt.empty());
+    for (cudec_mem_space space : spaces) {
+        std::vector<SChunk> b = {
+            SChunk{&fixtures[0].compressed, fixtures[0].original.size() + 8},
+            SChunk{&corrupt, 1 << 16},
+            SChunk{&fixtures[0].compressed, fixtures[0].original.size() + 8}};
+        std::vector<cudec_chunk_result> res;
+        std::vector<std::vector<unsigned char>> dst;
+        cudec_status agg;
+        REQUIRE(RunStream(b, space, 2, &res, &dst, &agg) == 0);
+        REQUIRE_CTX(res[0].status == CUDEC_OK, "space=%d",
+                    static_cast<int>(space));
+        REQUIRE_CTX(res[2].status == CUDEC_OK, "space=%d",
+                    static_cast<int>(space));
+        REQUIRE_CTX(res[1].status != CUDEC_OK, "space=%d",
+                    static_cast<int>(space));
+        REQUIRE_CTX(res[1].bytes_written == 0, "space=%d",
+                    static_cast<int>(space));
+        REQUIRE_CTX(agg == static_cast<cudec_status>(res[1].status),
+                    "space=%d", static_cast<int>(space));
+    }
+
+    /* An undersized dst fails only its chunk; the neighbour decodes OK. */
+    for (cudec_mem_space space : spaces) {
+        std::vector<SChunk> b = {
+            SChunk{&fixtures[0].compressed, fixtures[0].original.size() + 8},
+            SChunk{&fixtures[0].compressed, fixtures[0].original.size() / 2}};
+        std::vector<cudec_chunk_result> res;
+        std::vector<std::vector<unsigned char>> dst;
+        cudec_status agg;
+        REQUIRE(RunStream(b, space, 2, &res, &dst, &agg) == 0);
+        REQUIRE_CTX(res[0].status == CUDEC_OK, "space=%d",
+                    static_cast<int>(space));
+        REQUIRE_CTX(res[1].status == CUDEC_ERR_OUTPUT_TOO_SMALL, "space=%d",
+                    static_cast<int>(space));
+        REQUIRE_CTX(res[1].bytes_written == 0, "space=%d",
+                    static_cast<int>(space));
+        REQUIRE_CTX(agg == CUDEC_ERR_OUTPUT_TOO_SMALL, "space=%d",
+                    static_cast<int>(space));
+    }
+
+    /* Zero chunks and a NULL destination with a claimed capacity reject
+     * synchronously. */
+    {
+        const void* s0 = fixtures[0].compressed.data();
+        size_t sz0 = fixtures[0].compressed.size();
+        void* d0 = nullptr;
+        size_t cap0 = 100;
+        cudec_chunk_result r0;
+        REQUIRE(cudec_lz4_decompress_stream(&s0, &sz0, &d0, &cap0, 0,
+                                            CUDEC_MEM_HOST, 4,
+                                            &r0) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(cudec_lz4_decompress_stream(&s0, &sz0, &d0, &cap0, 1,
+                                            CUDEC_MEM_HOST, 4,
+                                            &r0) == CUDEC_ERR_INVALID_ARGUMENT);
+    }
+
+    std::printf("PASS: streaming decode bit-identical across streams {1,2,4,7} "
+                "x {host,device} in oracle parity over %zu chunks; corrupt "
+                "isolation, undersized, zero-chunk, null-dst all fail-closed\n",
+                n);
+    return 0;
+}


### PR DESCRIPTION
# What & why

The pinned-host streaming decode path (masterplan section 4, the
asset-streaming memory path). Adds a decode entry point that takes
host-resident compressed chunks and pipelines the H2D copy against decode
across CUDA streams, so a caller streaming compressed assets from
disk/network does not serialize copy-then-decode. Refs #24.

This is **PR1 of two**: the entry point plus its correctness/determinism
lock. The overlap measurement, a `--gpu-stream` end-to-end bench, the
`stream_overlap` event-interval lock, and `docs/BENCHMARKS.md` numbers, is
PR2 (deliberately deferred per the plan on the issue).

Design chosen by a 4-approach design panel (2 judges, unanimous); the plan,
alternatives, and the named conformance test are on the issue.

- **No kernel, no parser code.** Pure host-side stream choreography around
  the unchanged, already-fuzzed `cudec_lz4_decompress_batch`, reused
  verbatim per wave. The fuzzed attack surface does not move.
- **ABI:** `cudec_mem_space {CUDEC_MEM_HOST, CUDEC_MEM_DEVICE}` and
  `cudec_lz4_decompress_stream(h_src_ptrs, h_src_sizes, dst_ptrs, dst_caps,
  chunk_count, dst_space, streams, h_results)`. All arrays are host arrays;
  compressed input is host memory; output goes to host (D2H) or stays in
  device VRAM per `dst_space`. Synchronous.
- **Determinism by construction:** per-chunk output and result indices are
  disjoint across waves and streams, so interleaving cannot change the
  bytes, the output is bit-identical for every `streams` value. On a
  successful chunk the destination holds exactly `bytes_written` bytes and
  the space beyond is left untouched, in both memory spaces.
- **`src/stream.cpp`:** N streams (default 4), a ring of 2N slots each with
  a pinned staging buffer + device src buffer + pinned/device metadata +
  (host-output) device dst staging + a completion event; the batch is tiled
  into 64-chunk waves, wave i on stream i mod N, a slot's event gating its
  reuse. RAII owners free on every path; an unconditional per-stream drain
  runs before teardown; a `try/catch` at the C-ABI boundary contains
  `std::bad_alloc`. Device output writes caller VRAM directly and the
  copy/decode pipeline overlaps; host output copies exactly `bytes_written`
  per chunk after a per-wave sync (the readback to pageable caller memory is
  synchronous, so host output is serial in this cut, device output is the
  overlapped path, and PR2 measures it).
- **Fail-closed aggregate:** the pipeline drains fully (no early abort), then
  the aggregate is `CUDEC_OK` iff every chunk decoded OK, else a CUDA
  resource failure takes precedence, else the first non-OK chunk in index
  order. A failed chunk reports its defined error with `bytes_written 0`;
  neighbours are unaffected.

## Type of change

- [x] API surface
- [x] Decode kernel / device code (host-side CUDA orchestration; the kernel
      itself is unchanged)

## Engineering checklist

- [x] Fail-closed preserved: null/zero/over-limit/undersized/corrupt all
      reject with a defined status; per-chunk isolation; negative tests for
      each branch in both memory spaces.
- [x] Oracle coverage: `stream_twin` decodes a multi-wave batch through the
      streaming entry byte-exact to liblz4 across `streams ∈ {1,2,4,7}` and
      both `dst_space` values.
- [x] Determinism preserved: whole-buffer bit-identical across every stream
      count and both spaces (the substitute gate extended to the concurrency
      axis; compute-sanitizer cannot run under WSL2/WDDM).
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [x] Adversarial review run (`/security-review`), two rounds, all five
      lenses incl. cuda-reviewer PASS — see Notes.

## Performance checklist

No performance claim in this PR, the overlap measurement is PR2. The
structure (async pinned H2D, pinned-mirror result readback, double-buffer
ring, non-blocking streams, zero device-wide sync) is built so PR2 can
measure the device-output overlap honestly.

## Quality checklist

- [x] Minimal, self-documenting; the load-bearing CUDA-seam "why" comments
      are kept.
- [x] Conformance: `cudec_lz4_decompress_stream` and `cudec_mem_space` are
      resolved from the plain-C conformance test; determinism-across-stream-
      count is locked by `stream_twin`. (The `stream_overlap` structural
      lock lands with PR2.)

## Verification

Pinned dev container (`nvidia/cuda:12.6.2-devel-ubuntu24.04`, RTX 3080,
nvcc 12.6.77), clean rebuild, host C/CXX/CUDA all `-Werror`:

```
100% tests passed, 0 tests failed out of 9
    Start 8: stream_twin
8/9 Test #8: stream_twin ......................   Passed    1.21 sec
```

- [x] `cmake --build`, clean.
- [x] `ctest`, 9/9 green (stream_twin incl.).
- [x] Prettier, clean.

## Notes

Adversarial review: two rounds of the refute-by-default panel (correctness /
robustness / integration / performance + cuda-reviewer), converging to PASS
on every lens.

Round 1 (correctness PASS, four NEEDS_IMPROVEMENT), the central finding: the
host-output D2H copied full `dst_caps`, clobbering the caller's buffer past
`bytes_written` with uninitialized/prior-wave-plaintext staging content
(nondeterministic tail, a device/host contract divergence, and to pageable
memory so it defeated overlap anyway). Fixed: the host path now drains each
wave, reads `bytes_written` from the pinned result mirror, and copies exactly
that many bytes, leaving the tail untouched, symmetric with device output,
no cross-chunk residue. Also fixed: the unmeasured "overlap holds
unconditionally" header claim (softened; overlap honestly scoped to device
output); the error-path teardown relying on `cudaFree`'s implicit device sync
(now an unconditional explicit drain before RAII teardown); a NULL `src[k]`
with non-zero size host-segfaulting (now rejected `INVALID_ARGUMENT`);
`h_results` unwritten on the error path (now a 0xFF non-OK sentinel published
on every path); the new symbol not conformance-tested from C (added);
default-stream fragility (streams now `cudaStreamNonBlocking`). Tests
strengthened to compare the whole caller buffer (locking no-clobber) and to
run the fail-closed ladder in both memory spaces.

Round 2: all five lenses PASS; two remaining LOW notes closed in-line (the
header now enumerates the NULL-src reject; host mode collapses to a single
stream since its per-wave sync makes a fan-out pointless).

CodeRabbit remains inactive on the repo (see the earlier PR notes); the app
installation is a decision of mine.
