### PR TITLE
Add a host-side ASan/UBSan gate over the untrusted-input decode path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,76 @@ jobs:
           grep -E ': frame_twin$' gpu-deferred.txt &&
           grep -E ': stream_twin$' gpu-deferred.txt
 
+  sanitize:
+    # The host-side ASan/UBSan gate over the untrusted-input decode path (issue
+    # #42): builds only the GPU-less, host-instrumentable subset (the frame
+    # parse, the single-sourced block parser via the CPU twin, and the C-ABI
+    # argument validation) with AddressSanitizer + UndefinedBehaviorSanitizer,
+    # and runs the negative/mutation/oracle/conformance tests under it, so an
+    # out-of-bounds access, an uninitialised read, or integer/shift UB on a
+    # hostile bitstream reds the build. The sanitizer never touches nvcc/device
+    # compilation (CUDEC_SANITIZE guards it to the host C/C++ path); the device
+    # net stays compute-sanitizer + the whole-corpus GPU/oracle byte diff.
+    name: sanitize
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Same pinned image/digest as build: nvcc is present (the library's device
+    # TU still compiles) and the runner has no GPU (the sanitized subset rejects
+    # or decodes all-uncompressed frames before any CUDA call).
+    container:
+      image: nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # Same git-before-checkout lesson as the build job: git in the container
+      # keeps actions/checkout off the flakier REST-tarball fallback, and the
+      # CUDA apt repo is dropped before the update.
+      - name: Install git and CMake
+        run: >-
+          rm -f /etc/apt/sources.list.d/cuda*.list &&
+          apt-get update -q -o Acquire::Retries=3 &&
+          apt-get install -yq -o Acquire::Retries=3 --no-install-recommends
+          git cmake
+
+      - name: Check out the source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Host-only subset with the sanitizers on. The GPU tests and bench are
+      # skipped by the CMake gate (they are nvcc-linked), so the build is pure
+      # host. The test -x lines are fail-closed: the four sanitized binaries
+      # must exist, so a build that silently stopped producing them reds here.
+      - name: Build the host attack surface with ASan+UBSan
+        run: >-
+          cmake -B build-san -DCUDEC_ENABLE_CUDA=ON
+          -DCUDEC_SANITIZE=address,undefined &&
+          cmake --build build-san -j &&
+          test -x build-san/tests/conformance_c &&
+          test -x build-san/tests/oracle_lz4 &&
+          test -x build-san/tests/parser_twin &&
+          test -x build-san/tests/frame_host_negative
+
+      # Prove the sanitizer runtimes are actually linked: a dropped or renamed
+      # -fsanitize flag would still build and test green but check nothing, so
+      # pin it empirically here - a sanitized binary links libasan and libubsan.
+      - name: Verify the sanitizer runtimes are linked
+        run: >-
+          ldd build-san/tests/parser_twin | grep -q libasan &&
+          ldd build-san/tests/parser_twin | grep -q libubsan
+
+      # Run the untrusted-input subset under the sanitizers. --no-tests=error
+      # reds a vacuous selection; the regex pins exactly the host tests this
+      # gate owns (launch_fail and bench are excluded: they initialise the CUDA
+      # runtime / are nvcc-linked, outside the host attack surface).
+      - name: Run the untrusted-input decode path under ASan+UBSan
+        run: >-
+          ctest --test-dir build-san --no-tests=error --output-on-failure -R
+          '^(conformance_c|oracle_lz4|parser_twin|frame_host_negative)$'
+
   format:
     name: format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,11 +169,20 @@ jobs:
       # Run the untrusted-input subset under the sanitizers. --no-tests=error
       # reds a vacuous selection; the regex pins exactly the host tests this
       # gate owns (launch_fail and bench are excluded: they initialise the CUDA
-      # runtime / are nvcc-linked, outside the host attack surface).
+      # runtime / are nvcc-linked, outside the host attack surface). The
+      # per-name identity greps mirror the build job: --no-tests=error only
+      # reds on a ZERO selection, so a single sanitized test silently losing
+      # its registration (say, by gaining a gpu-matching label) would shrink
+      # the set unnoticed - the greps pin all four by name so that reds too.
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|frame_host_negative)$'
+          '^(conformance_c|oracle_lz4|parser_twin|frame_host_negative)$' &&
+          ctest --test-dir build-san -N | tee san-selected.txt &&
+          grep -E ': conformance_c$' san-selected.txt &&
+          grep -E ': oracle_lz4$' san-selected.txt &&
+          grep -E ': parser_twin$' san-selected.txt &&
+          grep -E ': frame_host_negative$' san-selected.txt
 
   format:
     name: format

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build output - reproducible from the sources via CMake.
 build/
 build-cuda/
+build-san/
 
 # Downloaded benchmark corpora - hash-pinned by bench/get-corpora.sh,
 # never committed.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,48 @@ project(cudec VERSION 0.0.1 LANGUAGES C)
 # gate). CI flips this on together with the CUDA toolchain (issue #3).
 option(CUDEC_ENABLE_CUDA "Build the CUDA decode engine and its tests" OFF)
 
+# Host-side sanitizer gate (issue #42): opt-in, default OFF. When set (e.g.
+# -DCUDEC_SANITIZE=address,undefined) it instruments the HOST untrusted-input
+# attack surface - the frame parse (src/frame.cpp), the single-sourced block
+# parser exercised by the CPU twin, and the C-ABI argument validation - and the
+# GPU-less test subset runs under the sanitizer, so an out-of-bounds access, an
+# uninitialised read, or integer/shift UB on a hostile bitstream reds the
+# build. It never touches device (nvcc) compilation: host ASan cannot
+# instrument device code, and the device net stays compute-sanitizer plus the
+# whole-corpus GPU/oracle byte diff (masterplan section 5). Fail-closed:
+# -fno-sanitize-recover=all makes a UBSan finding abort with a non-zero status
+# instead of printing and continuing green.
+set(CUDEC_SANITIZE ""
+    CACHE STRING
+          "Host sanitizers to enable, e.g. 'address,undefined' (empty = off)")
+if(CUDEC_SANITIZE)
+  if(MSVC)
+    message(FATAL_ERROR "CUDEC_SANITIZE requires a GCC/Clang host toolchain "
+                        "(the pinned Linux container is the maintained path).")
+  endif()
+  # Host C/C++ only - the generator expression keeps these off any CUDA
+  # translation unit. The compile flags instrument the TUs; the link flags pull
+  # in the sanitizer runtimes on the executables that run under the gate.
+  set(CUDEC_SANITIZE_COMPILE_FLAGS
+      -fsanitize=${CUDEC_SANITIZE} -fno-sanitize-recover=all
+      -fno-omit-frame-pointer)
+  set(CUDEC_SANITIZE_LINK_FLAGS -fsanitize=${CUDEC_SANITIZE})
+endif()
+
 add_library(cudec src/version.c)
 target_include_directories(cudec PUBLIC include)
 
 if(NOT MSVC)
   target_compile_options(cudec
                          PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wall;-Wextra;-Werror>)
+endif()
+
+# Instrument the library's host TUs (version.c now; frame.cpp/stream.cpp once
+# the CUDA engine is enabled). Guarded to C/C++ so batch.cu is never sanitized.
+if(CUDEC_SANITIZE)
+  target_compile_options(
+    cudec
+    PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:${CUDEC_SANITIZE_COMPILE_FLAGS}>)
 endif()
 
 if(CUDEC_ENABLE_CUDA)
@@ -72,5 +108,11 @@ if(CUDEC_ENABLE_CUDA)
   # follows because it consumes targets defined in tests/ and is
   # consumer-only by rule (it links project targets, never modifies them).
   add_subdirectory(tests)
-  add_subdirectory(bench)
+  # bench_lz4 is a single nvcc-linked binary (bench_lz4.cpp + gpu_bench.cu); it
+  # cannot link the ASan-instrumented cudec without dragging the sanitizer onto
+  # the device link, so the host-only sanitizer gate omits bench entirely. Its
+  # CPU self-checks stay covered by the normal (non-sanitized) build.
+  if(NOT CUDEC_SANITIZE)
+    add_subdirectory(bench)
+  endif()
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,15 @@ set_target_properties(cudec_test_fixtures PROPERTIES CXX_STANDARD 17
 target_compile_options(
   cudec_test_fixtures
   PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror;-O2>)
+# Sanitizer gate (issue #42): the harness that builds and byte-verifies the
+# corpora is host code on the untrusted-input path, so it runs under the
+# sanitizer too. The lz4 oracle it links is deliberately left uninstrumented
+# (third-party, audited by hash - the reference must not red the gate).
+if(CUDEC_SANITIZE)
+  target_compile_options(
+    cudec_test_fixtures
+    PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:${CUDEC_SANITIZE_COMPILE_FLAGS}>)
+endif()
 
 # GPU tests carry the label (the GPU-less CI runner selects -LE gpu) and
 # run serially: one physical device, and deterministic device state is
@@ -66,6 +75,13 @@ target_compile_options(
 # banned pattern is recorded in docs/MASTERPLAN.md section 5.
 function(cudec_add_test name)
   cmake_parse_arguments(T "GPU" "" "SOURCES;LIBS" ${ARGN})
+  # The host-only sanitizer gate (issue #42) builds only the GPU-less,
+  # host-instrumentable subset: a GPU test is a .cu binary linked by nvcc,
+  # which cannot pull in the ASan-instrumented cudec without sanitizing the
+  # device link. Skip them so the sanitizer build stays pure host.
+  if(T_GPU AND CUDEC_SANITIZE)
+    return()
+  endif()
   add_executable(${name} ${T_SOURCES})
   target_link_libraries(${name} PRIVATE cudec ${T_LIBS})
   set_target_properties(
@@ -75,6 +91,14 @@ function(cudec_add_test name)
   target_compile_options(
     ${name} PRIVATE ${CUDEC_CUDA_STRICT_FLAGS}
                     $<$<COMPILE_LANGUAGE:C,CXX>:-Wall;-Wextra;-Werror>)
+  # Sanitizer flags on the host test's own TUs (C/C++ only) and its link, so
+  # the instrumented cudec/fixtures objects pull in the runtimes. GPU tests
+  # returned above, so this only ever reaches host executables.
+  if(CUDEC_SANITIZE)
+    target_compile_options(
+      ${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:${CUDEC_SANITIZE_COMPILE_FLAGS}>)
+    target_link_options(${name} PRIVATE ${CUDEC_SANITIZE_LINK_FLAGS})
+  endif()
   add_test(NAME ${name} COMMAND ${name})
   if(T_GPU)
     set_tests_properties(${name} PROPERTIES LABELS gpu RUN_SERIAL TRUE)
@@ -91,6 +115,15 @@ cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # ladder step 2).
 target_include_directories(parser_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The frame parse's reject branches and its host-only assembly path exercised
+# with NO GPU: every case rejects (or decodes an all-uncompressed frame) before
+# the first CUDA call, so it runs on the GPU-less runner and, under the
+# sanitizer gate (issue #42), gives src/frame.cpp's hostile-input pointer
+# arithmetic ASan/UBSan coverage that the GPU-labeled frame_twin cannot get in
+# CI. It computes header checksums with the library's own xxhash32.h.
+cudec_add_test(frame_host_negative SOURCES frame_host_negative.cpp)
+target_include_directories(frame_host_negative
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 cudec_add_test(launch_fail SOURCES launch_fail.cpp)
 # Belt and suspenders with the setenv inside launch_fail.cpp: zero visible
 # devices is the test condition, on the GPU machine too.
@@ -101,8 +134,12 @@ cudec_add_test(gpu_fixture SOURCES gpu_fixture.cu LIBS cudec_test_fixtures
                GPU)
 cudec_add_test(frame_twin SOURCES frame_twin.cu LIBS lz4_frame_oracle GPU)
 # frame_twin verifies the library's own xxhash32.h against liblz4's XXH32.
-target_include_directories(frame_twin
-                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# Guarded: the host-only sanitizer build (issue #42) skips the GPU targets, so
+# this follow-up only runs when the target actually exists.
+if(TARGET frame_twin)
+  target_include_directories(frame_twin
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+endif()
 cudec_add_test(stream_twin SOURCES stream_twin.cu LIBS cudec_test_fixtures GPU)
 
 # ---- Structural conformance, configure time: a violation reds every CI

--- a/tests/frame_host_negative.cpp
+++ b/tests/frame_host_negative.cpp
@@ -1,0 +1,289 @@
+/* The LZ4 frame parse's reject branches and its host assembly path, driven
+ * with NO GPU (issue #42). Every case here rejects, or decodes an
+ * all-uncompressed frame, BEFORE the first CUDA call: the frame descriptor and
+ * block-table walk in src/frame.cpp reject on the host, and an all-uncompressed
+ * frame assembles entirely on the host (DecodeAndAssemble makes no CUDA call
+ * when there are no compressed blocks). So this runs on the GPU-less CI runner
+ * and, under the sanitizer gate, gives frame.cpp's hostile-input pointer
+ * arithmetic the ASan/UBSan coverage the GPU-labeled frame_twin cannot get in
+ * CI. It is a memory-safety and fail-closed test, not an oracle-parity one:
+ * every crafted frame is malformed by construction and its expected status is
+ * pinned. Header checksums are computed with the library's own xxhash32.h so
+ * the deeper reject branches (past the header-checksum gate) are reachable. */
+#include "cudec.h"
+#include "require.h"
+#include "xxhash32.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+void PutMagic(Bytes* f) {
+    /* 0x184D2204, little-endian. */
+    f->push_back(0x04);
+    f->push_back(0x22);
+    f->push_back(0x4D);
+    f->push_back(0x18);
+}
+
+void Put32(Bytes* f, uint32_t v) {
+    f->push_back(static_cast<unsigned char>(v & 0xFF));
+    f->push_back(static_cast<unsigned char>((v >> 8) & 0xFF));
+    f->push_back(static_cast<unsigned char>((v >> 16) & 0xFF));
+    f->push_back(static_cast<unsigned char>((v >> 24) & 0xFF));
+}
+
+/* The frame header checksum byte: (XXH32(descriptor) >> 8) & 0xFF over the
+ * `desc_len` descriptor bytes that start at offset 4 (FLG onward). */
+unsigned char Hc(const Bytes& f, size_t desc_len) {
+    return static_cast<unsigned char>(
+        (cudec_detail::xxhash32(f.data() + 4, desc_len) >> 8) & 0xFF);
+}
+
+/* Builds a frame of UNCOMPRESSED blocks with a correct header checksum and no
+ * content-size field. BD is fixed at 0x40 (bmax 4 -> 64 KiB block max) unless a
+ * caller overrides it. FLG bit 4 (block checksum) and bit 2 (content checksum)
+ * are honored so those branches are reachable; every block is stored
+ * uncompressed, so a well-formed frame decodes entirely on the host. */
+Bytes BuildFrame(unsigned char flg, unsigned char bd,
+                 const std::vector<Bytes>& blocks) {
+    const bool block_ck = (flg >> 4) & 1;
+    const bool content_ck = (flg >> 2) & 1;
+    Bytes f;
+    PutMagic(&f);
+    f.push_back(flg);
+    f.push_back(bd);
+    f.push_back(Hc(f, 2)); /* descriptor is FLG,BD when there is no content size */
+    Bytes out;             /* the assembled content, for the content checksum */
+    for (const auto& b : blocks) {
+        Put32(&f, 0x80000000u | static_cast<uint32_t>(b.size())); /* uncompressed */
+        f.insert(f.end(), b.begin(), b.end());
+        if (block_ck) {
+            Put32(&f, cudec_detail::xxhash32(b.data(), b.size()));
+        }
+        out.insert(out.end(), b.begin(), b.end());
+    }
+    Put32(&f, 0); /* end mark */
+    if (content_ck) {
+        Put32(&f, cudec_detail::xxhash32(out.data(), out.size()));
+    }
+    return f;
+}
+
+/* A frame that must be rejected: pins the exact status AND that no output byte
+ * is presented (bytes_written stays 0). The output buffer is generous so a
+ * reject is never masked by an OUTPUT_TOO_SMALL from a small buffer. */
+int ExpectReject(const char* name, const Bytes& frame, cudec_status expected) {
+    Bytes out(1u << 16, 0xCC);
+    size_t written = 777;
+    const cudec_status s = cudec_lz4f_decompress(frame.data(), frame.size(),
+                                                 out.data(), out.size(),
+                                                 &written);
+    REQUIRE_CTX(s == expected, "%s: status %d (want %d)", name,
+                static_cast<int>(s), static_cast<int>(expected));
+    REQUIRE_CTX(written == 0, "%s: bytes_written %zu (want 0)", name, written);
+    return 0;
+}
+
+/* A frame that must decode, host-only, to exactly `expected`. */
+int ExpectDecode(const char* name, const Bytes& frame, const Bytes& expected) {
+    Bytes out(expected.size() + 16, 0xEE); /* padding proves we stop at size */
+    size_t written = 777;
+    const cudec_status s = cudec_lz4f_decompress(frame.data(), frame.size(),
+                                                 out.data(), out.size(),
+                                                 &written);
+    REQUIRE_CTX(s == CUDEC_OK, "%s: status %d (want OK)", name,
+                static_cast<int>(s));
+    REQUIRE_CTX(written == expected.size(), "%s: size %zu (want %zu)", name,
+                written, expected.size());
+    REQUIRE_CTX(equal_bytes(out.data(), expected.data(), written), "%s bytes",
+                name);
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    const Bytes b8 = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'};
+    const Bytes b3 = {'x', 'y', 'z'};
+
+    /* --- Well-formed all-uncompressed frames: the host assembly + capacity
+     * path, exercised under the sanitizer with no GPU call. --- */
+    REQUIRE(ExpectDecode("empty", BuildFrame(0x60, 0x40, {}), {}) == 0);
+    REQUIRE(ExpectDecode("one-uncompressed", BuildFrame(0x60, 0x40, {b8}), b8) ==
+            0);
+    {
+        Bytes concat = b8;
+        concat.insert(concat.end(), b3.begin(), b3.end());
+        REQUIRE(ExpectDecode("two-uncompressed",
+                             BuildFrame(0x60, 0x40, {b8, b3}), concat) == 0);
+    }
+    /* Content and block checksums verified on the success side too. */
+    REQUIRE(ExpectDecode("content-ck-ok", BuildFrame(0x64, 0x40, {b8}), b8) ==
+            0);
+    REQUIRE(ExpectDecode("block-ck-ok", BuildFrame(0x70, 0x40, {b8}), b8) == 0);
+
+    /* A NULL destination with a zero capacity is valid for a zero-byte decode:
+     * the assembly must never dereference it. */
+    {
+        const Bytes f = BuildFrame(0x60, 0x40, {});
+        size_t written = 777;
+        REQUIRE(cudec_lz4f_decompress(f.data(), f.size(), nullptr, 0,
+                                      &written) == CUDEC_OK);
+        REQUIRE(written == 0);
+    }
+
+    /* --- Header reject branches (all fire before the block-table walk). --- */
+
+    /* Under the 7-byte minimum header: the magic must NOT be read (short
+     * frames short-circuit), so ASan would catch an over-read here. */
+    REQUIRE(ExpectReject("too-short-3", Bytes{0x04, 0x22, 0x4D},
+                         CUDEC_ERR_CORRUPT_INPUT) == 0);
+    REQUIRE(ExpectReject("too-short-6", Bytes{0x04, 0x22, 0x4D, 0x18, 0x60,
+                                              0x40},
+                         CUDEC_ERR_CORRUPT_INPUT) == 0);
+
+    {
+        Bytes f = BuildFrame(0x60, 0x40, {b8});
+        f[0] ^= 0xFF;
+        REQUIRE(ExpectReject("bad-magic", f, CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+    /* Version field != 01 (FLG bits 7-6). */
+    REQUIRE(ExpectReject("bad-version", BuildFrame(0x20, 0x40, {b8}),
+                         CUDEC_ERR_CORRUPT_INPUT) == 0);
+    /* Reserved FLG bit 1 set. */
+    REQUIRE(ExpectReject("reserved-flg", BuildFrame(0x62, 0x40, {b8}),
+                         CUDEC_ERR_CORRUPT_INPUT) == 0);
+    /* Reserved BD bit (bit 0) set. */
+    REQUIRE(ExpectReject("bd-reserved", BuildFrame(0x60, 0x41, {b8}),
+                         CUDEC_ERR_CORRUPT_INPUT) == 0);
+    /* Block-max code out of the 4..7 range. */
+    REQUIRE(ExpectReject("bad-bmax", BuildFrame(0x60, 0x30, {b8}),
+                         CUDEC_ERR_CORRUPT_INPUT) == 0);
+    /* Block-linked mode and a dictionary id are valid-but-unsupported. */
+    REQUIRE(ExpectReject("linked", BuildFrame(0x40, 0x40, {b8}),
+                         CUDEC_ERR_UNSUPPORTED) == 0);
+    REQUIRE(ExpectReject("dictid", BuildFrame(0x61, 0x40, {b8}),
+                         CUDEC_ERR_UNSUPPORTED) == 0);
+    /* Corrupt header checksum (the HC byte at offset 6). */
+    {
+        Bytes f = BuildFrame(0x60, 0x40, {b8});
+        f[6] ^= 0xFF;
+        REQUIRE(ExpectReject("bad-hc", f, CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+    /* Content-size flag set but the 8-byte field is truncated. */
+    {
+        Bytes f;
+        PutMagic(&f);
+        f.push_back(0x68); /* FLG: version 01, independent, content-size bit 3 */
+        f.push_back(0x40);
+        f.push_back(0);
+        f.push_back(0);
+        f.push_back(0); /* frame_size 9 < 6 + 8 */
+        REQUIRE(ExpectReject("content-size-truncated", f,
+                             CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+    /* Content-size field present but the frame ends before the HC byte. */
+    {
+        Bytes f;
+        PutMagic(&f);
+        f.push_back(0x68);
+        f.push_back(0x40);
+        for (int i = 0; i < 8; i++) {
+            f.push_back(0); /* frame_size 14: past the size field, no HC */
+        }
+        REQUIRE(ExpectReject("content-size-no-hc", f,
+                             CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+
+    /* --- Block-table walk reject branches (host pointer arithmetic on the
+     * hostile block sizes - the surface issue #42 gap 2 names). --- */
+
+    /* No block-size field at all, and a partial one. */
+    {
+        Bytes f = BuildFrame(0x60, 0x40, {b8});
+        f.resize(7);
+        REQUIRE(ExpectReject("no-block-table", f, CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+    {
+        Bytes f = BuildFrame(0x60, 0x40, {b8});
+        f.resize(9); /* header + 2 of the 4 block-size bytes */
+        REQUIRE(ExpectReject("block-size-truncated", f,
+                             CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+    /* A non-end-mark block whose declared length is zero. */
+    {
+        Bytes f;
+        PutMagic(&f);
+        f.push_back(0x60);
+        f.push_back(0x40);
+        f.push_back(Hc(f, 2));
+        Put32(&f, 0x80000000u); /* uncompressed, blen 0 (not the 0 end mark) */
+        REQUIRE(ExpectReject("block-blen-zero", f, CUDEC_ERR_CORRUPT_INPUT) ==
+                0);
+    }
+    /* A block whose declared length exceeds the block max. */
+    {
+        Bytes f;
+        PutMagic(&f);
+        f.push_back(0x60);
+        f.push_back(0x40);
+        f.push_back(Hc(f, 2));
+        Put32(&f, 0x80000000u | 65537u); /* > 64 KiB block max */
+        REQUIRE(ExpectReject("block-blen-over-max", f,
+                             CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+    /* A block whose declared length runs past the end of the frame. */
+    {
+        Bytes f;
+        PutMagic(&f);
+        f.push_back(0x60);
+        f.push_back(0x40);
+        f.push_back(Hc(f, 2));
+        Put32(&f, 0x80000000u | 100u);
+        for (int i = 0; i < 10; i++) {
+            f.push_back(0xAB); /* only 10 of the 100 declared bytes */
+        }
+        REQUIRE(ExpectReject("block-blen-truncated", f,
+                             CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+    /* A block checksum that does not match its payload (payload corrupted after
+     * the stored checksum was computed). */
+    {
+        Bytes f = BuildFrame(0x70, 0x40, {b8}); /* FLG bit 4: block checksum */
+        f[11] ^= 0xFF; /* first payload byte: header 7 + block-size 4 */
+        REQUIRE(ExpectReject("block-checksum-mismatch", f,
+                             CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+    /* A content checksum that does not match the assembled output. This one
+     * runs the whole host assembly (n == 0, no GPU) and then the content-
+     * checksum branch. */
+    {
+        Bytes f = BuildFrame(0x64, 0x40, {b8}); /* FLG bit 2: content checksum */
+        f.back() ^= 0xFF;
+        REQUIRE(ExpectReject("content-checksum-mismatch", f,
+                             CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+
+    /* An output buffer too small for an all-uncompressed frame: the host
+     * assembly checks capacity before writing and rejects with nothing
+     * written. */
+    {
+        const Bytes f = BuildFrame(0x60, 0x40, {b8});
+        Bytes out(4, 0xEE);
+        size_t written = 777;
+        REQUIRE(cudec_lz4f_decompress(f.data(), f.size(), out.data(),
+                                      out.size(), &written) ==
+                CUDEC_ERR_OUTPUT_TOO_SMALL);
+        REQUIRE(written == 0);
+    }
+
+    std::printf("PASS: frame header + block-table reject branches and the "
+                "host assembly path exercised GPU-less; fail-closed on every "
+                "malformed frame\n");
+    return 0;
+}

--- a/tests/frame_host_negative.cpp
+++ b/tests/frame_host_negative.cpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
+#include <memory>
 #include <vector>
 
 namespace {
@@ -35,6 +37,12 @@ void Put32(Bytes* f, uint32_t v) {
     f->push_back(static_cast<unsigned char>((v >> 8) & 0xFF));
     f->push_back(static_cast<unsigned char>((v >> 16) & 0xFF));
     f->push_back(static_cast<unsigned char>((v >> 24) & 0xFF));
+}
+
+void Put64(Bytes* f, uint64_t v) {
+    for (int i = 0; i < 8; i++) {
+        f->push_back(static_cast<unsigned char>((v >> (i * 8)) & 0xFF));
+    }
 }
 
 /* The frame header checksum byte: (XXH32(descriptor) >> 8) & 0xFF over the
@@ -74,15 +82,62 @@ Bytes BuildFrame(unsigned char flg, unsigned char bd,
     return f;
 }
 
+/* Like BuildFrame but with the optional declared content-size field (FLG bit 3)
+ * present: the 8-byte little-endian `declared` size follows BD, and the header
+ * checksum is recomputed over the now-10-byte descriptor. Lets the
+ * content-size match/mismatch branch in src/frame.cpp be driven in both
+ * directions. The caller passes an FLG with bit 3 set (0x68). */
+Bytes BuildFrameContentSize(unsigned char flg, unsigned char bd,
+                            const std::vector<Bytes>& blocks,
+                            uint64_t declared) {
+    const bool block_ck = (flg >> 4) & 1;
+    const bool content_ck = (flg >> 2) & 1;
+    Bytes f;
+    PutMagic(&f);
+    f.push_back(flg);
+    f.push_back(bd);
+    Put64(&f, declared);
+    f.push_back(Hc(f, 10)); /* descriptor is FLG,BD,8-byte content size */
+    Bytes out;
+    for (const auto& b : blocks) {
+        Put32(&f, 0x80000000u | static_cast<uint32_t>(b.size())); /* uncompressed */
+        f.insert(f.end(), b.begin(), b.end());
+        if (block_ck) {
+            Put32(&f, cudec_detail::xxhash32(b.data(), b.size()));
+        }
+        out.insert(out.end(), b.begin(), b.end());
+    }
+    Put32(&f, 0); /* end mark */
+    if (content_ck) {
+        Put32(&f, cudec_detail::xxhash32(out.data(), out.size()));
+    }
+    return f;
+}
+
+/* Copies the crafted frame into an EXACTLY-sized heap allocation and decodes
+ * from THAT pointer. The crafted frames are assembled with std::vector, whose
+ * capacity is rounded up past the logical size, so a 1-4-byte over-read past
+ * frame_size would read valid slack and leave ASan green - hiding exactly the
+ * truncation/off-by-one class this gate exists to catch. A tight allocation
+ * puts an ASan redzone immediately after the last frame byte, so any such
+ * over-read reds the sanitizer build. */
+cudec_status DecodeTight(const Bytes& frame, unsigned char* dst,
+                         size_t dst_capacity, size_t* written) {
+    const size_t n = frame.size();
+    auto tight = std::make_unique<unsigned char[]>(n);
+    if (n != 0) {
+        std::memcpy(tight.get(), frame.data(), n);
+    }
+    return cudec_lz4f_decompress(tight.get(), n, dst, dst_capacity, written);
+}
+
 /* A frame that must be rejected: pins the exact status AND that no output byte
  * is presented (bytes_written stays 0). The output buffer is generous so a
  * reject is never masked by an OUTPUT_TOO_SMALL from a small buffer. */
 int ExpectReject(const char* name, const Bytes& frame, cudec_status expected) {
     Bytes out(1u << 16, 0xCC);
     size_t written = 777;
-    const cudec_status s = cudec_lz4f_decompress(frame.data(), frame.size(),
-                                                 out.data(), out.size(),
-                                                 &written);
+    const cudec_status s = DecodeTight(frame, out.data(), out.size(), &written);
     REQUIRE_CTX(s == expected, "%s: status %d (want %d)", name,
                 static_cast<int>(s), static_cast<int>(expected));
     REQUIRE_CTX(written == 0, "%s: bytes_written %zu (want 0)", name, written);
@@ -93,9 +148,7 @@ int ExpectReject(const char* name, const Bytes& frame, cudec_status expected) {
 int ExpectDecode(const char* name, const Bytes& frame, const Bytes& expected) {
     Bytes out(expected.size() + 16, 0xEE); /* padding proves we stop at size */
     size_t written = 777;
-    const cudec_status s = cudec_lz4f_decompress(frame.data(), frame.size(),
-                                                 out.data(), out.size(),
-                                                 &written);
+    const cudec_status s = DecodeTight(frame, out.data(), out.size(), &written);
     REQUIRE_CTX(s == CUDEC_OK, "%s: status %d (want OK)", name,
                 static_cast<int>(s));
     REQUIRE_CTX(written == expected.size(), "%s: size %zu (want %zu)", name,
@@ -132,10 +185,49 @@ int main() {
     {
         const Bytes f = BuildFrame(0x60, 0x40, {});
         size_t written = 777;
-        REQUIRE(cudec_lz4f_decompress(f.data(), f.size(), nullptr, 0,
-                                      &written) == CUDEC_OK);
+        REQUIRE(DecodeTight(f, nullptr, 0, &written) == CUDEC_OK);
         REQUIRE(written == 0);
     }
+
+    /* --- C-ABI argument validation: the extern "C" guard rejects before any
+     * parse with nothing written. Each case pins CUDEC_ERR_INVALID_ARGUMENT
+     * and, where bytes_written is observable, written == 0. --- */
+    {
+        const Bytes f = BuildFrame(0x60, 0x40, {b8});
+        Bytes out(1u << 16, 0xCC);
+        size_t written = 777;
+        /* NULL frame. */
+        REQUIRE(cudec_lz4f_decompress(nullptr, f.size(), out.data(),
+                                      out.size(), &written) ==
+                CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(written == 0);
+        /* NULL bytes_written (no output parameter left to observe). */
+        REQUIRE(cudec_lz4f_decompress(f.data(), f.size(), out.data(),
+                                      out.size(), nullptr) ==
+                CUDEC_ERR_INVALID_ARGUMENT);
+        /* NULL destination with a non-zero capacity. */
+        written = 777;
+        REQUIRE(cudec_lz4f_decompress(f.data(), f.size(), nullptr, out.size(),
+                                      &written) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(written == 0);
+    }
+
+    /* --- Declared content size (FLG bit 3): the size-match branch driven in
+     * both directions. --- */
+    /* Valid: the declared size equals the produced size. */
+    REQUIRE(ExpectDecode("content-size-ok",
+                         BuildFrameContentSize(0x68, 0x40, {b8}, b8.size()),
+                         b8) == 0);
+    /* Declared too large. */
+    REQUIRE(ExpectReject(
+                "content-size-too-large",
+                BuildFrameContentSize(0x68, 0x40, {b8}, b8.size() + 1),
+                CUDEC_ERR_CORRUPT_INPUT) == 0);
+    /* Declared too small. */
+    REQUIRE(ExpectReject(
+                "content-size-too-small",
+                BuildFrameContentSize(0x68, 0x40, {b8}, b8.size() - 1),
+                CUDEC_ERR_CORRUPT_INPUT) == 0);
 
     /* --- Header reject branches (all fire before the block-table walk). --- */
 
@@ -160,6 +252,9 @@ int main() {
                          CUDEC_ERR_CORRUPT_INPUT) == 0);
     /* Reserved BD bit (bit 0) set. */
     REQUIRE(ExpectReject("bd-reserved", BuildFrame(0x60, 0x41, {b8}),
+                         CUDEC_ERR_CORRUPT_INPUT) == 0);
+    /* Reserved BD bit 7 set (the high reserved bit; bmax field still 4). */
+    REQUIRE(ExpectReject("bd-reserved-bit7", BuildFrame(0x60, 0xC0, {b8}),
                          CUDEC_ERR_CORRUPT_INPUT) == 0);
     /* Block-max code out of the 4..7 range. */
     REQUIRE(ExpectReject("bad-bmax", BuildFrame(0x60, 0x30, {b8}),
@@ -268,6 +363,42 @@ int main() {
         REQUIRE(ExpectReject("content-checksum-mismatch", f,
                              CUDEC_ERR_CORRUPT_INPUT) == 0);
     }
+    /* Block-checksum flag set (FLG bit 4) but the 4-byte block checksum is
+     * truncated: frame_size < pos + blen + 4, so the checksum read must not
+     * happen. */
+    {
+        Bytes f;
+        PutMagic(&f);
+        f.push_back(0x70); /* FLG bit 4: block checksum */
+        f.push_back(0x40);
+        f.push_back(Hc(f, 2));
+        Put32(&f, 0x80000000u | 8u); /* uncompressed, 8-byte block */
+        for (int i = 0; i < 8; i++) {
+            f.push_back(0xAB); /* the 8 payload bytes */
+        }
+        f.push_back(0x00);
+        f.push_back(0x00); /* only 2 of the 4 block-checksum bytes */
+        REQUIRE(ExpectReject("block-checksum-truncated", f,
+                             CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
+    /* Content-checksum flag set (FLG bit 2) but the 4-byte content checksum is
+     * truncated: frame_size < pos + 4 after the end mark. */
+    {
+        Bytes f;
+        PutMagic(&f);
+        f.push_back(0x64); /* FLG bit 2: content checksum */
+        f.push_back(0x40);
+        f.push_back(Hc(f, 2));
+        Put32(&f, 0x80000000u | 8u); /* uncompressed, 8-byte block */
+        for (int i = 0; i < 8; i++) {
+            f.push_back(0xAB);
+        }
+        Put32(&f, 0); /* end mark */
+        f.push_back(0x00);
+        f.push_back(0x00); /* only 2 of the 4 content-checksum bytes */
+        REQUIRE(ExpectReject("content-checksum-truncated", f,
+                             CUDEC_ERR_CORRUPT_INPUT) == 0);
+    }
 
     /* An output buffer too small for an all-uncompressed frame: the host
      * assembly checks capacity before writing and rejects with nothing
@@ -276,8 +407,7 @@ int main() {
         const Bytes f = BuildFrame(0x60, 0x40, {b8});
         Bytes out(4, 0xEE);
         size_t written = 777;
-        REQUIRE(cudec_lz4f_decompress(f.data(), f.size(), out.data(),
-                                      out.size(), &written) ==
+        REQUIRE(DecodeTight(f, out.data(), out.size(), &written) ==
                 CUDEC_ERR_OUTPUT_TOO_SMALL);
         REQUIRE(written == 0);
     }

--- a/tests/parser_twin.cpp
+++ b/tests/parser_twin.cpp
@@ -11,6 +11,8 @@
 #include "require.h"
 
 #include <cstdio>
+#include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -23,7 +25,19 @@ namespace {
 cudec_status TwinDecode(const std::vector<unsigned char>& stream,
                         size_t capacity, std::vector<unsigned char>* out) {
     out->assign(capacity, 0);
-    cudec_detail::Lz4Parser parser{stream.data(), stream.size(), capacity};
+    /* Parse from an EXACTLY-sized copy of the stream: the mutation corpus
+     * truncates by resize()-DOWN, which leaves the vector's rounded-up
+     * capacity readable, so a src/lz4_block.h over-read past src_size would
+     * land in that slack and leave ASan green. A tight allocation puts an ASan
+     * redzone right after the last stream byte so the over-read reds instead.
+     * Literals are still executed from `stream` below, but only over the
+     * ranges the parser has already bound to <= src_size. */
+    const size_t stream_size = stream.size();
+    auto tight = std::make_unique<unsigned char[]>(stream_size);
+    if (stream_size != 0) {
+        std::memcpy(tight.get(), stream.data(), stream_size);
+    }
+    cudec_detail::Lz4Parser parser{tight.get(), stream_size, capacity};
     cudec_detail::Lz4Sequence seq;
     bool done = false;
     while (true) {


### PR DESCRIPTION
# What & why

Fail-closed decode of hostile input is the product's core claim, but the
host-side parse surface had memory-sanitizer coverage nowhere, and part of it
ran in no CI at all. This adds an opt-in, GPU-less ASan+UBSan gate over the
untrusted-input decode/parse path.

Two gaps closed:

1. **No memory sanitizer on the single-sourced parser.** `src/lz4_block.h` is
   single-sourced host/device, so a memory error caught in a host ASan build is
   the same error on the device path, the practical coverage the device path
   cannot get on this machine (compute-sanitizer is unavailable under
   WSL2/WDDM). The twin's differential/mutation corpus was only
   output-equivalence-sound; ASan/UBSan make it memory-safety-sound (an OOB
   read, an uninitialised read, or integer/shift UB that does not perturb the
   compared bytes now reds the build).
2. **The frame host-parse reject paths ran in no CI.** The frame header and
   block-table walk in `src/frame.cpp` `DecodeFrame` is pure host pointer
   arithmetic on hostile input that rejects before any GPU launch, but the only
   test covering those branches (`frame_twin`) is GPU-labeled and deferred off
   the CI runner. A new host-only negative test now exercises them in CI, under
   the sanitizer.

What landed:

- **`CMakeLists.txt`**, `CUDEC_SANITIZE` cache option (e.g.
  `-DCUDEC_SANITIZE=address,undefined`), default OFF. When set it adds
  `-fsanitize=<value> -fno-sanitize-recover=all -fno-omit-frame-pointer` to the
  HOST C/C++ compile+link only, guarded by `$<COMPILE_LANGUAGE:C,CXX>` so it
  never reaches nvcc/device compilation. `-fno-sanitize-recover=all` makes a
  UBSan finding abort non-zero (halt-on-error), so it reds instead of printing
  and continuing green. The normal build is untouched.
- **`tests/CMakeLists.txt`** - host tests + corpus fixtures build under the
  sanitizer; the third-party lz4 oracle stays uninstrumented (audited by hash - 
  the reference must not red the gate). GPU tests (nvcc-linked) are skipped
  under the gate so the sanitizer build stays pure host; the `frame_twin`
  include follow-up is guarded with `if(TARGET ...)`.
- **`CMakeLists.txt`**, `bench` (one nvcc-linked binary) is omitted under the
  gate for the same reason; its CPU self-checks stay covered by the normal
  build.
- **`tests/frame_host_negative.cpp`**, new host test driving
  `cudec_lz4f_decompress` over crafted malformed frames (bad magic, version and
  reserved bits, BD reserved, out-of-range block-max, linked/dict, truncated
  content-size, bad header checksum, truncated block-size field, `blen` zero /
  over-max / truncated, block- and content-checksum mismatch) plus valid
  all-uncompressed frames. Every case rejects, or assembles on the host, before
  the first CUDA call, so it runs GPU-less and pins `bytes_written == 0` on
  every reject.
- **`.github/workflows/ci.yml`**, a new `sanitize` job (same pinned container +
  git-before-checkout as `build`) builds the host subset with
  `address,undefined` and runs `conformance_c`, `oracle_lz4`, `parser_twin`,
  `frame_host_negative` under it.

Closes #42

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: no runtime behavior of the shipped library
      changed — this is a test/CI hardening change. The new negative test adds
      reject-path coverage for the frame parse; every case has a defined
      expected status and asserts no output is presented.
- [x] Oracle coverage: unchanged. `parser_twin`/`oracle_lz4` still diff against
      liblz4; the new frame test is a memory-safety/fail-closed test over
      crafted-malformed frames (frame-vs-liblz4 parity stays in the GPU-labeled
      `frame_twin`), so it pins statuses rather than diffing bytes.
- [x] Determinism preserved: no decode path changed.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI - 
      no library code changed. ASan/UBSan surfaced no defect on the gated path.
- [ ] An adversarial review (`/security-review`) was run - deferred to the
      orchestrator's independent security panel before merge (per task).

## Performance checklist

Not on the hot path, no kernel or decode-path change. N/A.

## Quality checklist

- [x] Minimal: opt-in flags + one guarded skip for the nvcc-linked targets +
      one negative test; no library code touched.
- [x] Self-documenting: intention-revealing names; comments explain the
      why (why the sanitizer stays off nvcc, why bench/GPU targets are skipped,
      why the oracle is left uninstrumented).
- [x] Conformance tests pass. The new sanitized job is itself the drift
      detector for this property (an ASan/UBSan finding reds it).

## Verification

Run in the pinned Linux container (`nvidia/cuda:12.6.2-devel-ubuntu24.04`,
same digest as the `build` job) with **no GPU**, exactly how the CI `sanitize`
job runs.

**Sanitizer subset** (`-DCUDEC_ENABLE_CUDA=ON -DCUDEC_SANITIZE=address,undefined`):

```
=== LDD CHECK ===
libasan: linked
libubsan: linked
=== CTEST (sanitized subset) ===
1/4 Test #1: conformance_c ....................   Passed    0.02 sec
2/4 Test #2: oracle_lz4 .......................   Passed    0.05 sec
3/4 Test #3: parser_twin ......................   Passed    0.10 sec
4/4 Test #4: frame_host_negative ..............   Passed    0.03 sec
100% tests passed, 0 tests failed out of 4
```

No ASan/UBSan finding surfaced, the parse/frame path is clean under the gate.

**Normal build unaffected** (`-DCUDEC_ENABLE_CUDA=ON`, no sanitizer):

```
host-only stub build (cmake -B build): exit 0
CUDA build: exit 0; smoke/gpu_fixture/frame_twin/stream_twin/bench_lz4 all present
parser_twin (normal build): no sanitizer runtime linked (correct — opt-in)
ctest -LE gpu: 7/7 Passed (incl. frame_host_negative, launch_fail, bench selfchecks)
```

- [x] `cmake --build build`, builds clean (host stub + CUDA build both green).
- [x] `ctest` host subset, green in both the normal and sanitized builds.
- [x] Prettier (`**/*.{md,yml,yaml}`), clean.
- [x] Docs synced: no behavior/API/perf change; README/MASTERPLAN/BENCHMARKS
      untouched (out of scope — issue #37 is editing README/MASTERPLAN).

## Notes

- **Supply chain:** the new `sanitize` job pins `actions/checkout` to the same
  full commit SHA already used by the `build` job
  (`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`, v7.0.0). No new action
  introduced.
- **Scope of the sanitized run:** `launch_fail` and `bench` are deliberately
  excluded from the sanitized ctest selection, `launch_fail` initialises the
  CUDA runtime (LeakSanitizer noise from the driver at exit) and `bench_lz4` is
  a single nvcc-linked binary. The gate targets the pure-host parse/validation
  attack surface. Both still run in the normal `build` job.
- **Findings:** none. The gate is green on current code with no
  `-fsanitize-recover` escape hatch and no suppression.
