### PR TITLE
Single-source the host-side CUDA RAII owners into src/cuda_raii.h

### DIFF
--- a/src/cuda_raii.h
+++ b/src/cuda_raii.h
@@ -1,0 +1,142 @@
+/* Shared host-side CUDA RAII owners and the cudaSuccess-check macro for the
+ * CUDA host-orchestration translation units (frame.cpp, stream.cpp, and the
+ * Snappy/GDeflate host paths to come). INTERNAL - device-independent host glue,
+ * never part of the public C ABI in include/cudec.h.
+ *
+ * Each owner owns exactly one CUDA handle, is non-copyable, and frees it on
+ * EVERY scope exit - including the hostile-input reject paths, not just on
+ * success. A leak on the expected corrupt-input path is a device/pinned-memory
+ * exhaustion DoS in a library entry point. Cleanup errors are discarded
+ * deliberately: they are not actionable and must not mask the real decode
+ * status. On an allocation failure the owner holds nothing (null, cap 0), so
+ * the destructor never double-frees; the enclosing caller decides whether the
+ * failure poisons a reusable context.
+ *
+ * The member types have external linkage (this is a named namespace, not an
+ * anonymous one) so an ABI-visible struct built from them - cudec_stream_ctx -
+ * triggers no subobject-linkage diagnostic. */
+#ifndef CUDEC_CUDA_RAII_H
+#define CUDEC_CUDA_RAII_H
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+
+/* Evaluate a CUDA runtime `call` exactly once; if it did not return
+ * cudaSuccess, run `on_failure`. `on_failure` maps the fault to a defined
+ * cudec_status return (and, for the reusable stream context, poisons it first
+ * so only destruction is valid afterwards). The single expansion is why `call`
+ * is never evaluated twice - the failure policy is the caller's, the check is
+ * single-sourced here. */
+#define CUDEC_CUDA_CHECK(call, on_failure) \
+    do {                                   \
+        if ((call) != cudaSuccess) {       \
+            on_failure;                    \
+        }                                  \
+    } while (0)
+
+namespace cudec_cuda {
+
+/* Grow-only device buffer. ensure() reuses the existing allocation when it is
+ * already large enough (the amortization); otherwise it frees the old one and
+ * allocates the larger size. On failure the owner holds nothing (null, cap 0),
+ * so the destructor never double-frees - the enclosing context is poisoned by
+ * the caller and only its destruction is valid afterwards. All grows happen
+ * before any staging in a decode, so no live buffer is ever reallocated
+ * mid-call. A one-shot caller simply calls ensure() once on a fresh owner: the
+ * first ensure of a non-zero size allocates exactly once. */
+struct DevBuf {
+    void* p = nullptr;
+    size_t cap = 0;
+    DevBuf() = default;
+    DevBuf(const DevBuf&) = delete;
+    DevBuf& operator=(const DevBuf&) = delete;
+    ~DevBuf() {
+        if (p != nullptr) {
+            (void)cudaFree(p);
+        }
+    }
+    cudaError_t ensure(size_t bytes) {
+        if (bytes <= cap) {
+            return cudaSuccess;
+        }
+        if (p != nullptr) {
+            (void)cudaFree(p);
+            p = nullptr;
+            cap = 0;
+        }
+        const cudaError_t e = cudaMalloc(&p, bytes);
+        if (e != cudaSuccess) {
+            p = nullptr;
+            return e;
+        }
+        cap = bytes;
+        return cudaSuccess;
+    }
+};
+
+/* Grow-only pinned host buffer, same contract as DevBuf. */
+struct PinnedBuf {
+    void* p = nullptr;
+    size_t cap = 0;
+    PinnedBuf() = default;
+    PinnedBuf(const PinnedBuf&) = delete;
+    PinnedBuf& operator=(const PinnedBuf&) = delete;
+    ~PinnedBuf() {
+        if (p != nullptr) {
+            (void)cudaFreeHost(p);
+        }
+    }
+    cudaError_t ensure(size_t bytes) {
+        if (bytes <= cap) {
+            return cudaSuccess;
+        }
+        if (p != nullptr) {
+            (void)cudaFreeHost(p);
+            p = nullptr;
+            cap = 0;
+        }
+        const cudaError_t e = cudaHostAlloc(&p, bytes, cudaHostAllocDefault);
+        if (e != cudaSuccess) {
+            p = nullptr;
+            return e;
+        }
+        cap = bytes;
+        return cudaSuccess;
+    }
+};
+
+struct StreamOwner {
+    cudaStream_t s = nullptr;
+    StreamOwner() = default;
+    StreamOwner(const StreamOwner&) = delete;
+    StreamOwner& operator=(const StreamOwner&) = delete;
+    ~StreamOwner() {
+        if (s != nullptr) {
+            (void)cudaStreamDestroy(s);
+        }
+    }
+    cudaError_t create() {
+        /* Non-blocking so a wave does not depend on the legacy default stream
+         * staying idle (a caller with default-stream work in the same context
+         * would otherwise serialize every wave). */
+        return cudaStreamCreateWithFlags(&s, cudaStreamNonBlocking);
+    }
+};
+
+struct EventOwner {
+    cudaEvent_t e = nullptr;
+    EventOwner() = default;
+    EventOwner(const EventOwner&) = delete;
+    EventOwner& operator=(const EventOwner&) = delete;
+    ~EventOwner() {
+        if (e != nullptr) {
+            (void)cudaEventDestroy(e);
+        }
+    }
+    cudaError_t create() { return cudaEventCreate(&e); }
+};
+
+}  // namespace cudec_cuda
+
+#endif  // CUDEC_CUDA_RAII_H

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -6,6 +6,7 @@
  * optional declared content size are verified fail-closed. Frame spec
  * (public): lz4_Frame_format.md. */
 #include "cudec.h"
+#include "cuda_raii.h"
 #include "xxhash32.h"
 
 #include <cuda_runtime.h>
@@ -37,25 +38,6 @@ struct FrameBlock {
     bool uncompressed;
 };
 
-/* Owns one cudaMalloc allocation and frees it on every scope exit - so the
- * device buffers are reclaimed on ALL return paths, including the hostile-
- * input reject paths, not just on success. A leak on the expected corrupt-
- * frame path is a GPU-memory-exhaustion DoS in a library entry point. */
-struct DevPtr {
-    void* p = nullptr;
-    DevPtr() = default;
-    DevPtr(const DevPtr&) = delete;
-    DevPtr& operator=(const DevPtr&) = delete;
-    ~DevPtr() {
-        /* Cleanup errors are not actionable and must not mask the real
-         * status; the discard is deliberate. */
-        if (p != nullptr) {
-            (void)cudaFree(p);
-        }
-    }
-    cudaError_t alloc(size_t bytes) { return cudaMalloc(&p, bytes); }
-};
-
 /* Decodes the compressed blocks in one device batch and assembles the whole
  * frame output (compressed decoded bytes + uncompressed blocks copied
  * verbatim) into `out`, bounded by dst_capacity, writing the produced size
@@ -72,12 +54,7 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
                                const std::vector<FrameBlock>& blocks,
                                size_t block_max, unsigned char* out,
                                size_t dst_capacity, size_t* total_out) {
-#define FRAME_CUDA(call)                        \
-    do {                                        \
-        if ((call) != cudaSuccess) {            \
-            return CUDEC_ERR_CUDA;              \
-        }                                       \
-    } while (0)
+#define FRAME_CUDA(call) CUDEC_CUDA_CHECK(call, return CUDEC_ERR_CUDA)
 
     std::vector<size_t> cidx;
     size_t total_src = 0;
@@ -92,15 +69,19 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
     /* Decoded output size per block; uncompressed blocks use src_len. */
     std::vector<size_t> decoded_len(blocks.size(), 0);
 
-    DevPtr d_src, d_dst, dd_src, dd_dst, dd_ssz, dd_dcp, dd_res;
+    /* One-shot owners: each buffer is allocated once here and freed on every
+     * scope exit. The shared grow-only DevBuf serves this by a single ensure()
+     * from cap 0 - every size below is non-zero (guarded by n != 0), so the
+     * first ensure allocates exactly once, identical to a bare cudaMalloc. */
+    cudec_cuda::DevBuf d_src, d_dst, dd_src, dd_dst, dd_ssz, dd_dcp, dd_res;
     if (n != 0) {
         /* One destination slot of block_max per compressed block. Guard the
          * product against size_t overflow before asking the driver. */
         if (block_max != 0 && n > SIZE_MAX / block_max) {
             return CUDEC_ERR_CORRUPT_INPUT;
         }
-        FRAME_CUDA(d_src.alloc(total_src));
-        FRAME_CUDA(d_dst.alloc(n * block_max));
+        FRAME_CUDA(d_src.ensure(total_src));
+        FRAME_CUDA(d_dst.ensure(n * block_max));
 
         std::vector<const void*> h_src(n);
         std::vector<void*> h_dst(n);
@@ -123,11 +104,11 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
                                   cudaMemcpyHostToDevice));
         }
 
-        FRAME_CUDA(dd_src.alloc(n * sizeof(void*)));
-        FRAME_CUDA(dd_dst.alloc(n * sizeof(void*)));
-        FRAME_CUDA(dd_ssz.alloc(n * sizeof(size_t)));
-        FRAME_CUDA(dd_dcp.alloc(n * sizeof(size_t)));
-        FRAME_CUDA(dd_res.alloc(n * sizeof(cudec_chunk_result)));
+        FRAME_CUDA(dd_src.ensure(n * sizeof(void*)));
+        FRAME_CUDA(dd_dst.ensure(n * sizeof(void*)));
+        FRAME_CUDA(dd_ssz.ensure(n * sizeof(size_t)));
+        FRAME_CUDA(dd_dcp.ensure(n * sizeof(size_t)));
+        FRAME_CUDA(dd_res.ensure(n * sizeof(cudec_chunk_result)));
         FRAME_CUDA(cudaMemcpy(dd_src.p, h_src.data(), n * sizeof(void*),
                               cudaMemcpyHostToDevice));
         FRAME_CUDA(cudaMemcpy(dd_dst.p, h_dst.data(), n * sizeof(void*),

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -25,6 +25,8 @@
  * for the corrected overlap analysis and the output-D2H future lever. */
 #include "cudec.h"
 
+#include "cuda_raii.h"
+
 #include <cuda_runtime.h>
 
 #include <cstdint>
@@ -49,105 +51,6 @@ inline bool MulOverflows(size_t a, size_t b) {
     return a != 0 && b > SIZE_MAX / a;
 }
 
-/* Grow-only device buffer. ensure() reuses the existing allocation when it is
- * already large enough (the amortization); otherwise it frees the old one and
- * allocates the larger size. On failure the owner holds nothing (null, cap 0),
- * so the destructor never double-frees - the enclosing context is poisoned by
- * the caller and only its destruction is valid afterwards. All grows happen
- * before any staging in a decode, so no live buffer is ever reallocated
- * mid-call. */
-struct DevBuf {
-    void* p = nullptr;
-    size_t cap = 0;
-    DevBuf() = default;
-    DevBuf(const DevBuf&) = delete;
-    DevBuf& operator=(const DevBuf&) = delete;
-    ~DevBuf() {
-        if (p != nullptr) {
-            (void)cudaFree(p);
-        }
-    }
-    cudaError_t ensure(size_t bytes) {
-        if (bytes <= cap) {
-            return cudaSuccess;
-        }
-        if (p != nullptr) {
-            (void)cudaFree(p);
-            p = nullptr;
-            cap = 0;
-        }
-        const cudaError_t e = cudaMalloc(&p, bytes);
-        if (e != cudaSuccess) {
-            p = nullptr;
-            return e;
-        }
-        cap = bytes;
-        return cudaSuccess;
-    }
-};
-
-/* Grow-only pinned host buffer, same contract as DevBuf. */
-struct PinnedBuf {
-    void* p = nullptr;
-    size_t cap = 0;
-    PinnedBuf() = default;
-    PinnedBuf(const PinnedBuf&) = delete;
-    PinnedBuf& operator=(const PinnedBuf&) = delete;
-    ~PinnedBuf() {
-        if (p != nullptr) {
-            (void)cudaFreeHost(p);
-        }
-    }
-    cudaError_t ensure(size_t bytes) {
-        if (bytes <= cap) {
-            return cudaSuccess;
-        }
-        if (p != nullptr) {
-            (void)cudaFreeHost(p);
-            p = nullptr;
-            cap = 0;
-        }
-        const cudaError_t e = cudaHostAlloc(&p, bytes, cudaHostAllocDefault);
-        if (e != cudaSuccess) {
-            p = nullptr;
-            return e;
-        }
-        cap = bytes;
-        return cudaSuccess;
-    }
-};
-
-struct StreamOwner {
-    cudaStream_t s = nullptr;
-    StreamOwner() = default;
-    StreamOwner(const StreamOwner&) = delete;
-    StreamOwner& operator=(const StreamOwner&) = delete;
-    ~StreamOwner() {
-        if (s != nullptr) {
-            (void)cudaStreamDestroy(s);
-        }
-    }
-    cudaError_t create() {
-        /* Non-blocking so a wave does not depend on the legacy default stream
-         * staying idle (a caller with default-stream work in the same context
-         * would otherwise serialize every wave). */
-        return cudaStreamCreateWithFlags(&s, cudaStreamNonBlocking);
-    }
-};
-
-struct EventOwner {
-    cudaEvent_t e = nullptr;
-    EventOwner() = default;
-    EventOwner(const EventOwner&) = delete;
-    EventOwner& operator=(const EventOwner&) = delete;
-    ~EventOwner() {
-        if (e != nullptr) {
-            (void)cudaEventDestroy(e);
-        }
-    }
-    cudaError_t create() { return cudaEventCreate(&e); }
-};
-
 }  // namespace cudec_stream_detail
 
 /* The opaque context (the header forward-declares `struct cudec_stream_ctx`).
@@ -159,18 +62,19 @@ struct EventOwner {
  * during a decode: only destruction is valid afterwards.
  *
  * Not thread-safe: one context per thread, no internal locking (documented on
- * the ABI). The member types have external linkage (named namespace) so this
- * ABI-visible struct triggers no subobject-linkage diagnostic. */
+ * the ABI). The member types have external linkage (the shared cudec_cuda
+ * namespace, not an anonymous one) so this ABI-visible struct triggers no
+ * subobject-linkage diagnostic. */
 struct cudec_stream_ctx {
-    cudec_stream_detail::StreamOwner stream;
-    cudec_stream_detail::EventOwner reuse_ev;
-    cudec_stream_detail::PinnedBuf p_src;
-    cudec_stream_detail::DevBuf d_src;
-    cudec_stream_detail::PinnedBuf p_meta;
-    cudec_stream_detail::DevBuf d_meta;
-    cudec_stream_detail::DevBuf d_dst; /* host-output staging only */
-    cudec_stream_detail::DevBuf d_results;
-    cudec_stream_detail::PinnedBuf p_results;
+    cudec_cuda::StreamOwner stream;
+    cudec_cuda::EventOwner reuse_ev;
+    cudec_cuda::PinnedBuf p_src;
+    cudec_cuda::DevBuf d_src;
+    cudec_cuda::PinnedBuf p_meta;
+    cudec_cuda::DevBuf d_meta;
+    cudec_cuda::DevBuf d_dst; /* host-output staging only */
+    cudec_cuda::DevBuf d_results;
+    cudec_cuda::PinnedBuf p_results;
     bool poisoned = false;
 };
 
@@ -286,13 +190,8 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
      * cudaMalloc) leaves the context's buffers partially grown; poison so only
      * destruction is valid afterwards. This is a DEFINED failure, reachable
      * through the public API without any undefined behavior. */
-#define GROW(call)                   \
-    do {                             \
-        if ((call) != cudaSuccess) { \
-            ctx.poisoned = true;     \
-            return CUDEC_ERR_CUDA;   \
-        }                            \
-    } while (0)
+#define GROW(call) \
+    CUDEC_CUDA_CHECK(call, { ctx.poisoned = true; return CUDEC_ERR_CUDA; })
     GROW(ctx.p_src.ensure(max_wave_src));
     GROW(ctx.d_src.ensure(max_wave_src));
     GROW(ctx.p_meta.ensure(kMetaBytes));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,3 +189,37 @@ foreach(_probe host_warning device_warning)
         "under the strict flags")
   endif()
 endforeach()
+
+# Single-source lock (issue #40): the host-side CUDA RAII owners live once, in
+# src/cuda_raii.h, and every CUDA host translation unit reuses them instead of
+# carrying its own copy. This detector reds the build if the header stops
+# defining an owner, or if a host TU drops the include or re-introduces a local
+# owner definition. Honest limit (as with the checks above): it catches a
+# re-copy under the SAME struct names, not one smuggled in under a fresh name -
+# a drift detector, not tamper-proofing.
+set(_raii_header ${CMAKE_CURRENT_SOURCE_DIR}/../src/cuda_raii.h)
+if(NOT EXISTS ${_raii_header})
+  message(FATAL_ERROR "src/cuda_raii.h is missing: the shared CUDA RAII owners "
+                      "must be single-sourced there (issue #40)")
+endif()
+file(READ ${_raii_header} _raii_src)
+foreach(_owner DevBuf PinnedBuf StreamOwner EventOwner)
+  if(NOT _raii_src MATCHES "struct ${_owner}")
+    message(FATAL_ERROR "src/cuda_raii.h no longer defines the shared owner "
+                        "'${_owner}' (issue #40)")
+  endif()
+endforeach()
+foreach(_tu frame.cpp stream.cpp)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_tu} _tu_src)
+  if(NOT _tu_src MATCHES "#include \"cuda_raii.h\"")
+    message(FATAL_ERROR "src/${_tu} no longer includes cuda_raii.h: it must "
+                        "reuse the shared CUDA RAII owners (issue #40)")
+  endif()
+  foreach(_owner DevBuf PinnedBuf StreamOwner EventOwner DevPtr)
+    if(_tu_src MATCHES "struct ${_owner}")
+      message(FATAL_ERROR "src/${_tu} defines a local 'struct ${_owner}': the "
+                          "CUDA RAII owners are single-sourced in cuda_raii.h "
+                          "(issue #40)")
+    endif()
+  endforeach()
+endforeach()


### PR DESCRIPTION
# What & why

Single-source the duplicated host-side CUDA glue. `frame.cpp` and `stream.cpp`
each carried their own copy of the same grow-only device/pinned buffer + CUDA
stream/event RAII owners and a `cudaSuccess`-check macro. This consolidates the
owners and the check into one internal header, `src/cuda_raii.h` (namespace
`cudec_cuda`), that both translation units include, so the next CUDA host TU
(Snappy / GDeflate frame decode, M3+) reuses them instead of re-copying.
Internal only - `include/cudec.h` is untouched.

Closes #40.

**Divergence found (surfaced, not silently resolved).** The issue was filed
against an earlier `stream.cpp`; PR #34 had since reworked it, so the two copies
were no longer byte-identical and a verbatim move was impossible. I unified to
the strictly-safer form:

- **Owners.** The moved owners are the grow-only `DevBuf`/`PinnedBuf`
  (`ensure()`, tracked `cap`, explicit null-on-failure) plus
  `StreamOwner`/`EventOwner`. `frame.cpp` dropped its own one-shot `DevPtr` and
  now uses `cudec_cuda::DevBuf`: each frame allocation becomes a single
  `ensure()` from `cap 0` over a **non-zero** size (guarded by `n != 0`), which
  allocates exactly once - identical result to the old bare `cudaMalloc`.
  `DevBuf` additionally nulls its pointer on a failed allocation, so it is
  **strictly safer** than `DevPtr` on the reject path (no reliance on the
  driver zeroing the out-pointer before the RAII free runs).
- **Check macro.** Hoisted as `CUDEC_CUDA_CHECK(call, on_failure)` - it
  single-sources the `!= cudaSuccess` test and lets each site keep its failure
  policy. `frame`'s `FRAME_CUDA` stays a plain `return CUDEC_ERR_CUDA`;
  `stream`'s `GROW` still poisons the reusable context before returning. Both
  are now thin wrappers over the shared macro. The two macros were **not**
  identical (`GROW` poisons), so a single plain macro would have changed
  behaviour - hence the parameterised failure action.

The inline `!= cudaSuccess` / `WAVE_FAIL` break-path checks in the stream wave
loop (which must `break`, not `return`) and `MulOverflows` stay in
`stream.cpp`, untouched.

No bug was found in the divergence, so no new issue was filed - the one-shot
vs grow-only difference is a safe superset, not a latent fault.

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] API surface (internal host wrappers around the C-ABI batch/frame/stream
      entries; the public ABI is unchanged)
- [ ] Performance
- [ ] Bug fix
- [x] Refactor / code quality
- [ ] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: no parse/decode path changed. All allocation and
      free flows through the moved owners; the reject-path free guarantee is
      preserved (and strengthened for `frame.cpp`, see above). No new reachable
      OOB.
- [x] Oracle coverage: unchanged and green - `frame_twin` (liblz4 frame oracle)
      and `parser_twin` still diff decode output against the CPU reference.
- [x] Determinism preserved (bit-exact): `stream_twin` green across
      {1,2,4,7}x{host,device}; no output path changed.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI -
      the checks moved verbatim into the shared macro/owners.
- [ ] An adversarial review (`/security-review`) was run - deferred to the
      reviewer/orchestrator per the delivery split; not run in this branch.

## Performance checklist

Not on the hot path - host-side setup glue only, no kernel or copy-choreography
change. No measurement needed.

## Quality checklist

- [x] Minimal: removes one full `DevPtr` copy + one macro body, consolidates
      ~55 lines of owner boilerplate into one header. Net across the four files:
      +206 / -150, and every future CUDA host TU now carries zero copies.
- [x] Self-documenting: the load-bearing "why" comments (lifetime, double-free,
      poison interplay, non-blocking-stream rationale) moved with the owners; a
      new comment on the `frame.cpp` site explains the one-shot-via-`ensure()`
      choice.
- [x] Conformance tests pass; the new structural property (owners
      single-sourced) is locked as a configure-time drift detector in
      `tests/CMakeLists.txt`.

## Verification

Pinned CUDA container (`nvidia/cuda:12.6.2-devel-ubuntu24.04`, nvcc 12.6.77,
`sm_80`+`sm_86`, RTX 3080):

- [x] `cmake --build build-cuda` - builds clean, `-Werror` clean.
- [x] `ctest --test-dir build-cuda` - **10/10 passed, 0 failed**:
      `conformance_c`, `oracle_lz4`, `parser_twin`, `launch_fail`, `smoke`,
      `gpu_fixture`, `frame_twin`, `stream_twin`, `bench_selfcheck`,
      `bench_worst4b_selfcheck`. `frame_twin` + `stream_twin` (the
      behaviour-preservation pins) green.
- [x] Prettier (`**/*.{md,yml,yaml}`) - no touched files in scope (only
      `.cpp`/`.h`/CMake changed).
- [x] Docs synced: no behaviour, API, or performance change - nothing to sync.

## Notes

**Structural lock scope.** The drift detector is configure-time (matching the
existing structural-conformance block): it reds the build if `cuda_raii.h`
stops defining an owner, or if `frame.cpp`/`stream.cpp` drop the include or
re-introduce a local owner struct. Honest limit, same as the neighbouring
checks: it catches a re-copy under the **same** struct names, not one smuggled
in under a fresh name - a drift detector, not tamper-proofing. The real
behaviour-preservation proof is the green `frame_twin` + `stream_twin`.

**Out of scope / follow-up.** The issue's optional "collapse the four owners
into one policy-templated owner" step is deliberately not taken here - the four
plain structs are self-documenting and the verbatim-move is the conservative,
behaviour-preserving change. Left for my call.
