### PR TITLE
Add the worst-4Bmatch adversarial corpus to the bench sweep

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -28,3 +28,10 @@ target_compile_options(
 # milestones. (--selfcheck stays CPU-only so it runs on the GPU-less CI
 # runner; the GPU path is exercised by the /bench command and BENCHMARKS.md.)
 add_test(NAME bench_selfcheck COMMAND bench_lz4 --selfcheck)
+
+# The worst-4Bmatch corpus is constructed in-harness and oracle-validated
+# before timing; this runs that construction through the same self-checked
+# path (a few chunks, CPU-only) so a broken generator - one whose stream the
+# oracle no longer accepts, or that stops round-tripping - reds CI, not just
+# a manual bench.
+add_test(NAME bench_worst4b_selfcheck COMMAND bench_lz4 --worst4b --selfcheck)

--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -26,12 +26,26 @@ constexpr size_t kChunkBytes = 65536;
 
 constexpr size_t kMaxRuns = 1000000;
 
+/* The worst-case sweep replicates one adversarial block to this many chunks:
+ * enough 64 KB warps to saturate the RTX 3080 (68 SMs, >= 32 warps/SM) and
+ * the same ~200 MB scale as the Silesia GPU row, so the two throughput
+ * numbers are directly comparable. */
+constexpr size_t kWorst4bChunks = 3200;
+
+/* The CI rot check (--worst4b --selfcheck) exercises the identical
+ * construction on a handful of chunks so it stays fast on the GPU-less
+ * runner; the block itself is the same regardless of the replica count. */
+constexpr size_t kWorst4bSelfcheckChunks = 4;
+
 struct Corpus {
     std::string name;
     std::vector<std::vector<unsigned char>> originals;
     std::vector<std::vector<unsigned char>> compressed;
     size_t original_bytes = 0;
     size_t compressed_bytes = 0;
+    /* How the compressed streams were produced - printed verbatim in the
+     * methodology block, so it must stay true for whichever corpus ran. */
+    std::string provenance = "compressed in-harness via LZ4_compress_default";
 };
 
 bool AppendFileChunked(const std::string& path, Corpus* corpus) {
@@ -75,6 +89,96 @@ void CompressAll(Corpus* corpus) {
         corpus->original_bytes += original.size();
         corpus->compressed_bytes += corpus->compressed.back().size();
     }
+}
+
+/* Builds one adversarial-but-valid LZ4 block: back-to-back minimum matches
+ * (match length 4, offset 1). This is the maximum sequence density a valid
+ * block can carry - one parsed sequence per 4 decoded bytes - and it drives
+ * the kernel's per-byte closed-form modular gather on every match byte, so
+ * the redundant lockstep parse floors here. LZ4_compress_default never emits
+ * it (it extends any offset-1 run into a single long match, the best case),
+ * so the stream is constructed directly and proven valid by the oracle
+ * before timing.
+ *
+ * The block decodes to `out_bytes` copies of one seed byte. Wire layout:
+ *   token 0x10, 1 seed literal, offset 0x0001      (1 literal + 4 match)
+ *   token 0x00, offset 0x0001               x M    (4 match bytes each)
+ *   token (literal-length tail), >= 12 trailing literals
+ * The trailing literal run keeps the last match clear of the block end,
+ * satisfying LZ4's parsing restrictions (LASTLITERALS = 5, last match >= 12
+ * bytes before the end); the oracle is the sole authority and confirms the
+ * verdict in BuildWorst4bCorpus before any timing. Assumes out_bytes is a
+ * full chunk (kChunkBytes) - comfortably above the tail minimum. */
+void BuildWorst4bBlock(size_t out_bytes, std::vector<unsigned char>* original,
+                       std::vector<unsigned char>* compressed) {
+    constexpr unsigned char kSeed = 0xA5;
+    constexpr size_t kMinTail = 12; /* >= LZ4's last-match distance rule */
+
+    original->assign(out_bytes, kSeed);
+
+    std::vector<unsigned char>& c = *compressed;
+    c.clear();
+    /* Seed sequence: one real literal, then a length-4 offset-1 match that
+     * copies it forward (offset 1 = run-length; the match reads the byte
+     * just written). */
+    c.push_back(0x10);  /* literal length 1, match length 4 */
+    c.push_back(kSeed); /* the one literal byte */
+    c.push_back(0x01);  /* offset low byte (offset = 1) */
+    c.push_back(0x00);  /* offset high byte */
+    size_t produced = 5; /* 1 literal + 4 match bytes */
+
+    /* Minimum matches until only the tail (>= kMinTail literals) remains. */
+    while (produced + 4 <= out_bytes - kMinTail) {
+        c.push_back(0x00); /* literal length 0, match length 4 */
+        c.push_back(0x01);
+        c.push_back(0x00);
+        produced += 4;
+    }
+
+    /* Literals-only tail sequence (no offset/match follows the literals; the
+     * decoder detects end-of-block when the input is exhausted). */
+    const size_t tail = out_bytes - produced;
+    if (tail < 15) {
+        c.push_back(static_cast<unsigned char>(tail << 4));
+    } else {
+        c.push_back(0xF0); /* literal length >= 15: read extension bytes */
+        size_t rem = tail - 15;
+        while (rem >= 255) {
+            c.push_back(255);
+            rem -= 255;
+        }
+        c.push_back(static_cast<unsigned char>(rem));
+    }
+    c.insert(c.end(), tail, kSeed);
+}
+
+/* Replicates the worst-case block to `chunks` identical chunks. Rejects an
+ * invalid construction before any timing: the oracle (liblz4) is the sole
+ * authority on validity, and honest numbers require a stream that actually
+ * decodes (docs/MASTERPLAN.md, "the oracles decide"). */
+bool BuildWorst4bCorpus(Corpus* corpus, size_t chunks) {
+    std::vector<unsigned char> original;
+    std::vector<unsigned char> compressed;
+    BuildWorst4bBlock(kChunkBytes, &original, &compressed);
+
+    std::vector<unsigned char> decoded;
+    if (!OracleDecodes(compressed, original.size(), &decoded) ||
+        decoded.size() != original.size() ||
+        std::memcmp(decoded.data(), original.data(), decoded.size()) != 0) {
+        std::fprintf(stderr, "worst-4Bmatch construction rejected by the "
+                             "oracle - refusing to time an invalid stream\n");
+        return false;
+    }
+
+    corpus->name = "worst-4Bmatch";
+    corpus->originals.assign(chunks, original);
+    corpus->compressed.assign(chunks, compressed);
+    corpus->original_bytes = original.size() * chunks;
+    corpus->compressed_bytes = compressed.size() * chunks;
+    corpus->provenance = "hand-constructed offset-1 minmatch worst case "
+                         "(oracle-validated; LZ4_compress_default never emits "
+                         "it)";
+    return true;
 }
 
 /* One measured repetition: decode the whole batch, wall clock. The timed
@@ -179,13 +283,13 @@ void PrintReport(const Corpus& corpus, const std::vector<double>& sorted,
                 "decoder)\n",
                 cudec_version());
     std::printf("- corpus: %s, %zu chunks, %.2f MB original, %.2f MB "
-                "compressed (ratio %.3f), compressed in-harness via "
-                "LZ4_compress_default\n",
+                "compressed (ratio %.3f), %s\n",
                 corpus.name.c_str(), corpus.originals.size(),
                 static_cast<double>(corpus.original_bytes) / 1e6,
                 static_cast<double>(corpus.compressed_bytes) / 1e6,
                 static_cast<double>(corpus.compressed_bytes) /
-                    static_cast<double>(corpus.original_bytes));
+                    static_cast<double>(corpus.original_bytes),
+                corpus.provenance.c_str());
     std::printf("- chunk sizes: min %zu / median %zu / max %zu bytes\n",
                 sizes.front(), sizes[sizes.size() / 2], sizes.back());
     std::printf("- method: %zu warmup + %zu measured runs, wall clock per "
@@ -212,6 +316,7 @@ int main(int argc, char** argv) {
     bool selfcheck = false;
     bool gpu = false;
     bool gpu_stream = false;
+    bool worst4b = false;
     std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
@@ -221,6 +326,8 @@ int main(int argc, char** argv) {
             gpu = true;
         } else if (arg == "--gpu-stream") {
             gpu_stream = true;
+        } else if (arg == "--worst4b") {
+            worst4b = true;
         } else if (arg == "--runs" && i + 1 < argc) {
             if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
                 std::fprintf(stderr, "--runs must be in [1, %zu]\n",
@@ -239,7 +346,8 @@ int main(int argc, char** argv) {
         } else if (!arg.empty() && arg[0] == '-') {
             std::fprintf(stderr,
                          "usage: bench_lz4 [--runs N] [--warmup N] [--gpu] "
-                         "[--gpu-stream] [--selfcheck] [corpus files...]\n");
+                         "[--gpu-stream] [--worst4b] [--selfcheck] "
+                         "[corpus files...]\n");
             return 2;
         } else {
             files.push_back(arg);
@@ -251,7 +359,19 @@ int main(int argc, char** argv) {
     }
 
     Corpus corpus;
-    if (files.empty()) {
+    if (worst4b) {
+        /* The worst-case corpus is generated, not read: it carries its own
+         * hand-built compressed streams, so it must not also take files. */
+        if (!files.empty()) {
+            std::fprintf(stderr, "--worst4b builds its own corpus; do not "
+                                 "also pass corpus files\n");
+            return 2;
+        }
+        if (!BuildWorst4bCorpus(&corpus, selfcheck ? kWorst4bSelfcheckChunks
+                                                   : kWorst4bChunks)) {
+            return 1;
+        }
+    } else if (files.empty()) {
         corpus.name = "builtin";
         for (auto& fixture : MakeLz4BlockFixtures()) {
             corpus.originals.push_back(std::move(fixture.original));
@@ -286,7 +406,13 @@ int main(int argc, char** argv) {
             return 1;
         }
     }
-    CompressAll(&corpus);
+    /* The worst-case corpus already carries its hand-built streams; the
+     * standard compressor would replace them with a single long match (the
+     * best case), defeating the point. Every other corpus is compressed by
+     * the oracle here. */
+    if (!worst4b) {
+        CompressAll(&corpus);
+    }
 
     /* Byte-verify every chunk once, outside the timed region. */
     std::vector<unsigned char> scratch;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -78,6 +78,61 @@ phase-1, which shares the identical serial parse, so two-phase cannot reach
 two-phase help? — is answered NO by the arithmetic. The path to higher
 throughput is structural single-pass work, not a decomposition change.
 
+### Worst case: the worst-4Bmatch adversarial-but-valid corpus (issue #19)
+
+A security-posture number. The Silesia rows are an average; the worst case
+for this kernel's throughput is an adversarial-but-valid block of
+back-to-back minimum matches (match length 4, offset 1) — the maximum
+sequence density a valid LZ4 block can carry, one parsed sequence per 4
+decoded bytes, which drives the redundant 32-lane lockstep parse and the
+closed-form modular gather on every match byte. The standard compressor
+never emits it (it extends any offset-1 run into a single long match, the
+best case), so the harness constructs the block directly (`--worst4b`) and
+the oracle validates it (LZ4_decompress_safe accepts and it round-trips)
+before any timing. Recorded 2026-07-17, same container and RTX 3080 as the
+M1 rows above; 3200 identical 64 KB chunks (~210 MB), enough to saturate
+the device and sit at the Silesia scale for a direct comparison.
+`--worst4b --gpu`.
+
+```
+## bench_lz4 report
+- decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
+- corpus: worst-4Bmatch, 3200 chunks, 209.72 MB original, 157.31 MB compressed (ratio 0.750), hand-constructed offset-1 minmatch worst case (oracle-validated; LZ4_compress_default never emits it)
+- chunk sizes: min 65536 / median 65536 / max 65536 bytes
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
+- wall per run: p50 140.704 ms / p90 143.329 ms / p99 146.840 ms
+- decode throughput: p50 1.490 GB/s / p90 1.463 GB/s / p99 1.428 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs): p50 25.917 ms, 8.1 GB/s
+- GPU parse-only ceiling (copies elided): p50 13.710 ms, 15.3 GB/s - ceilings this design AND any two-phase phase-1 (shared parse)
+```
+
+**The degradation is linear and bounded — not an amplification vector.**
+
+- Every path degrades by the same ~2.2–2.3× against the Silesia average:
+  CPU 3.46 → 1.49 GB/s, GPU decode 18.1 → 8.1 GB/s, GPU parse-only ceiling
+  34.6 → 15.3 GB/s. The uniform factor is the sequence density (one
+  sequence per 4 bytes here versus Silesia's longer average matches): the
+  cost is linear in the number of sequences — exactly the redundant parse
+  the kernel design accepts, no super-linear blow-up. This is below the
+  issue's pessimistic ~4× estimate.
+- No size amplification. The block barely compresses (ratio 0.750, 157 MB →
+  210 MB, ~1.33× expansion) and each chunk decodes to exactly 65536 bytes,
+  capped by the caller's destination capacity — never more. The two
+  adversarial axes are mutually exclusive for LZ4: a decompression bomb
+  (one offset-1 match extended to a full 64 KB, ~3000× expansion) is a
+  single fast sequence, the opposite of this throughput worst case, and
+  cudec's fixed per-chunk output cap fail-closes the size axis regardless.
+- The GPU advantage holds under the worst input: 8.1 GB/s worst-case GPU is
+  still ~5.4× the CPU worst case (1.49 GB/s) and ~2.3× the CPU's Silesia
+  _average_ (3.46 GB/s). A second run confirmed the numbers within GPU
+  jitter (8.2 GB/s decode, 15.7 GB/s parse-only).
+
+Reproduce with `bench_lz4 --worst4b --gpu`; the construction is oracle-
+validated in-harness and locked against rot by the `bench_worst4b_selfcheck`
+ctest on the GPU-less runner.
+
 ## M2: pinned-host streaming decode, end-to-end (Silesia)
 
 The streaming decode path (`cudec_lz4_decompress_stream`, issue #24) times the


### PR DESCRIPTION
# What & why

Adds a worst-case corpus to the bench sweep so the sweep reports the
kernel's throughput floor, not only Silesia's average. The floor is an
adversarial-but-valid LZ4 block of back-to-back minimum matches (match
length 4, offset 1): the maximum sequence density a valid block can carry -
one parsed sequence per 4 decoded bytes - which drives the redundant 32-lane
lockstep parse and the closed-form modular gather on every match byte. The
standard compressor never emits it (it extends any offset-1 run into a
single long match, the best case), so `--worst4b` constructs the block
directly and the oracle validates it before any timing.

Consumer-only: the bench links the library and never modifies it. No kernel,
format-parsing, or C-ABI code is touched.

Closes #19

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [x] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: the generator refuses to time a stream the
      oracle rejects, and the new `bench_worst4b_selfcheck` ctest reds if the
      construction ever stops decoding. No new library parse path is added.
- [x] Oracle coverage: the hand-built stream is validated by
      `LZ4_decompress_safe` and round-trip-checked before timing; the GPU
      decode is byte-verified against the expected output by the existing
      `cudec_bench_gpu` correctness precondition.
- [x] Determinism preserved: no library change; the corpus is a fixed
      construction (single seed byte, fixed layout), identical every run.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI:
      no new CUDA or ABI code - the GPU path reuses `cudec_bench_gpu`/
      `cudec_lz4_decompress_batch` unchanged.
- [ ] An adversarial review (`/security-review`) was run: deferred to
      my independent gate at merge (this delivery stops at PR). The
      touched surface is the consumer-only bench harness plus one ctest
      registration - no kernel/ABI/format-parsing/workflow code.

## Performance checklist

- [x] The claim is measured, not reasoned: full methodology block, RTX 3080
      (sm_86), driver 12.6, runtime 12.6, in the digest-pinned container;
      corpus 3200 x 64 KB (~210 MB), all chunks 65536 bytes; 3 warmup + 30
      runs; reproduced in a second run within GPU jitter. Numbers in
      docs/BENCHMARKS.md.
- [x] No regression against the recorded baseline: this adds a new
      worst-case row; the existing Silesia/streaming baselines are unchanged.

## Quality checklist

- [x] Minimal: reuses the existing verify/timing/report/GPU paths; only the
      generator and the `--worst4b` wiring are new.
- [x] Self-documenting: intention-revealing names, small functions, comments
      explain why (the worst-case rationale, the parsing-restriction tail).
- [x] Conformance tests pass; the new structural property (the worst-case
      construction stays oracle-valid) is locked in as `bench_worst4b_selfcheck`.

## Verification

Container gate (`nvidia/cuda:12.6.2-devel-ubuntu24.04`, RTX 3080):

- [x] `cmake --build build-cuda`, clean, host C/CXX/CUDA all `-Werror`.
- [x] `ctest --test-dir build-cuda`, 11/11 passed, including the new
      `bench_worst4b_selfcheck`.
- [x] Prettier (`**/*.{md,yml,yaml}`), clean.
- [x] Docs synced: docs/BENCHMARKS.md carries the worst-case section with the
      full methodology block.

Measured worst-case (`bench_lz4 --worst4b --gpu`, p50 of 30 runs):

```
- corpus: worst-4Bmatch, 3200 chunks, 209.72 MB original, 157.31 MB compressed (ratio 0.750)
- CPU decode (liblz4 oracle, single thread): 1.490 GB/s
- GPU decode (device-resident, CUDA-event timed): 25.917 ms, 8.1 GB/s
- GPU parse-only ceiling (copies elided): 13.710 ms, 15.3 GB/s
```

## Notes

- Finding: the degradation is linear and bounded, not an amplification
  vector. Every path degrades by the same ~2.2-2.3x against the Silesia
  average (CPU 3.46 -> 1.49, GPU 18.1 -> 8.1, parse-only 34.6 -> 15.3 GB/s) -
  the uniform factor is the sequence density, a cost linear in the sequence
  count. No size amplification: the block barely compresses (ratio 0.750,
  ~1.33x expansion) and each chunk is capped at 65536 output bytes. Below the
  issue's pessimistic ~4x estimate. The GPU advantage holds under the worst
  input: 8.1 GB/s is still ~5.4x the CPU worst case and ~2.3x the CPU Silesia
  average.
- The worst-case sweep (`--gpu`) needs a GPU, so it runs via the bench, not
  CI; CI covers the generator's validity through the CPU-only
  `bench_worst4b_selfcheck`.
