### PR TITLE
Dedupe the device pointer-table upload in gpu_fixture.cu

### DIFF
--- a/tests/gpu_fixture.cu
+++ b/tests/gpu_fixture.cu
@@ -26,6 +26,35 @@ struct Chunk {
     size_t dst_capacity;
 };
 
+/* Allocates the five device pointer/size/result tables for an n-chunk
+ * batch, uploads the four host tables, and primes the results buffer with
+ * the 0xFF non-OK sentinel. Shared by RunBatch and the grid-stride
+ * wraparound test below, which stage their host tables differently
+ * (per-chunk allocation vs. one shared src/dst buffer repeated wrap_n
+ * times) but need the identical device-side upload. */
+int UploadBatchTables(size_t n, const std::vector<const void*>& h_srcs,
+                      const std::vector<void*>& h_dsts,
+                      const std::vector<size_t>& h_sizes,
+                      const std::vector<size_t>& h_caps,
+                      const void*** d_srcs, void*** d_dsts, size_t** d_sizes,
+                      size_t** d_caps, cudec_chunk_result** d_results) {
+    REQUIRE_CUDA(cudaMalloc(d_srcs, n * sizeof(**d_srcs)));
+    REQUIRE_CUDA(cudaMalloc(d_dsts, n * sizeof(**d_dsts)));
+    REQUIRE_CUDA(cudaMalloc(d_sizes, n * sizeof(**d_sizes)));
+    REQUIRE_CUDA(cudaMalloc(d_caps, n * sizeof(**d_caps)));
+    REQUIRE_CUDA(cudaMalloc(d_results, n * sizeof(**d_results)));
+    REQUIRE_CUDA(cudaMemcpy(*d_srcs, h_srcs.data(), n * sizeof(**d_srcs),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(*d_dsts, h_dsts.data(), n * sizeof(**d_dsts),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(*d_sizes, h_sizes.data(), n * sizeof(**d_sizes),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(*d_caps, h_caps.data(), n * sizeof(**d_caps),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemset(*d_results, 0xFF, n * sizeof(**d_results)));
+    return 0;
+}
+
 /* Uploads a batch, runs it through the entry point on a created stream,
  * and returns the per-chunk results plus the downloaded (poisoned)
  * destination buffers. Plain int-returning so REQUIRE can early-abort. */
@@ -59,20 +88,8 @@ int RunBatch(const std::vector<Chunk>& chunks,
     size_t* d_sizes;
     size_t* d_caps;
     cudec_chunk_result* d_results;
-    REQUIRE_CUDA(cudaMalloc(&d_srcs, n * sizeof(*d_srcs)));
-    REQUIRE_CUDA(cudaMalloc(&d_dsts, n * sizeof(*d_dsts)));
-    REQUIRE_CUDA(cudaMalloc(&d_sizes, n * sizeof(*d_sizes)));
-    REQUIRE_CUDA(cudaMalloc(&d_caps, n * sizeof(*d_caps)));
-    REQUIRE_CUDA(cudaMalloc(&d_results, n * sizeof(*d_results)));
-    REQUIRE_CUDA(cudaMemcpy(d_srcs, h_srcs.data(), n * sizeof(*d_srcs),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_dsts, h_dsts.data(), n * sizeof(*d_dsts),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_sizes, h_sizes.data(), n * sizeof(*d_sizes),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_caps, h_caps.data(), n * sizeof(*d_caps),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemset(d_results, 0xFF, n * sizeof(*d_results)));
+    REQUIRE(UploadBatchTables(n, h_srcs, h_dsts, h_sizes, h_caps, &d_srcs,
+                              &d_dsts, &d_sizes, &d_caps, &d_results) == 0);
 
     cudaStream_t stream;
     REQUIRE_CUDA(cudaStreamCreate(&stream));
@@ -228,20 +245,8 @@ int main() {
         size_t* d_sz;
         size_t* d_cp;
         cudec_chunk_result* d_r;
-        REQUIRE_CUDA(cudaMalloc(&d_s, wrap_n * sizeof(*d_s)));
-        REQUIRE_CUDA(cudaMalloc(&d_d, wrap_n * sizeof(*d_d)));
-        REQUIRE_CUDA(cudaMalloc(&d_sz, wrap_n * sizeof(*d_sz)));
-        REQUIRE_CUDA(cudaMalloc(&d_cp, wrap_n * sizeof(*d_cp)));
-        REQUIRE_CUDA(cudaMalloc(&d_r, wrap_n * sizeof(*d_r)));
-        REQUIRE_CUDA(cudaMemcpy(d_s, h_s.data(), wrap_n * sizeof(*d_s),
-                                cudaMemcpyHostToDevice));
-        REQUIRE_CUDA(cudaMemcpy(d_d, h_d.data(), wrap_n * sizeof(*d_d),
-                                cudaMemcpyHostToDevice));
-        REQUIRE_CUDA(cudaMemcpy(d_sz, h_sz.data(), wrap_n * sizeof(*d_sz),
-                                cudaMemcpyHostToDevice));
-        REQUIRE_CUDA(cudaMemcpy(d_cp, h_cp.data(), wrap_n * sizeof(*d_cp),
-                                cudaMemcpyHostToDevice));
-        REQUIRE_CUDA(cudaMemset(d_r, 0xFF, wrap_n * sizeof(*d_r)));
+        REQUIRE(UploadBatchTables(wrap_n, h_s, h_d, h_sz, h_cp, &d_s, &d_d,
+                                  &d_sz, &d_cp, &d_r) == 0);
         REQUIRE(cudec_lz4_decompress_batch(d_s, d_sz, d_d, d_cp, wrap_n, d_r,
                                            nullptr) == CUDEC_OK);
         REQUIRE_CUDA(cudaDeviceSynchronize());


### PR DESCRIPTION
# What & why

`tests/gpu_fixture.cu` had the same device-side batch setup (five
`cudaMalloc`s for the src/dst/sizes/caps/results tables, four `cudaMemcpy`
uploads, the `0xFF` non-OK sentinel `memset`) duplicated between `RunBatch`
and the Batch 3 grid-stride wraparound test. The wraparound re-inlines it
only because it deliberately shares one src/dst buffer across 40000 chunks
(avoiding 80000 allocations) rather than allocating per chunk like
`RunBatch`, but the pointer-table upload itself was identical, so any
change to the batch argument convention had to be edited in two places.

Extracts a file-local `UploadBatchTables(n, host tables..., device table
out-params)` helper covering exactly the five allocations, four uploads,
and the results memset; both call sites now call it with their own
host-side tables. Pure test-internal refactor, no library, ABI, or test
behavior/coverage change.

Closes #41

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [x] Refactor / code quality
- [ ] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [ ] Fail-closed preserved: every new parse/decode path rejects invalid
      input with a defined error; no out-of-bounds access is reachable from
      hostile input, and every reject path has a negative test.
      (N/A — no decode/parse path touched; the fail-closed assertions in
      the test are unchanged.)
- [ ] Oracle coverage: decode output is diff-tested against the CPU
      reference (liblz4 / zlib / libzstd) for every touched format path.
      (N/A — no format path touched.)
- [x] Determinism preserved (same input → same output, bit-exact), or the
      break is a documented, gated decision.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [ ] An adversarial review (`/security-review`) was run for changes to
      kernels, format parsing, the C-ABI boundary, build/tools, or workflows.
      (Not run — this change touches only `tests/gpu_fixture.cu`, none of
      which the gate covers per CLAUDE.md; deferred to the orchestrator's
      independent review.)

## Performance checklist

N/A, test-only refactor, no hot-path change.

## Quality checklist

- [x] Minimal: the change adds no more code than the problem requires; no
      duplication, no dead code.
- [x] Self-documenting: intention-revealing names and small, single-purpose
      functions; comments explain why, not what.
- [x] Conformance tests pass, and any new structural property this change
      establishes is locked in as a new conformance test. (No new
      structural property — this is a dedup, not a new invariant.)

## Verification

Ran the pinned CUDA container gate (mounting this worktree):

```
docker run --rm --gpus all -v "<worktree>:/w" -w /w nvidia/cuda:12.6.2-devel-ubuntu24.04 sh -c "apt-get update -q >/dev/null && apt-get install -yq cmake >/dev/null 2>&1 && cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j && ctest --test-dir build-cuda --no-tests=error --output-on-failure"
```

- [x] `cmake --build build-cuda` - builds clean, `-Werror` clean (nvcc
      12.6.77, sm_80+sm_86).
- [x] `ctest --test-dir build-cuda` - 100% tests passed, 0 failed, 10/10:
      conformance_c, oracle_lz4, parser_twin, launch_fail, smoke,
      **gpu_fixture (0.38s, unchanged)**, frame_twin, stream_twin,
      bench_selfcheck, bench_worst4b_selfcheck.
- [ ] Prettier (`**/*.{md,yml,yaml}`) - no `.md`/`.yml`/`.yaml` files
      changed in this PR.
- [ ] Docs synced, N/A, no behavior/API/performance change to document.

## Notes

Only `tests/gpu_fixture.cu` is touched. `tests/CMakeLists.txt` was
deliberately left untouched (no new source file, no new target, the
helper lives inside the existing `gpu_fixture.cu` translation unit).
