### PR TITLE
Collapse the two frame_host_negative builders into one

### DIFF
--- a/tests/frame_host_negative.cpp
+++ b/tests/frame_host_negative.cpp
@@ -52,21 +52,30 @@ unsigned char Hc(const Bytes& f, size_t desc_len) {
         (cudec_detail::xxhash32(f.data() + 4, desc_len) >> 8) & 0xFF);
 }
 
-/* Builds a frame of UNCOMPRESSED blocks with a correct header checksum and no
- * content-size field. BD is fixed at 0x40 (bmax 4 -> 64 KiB block max) unless a
- * caller overrides it. FLG bit 4 (block checksum) and bit 2 (content checksum)
- * are honored so those branches are reachable; every block is stored
- * uncompressed, so a well-formed frame decodes entirely on the host. */
+/* Builds a frame of UNCOMPRESSED blocks with a correct header checksum. BD is
+ * fixed at 0x40 (bmax 4 -> 64 KiB block max) unless a caller overrides it. FLG
+ * bit 4 (block checksum) and bit 2 (content checksum) are honored so those
+ * branches are reachable; every block is stored uncompressed, so a well-formed
+ * frame decodes entirely on the host. `content_size` is the optional declared
+ * content-size field (FLG bit 3): nullptr omits it (the descriptor is the
+ * 2-byte FLG,BD); non-null inserts the 8-byte little-endian size after BD and
+ * extends the header-checksum descriptor to 10 bytes. */
 Bytes BuildFrame(unsigned char flg, unsigned char bd,
-                 const std::vector<Bytes>& blocks) {
+                 const std::vector<Bytes>& blocks,
+                 const uint64_t* content_size = nullptr) {
     const bool block_ck = (flg >> 4) & 1;
     const bool content_ck = (flg >> 2) & 1;
     Bytes f;
     PutMagic(&f);
     f.push_back(flg);
     f.push_back(bd);
-    f.push_back(Hc(f, 2)); /* descriptor is FLG,BD when there is no content size */
-    Bytes out;             /* the assembled content, for the content checksum */
+    size_t desc_len = 2; /* FLG,BD when there is no content size */
+    if (content_size != nullptr) {
+        Put64(&f, *content_size);
+        desc_len = 10; /* FLG,BD,8-byte content size */
+    }
+    f.push_back(Hc(f, desc_len));
+    Bytes out; /* the assembled content, for the content checksum */
     for (const auto& b : blocks) {
         Put32(&f, 0x80000000u | static_cast<uint32_t>(b.size())); /* uncompressed */
         f.insert(f.end(), b.begin(), b.end());
@@ -82,36 +91,13 @@ Bytes BuildFrame(unsigned char flg, unsigned char bd,
     return f;
 }
 
-/* Like BuildFrame but with the optional declared content-size field (FLG bit 3)
- * present: the 8-byte little-endian `declared` size follows BD, and the header
- * checksum is recomputed over the now-10-byte descriptor. Lets the
- * content-size match/mismatch branch in src/frame.cpp be driven in both
- * directions. The caller passes an FLG with bit 3 set (0x68). */
+/* Thin wrapper: BuildFrame with the optional declared content-size field
+ * present. Lets the content-size match/mismatch branch in src/frame.cpp be
+ * driven in both directions. The caller passes an FLG with bit 3 set (0x68). */
 Bytes BuildFrameContentSize(unsigned char flg, unsigned char bd,
                             const std::vector<Bytes>& blocks,
                             uint64_t declared) {
-    const bool block_ck = (flg >> 4) & 1;
-    const bool content_ck = (flg >> 2) & 1;
-    Bytes f;
-    PutMagic(&f);
-    f.push_back(flg);
-    f.push_back(bd);
-    Put64(&f, declared);
-    f.push_back(Hc(f, 10)); /* descriptor is FLG,BD,8-byte content size */
-    Bytes out;
-    for (const auto& b : blocks) {
-        Put32(&f, 0x80000000u | static_cast<uint32_t>(b.size())); /* uncompressed */
-        f.insert(f.end(), b.begin(), b.end());
-        if (block_ck) {
-            Put32(&f, cudec_detail::xxhash32(b.data(), b.size()));
-        }
-        out.insert(out.end(), b.begin(), b.end());
-    }
-    Put32(&f, 0); /* end mark */
-    if (content_ck) {
-        Put32(&f, cudec_detail::xxhash32(out.data(), out.size()));
-    }
-    return f;
+    return BuildFrame(flg, bd, blocks, &declared);
 }
 
 /* Copies the crafted frame into an EXACTLY-sized heap allocation and decodes


### PR DESCRIPTION
# What & why

`tests/frame_host_negative.cpp` carried two near-identical crafted-frame
builders. `BuildFrame` and `BuildFrameContentSize` differed only in the
optional 8-byte declared-content-size field: the content-size variant inserted
`Put64(declared)` after BD and computed the header checksum over the 10-byte
descriptor (`Hc(f, 10)`) instead of the 2-byte one (`Hc(f, 2)`). The per-block
uncompressed-header emit, the optional block checksum, the assembled-content
accumulation, the end mark, and the optional content-checksum tail were
byte-for-byte duplicated (~20 lines).

This collapses them into one builder:

- `BuildFrame` gains an optional `const uint64_t* content_size` (default
  `nullptr`): `nullptr` omits the field and keeps the 2-byte FLG,BD descriptor;
  non-null inserts the little-endian size after BD and extends the
  header-checksum descriptor to 10 bytes.
- `BuildFrameContentSize` becomes a one-line wrapper over `BuildFrame`, so its
  signature and every call site are unchanged.

No call site, test case, expectation, or assertion changed. The emitted frame
bytes are identical for every existing caller, only the presence of the
content-size field and its matching HC descriptor length vary between the two
paths, and both are preserved exactly.

Closes #60

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [x] Refactor / code quality
- [ ] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: no new parse/decode path. This is a test-only
      builder refactor; every existing `ExpectReject`/`ExpectDecode` case and
      its pinned status and byte counts are untouched.
- [ ] Oracle coverage: N/A, no format/decode path touched. `frame_host_negative`
      is a fail-closed/memory-safety negative test, not an oracle-parity test.
- [x] Determinism preserved: crafted frame bytes are byte-for-byte identical for
      every caller; no library/kernel code changed.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI:
      N/A — no library or ABI code touched.
- [ ] Adversarial review (`/security-review`): not required - the change touches
      no kernel, format parsing, C-ABI boundary, build/tools, or workflow; it is
      confined to a test-side helper.

## Performance checklist

N/A, not on the hot path (test-side frame builder only).

## Quality checklist

- [x] Minimal: removes ~20 lines of duplicated builder body; no dead code.
- [x] Self-documenting: one builder parameterized on the single real difference
      (the optional content-size field); the load-bearing descriptor-length
      "why" comments are preserved.
- [x] Conformance tests pass (via CI): no new structural property is
      established, so no new conformance test is added.

## Verification

The Windows host has no cmake/C++ toolchain, so the build is verified by CI, not
locally.

- [ ] `cmake --build build`, verified by CI (build job).
- [ ] `ctest` - the GPU-less `frame_host_negative` runs in CI in both the build
      job (`-LE gpu`) and the sanitize job (ASan+UBSan); a green run proves the
      crafted frames and their fail-closed verdicts are byte-for-byte the same.
- [x] Prettier (`**/*.{md,yml,yaml}`), no md/yml/yaml changed.
- [x] Docs synced: no behavior, API, or performance change; nothing to sync.

## Notes

Behavior-preserving, test-only. Byte-for-byte equivalence holds by construction:
the `nullptr` path reproduces the old `BuildFrame` (descriptor length 2, no
`Put64`); the wrapper's non-null path reproduces the old `BuildFrameContentSize`
(descriptor length 10, `Put64` after BD). Everything after the descriptor is the
shared, previously-duplicated body.
