### PR TITLE
Document the format-provenance rule in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,16 @@ Issue-driven, gate-driven:
 - **The oracles decide.** Decode output is diff-tested on real and fuzzed
   corpora against the reference implementations — liblz4 today, with zlib and
   libzstd joining as the DEFLATE and Zstd formats land.
+- **Format provenance.** Every format is implemented from its public
+  specification only — the LZ4 block/frame spec, Snappy, DEFLATE (RFC 1951),
+  the GDeflate spec, Zstd (RFC 8878). The reference decoders (liblz4, zlib,
+  libzstd) are test oracles, never a source to copy from: they ship under their
+  own BSD/zlib licenses and pasted code would muddy the provenance of an
+  Apache-2.0 tree. "The oracles decide" means the reference settles
+  _correctness by differential test_ — not that its code may be _derived from_.
+  nvCOMP is proprietary: never copy its headers or source, and cudec claims no
+  compatibility with it (nominative references and CPU-only benchmark
+  comparisons are fine).
 - **Determinism**: same input → same output, bit-exact per code path.
 - **Performance claims are measured**, never reasoned: numbers ship with GPU
   model, driver, CUDA version, corpus, and chunk-size distribution.


### PR DESCRIPTION
# What & why

Adds a "Format provenance" bullet to `CONTRIBUTING.md`, next to "The oracles
decide", so an outside contributor learns how formats must be sourced. Until
now nothing in the public tree stated that formats are implemented from public
specs only and that the reference decoders are test oracles, not code to copy
from. "The oracles decide" on its own reads as an invitation to derive from the
reference, the opposite of the intent, leaving a legal/onboarding gap for an
Apache-2.0 project.

The new bullet states three rules: implement each format from its public
specification only (LZ4 block/frame, Snappy, DEFLATE RFC 1951, GDeflate, Zstd
RFC 8878); the reference decoders (liblz4, zlib, libzstd) are test oracles under
their own BSD/zlib licenses and never a copy source; nvCOMP is proprietary - 
never copy its headers/source and claim no compatibility (nominative references
and CPU-only benchmark comparisons are fine).

Docs-only, one file. The issue notes optionally mirroring one sentence into
MASTERPLAN section 4; left out of scope here.

Closes #63

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: N/A, docs-only, no parse/decode path touched.
- [x] Oracle coverage: N/A, no format path changed.
- [x] Determinism preserved: N/A, no code changed.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI:
      N/A — no code changed.
- [x] Adversarial review (`/security-review`): N/A - no kernel, format parsing,
      C-ABI, build/tools, or workflow change; a prose paragraph in CONTRIBUTING.

## Performance checklist

Not applicable, no hot-path or behavior change.

## Quality checklist

- [x] Minimal: a single bullet added next to the related "The oracles decide"
      material; no duplication, no dead code.
- [x] Self-documenting: terse voice matching the surrounding bullets.
- [x] Conformance tests pass: unaffected - no code or structural property
      changed, so no new conformance test applies.

## Verification

- [ ] `cmake --build build`, N/A (docs-only; the build is unaffected).
- [ ] `ctest --test-dir build`, N/A (docs-only).
- [x] Prettier (`**/*.{md,yml,yaml}`), clean on `CONTRIBUTING.md`.
- [x] Docs synced: CONTRIBUTING is the doc; MASTERPLAN/README/BENCHMARKS need no
      change (this run is deliberately CONTRIBUTING-only).

CI is the merge gate. Being docs-only, no GPU run applies; the `build`,
`format`, and `sanitize` checks exercise this PR and are unaffected by prose.

## Notes

Scope is intentionally `CONTRIBUTING.md` only. The optional MASTERPLAN mirror
from the issue is left for a separate change to keep this diff single-file.
