### PR TITLE
Measure the streaming decode path: an honest negative result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,8 @@ jobs:
           test -x build-cuda/tests/smoke &&
           test -x build-cuda/tests/gpu_fixture &&
           test -x build-cuda/tests/frame_twin &&
-          test -x build-cuda/tests/stream_twin
+          test -x build-cuda/tests/stream_twin &&
+          test -x build-cuda/tests/stream_overlap
 
       # The host-side subset; gpu-labeled tests run in this same container
       # on the maintainer's machine and their output is pasted into the PR.
@@ -102,7 +103,8 @@ jobs:
           grep -E ': smoke$' gpu-deferred.txt &&
           grep -E ': gpu_fixture$' gpu-deferred.txt &&
           grep -E ': frame_twin$' gpu-deferred.txt &&
-          grep -E ': stream_twin$' gpu-deferred.txt
+          grep -E ': stream_twin$' gpu-deferred.txt &&
+          grep -E ': stream_overlap$' gpu-deferred.txt
 
   format:
     name: format

--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -211,6 +211,7 @@ int main(int argc, char** argv) {
     size_t warmup = 3;
     bool selfcheck = false;
     bool gpu = false;
+    bool gpu_stream = false;
     std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
@@ -218,6 +219,8 @@ int main(int argc, char** argv) {
             selfcheck = true;
         } else if (arg == "--gpu") {
             gpu = true;
+        } else if (arg == "--gpu-stream") {
+            gpu_stream = true;
         } else if (arg == "--runs" && i + 1 < argc) {
             if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
                 std::fprintf(stderr, "--runs must be in [1, %zu]\n",
@@ -234,8 +237,9 @@ int main(int argc, char** argv) {
             std::fprintf(stderr, "%s needs a value\n", arg.c_str());
             return 2;
         } else if (!arg.empty() && arg[0] == '-') {
-            std::fprintf(stderr, "usage: bench_lz4 [--runs N] [--warmup N] "
-                                 "[--gpu] [--selfcheck] [corpus files...]\n");
+            std::fprintf(stderr,
+                         "usage: bench_lz4 [--runs N] [--warmup N] [--gpu] "
+                         "[--gpu-stream] [--selfcheck] [corpus files...]\n");
             return 2;
         } else {
             files.push_back(arg);
@@ -336,6 +340,63 @@ int main(int argc, char** argv) {
                     "%.1f GB/s - ceilings this design AND any two-phase "
                     "phase-1 (shared parse)\n",
                     g.parse_only_ms_p50, g.parse_only_gbps_p50);
+    }
+
+    if (gpu_stream) {
+        std::vector<const unsigned char*> comp_ptrs(corpus.compressed.size());
+        std::vector<size_t> comp_sizes(corpus.compressed.size());
+        std::vector<size_t> orig_sizes(corpus.originals.size());
+        for (size_t i = 0; i < corpus.compressed.size(); i++) {
+            comp_ptrs[i] = corpus.compressed[i].data();
+            comp_sizes[i] = corpus.compressed[i].size();
+            orig_sizes[i] = corpus.originals[i].size();
+        }
+        const unsigned kStreams = 4;
+        cudec_stream_result s;
+        if (!cudec_bench_gpu_stream(comp_ptrs.data(), comp_sizes.data(),
+                                    orig_sizes.data(), corpus.originals.size(),
+                                    static_cast<int>(warmup),
+                                    static_cast<int>(runs), kStreams, &s)) {
+            std::fprintf(stderr, "GPU streaming bench failed\n");
+            return 1;
+        }
+        /* The effective overlap depth: the entry caps streams to the wave
+         * count (64 chunks/wave), so a small corpus runs fewer than requested.
+         */
+        const size_t kWaveChunks = 64;
+        const size_t waves =
+            (corpus.originals.size() + kWaveChunks - 1) / kWaveChunks;
+        const unsigned eff_streams = static_cast<unsigned>(
+            s.overlap_streams < waves ? s.overlap_streams : waves);
+        /* End-to-end throughput = decoded output bytes / wall time (H2D and,
+         * for host output, D2H included). The wall also includes the one-shot
+         * per-call ring allocation this synchronous entry does (a reusable
+         * context is deferred): the numbers below are DOMINATED by that setup,
+         * not by copy or decode - compare the device wall to the pure-H2D and
+         * device-resident-decode rows. For the same reason the two device rows
+         * are NOT a clean overlap comparison: the higher-stream config
+         * provisions proportionally more ring, so its extra time is setup, not
+         * a copy/decode-overlap regression. A setup-free overlap number needs
+         * the reusable context (follow-up); the overlap CAPABILITY itself is
+         * locked by the stream_overlap test. */
+        std::printf("- GPU streaming, end-to-end, ONE-SHOT-SETUP-DOMINATED "
+                    "(host compressed in -> decoded out; wall clock around the "
+                    "whole synchronous call incl. per-call ring setup; %d "
+                    "warmup + %d runs):\n",
+                    static_cast<int>(warmup), static_cast<int>(runs));
+        std::printf("    device out: 1 stream p50 %.1f ms, %.2f GB/s ; %u "
+                    "streams (of %u requested) p50 %.1f ms, %.2f GB/s\n",
+                    s.device_serial_ms, s.device_serial_gbps, eff_streams,
+                    s.overlap_streams, s.device_overlap_ms,
+                    s.device_overlap_gbps);
+        std::printf("    host out (1 internal stream; readback synchronous): "
+                    "p50 %.1f ms, %.2f GB/s\n",
+                    s.host_ms, s.host_gbps);
+        std::printf("    context: pure contiguous H2D of %.2f MB compressed = "
+                    "p50 %.3f ms (a best-case floor; the pipeline stages many "
+                    "smaller per-wave copies) - dwarfed by the walls above, so "
+                    "the walls are setup-bound, not PCIe-bound\n",
+                    static_cast<double>(s.compressed_bytes) / 1e6, s.h2d_ms);
     }
 
     if (selfcheck) {

--- a/bench/gpu_bench.cu
+++ b/bench/gpu_bench.cu
@@ -10,6 +10,8 @@
 #include <cuda_runtime.h>
 
 #include <algorithm>
+#include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 
@@ -80,6 +82,39 @@ cudec_status LaunchFull(const void* const* s, const size_t* ss,
                         void* const* d, const size_t* dc, size_t n,
                         cudec_chunk_result* r, cudaStream_t stream) {
     return cudec_lz4_decompress_batch(s, ss, d, dc, n, r, stream);
+}
+
+/* Wall-clock-times the synchronous streaming entry over `runs` iterations
+ * after `warmup`, returning the p50 milliseconds. The call drains internally,
+ * so std::chrono around it is the honest end-to-end (pinned staging + H2D +
+ * decode + [D2H] + the one-shot ring setup, as a caller sees it). */
+bool TimeStream(const void* const* h_src, const size_t* h_ssz,
+                void* const* h_dst, const size_t* h_cap, size_t n,
+                cudec_mem_space space, unsigned streams,
+                cudec_chunk_result* results, int warmup, int runs,
+                double* p50_ms) {
+    for (int i = 0; i < warmup; i++) {
+        if (cudec_lz4_decompress_stream(h_src, h_ssz, h_dst, h_cap, n, space,
+                                        streams, results) != CUDEC_OK) {
+            return false;
+        }
+    }
+    std::vector<double> t(static_cast<size_t>(runs));
+    for (int i = 0; i < runs; i++) {
+        const auto s = std::chrono::steady_clock::now();
+        const cudec_status st = cudec_lz4_decompress_stream(
+            h_src, h_ssz, h_dst, h_cap, n, space, streams, results);
+        const auto e = std::chrono::steady_clock::now();
+        if (st != CUDEC_OK) {
+            return false;
+        }
+        t[static_cast<size_t>(i)] =
+            std::chrono::duration<double, std::milli>(e - s).count();
+    }
+    std::sort(t.begin(), t.end());
+    const size_t rank = (t.size() * 50 + 99) / 100;
+    *p50_ms = t[(rank == 0 ? 1 : rank) - 1];
+    return true;
 }
 
 }  // namespace
@@ -166,5 +201,144 @@ bool cudec_bench_gpu(const unsigned char* const* comp,
     out->parse_only_gbps_p50 = parse_ms > 0.0 ? gb / (parse_ms / 1e3) : 0.0;
     /* Buffers are reclaimed at process exit; the bench is a short-lived
      * one-shot, like the test harness. */
+    return true;
+}
+
+bool cudec_bench_gpu_stream(const unsigned char* const* comp,
+                            const size_t* comp_sizes, const size_t* orig_sizes,
+                            size_t n, int warmup, int runs, unsigned streams,
+                            cudec_stream_result* out) {
+    size_t total_out = 0;
+    size_t total_comp = 0;
+    for (size_t i = 0; i < n; i++) {
+        /* Overflow-guard the arena sizes, as the library entry does its own
+         * (a wrapped sum would under-allocate d_out and drive OOB slicing). */
+        if (SIZE_MAX - total_out < orig_sizes[i] ||
+            SIZE_MAX - total_comp < comp_sizes[i]) {
+            return false;
+        }
+        total_out += orig_sizes[i];
+        total_comp += comp_sizes[i];
+    }
+
+    /* Host input arrays: the compressed blocks stay where the caller has
+     * them (host memory); the library stages them through its pinned ring. */
+    std::vector<const void*> h_src(n);
+    std::vector<size_t> h_ssz(n), h_cap(n);
+    for (size_t i = 0; i < n; i++) {
+        h_src[i] = comp[i];
+        h_ssz[i] = comp_sizes[i];
+        h_cap[i] = orig_sizes[i];
+    }
+    std::vector<cudec_chunk_result> res(n);
+
+    /* One device and one host output arena, sliced per chunk. */
+    void* d_out = nullptr;
+    BG_CUDA(cudaMalloc(&d_out, total_out ? total_out : 1));
+    std::vector<void*> d_dst(n);
+    std::vector<unsigned char> h_out(total_out ? total_out : 1);
+    std::vector<void*> h_dst(n);
+    {
+        size_t off = 0;
+        for (size_t i = 0; i < n; i++) {
+            d_dst[i] = static_cast<unsigned char*>(d_out) + off;
+            h_dst[i] = h_out.data() + off;
+            off += orig_sizes[i];
+        }
+    }
+
+    /* Correctness precondition on both paths: every chunk returns CUDEC_OK
+     * with its original decoded size, or the numbers are meaningless
+     * (honest-numbers rule). Byte-for-byte correctness is gated by the
+     * stream_twin / gpu_fixture oracle tests, not re-verified here. */
+    for (int pass = 0; pass < 2; pass++) {
+        void* const* dst = (pass == 0) ? d_dst.data() : h_dst.data();
+        const cudec_mem_space sp =
+            (pass == 0) ? CUDEC_MEM_DEVICE : CUDEC_MEM_HOST;
+        if (cudec_lz4_decompress_stream(h_src.data(), h_ssz.data(), dst,
+                                        h_cap.data(), n, sp, streams,
+                                        res.data()) != CUDEC_OK) {
+            return false;
+        }
+        for (size_t i = 0; i < n; i++) {
+            if (res[i].status != CUDEC_OK ||
+                res[i].bytes_written != orig_sizes[i]) {
+                std::fprintf(stderr,
+                             "stream bench: chunk %zu did not decode (%s)\n", i,
+                             pass == 0 ? "device" : "host");
+                return false;
+            }
+        }
+    }
+
+    /* Device output at 1 stream (no overlap) and at `streams` (overlapped);
+     * host output at 1 stream (the entry forces it serial anyway, so more
+     * would only provision unused ring). */
+    double dev_serial = 0.0;
+    double dev_overlap = 0.0;
+    double host_ms = 0.0;
+    if (!TimeStream(h_src.data(), h_ssz.data(), d_dst.data(), h_cap.data(), n,
+                    CUDEC_MEM_DEVICE, 1, res.data(), warmup, runs,
+                    &dev_serial) ||
+        !TimeStream(h_src.data(), h_ssz.data(), d_dst.data(), h_cap.data(), n,
+                    CUDEC_MEM_DEVICE, streams, res.data(), warmup, runs,
+                    &dev_overlap) ||
+        !TimeStream(h_src.data(), h_ssz.data(), h_dst.data(), h_cap.data(), n,
+                    CUDEC_MEM_HOST, 1, res.data(), warmup, runs, &host_ms)) {
+        return false;
+    }
+
+    /* Pure H2D of the compressed bytes, pinned->device, for context: a
+     * best-case PCIe floor. Comparing it to the end-to-end wall shows whether
+     * that wall is copy-bound or (as measured) dominated by per-call setup. */
+    double h2d_ms = 0.0;
+    {
+        void* d_comp = nullptr;
+        void* p_comp = nullptr;
+        BG_CUDA(cudaMalloc(&d_comp, total_comp ? total_comp : 1));
+        BG_CUDA(cudaHostAlloc(&p_comp, total_comp ? total_comp : 1,
+                              cudaHostAllocDefault));
+        size_t off = 0;
+        for (size_t i = 0; i < n; i++) {
+            if (comp_sizes[i]) {
+                std::copy(comp[i], comp[i] + comp_sizes[i],
+                          static_cast<unsigned char*>(p_comp) + off);
+            }
+            off += comp_sizes[i];
+        }
+        for (int i = 0; i < warmup; i++) {
+            BG_CUDA(cudaMemcpy(d_comp, p_comp, total_comp ? total_comp : 1,
+                               cudaMemcpyHostToDevice));
+        }
+        std::vector<double> t(static_cast<size_t>(runs));
+        for (int i = 0; i < runs; i++) {
+            const auto s = std::chrono::steady_clock::now();
+            BG_CUDA(cudaMemcpy(d_comp, p_comp, total_comp ? total_comp : 1,
+                               cudaMemcpyHostToDevice));
+            const auto e = std::chrono::steady_clock::now();
+            t[static_cast<size_t>(i)] =
+                std::chrono::duration<double, std::milli>(e - s).count();
+        }
+        std::sort(t.begin(), t.end());
+        const size_t rank = (t.size() * 50 + 99) / 100;
+        h2d_ms = t[(rank == 0 ? 1 : rank) - 1];
+    }
+
+    const double gb = static_cast<double>(total_out) / 1e9;
+    out->chunks = n;
+    out->output_bytes = total_out;
+    out->compressed_bytes = total_comp;
+    out->overlap_streams = streams;
+    out->device_serial_ms = dev_serial;
+    out->device_overlap_ms = dev_overlap;
+    out->host_ms = host_ms;
+    out->h2d_ms = h2d_ms;
+    out->device_serial_gbps = dev_serial > 0.0 ? gb / (dev_serial / 1e3) : 0.0;
+    out->device_overlap_gbps =
+        dev_overlap > 0.0 ? gb / (dev_overlap / 1e3) : 0.0;
+    out->host_gbps = host_ms > 0.0 ? gb / (host_ms / 1e3) : 0.0;
+    /* The output/context arenas (d_out, d_comp, p_comp) are reclaimed at
+     * process exit; the bench is a short-lived one-shot called once, like
+     * cudec_bench_gpu above. */
     return true;
 }

--- a/bench/gpu_bench.h
+++ b/bench/gpu_bench.h
@@ -22,4 +22,31 @@ bool cudec_bench_gpu(const unsigned char* const* comp,
                      const size_t* comp_sizes, const size_t* orig_sizes,
                      size_t n, int warmup, int runs, cudec_gpu_result* out);
 
+struct cudec_stream_result {
+    size_t chunks;
+    size_t output_bytes;
+    size_t compressed_bytes;
+    unsigned overlap_streams;   /* the N used for the overlapped device row */
+    double device_serial_ms;    /* device out, streams=1 (no overlap) */
+    double device_overlap_ms;   /* device out, streams=N (overlapped) */
+    double host_ms;             /* host out, end to end (serial by design) */
+    double h2d_ms;              /* pure H2D of the compressed bytes, context */
+    double device_serial_gbps;
+    double device_overlap_gbps;
+    double host_gbps;
+};
+
+/* Times the streaming entry cudec_lz4_decompress_stream END TO END (host
+ * compressed in -> decoded out, wall clock around the whole synchronous
+ * call, so the pinned staging, H2D, decode, and D2H are all included, as a
+ * caller would see them) over `runs` iterations after `warmup`. Measures the
+ * device-output path at streams=1 (serial) and streams=`streams` (overlapped)
+ * to expose the copy/decode overlap, plus the host-output path, plus a pure
+ * H2D of the compressed bytes for context. Returns false on any CUDA failure
+ * or if a chunk fails to decode. */
+bool cudec_bench_gpu_stream(const unsigned char* const* comp,
+                            const size_t* comp_sizes, const size_t* orig_sizes,
+                            size_t n, int warmup, int runs, unsigned streams,
+                            cudec_stream_result* out);
+
 #endif /* CUDEC_BENCH_GPU_BENCH_H */

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -78,6 +78,61 @@ phase-1, which shares the identical serial parse, so two-phase cannot reach
 two-phase help? — is answered NO by the arithmetic. The path to higher
 throughput is structural single-pass work, not a decomposition change.
 
+## M2: pinned-host streaming decode, end-to-end (Silesia)
+
+The streaming decode path (`cudec_lz4_decompress_stream`, issue #24) times the
+whole synchronous call by CPU wall clock — pinned staging, H2D, decode, and,
+for host output, D2H, plus the **one-shot per-call ring setup** — the number a
+caller of the one-shot entry actually sees. Recorded 2026-07-17, same container
+and RTX 3080 as the M1 rows. `--gpu --gpu-stream`, 3 warmup + 30 measured
+(the device-resident row below is the `--gpu` path in the same run, for
+comparison; it is CUDA-event timed, the streaming rows are wall-clock).
+
+```
+- GPU decode (device-resident, CUDA-event timed): p50 11.9 ms, 17.8 GB/s
+- GPU streaming, end-to-end, ONE-SHOT-SETUP-DOMINATED (host compressed in -> decoded out; wall clock around the whole synchronous call incl. per-call ring setup; 3 warmup + 30 runs):
+    device out: 1 stream p50 249.1 ms, 0.85 GB/s ; 4 streams (of 4 requested) p50 288.6 ms, 0.73 GB/s
+    host out (1 internal stream; readback synchronous): p50 384.2 ms, 0.55 GB/s
+    context: pure contiguous H2D of 102.44 MB compressed = p50 3.928 ms (a best-case floor; the pipeline stages many smaller per-wave copies) - dwarfed by the walls above, so the walls are setup-bound, not PCIe-bound
+```
+
+**The measurement falsifies the streaming path's value proposition as built —
+two honest findings (masterplan section 5: numbers decide, not intentions):**
+
+1. **Overlap does not pay off for LZ4.** The premise (issue #24) was that a
+   caller "serializes copy-then-decode." But the compressed H2D is only
+   **3.9 ms** — LZ4 compresses ~2:1, so the copy is small, while the decode is
+   ~12 ms. Serial copy-then-decode is ~16 ms; perfect overlap is
+   `max(4, 12) = 12 ms`, a ~25 % / ~4 ms win at best. The copy was never the
+   wall for LZ4, so there is little to hide. (Overlap pays off when the
+   compressed input is large relative to decode — not this format.)
+
+2. **The one-shot per-call ring setup dominates and is the real cost.** The
+   end-to-end wall (249 ms device-serial) dwarfs copy (~4 ms) + decode
+   (~12 ms) by ~15×; the unaccounted ~233 ms is not separately isolated, but
+   the prime suspect is the per-call `cudaHostAlloc` / `cudaMalloc` (and their
+   frees) of the pinned ring, disproportionately expensive on this WSL2/WDDM
+   setup — corroborated by the fact that it scales with stream count. Adding
+   streams makes it **slower**
+   (289 ms at 4 streams), because 4 streams provision ~4× the ring: the
+   setup, not the pipeline, scales with stream count, so the two device rows
+   are not a clean overlap comparison. PR1 deferred a reusable context "until
+   profiling shows per-call allocation dominating" — profiling now shows
+   exactly that. **The reusable context is required, not optional** (issue
+   filed as the #24-PR2 follow-up).
+
+The device-resident M1 row (~18 GB/s, H2D excluded) remains the kernel
+throughput; the streaming number is a different, honest metric (copy +
+setup included) and is not a regression of it. The `stream_overlap`
+conformance test verifies the copy/decode **overlap capability** holds on
+this hardware — an async H2D and the decode kernel on separate streams
+complete in materially less than the sum of their individual times. Whether
+cudec's own one-shot pipeline achieves that overlap is not externally
+observable while the per-call setup dominates the wall; it becomes a
+measurable, gate-able number once the reusable context lands. Both facts —
+the capability exists, the one-shot form buries it and overlap is weak for
+LZ4 anyway — are recorded rather than hidden.
+
 ## Baseline: CPU oracle (M0, pre-kernel)
 
 The reference the GPU decoder is measured against: the single-threaded CPU

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,8 @@ cudec_add_test(frame_twin SOURCES frame_twin.cu LIBS lz4_frame_oracle GPU)
 target_include_directories(frame_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 cudec_add_test(stream_twin SOURCES stream_twin.cu LIBS cudec_test_fixtures GPU)
+cudec_add_test(stream_overlap SOURCES stream_overlap.cu LIBS
+               cudec_test_fixtures GPU)
 
 # ---- Structural conformance, configure time: a violation reds every CI
 # build. These are drift detectors, not tamper-proofing - the honest limits

--- a/tests/stream_overlap.cu
+++ b/tests/stream_overlap.cu
@@ -1,0 +1,170 @@
+/* The overlap lock for the streaming decode path (#24). The internal streams
+ * of cudec_lz4_decompress_stream are not observable across the C ABI, so this
+ * test cannot introspect the library's own pipeline; it locks the CAPABILITY
+ * the streaming overlap is built on - that an async H2D copy and the shipped
+ * decode kernel EXECUTE CONCURRENTLY on this platform.
+ *
+ * It measures each stage's duration ALONE, then runs both together on separate
+ * non-blocking streams and measures the combined wall time from a common
+ * origin. If they truly overlap, the combined time is materially less than the
+ * sum of the two alone (a serialized run would take ~the sum); the test asserts
+ * that at least half of the shorter stage is hidden behind the longer. This is
+ * a real concurrency measurement, not an event-ordering artifact: it uses only
+ * completion events (accurate) and the two alone-durations, so a run that did
+ * NOT overlap (the copy and decode funneled onto one queue) fails. Both stages
+ * are milliseconds - above WSL2/WDDM jitter - and the margin is generous (the
+ * concurrent/serial gap is ~2x), so it is not flaky.
+ *
+ * Whether cudec's OWN streaming pipeline achieves this overlap is a separate,
+ * currently un-gateable question (the one-shot per-call ring setup dominates
+ * the end-to-end wall, masking the internal overlap - see docs/BENCHMARKS.md
+ * and the reusable-context follow-up); this test locks the platform premise
+ * that the overlap is even possible here. */
+#include "cudec.h"
+#include "fixtures.h"
+#include "require.h"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+/* Event-times one op enqueued by `enqueue` on `stream`, alone. The op starts
+ * immediately after e0 (the stream is idle), so the elapsed e0->e1 is the op's
+ * true duration - no wait sits between the event and the op. */
+template <typename F>
+float TimeAlone(cudaStream_t stream, cudaEvent_t e0, cudaEvent_t e1, F enqueue) {
+    float ms = 0.0f;
+    if (cudaEventRecord(e0, stream) != cudaSuccess) return -1.0f;
+    enqueue();
+    if (cudaEventRecord(e1, stream) != cudaSuccess) return -1.0f;
+    if (cudaEventSynchronize(e1) != cudaSuccess) return -1.0f;
+    if (cudaEventElapsedTime(&ms, e0, e1) != cudaSuccess) return -1.0f;
+    return ms;
+}
+
+}  // namespace
+
+int main() {
+    /* A real compressed chunk, replicated to a batch whose decode takes
+     * milliseconds (grid-stride re-entry past 8192 blocks is fine - this is a
+     * timing workload, output is not checked here). */
+    const auto fixtures = MakeLz4BlockFixtures();
+    REQUIRE(!fixtures.empty());
+    const Fixture* big = &fixtures[0];
+    for (const auto& f : fixtures) {
+        if (f.compressed.size() > big->compressed.size()) {
+            big = &f;
+        }
+    }
+    const size_t n = 60000;
+
+    void* d_src = nullptr;
+    void* d_dst = nullptr;
+    REQUIRE_CUDA(cudaMalloc(&d_src, big->compressed.size()));
+    REQUIRE_CUDA(cudaMemcpy(d_src, big->compressed.data(),
+                            big->compressed.size(), cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMalloc(&d_dst, big->original.size()));
+
+    std::vector<const void*> h_s(n, d_src);
+    std::vector<void*> h_d(n, d_dst);
+    std::vector<size_t> h_ss(n, big->compressed.size());
+    std::vector<size_t> h_dc(n, big->original.size());
+    const void** dd_s;
+    void** dd_d;
+    size_t* dd_ss;
+    size_t* dd_dc;
+    cudec_chunk_result* dd_r;
+    REQUIRE_CUDA(cudaMalloc(&dd_s, n * sizeof(*dd_s)));
+    REQUIRE_CUDA(cudaMalloc(&dd_d, n * sizeof(*dd_d)));
+    REQUIRE_CUDA(cudaMalloc(&dd_ss, n * sizeof(*dd_ss)));
+    REQUIRE_CUDA(cudaMalloc(&dd_dc, n * sizeof(*dd_dc)));
+    REQUIRE_CUDA(cudaMalloc(&dd_r, n * sizeof(*dd_r)));
+    REQUIRE_CUDA(cudaMemcpy(dd_s, h_s.data(), n * sizeof(*dd_s),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(dd_d, h_d.data(), n * sizeof(*dd_d),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(dd_ss, h_ss.data(), n * sizeof(*dd_ss),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(dd_dc, h_dc.data(), n * sizeof(*dd_dc),
+                            cudaMemcpyHostToDevice));
+
+    /* A milliseconds-scale H2D, sized to be comparable to the decode so the
+     * overlap saving is a large, robust fraction of the total. Pinned so it is
+     * a real async DMA. */
+    const size_t kBig = size_t{128} << 20; /* 128 MiB -> ~10 ms over PCIe */
+    void* p_big = nullptr;
+    void* d_big = nullptr;
+    REQUIRE_CUDA(cudaHostAlloc(&p_big, kBig, cudaHostAllocDefault));
+    REQUIRE_CUDA(cudaMalloc(&d_big, kBig));
+
+    cudaStream_t copy_stream, decode_stream;
+    REQUIRE_CUDA(cudaStreamCreateWithFlags(&copy_stream, cudaStreamNonBlocking));
+    REQUIRE_CUDA(
+        cudaStreamCreateWithFlags(&decode_stream, cudaStreamNonBlocking));
+
+    cudaEvent_t e0, e1, origin, copy_done, decode_done;
+    REQUIRE_CUDA(cudaEventCreate(&e0));
+    REQUIRE_CUDA(cudaEventCreate(&e1));
+    REQUIRE_CUDA(cudaEventCreate(&origin));
+    REQUIRE_CUDA(cudaEventCreate(&copy_done));
+    REQUIRE_CUDA(cudaEventCreate(&decode_done));
+
+    auto do_copy = [&]() {
+        (void)cudaMemcpyAsync(d_big, p_big, kBig, cudaMemcpyHostToDevice,
+                              copy_stream);
+    };
+    auto do_decode = [&]() {
+        (void)cudec_lz4_decompress_batch(dd_s, dd_ss, dd_d, dd_dc, n, dd_r,
+                                         decode_stream);
+    };
+
+    /* Warm both paths (module load, first-copy page-locking), then time each
+     * alone. */
+    do_decode();
+    do_copy();
+    REQUIRE_CUDA(cudaDeviceSynchronize());
+    const float copy_ms = TimeAlone(copy_stream, e0, e1, do_copy);
+    const float decode_ms = TimeAlone(decode_stream, e0, e1, do_decode);
+    REQUIRE(copy_ms > 0.0f && decode_ms > 0.0f);
+    /* Both stages must be well above timing jitter for the margin to mean
+     * something. */
+    REQUIRE_CTX(copy_ms > 2.0f && decode_ms > 2.0f,
+                "stages too short to time overlap: copy %.2f ms, decode %.2f ms",
+                copy_ms, decode_ms);
+
+    /* Run both concurrently from a common origin; measure the combined wall. */
+    REQUIRE_CUDA(cudaEventRecord(origin, copy_stream));
+    REQUIRE_CUDA(cudaStreamWaitEvent(decode_stream, origin, 0));
+    do_copy();
+    REQUIRE_CUDA(cudaEventRecord(copy_done, copy_stream));
+    do_decode();
+    REQUIRE_CUDA(cudaEventRecord(decode_done, decode_stream));
+    REQUIRE_CUDA(cudaEventSynchronize(copy_done));
+    REQUIRE_CUDA(cudaEventSynchronize(decode_done));
+
+    float t_copy_end = 0.0f;
+    float t_decode_end = 0.0f;
+    REQUIRE_CUDA(cudaEventElapsedTime(&t_copy_end, origin, copy_done));
+    REQUIRE_CUDA(cudaEventElapsedTime(&t_decode_end, origin, decode_done));
+    const float concurrent_ms = std::max(t_copy_end, t_decode_end);
+
+    /* A serialized run would take ~copy_ms + decode_ms; true overlap hides the
+     * shorter stage behind the longer. Require at least half of the shorter
+     * stage hidden - a wide margin around the ~2x concurrent/serial gap. */
+    const float shorter = std::min(copy_ms, decode_ms);
+    const float serial_ms = copy_ms + decode_ms;
+    REQUIRE_CTX(concurrent_ms < serial_ms - 0.5f * shorter,
+                "no overlap: concurrent %.2f ms vs serial %.2f ms (copy %.2f + "
+                "decode %.2f)",
+                concurrent_ms, serial_ms, copy_ms, decode_ms);
+
+    std::printf("PASS: H2D copy (%.2f ms) and decode (%.2f ms) run concurrently "
+                "- combined %.2f ms vs %.2f ms serial (overlap capability the "
+                "streaming path relies on)\n",
+                copy_ms, decode_ms, concurrent_ms, serial_ms);
+    return 0;
+}


### PR DESCRIPTION
# What & why

The overlap measurement for the streaming decode path, PR2 of two for #24
(PR1 shipped the entry point). A `--gpu-stream` end-to-end bench, the
`stream_overlap` conformance lock, and the honest numbers in
`docs/BENCHMARKS.md`. Refs #24.

**The measurement is an honest negative result** (masterplan section 5:
numbers decide). Recorded on Silesia, RTX 3080, the digest-pinned container:

```
device out: 1 stream p50 249.1 ms, 0.85 GB/s ; 4 streams p50 288.6 ms, 0.73 GB/s
host out:   p50 384.2 ms, 0.55 GB/s (host readback synchronous)
context:    pure H2D of 102.44 MB compressed = p50 3.9 ms ; device-resident decode 11.9 ms
```

Two findings the measurement forced out:

1. **Overlap does not pay off for LZ4.** The compressed H2D is only ~3.9 ms
   (LZ4 is ~2:1, so the copy is small) while the decode is ~12 ms. Serial
   copy-then-decode ≈ 16 ms; perfect overlap ≈ max(4, 12) = 12 ms, a ~25 %
   ceiling. The copy was never the wall for this format, so there is little
   to hide behind the decode.
2. **The one-shot per-call ring setup dominates.** The 249 ms device-serial
   wall dwarfs copy (~4 ms) + decode (~12 ms) by ~15×; the ~233 ms
   unaccounted is not separately isolated, but the prime suspect is the
   per-call `cudaHostAlloc`/`cudaMalloc` of the pinned ring (and its frees),
   disproportionately expensive on this WSL2/WDDM setup, corroborated by it
   scaling with stream count (4 streams provision ~4× the ring, so the
   "overlapped" row is *slower*, not faster; the two device rows are not a
   clean overlap comparison). PR1 deferred a reusable context "until profiling
   shows per-call allocation dominating", it now does. Filed as a follow-up.

- `bench/gpu_bench.{h,cu}`: `cudec_bench_gpu_stream` times the synchronous
  streaming entry end-to-end (wall clock, all copies + per-call setup
  included) for device 1-stream and N-stream, host, and a pure-H2D context
  floor; verifies every chunk decodes before timing.
- `bench/bench_lz4.cpp`: a `--gpu-stream` flag + the report, labeled
  ONE-SHOT-SETUP-DOMINATED and stating plainly the walls are setup-bound (not
  PCIe-bound) and that the two device rows are not a clean overlap comparison.
- `tests/stream_overlap.cu`: the overlap **capability** lock. The streaming
  entry's internal streams are not observable across the C ABI, so this
  cannot introspect cudec's own pipeline; it locks the platform capability the
  overlap relies on. It times an async H2D and the shipped decode kernel each
  ALONE, then runs both concurrently on separate streams and asserts the
  combined wall is materially less than the sum of the two alone (at least
  half the shorter stage hidden), a serialized run would take ~the sum. Both
  stages are ms-scale; the margin is generous (copy ~5 ms + decode ~8 ms vs
  combined ~7–8 ms, stable across runs).

## Type of change

- [x] Performance (measurement)
- [x] Build / CI / supply chain (bench + a new GPU test)

## Engineering checklist

- [x] Fail-closed - n/a (consumer-only bench + a timing test); the bench
      verifies every chunk decodes OK before timing.
- [x] Determinism - n/a to timing; the decoded output is the M1 kernel's,
      already gated.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [x] Adversarial review run (`/security-review`), two rounds, see Notes.

## Performance checklist

- [x] The claim is measured, not reasoned: the numbers above, full
      methodology in the report and `docs/BENCHMARKS.md`. The result is
      honest and negative — overlap does not yield a speedup for LZ4 as a
      one-shot, and the finding is recorded, not hidden.

## Quality checklist

- [x] Minimal, self-documenting; the bench stays consumer-only (links the
      library, never modifies it).
- [x] Conformance: `stream_overlap` locks the copy/decode overlap capability
      the streaming path relies on (the conformance test #24 introduces).

## Verification

Pinned dev container (RTX 3080, nvcc 12.6.77), clean rebuild, host C/CXX/CUDA
all `-Werror`:

```
100% tests passed, 0 tests failed out of 10
    Start 9: stream_overlap
9/10 Test #9: stream_overlap ...................   Passed    0.49 sec
```

- [x] `cmake --build`, clean.
- [x] `ctest`, 10/10 green (stream_overlap incl.).
- [x] `--gpu --gpu-stream` bench run on Silesia - numbers above and in
      BENCHMARKS.md.
- [x] Prettier, clean.

## Notes

Adversarial review (`/security-review`), two rounds of the refute-by-default
panel (correctness / robustness / integration / performance + cuda-reviewer),
converging to PASS on every lens.

Round 1 (integration PASS, four NEEDS_IMPROVEMENT), the panel caught real
measurement-honesty defects, all fixed:

- **The serial-vs-overlap "(Nx)" ratio was contaminated** (performance rated
  HIGH): the overlapped config provisions ~4× the pinned ring inside the
  timed region, so the ratio conflated overlap with an allocation tax. The
  ratio is removed; the device rows are now presented as raw, honestly
  setup-dominated numbers that are explicitly not a clean overlap comparison.
- **"PCIe-bound" mislabeled a setup-bound number**, reframed to
  "setup-bound, not PCIe-bound", tied to the measured H2D.
- **`stream_overlap`'s interval-intersection was true by construction** (the
  start events were recorded before their ops, anchoring both intervals at
  the origin, so it proved almost nothing): rewritten to a real concurrency
  measurement (alone durations + combined wall vs the sum), which a
  serialized run genuinely fails.
- Plus the LOW hardening: an overflow guard on the arena sums, an
  arena-reclaimed-at-exit note, the verify-checks-status-not-bytes comment
  corrected, the H2D context relabeled a best-case floor, the effective vs
  requested stream count reported, host output timed at 1 stream.

Round 2: all four re-reviewed lenses PASS; three remaining LOW
comment/prose-consistency items closed in-line (a stale "PCIe wall" comment,
an over-definite causal attribution softened to "prime suspect", and the
fenced block's provenance corrected to `--gpu --gpu-stream`).

This does not `Close` #24: the issue's third acceptance item was a *measured
speedup*, and the honest measured answer is that overlap does not produce one
for LZ4 as built. The entry point (PR1) and the measurement (PR2) are
delivered; the actionable follow-up, a reusable streaming context to
amortize the per-call setup, and a reassessment of overlap's weak payoff for
this format, is filed as a separate issue.
