### PR TITLE
Refresh the public docs to the shipped M1/M2 reality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,9 @@ Issue-driven, gate-driven:
 - **Fail-closed decoding.** A bitstream that does not validate produces a
   defined error code, never an out-of-bounds access, never a partial guess.
   Every reject path carries an explicit negative test.
-- **The oracles decide.** Decode output is diff-tested against the reference
-  implementations (liblz4, zlib, libzstd) on real and fuzzed corpora.
+- **The oracles decide.** Decode output is diff-tested on real and fuzzed
+  corpora against the reference implementations — liblz4 today, with zlib and
+  libzstd joining as the DEFLATE and Zstd formats land.
 - **Determinism**: same input → same output, bit-exact per code path.
 - **Performance claims are measured**, never reasoned: numbers ship with GPU
   model, driver, CUDA version, corpus, and chunk-size distribution.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ properties a closed binary cannot offer:
 
 - **Auditability.** Decompressors are classic attack surface. Every bounds
   check in cudec is readable, tested, and fuzz-diffed against the reference
-  implementations (liblz4, zlib, libzstd).
+  implementation — liblz4 today, with zlib and libzstd joining as the DEFLATE
+  and Zstd formats land.
 - **Portability.** CUDA first; a HIP port is a planned milestone. A
   vendor-locked binary can never follow.
 - **Hackability.** Format quirks, tuning trade-offs, and kernel design are
@@ -35,19 +36,25 @@ one, and this README will never claim otherwise.
 
 ## Status
 
-**Design phase.** The architecture is being recorded in
-[docs/MASTERPLAN.md](docs/MASTERPLAN.md); progress is tracked in the issues
-and milestones:
+**M0 and M1 are complete; M2 is in progress.** cudec decodes real LZ4 on an
+NVIDIA GPU today — batch block decode, the `.lz4` frame format
+(block-independent subset), and a pinned-host streaming path — all fail-closed
+and fuzz-diffed against liblz4. The design record is
+[docs/MASTERPLAN.md](docs/MASTERPLAN.md); the measured LZ4 block and streaming
+baselines, each carrying its full methodology, are in
+[docs/BENCHMARKS.md](docs/BENCHMARKS.md). Snappy, GDeflate, Zstd, and the HIP
+port are planned, not yet implemented. Progress is tracked in the issues and
+milestones:
 
-| Milestone        | Deliverable                                         |
-| ---------------- | --------------------------------------------------- |
-| M0 — Foundation  | Toolchain, CMake+CUDA skeleton, CI, test harness    |
-| M1 — LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed      |
-| M2 — LZ4 batch   | Frame format, batch API, streaming path, benchmarks |
-| M3 — Snappy      | Snappy decode on the same kernel family             |
-| M4 — GDeflate    | The first open GPU GDeflate decoder                 |
-| M5 — Zstd        | Zstd decode (FSE/Huffman sequences)                 |
-| M6 — Portability | HIP port                                            |
+| Milestone        | Deliverable                                         | Status      |
+| ---------------- | --------------------------------------------------- | ----------- |
+| M0 — Foundation  | Toolchain, CMake+CUDA skeleton, CI, test harness    | done        |
+| M1 — LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed      | done        |
+| M2 — LZ4 batch   | Frame format, batch API, streaming path, benchmarks | in progress |
+| M3 — Snappy      | Snappy decode on the same kernel family             | planned     |
+| M4 — GDeflate    | The first open GPU GDeflate decoder                 | planned     |
+| M5 — Zstd        | Zstd decode (FSE/Huffman sequences)                 | planned     |
+| M6 — Portability | HIP port                                            | planned     |
 
 ## Principles
 
@@ -64,15 +71,17 @@ and milestones:
 
 ## Building
 
-Host-only stub (CMake ≥ 3.24 and a C compiler, no CUDA toolchain needed):
+Two builds. The host-only build needs just a C compiler and compiles the ABI
+and version surface — not the decoder — so CI has a real build gate without a
+CUDA toolchain (CMake ≥ 3.24):
 
 ```sh
 cmake -B build && cmake --build build
 ```
 
-With the CUDA engine (CUDA 12.x toolchain; the maintained path is the
-pinned dev container — GPU required only for the gpu-labeled tests, not the
-build: without a GPU, drop `--gpus all` and add `-LE gpu` to the ctest line
+The CUDA build is the decoder (CUDA 12.x toolchain; the maintained path is the
+pinned dev container — a GPU is required only for the gpu-labeled tests, not
+the build: without a GPU, drop `--gpus all` and add `-LE gpu` to the ctest line
 to build everything and run the host-side subset):
 
 ```sh

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -72,10 +72,14 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
   by device-side arrays (src pointers/sizes, dst pointers/capacities) on a
   caller-provided stream, reporting per-chunk status — modeled on the shape
   proven by nvCOMP's batch interface, implemented independently.
-- **Kernel dispatch by chunk size.** Warp-per-chunk for small chunks,
-  block-per-chunk (a warp team sharing staged input) for large ones; the
-  dispatcher picks per batch histogram. Shared-memory staging via
-  `cp.async`.
+- **Kernel dispatch by chunk size.** The shipped M1 decoder is a single
+  warp-per-chunk kernel with no dispatch heuristic, no shared memory, and no
+  `cp.async` staging: the design panel settled that shape on the arithmetic
+  (section 9), and the asynchronous batch ABI rules out host-side
+  histogramming (section 8). A block-per-chunk path (a warp team sharing
+  staged input via `cp.async`) and device-side chunk-size binning remain
+  deferred options for large-chunk or future-format workloads — not a
+  decision the current code took.
 - **Two memory paths.** Device-resident (caller already has the data on the
   GPU) and a pinned-host streaming path that overlaps H2D copies with decode
   — the asset-streaming shape.
@@ -170,9 +174,9 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
 
 - Benchmark corpus set beyond Silesia/enwik (game-asset-like data) — M2.
 - Device-side chunk-size binning for mixed batches — M2 (see section 9:
-  the async ABI rules out host-side histogramming, so section 4's
-  "dispatcher picks per batch histogram" pillar resolves to device-side
-  binning or nothing; M1 ships without a dispatch heuristic).
+  the async ABI rules out host-side histogramming, so the block-per-chunk /
+  binning option in section 4 resolves to device-side binning or nothing;
+  M1 ships without a dispatch heuristic).
 
 Settled: test framework and oracle vendoring (section 5, via the #4 design
 review); dev-container image and CI toolchain pinning (issues #1/#3 —


### PR DESCRIPTION
# What & why

The README and MASTERPLAN still described cudec as unbuilt ("Design phase",
"host-only stub") while the tree ships a working, benchmarked GPU LZ4 decoder:
M0 and M1 are complete (warp-per-chunk block decode, fuzz-diffed against
liblz4) and the frame decoder plus the pinned-host streaming path are merged
under M2. A first-time reader reasonably concluded there was no decoder yet - 
the opposite of the truth.

This refreshes the public docs to the shipped reality. Docs only; no code
changes and no benchmark numbers move.

- **README "## Status"**, M0/M1 done, M2 in progress; names the three shipped
  LZ4 paths (block, frame, streaming); adds a Status column to the milestone
  table; links `docs/BENCHMARKS.md`.
- **README "## Building"**, drops "stub"; frames the host-only build as the
  ABI/version surface and the CUDA build as the decoder.
- **README "## Why"** and **CONTRIBUTING**, narrow the oracle claim to liblz4
  (the only reference implementation wired today); zlib and libzstd are named
  as arriving with the DEFLATE and Zstd formats. Both previously read as if all
  three were active oracles.
- **MASTERPLAN section 4**, the shipped kernel is single-pass warp-per-chunk
  with no dispatch heuristic, no shared memory, and no `cp.async`; the
  block-per-chunk / histogram / `cp.async` idea is now marked a deferred option,
  not a decision the code took. Section 8's cross-reference is updated to match.
  Reconciles the section-4 pillar with the settled design in section 9.

Closes #37. Supersedes #35 (a narrower duplicate, closed separately).

## Type of change

- [x] Docs

## Engineering checklist

N/A, docs only; no parse/decode path, kernel, or ABI changed.

## Performance checklist

N/A, not on the hot path; no numbers change.

## Quality checklist

- [x] Minimal: wording and one added table column only; no new sections, no
      duplication.
- [x] Self-documenting: the docs now state the truthful, current status.

## Verification

- [x] Prettier (`**/*.{md,yml,yaml}`) - clean; README, MASTERPLAN, and
      CONTRIBUTING checked with `prettier@3`.
- [x] Docs synced: README / MASTERPLAN / CONTRIBUTING now reflect the shipped
      M1/M2 reality; BENCHMARKS already carries the measured baselines.
- No build/test change (no code touched); the CI build + format required checks
  apply.

## Notes

Scope is the public docs a first-time contributor reads, issue #37's four
points plus the identical oracle-set overstatement in CONTRIBUTING. The
MASTERPLAN "two memory paths" pillar is deliberately left unchanged: the
N-stream streaming overlap it describes matches the currently merged ABI; the
reusable-context simplification (#29) is still in review (PR #34) and not yet
merged, so the doc stays at merged reality.