### PR TITLE
Record the perf pass 2 findings: the occupancy lever is rejected

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -78,6 +78,61 @@ phase-1, which shares the identical serial parse, so two-phase cannot reach
 two-phase help? — is answered NO by the arithmetic. The path to higher
 throughput is structural single-pass work, not a decomposition change.
 
+### Perf pass 2 (issue #21): the occupancy lever does not help either
+
+Perf pass 1 named the remaining structural lever — raise the ~34 GB/s parse
+ceiling through higher occupancy. This pass profiled the kernel and measured
+that lever directly; it too is rejected by measurement.
+
+**Profile (pinned container, RTX 3080 sm_86, `nvcc -Xptxas -v`).** The shipped
+`lz4_decode_batch` (Full) uses **46 registers/thread** on sm_86 (48 on sm_80).
+On sm_86 — 65536 registers/SM, 256-register warp allocation granularity,
+128-thread blocks — 46 rounds up to 1536 registers/warp, giving 10 resident
+blocks → **40 warps/SM (~83% occupancy)**. Register granularity is the wall:
+41–48 registers/thread all fall in the same 1536-register/warp bucket and all
+yield 40 warps; the next occupancy step (48 warps/SM, 100%) requires
+**≤ 40 registers/thread**.
+
+**The only reachable path forces a spill.** The parser's live state is
+dominated by the 64-bit stream cursors and the six-field `Lz4Sequence`. The
+anti-pattern rule (masterplan section 9) forbids narrowing any of it to 32-bit
+— the ABI's `size_t` capacities admit values above 2^32, pinned by the
+`SIZE_MAX` and beyond-convention capacity tests — so a legitimate drop to 40
+registers is not available. `__launch_bounds__(kBlockThreads, 12)` caps ptxas
+at 40 registers only by **spilling to local memory** (sm_86: 16-byte stack
+frame, 20 bytes spill stores, 20 bytes spill loads).
+
+Measured on Silesia, same session and hardware, with the CPU-oracle row and
+the parse-only row as controls (both run in the same invocation, so machine
+state is shared):
+
+| Configuration                                                     | Full decode                        | Parse-only (control) |
+| ----------------------------------------------------------------- | ---------------------------------- | -------------------- |
+| Baseline (`__launch_bounds__(kBlockThreads)`, 46 reg, 40 warps)   | p50 12.178 ms, **17.4 GB/s**       | 6.302 ms, 33.6 GB/s  |
+| `__launch_bounds__(kBlockThreads, 12)` (40 reg + spill, 48 warps) | p50 12.801 ms, **16.6 GB/s (−5%)** | 6.244 ms, 33.9 GB/s  |
+
+Forcing 100% occupancy **regresses** the full decode ~5%. Parse-only (still 28
+registers, no spill, so unaffected by the register cap) stays flat across the
+same runs — an internal control that attributes the regression to the spill,
+not to run-to-run variance; the CPU oracle baseline was in fact slightly faster
+during the variant run. The extra local-memory traffic in the already
+latency-bound parse loop costs more than the eight added warps hide. All ten
+ctest gates (`parser_twin` and `gpu_fixture` oracle parity, `stream_twin`
+determinism, and the rest) stay green on the variant — the change is
+measurement-rejected, not correctness-rejected. No code shipped; the kernel is
+unchanged.
+
+**Empirical conclusion.** The occupancy lever cannot be realized under the
+current fail-closed architecture: more warps need ≤ 40 registers/thread; ≤ 40
+registers needs either a forbidden 64-bit narrowing or a spill; and the spill
+regresses. Raising the parse ceiling therefore requires the warp-specialization
+rewrite that abandons the load-bearing redundant-lockstep-parse invariant — its
+own design panel, not a measured micro-pass — and under "formats over
+percentage points" (masterplan section 2) the next format outranks it. Of the
+two levers issue #21 named, the register-reduction lever is measured and
+rejected here; the warp-specialization lever is scoped as a larger design
+change deferred behind the format ladder.
+
 ## M2: pinned-host streaming decode, end-to-end (Silesia)
 
 The streaming decode path (`cudec_lz4_decompress_stream`, issue #24) times the

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -307,6 +307,18 @@ falsification trigger does NOT reopen two-phase: it stays ruled out by the
 shared parse ceiling regardless of the numeric condition (see
 BENCHMARKS.md).
 
+**Perf pass 2 outcome (issue #21): the occupancy lever is rejected by
+measurement too.** Profiling confirmed 46 registers/thread → 40 warps/SM
+(~83%) on sm_86; register granularity puts 100% occupancy behind ≤ 40
+registers/thread, reachable only by narrowing the 64-bit parser state (barred
+by the anti-pattern rule above) or by forcing a spill. `__launch_bounds__`
+with a min-blocks target of 12 forces the spill and regresses the full decode
+~5% (17.4 → 16.6 GB/s), parse-only flat as the control; no code shipped.
+Raising the parse ceiling needs the warp-specialization rewrite that abandons
+the redundant-lockstep-parse invariant (its own design panel), which under
+"formats over percentage points" ranks below the next format. Recorded in
+[docs/BENCHMARKS.md](BENCHMARKS.md).
+
 **Known limits, published:** the redundant-parse family ceiling is roughly
 250–400 GB/s after perf passes — deliberately accepted under "formats over
 percentage points"; batches under ~2,000 chunks underfill the machine and


### PR DESCRIPTION
# What & why

M1 kernel structural perf, pass 2 (issue #21), a documented negative result. Perf pass 1 (#16) found the micro-ops do not help and named the remaining structural lever: raise the ~34 GB/s parse ceiling through higher occupancy. This pass profiled the kernel and measured that lever directly. It regresses and is **not shipped** (masterplan rule: accepted only on a recorded improvement). Docs-only; the working tree kernel is byte-identical to the merged baseline.

**Profile** (RTX 3080 sm_86, `nvcc -Xptxas -v`, pinned container): the shipped `lz4_decode_batch` (Full) uses **46 registers/thread** → 1536 registers/warp → 10 blocks → **40 warps/SM (~83% occupancy)**. Register-allocation granularity (256/warp) is the wall: 41–48 registers/thread all yield 40 warps, so the next occupancy step (48 warps/SM, 100%) requires **≤ 40 registers/thread**. That is reachable only by narrowing the parser's 64-bit state (barred by the anti-pattern rule, the ABI's `size_t` capacities admit values above 2^32, pinned by the `SIZE_MAX` and beyond-convention capacity tests) or by forcing a spill.

**Measured** (`__launch_bounds__(kBlockThreads, 12)` forces 40 registers by spilling 20 bytes to local memory):

| Configuration                                                       | Full decode                        | Parse-only (control) |
| ------------------------------------------------------------------- | ---------------------------------- | -------------------- |
| Baseline (`__launch_bounds__(kBlockThreads)`, 46 reg, 40 warps)     | p50 12.178 ms, **17.4 GB/s**       | 6.302 ms, 33.6 GB/s  |
| `__launch_bounds__(kBlockThreads, 12)` (40 reg + spill, 48 warps)   | p50 12.801 ms, **16.6 GB/s (−5%)** | 6.244 ms, 33.9 GB/s  |

Forcing 100% occupancy **regresses** the full decode ~5%. Parse-only (still 28 registers, so the register cap does not bind it) stays flat in the same invocation, an internal control that attributes the regression to the spill, not to run-to-run variance (the CPU oracle baseline was in fact slightly faster during the variant run). The extra local-memory traffic in the already latency-bound parse loop costs more than the eight added warps hide.

## Type of change

- [x] Performance
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: no code change; the parser/validation ladder is untouched, and the variant (measured, then reverted) kept all ten ctest gates green including the reject-path negatives.
- [x] Oracle coverage: `parser_twin` and `gpu_fixture` (liblz4 parity) stay green on both the baseline and the measured variant.
- [x] Determinism preserved: `stream_twin` (whole-buffer determinism) green; the shipped kernel is unchanged.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI, unchanged (no code touched).
- [x] Adversarial review run: a focused refute-by-default gate (`cuda-reviewer` on the occupancy arithmetic + spill-causation, `correctness-lens` on number fidelity and the experimental logic), both PASS. No kernel/ABI code changed, so the full kernel panel has no code diff to review; the gate verified the CUDA-domain claims in the record instead.

## Performance checklist

- [x] The claim is measured, not reasoned: before/after above. Methodology, GPU NVIDIA RTX 3080 (sm_86), driver 12.6, CUDA 12.6.77, pinned container `nvidia/cuda:12.6.2-devel-ubuntu24.04`; corpus dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml (3239 chunks, 211.94 MB original, 102.44 MB compressed, chunk sizes min 8066 / median 65536 / max 65536); 3 warmup + 30 measured runs, CUDA-event timed, device-resident.
- [x] No regression against the recorded baseline: the optimization was rejected and reverted, so the shipped decoder is byte-identical to the merged baseline (~18 GB/s). Nothing regresses; the finding is documentation only.

## Quality checklist

- [x] Minimal: two doc additions, no code.
- [x] Self-documenting: the finding states the profile, the mechanism, the measured table with its control, and the conclusion.
- [x] Conformance tests pass: 10/10 ctest on both the baseline and the (reverted) variant; no new structural property is established (no code change).

## Verification

Pinned container gate (`docker run --gpus all … nvidia/cuda:12.6.2-devel-ubuntu24.04`), run on the baseline (unmodified kernel) this session:

- [x] `cmake --build build-cuda`, builds clean (`-Werror` / `--Werror=all-warnings`).
- [x] `ctest --test-dir build-cuda`, **10/10 passed** (conformance_c, oracle_lz4, parser_twin, launch_fail, smoke, gpu_fixture, frame_twin, stream_twin, stream_overlap, bench_selfcheck).
- [x] Prettier (`**/*.{md,yml,yaml}`), clean.
- [x] Docs synced: BENCHMARKS.md gains the perf-pass-2 subsection; MASTERPLAN section 9 records the outcome.

The measured variant (`__launch_bounds__(kBlockThreads, 12)`) also built clean and passed 10/10 ctest before being rejected on throughput and reverted, correctness held; only the number was the question.

## Notes

- **No code shipped.** The kernel change was measured on this branch, rejected by measurement, and reverted; the diff is the two docs only.
- Of the three levers #21 names, the occupancy/register-reduction lever is now measured and rejected. **Warp-specialization** and **two-sequence pipelining** remain, both are larger rewrites that abandon the load-bearing redundant-lockstep-parse invariant and need their own design panel, deferred under "formats over percentage points" (the next format outranks the next throughput percent). I left #21 open (`Refs #21`) so those levers stay tracked; close it if you consider the occupancy pass its actionable core and prefer a fresh design issue for warp-specialization.
- CodeRabbit remains uninstalled (see #7); merging gates on CI + this review.
