### PR TITLE
Add an AI-assistance disclosure to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ docker run --rm --gpus all -v "$PWD:/w" -w /w \
 Issue-driven: every change starts as an issue and lands as a gated PR — see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## AI assistance
+
+Claude (Anthropic) assisted in building cudec — with development, review, and
+English phrasing — always on individual process steps, never producing
+finished or unreviewed work. AI-assisted does not mean AI-run: a human
+maintainer directs and oversees every step, reviews the result through the
+project's adversarial review gate, has the final say on everything that
+lands, and remains responsible for it at all times.
+
 ## License
 
 [Apache-2.0](LICENSE)


### PR DESCRIPTION
# What & why

Adds an honest AI-assistance disclosure to the README. This is deliberate; I requested it.

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [x] Docs

## Engineering checklist

Not applicable, docs-only change, no kernel/format/ABI/build code touched.

- [ ] Fail-closed preserved: every new parse/decode path rejects invalid
      input with a defined error; no out-of-bounds access is reachable from
      hostile input, and every reject path has a negative test.
- [ ] Oracle coverage: decode output is diff-tested against the CPU
      reference (liblz4 / zlib / libzstd) for every touched format path.
- [ ] Determinism preserved (same input → same output, bit-exact), or the
      break is a documented, gated decision.
- [ ] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [ ] An adversarial review (`/security-review`) was run for changes to
      kernels, format parsing, the C-ABI boundary, build/tools, or workflows.

## Performance checklist

Not applicable, no hot-path change.

## Quality checklist

- [x] Minimal: the change adds no more code than the problem requires; no
      duplication, no dead code.
- [x] Self-documenting: intention-revealing names and small, single-purpose
      functions; comments explain why, not what.
- [x] Conformance tests pass, and any new structural property this change
      establishes is locked in as a new conformance test. (No new structural
      property here — pure doc text.)

## Verification

- [ ] `cmake --build build`, not applicable, no code changed.
- [ ] `ctest --test-dir build`, not applicable, no code changed.
- [x] Prettier (`**/*.{md,yml,yaml}`), clean (`npx prettier@3 --check README.md`).
- [x] Docs synced: only README.md changed; no behavior, API, or performance
      claim is affected.

## Notes

The inserted text is verbatim per issue #52 (as corrected by me): the disclosure adds an explicit human-responsibility point
("AI-assisted does not mean AI-run ... remains responsible for it at all
times"). Placed as a top-level `## AI assistance` section after
`## Contributing` and before `## License`, matching the existing heading
style and spacing. No other wording in the README changed; the repo
"About"/description is out of scope and untouched.
