### PR TITLE
Document CUDEC_ERR_NOT_IMPLEMENTED as reserved

### DIFF
--- a/include/cudec.h
+++ b/include/cudec.h
@@ -28,6 +28,10 @@ typedef enum cudec_status {
     CUDEC_ERR_CORRUPT_INPUT = 2,
     CUDEC_ERR_OUTPUT_TOO_SMALL = 3,
     CUDEC_ERR_CUDA = 4,
+    /* Reserved for an API entry point or decode path declared here but not
+     * yet implemented (e.g. a future format). No current entry point
+     * returns it; kept at this fixed value so a caller's switch stays
+     * exhaustive once it is wired up. */
     CUDEC_ERR_NOT_IMPLEMENTED = 5,
     /* A well-formed frame that uses a feature cudec does not decode
      * (block-linked mode, a dictionary id). Distinct from CORRUPT_INPUT:


### PR DESCRIPTION
# What & why

`CUDEC_ERR_NOT_IMPLEMENTED` (`include/cudec.h`, value 5 in `cudec_status`)
was public but never returned anywhere in the library and had no doc
comment, unlike its neighbour `CUDEC_ERR_UNSUPPORTED`. A caller reading the
header could not tell whether status 5 was reachable, reserved, or dead.

This documents it as intentionally reserved for a future API entry point or
decode path, mirroring the comment style already used on
`CUDEC_ERR_UNSUPPORTED` right below it. The enum value and its numeric
position are unchanged for ABI stability: `CUDEC_ERR_UNSUPPORTED = 6` and
the conformance tests depend on the exact numbers. Comment-only change, no
ABI or behavior impact.

Closes #38

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: comment-only change, no parse/decode path
      touched.
- [x] Oracle coverage: n/a, no decode path touched.
- [x] Determinism preserved: n/a, no decode path touched.
- [x] Every CUDA API call's error is checked; no exceptions cross the C
      ABI: unchanged.
- [ ] An adversarial review (`/security-review`) was run for changes to
      kernels, format parsing, the C-ABI boundary, build/tools, or
      workflows. — not run for this PR by design; this is a comment-only
      header edit with no ABI/layout/value change (verified: enum values
      and order unchanged, `git diff` shows only added comment lines). I
      will review and merge directly.

## Performance checklist

Not applicable: no hot-path code touched.

## Quality checklist

- [x] Minimal: adds a four-line doc comment, nothing else.
- [x] Self-documenting: mirrors the existing `CUDEC_ERR_UNSUPPORTED`
      comment voice.
- [x] Conformance tests pass: unaffected, no ABI/layout change (comment
      only).

## Verification

- [x] `git diff include/cudec.h` reviewed: only a new comment block added;
      no enum value, order, or layout change.
- Local cmake/ctest gate not re-run: no compilable behavior changed (header
  comment only).
- Prettier does not apply to `.h` files (scope is `**/*.{md,yml,yaml}` per
  CLAUDE.md); no trailing whitespace or tabs introduced (checked by hand).

## Notes

Deliberately did not remove the enum value (the issue's alternative
proposal): removal would be an ABI renumber risk for downstream switch
statements and isn't needed to close the issue, documenting it as reserved
is the minimal fix. No `/security-review` run per this PR's scope (comment-only,
non-sensitive-value change); I review and merges.
