### PR TITLE
Correct the MASTERPLAN overlap-copy claim to the shipped kernel

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -224,9 +224,14 @@ chases itself; it is a modular gather from bytes already final:
 the `__syncwarp()` preceding every copy has frozen. Each output byte is
 written exactly once, by a statically determined lane, as a pure function
 of lower addresses — deterministic because no ordering exists to get
-wrong. The inner loop tracks the modulus incrementally
-(`r += step; if (r >= off) r -= off`) so no lane pays a division per
-iteration.
+wrong. The shipped inner loop computes that `i mod off` directly — one
+64-bit modulo per output byte, so every lane pays a division per
+iteration (`dst[seq.match_dst + i] = dst[seq.match_src + (i % offset)]`
+in `src/lz4_decode.cuh`). Cutting that cost is deferred, measurement-gated
+perf work, not a present property: eliding the modulo when the match
+cannot wrap (`off >= len`, #36) and narrowing it to 32-bit (#58), neither
+merged. The fully incremental `r += step; if (r >= off) r -= off` scheme
+was itself tried and rejected by measurement — see perf pass 1 below.
 
 **The validation ladder** (fail-closed; every stream-decoded value checked
 before first use as address, length, or offset): token existence before


### PR DESCRIPTION
# What & why

MASTERPLAN section 9's "Overlap copy, closed form" paragraph described the shipped overlap-copy inner loop as division-free, tracking the modulus incrementally (`r += step; if (r >= off) r -= off`) so no lane pays a division per iteration. The shipped kernel does not do this: `src/lz4_decode.cuh` computes `dst[seq.match_dst + i] = dst[seq.match_src + (i % offset)]`, one 64-bit modulo per output byte, so every lane pays a division. A contributor reading the design record and then the code hit a direct contradiction, and it read as if a measured optimization shipped when it did not. The claim also contradicted the perf-pass-1 record later in the same section, which records the incremental-mod gather as measured and rejected in favour of the independent modulo the compiler overlaps.

This reword makes the paragraph describe what actually ships and files the division-avoidance work where it belongs (deferred, measurement-gated).

Docs-only. No `src/` or other code touched; behaviour, ABI, and performance are unchanged.

Closes #64

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: N/A, docs-only, no parse/decode path changed.
- [x] Oracle coverage: N/A, no format path touched.
- [x] Determinism preserved: N/A, no code change.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI: N/A, no code change.
- [x] Adversarial review: N/A, no kernel, format, C-ABI, build/tools, or workflow change; this only corrects prose to match the already-shipped kernel.

## Performance checklist

- [x] Not on the hot path, documentation only; no code and no measurable change. The reword removes a false division-free claim and records the reduced-cost variants (#36, #58) as deferred, measurement-gated perf work.

## Quality checklist

- [x] Minimal: one paragraph reworded; no other change.
- [x] Self-documenting: the corrected text names the shipped expression and file and points at the perf-pass-1 record for the rejected incremental scheme.
- [x] Conformance tests: N/A, no structural property changed.

## Verification

- [ ] `cmake --build build`, N/A (docs-only; host has no CUDA/CMake, and docs do not affect the build).
- [ ] `ctest --test-dir build`, N/A (docs-only; no GPU run applies).
- [x] Prettier (`**/*.{md,yml,yaml}`), clean (`prettier@3 --check docs/MASTERPLAN.md`).
- [x] Docs synced: this change is the MASTERPLAN sync itself; README/BENCHMARKS unaffected.

CI (`build`, `format`, `sanitize`) is the merge gate; a docs-only change does not affect the build, so all checks are expected green.

## Notes

Verified against the shipped kernel before rewording: `src/lz4_decode.cuh` computes `dst[seq.match_dst + i] = dst[seq.match_src + (i % offset)]` per output byte. The reword deliberately keeps the paragraph's abstract voice (`off`, `len`, `i mod off`) and adds a concrete code/file anchor so the design record and the code no longer contradict. It stays consistent with the perf-pass-1 paragraph, which already recorded the fully incremental scheme as measured-and-rejected; #36 (elide the modulo when the match cannot wrap) and #58 (narrow it to 32-bit) remain the live, deferred, unmerged reduced-cost options. No code change, so no new negative/conformance test is warranted.
