### PR TITLE
Revise the README AI disclosure to the fuller wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,19 @@ docker run --rm --gpus all -v "$PWD:/w" -w /w \
 Issue-driven: every change starts as an issue and lands as a gated PR — see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## AI assistance
+## 🤝 AI-assisted, human-owned
 
-Claude (Anthropic) assisted in building cudec — with development, review, and
-English phrasing — always on individual process steps, never producing
-finished or unreviewed work. AI-assisted does not mean AI-run: a human
-maintainer directs and oversees every step, reviews the result through the
-project's adversarial review gate, has the final say on everything that
-lands, and remains responsible for it at all times.
+Development here is AI-assisted. Claude (Anthropic) helps with individual
+process steps — generating and analysing code, running the adversarial
+security reviews, and translating documentation and comments into English. It
+never hands over finished, unreviewed work: each step is only a proposal. A
+human maintainer reviews, understands, edits where needed, and signs off on
+every one — the AI proposes, a person decides, and a human stays responsible
+for every line that ships, at all times. The review discipline is modelled,
+as far as is practical for a volunteer project, on the change-control
+expected of TÜV/BSI-certified software in a critical sector such as
+healthcare — with no claim to actual certification. In short: nothing lands
+because a tool suggested it; it lands because a person verified it.
 
 ## License
 


### PR DESCRIPTION
# What & why

Revises the README '## AI assistance' section (added in PR #53) to the
fuller, agreed 'AI-assisted, human-owned' wording. Same
placement, between Contributing and License. Closes #54.

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [x] Docs

## Engineering checklist

Not applicable, docs-only change, no kernel/format/ABI/build code touched.

- [ ] Fail-closed preserved: every new parse/decode path rejects invalid
      input with a defined error; no out-of-bounds access is reachable from
      hostile input, and every reject path has a negative test.
- [ ] Oracle coverage: decode output is diff-tested against the CPU
      reference (liblz4 / zlib / libzstd) for every touched format path.
- [ ] Determinism preserved (same input → same output, bit-exact), or the
      break is a documented, gated decision.
- [ ] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [ ] An adversarial review (`/security-review`) was run for changes to
      kernels, format parsing, the C-ABI boundary, build/tools, or workflows.

## Performance checklist

Not applicable, no hot-path change.

## Quality checklist

- [x] Minimal: the change adds no more code than the problem requires; no
      duplication, no dead code.
- [x] Self-documenting: intention-revealing names and small, single-purpose
      functions; comments explain why, not what.
- [x] Conformance tests pass, and any new structural property this change
      establishes is locked in as a new conformance test. (No new structural
      property here — pure doc text.)

## Verification

- [ ] `cmake --build build`, not applicable, no code changed.
- [ ] `ctest --test-dir build`, not applicable, no code changed.
- [x] Prettier (`**/*.{md,yml,yaml}`), clean (`npx prettier@3 --check "**/*.{md,yml,yaml}"`).
- [x] Docs synced: only README.md changed; no behavior, API, or performance
      claim is affected.

## Notes

The replacement text is verbatim per issue #54, including the 🤝 emoji
heading, a deliberate, curated single exception to the zero-AI-fingerprint
rule, not an oversight. Only the '## AI assistance' section (heading +
paragraph) was replaced, with the new '## 🤝 AI-assisted, human-owned'
heading, in the same place between Contributing and License. No other
README wording changed; the repo "About"/description is out of scope and
untouched.
