### PR TITLE
Add the longmatch bench corpus; record the rejected match-copy fast path

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -35,3 +35,11 @@ add_test(NAME bench_selfcheck COMMAND bench_lz4 --selfcheck)
 # oracle no longer accepts, or that stops round-tripping - reds CI, not just
 # a manual bench.
 add_test(NAME bench_worst4b_selfcheck COMMAND bench_lz4 --worst4b --selfcheck)
+
+# The long-non-overlap-match corpus (issue #36) is likewise hand-built and
+# oracle-validated before timing, with a compression-ratio shape lock. This
+# runs that construction through the self-checked path (a few chunks,
+# CPU-only) so a generator that stops round-tripping, or drifts off the
+# intended many-long-matches shape, reds CI rather than a manual bench.
+add_test(NAME bench_longmatch_selfcheck COMMAND bench_lz4 --longmatch
+                                                --selfcheck)

--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -37,6 +37,30 @@ constexpr size_t kWorst4bChunks = 3200;
  * runner; the block itself is the same regardless of the replica count. */
 constexpr size_t kWorst4bSelfcheckChunks = 4;
 
+/* The long-non-overlap-match corpus (issue #36). Same 64 KB chunk and
+ * ~200 MB scale as the Silesia/worst-4Bmatch GPU rows so the three
+ * throughput numbers are directly comparable. Its purpose is to expose the
+ * ONE regime neither recorded corpus measures: long matches whose source
+ * range does not overlap the destination (offset >= match_len), where the
+ * match copy has enough bytes to become issue/ALU-bound and the per-byte
+ * 64-bit modulo in the closed-form gather - unnecessary when offset >=
+ * match_len - would dominate if it were on the critical path. */
+constexpr size_t kLongmatchChunks = 3200;
+constexpr size_t kLongmatchSelfcheckChunks = 4;
+
+/* The block's shape: an initial literal seed the length of the match offset
+ * (so the first match's source is in-bounds), then back-to-back maximum-
+ * length matches at that fixed offset, then a literal tail. The offset is
+ * held >= the match length so EVERY match is non-overlapping - the exact,
+ * and only, case the fast path targets; the static_assert locks that. */
+constexpr size_t kLongmatchOffset = 512;
+constexpr size_t kLongmatchMatchLen = 255;
+static_assert(kLongmatchOffset >= kLongmatchMatchLen,
+              "longmatch must stay non-overlapping (offset >= match_len): "
+              "that disjoint-range regime is exactly what issue #36's fast "
+              "path targets, and an overlapping block would measure the "
+              "wrong thing");
+
 struct Corpus {
     std::string name;
     std::vector<std::vector<unsigned char>> originals;
@@ -212,6 +236,154 @@ bool BuildWorst4bCorpus(Corpus* corpus, size_t chunks) {
     return true;
 }
 
+/* Appends an LZ4 length-field extension for a field whose 4-bit token nibble
+ * is saturated at 15: the reference format encodes (value - 15) as a run of
+ * 255 bytes followed by the remainder. `value` is the full field (>= 15;
+ * literal length, or match length minus MINMATCH). */
+void EmitLengthExtension(std::vector<unsigned char>* c, size_t value) {
+    size_t rem = value - 15;
+    while (rem >= 255) {
+        c->push_back(255);
+        rem -= 255;
+    }
+    c->push_back(static_cast<unsigned char>(rem));
+}
+
+unsigned char LengthNibble(size_t value) {
+    return static_cast<unsigned char>(value < 15 ? value : 15);
+}
+
+/* Builds one valid LZ4 block of long, NON-overlapping matches (issue #36):
+ * a `kLongmatchOffset`-byte literal seed, then back-to-back matches of
+ * `kLongmatchMatchLen` bytes at that fixed offset, then a literal tail. The
+ * output is periodic with period `kLongmatchOffset` (each match copies the
+ * window one offset back), so the whole block is `seed[i % offset]` and the
+ * hand-built wire reproduces it exactly - proven by the oracle before timing.
+ *
+ * Every match satisfies offset >= match_len (512 >= 255), so its source and
+ * destination ranges are disjoint: this is precisely the case where the
+ * closed-form gather's per-byte 64-bit modulo is provably unnecessary
+ * (i % offset == i for i < match_len <= offset). The standard compressor
+ * never emits this shape (it would extend the fixed-offset run into a single
+ * long match), so the stream is constructed directly. */
+bool BuildLongmatchBlock(size_t out_bytes,
+                         std::vector<unsigned char>* original,
+                         std::vector<unsigned char>* compressed) {
+    constexpr size_t kMinTail = 12; /* >= LZ4's last-match distance rule */
+    /* Enough output for the seed, at least one match, and the tail; below
+     * this the size_t match-count arithmetic below would wrap. */
+    constexpr size_t kMinBytes = kLongmatchOffset + kLongmatchMatchLen +
+                                 kMinTail + 16;
+    if (out_bytes < kMinBytes) {
+        std::fprintf(stderr, "longmatch block needs at least %zu output "
+                             "bytes, got %zu\n",
+                     kMinBytes, out_bytes);
+        return false;
+    }
+
+    /* The seed pattern. Any deterministic non-degenerate fill works: the
+     * matches reproduce it and the oracle is the sole validity authority. */
+    original->resize(out_bytes);
+    for (size_t i = 0; i < out_bytes; i++) {
+        (*original)[i] =
+            static_cast<unsigned char>((i % kLongmatchOffset) * 191 + 13);
+    }
+
+    /* As many full matches as fit while leaving >= kMinTail literal bytes. */
+    const size_t matches =
+        (out_bytes - kLongmatchOffset - kMinTail) / kLongmatchMatchLen;
+    const size_t body = kLongmatchOffset + matches * kLongmatchMatchLen;
+    const size_t tail = out_bytes - body;
+
+    const size_t match_field = kLongmatchMatchLen - 4; /* minus MINMATCH */
+    std::vector<unsigned char>& c = *compressed;
+    c.clear();
+
+    /* Seed sequence: `kLongmatchOffset` literals, then the first match. */
+    c.push_back(static_cast<unsigned char>(
+        (LengthNibble(kLongmatchOffset) << 4) | LengthNibble(match_field)));
+    if (kLongmatchOffset >= 15) {
+        EmitLengthExtension(&c, kLongmatchOffset);
+    }
+    c.insert(c.end(), original->begin(),
+             original->begin() + static_cast<long>(kLongmatchOffset));
+    c.push_back(static_cast<unsigned char>(kLongmatchOffset & 0xFF));
+    c.push_back(static_cast<unsigned char>((kLongmatchOffset >> 8) & 0xFF));
+    if (match_field >= 15) {
+        EmitLengthExtension(&c, match_field);
+    }
+
+    /* Remaining matches: zero literals, same fixed offset and length. */
+    for (size_t m = 1; m < matches; m++) {
+        c.push_back(static_cast<unsigned char>(LengthNibble(match_field)));
+        c.push_back(static_cast<unsigned char>(kLongmatchOffset & 0xFF));
+        c.push_back(static_cast<unsigned char>((kLongmatchOffset >> 8) & 0xFF));
+        if (match_field >= 15) {
+            EmitLengthExtension(&c, match_field);
+        }
+    }
+
+    /* Literals-only tail (no offset/match follows; end-of-block is detected
+     * at exact input consumption), keeping the last match clear of the block
+     * end per LZ4's parsing restrictions. */
+    c.push_back(static_cast<unsigned char>(LengthNibble(tail) << 4));
+    if (tail >= 15) {
+        EmitLengthExtension(&c, tail);
+    }
+    c.insert(c.end(), original->begin() + static_cast<long>(body),
+             original->end());
+    return true;
+}
+
+/* Replicates the long-non-overlap-match block to `chunks` identical chunks.
+ * Like BuildWorst4bCorpus, the oracle (liblz4) is the sole validity authority
+ * and must accept and round-trip the hand-built stream before any timing, and
+ * a shape lock guards against generator rot leaving a valid-but-wrong block. */
+bool BuildLongmatchCorpus(Corpus* corpus, size_t chunks) {
+    std::vector<unsigned char> original;
+    std::vector<unsigned char> compressed;
+    if (!BuildLongmatchBlock(kChunkBytes, &original, &compressed)) {
+        return false;
+    }
+
+    std::vector<unsigned char> decoded;
+    if (!OracleDecodes(compressed, original.size(), &decoded) ||
+        decoded.size() != original.size() ||
+        std::memcmp(decoded.data(), original.data(), decoded.size()) != 0) {
+        std::fprintf(stderr, "longmatch construction rejected by the oracle "
+                             "- refusing to time an invalid stream\n");
+        return false;
+    }
+
+    /* Lock the SHAPE, not just validity. The intended block is many long
+     * matches over a small literal seed + tail, which compresses hard (ratio
+     * ~0.027). A generator that regressed to short matches or mostly literals
+     * would climb toward ~1.0; one that collapsed into a single giant match
+     * (a decompression-bomb shape, the opposite of this many-long-matches
+     * throughput probe) would fall toward ~1e-4. Requiring the ratio to sit
+     * in a band reds the selfcheck on either drift. original.size() is
+     * non-zero (kChunkBytes). */
+    const double ratio = static_cast<double>(compressed.size()) /
+                         static_cast<double>(original.size());
+    if (ratio < 0.005 || ratio > 0.10) {
+        std::fprintf(stderr, "longmatch block is not the intended shape: "
+                             "compressed/original %.5f outside the "
+                             "[0.005, 0.10] long-non-overlap-match band\n",
+                     ratio);
+        return false;
+    }
+
+    corpus->name = "longmatch";
+    corpus->originals.assign(chunks, original);
+    corpus->compressed.assign(chunks, compressed);
+    corpus->original_bytes = original.size() * chunks;
+    corpus->compressed_bytes = compressed.size() * chunks;
+    corpus->provenance = "hand-constructed long non-overlapping matches "
+                         "(offset 512 >= match length 255; oracle-validated; "
+                         "LZ4_compress_default never emits it)";
+    return true;
+}
+
 /* One measured repetition: decode the whole batch, wall clock. The timed
  * region contains ONLY LZ4_decompress_safe calls into a pre-sized scratch
  * buffer - no buffer clears, no allocation - so the label on the number
@@ -348,6 +520,7 @@ int main(int argc, char** argv) {
     bool gpu = false;
     bool gpu_stream_ctx = false;
     bool worst4b = false;
+    bool longmatch = false;
     std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
@@ -359,6 +532,8 @@ int main(int argc, char** argv) {
             gpu_stream_ctx = true;
         } else if (arg == "--worst4b") {
             worst4b = true;
+        } else if (arg == "--longmatch") {
+            longmatch = true;
         } else if (arg == "--runs" && i + 1 < argc) {
             if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
                 std::fprintf(stderr, "--runs must be in [1, %zu]\n",
@@ -377,8 +552,8 @@ int main(int argc, char** argv) {
         } else if (!arg.empty() && arg[0] == '-') {
             std::fprintf(stderr,
                          "usage: bench_lz4 [--runs N] [--warmup N] [--gpu] "
-                         "[--gpu-stream-ctx] [--worst4b] [--selfcheck] "
-                         "[corpus files...]\n");
+                         "[--gpu-stream-ctx] [--worst4b] [--longmatch] "
+                         "[--selfcheck] [corpus files...]\n");
             return 2;
         } else {
             files.push_back(arg);
@@ -387,6 +562,12 @@ int main(int argc, char** argv) {
     if (selfcheck) {
         warmup = 1;
         runs = 3;
+    }
+
+    if (worst4b && longmatch) {
+        std::fprintf(stderr, "--worst4b and --longmatch each build their own "
+                             "corpus; pass at most one\n");
+        return 2;
     }
 
     Corpus corpus;
@@ -400,6 +581,17 @@ int main(int argc, char** argv) {
         }
         if (!BuildWorst4bCorpus(&corpus, selfcheck ? kWorst4bSelfcheckChunks
                                                    : kWorst4bChunks)) {
+            return 1;
+        }
+    } else if (longmatch) {
+        /* Generated and hand-built like --worst4b, for the same reason. */
+        if (!files.empty()) {
+            std::fprintf(stderr, "--longmatch builds its own corpus; do not "
+                                 "also pass corpus files\n");
+            return 2;
+        }
+        if (!BuildLongmatchCorpus(&corpus, selfcheck ? kLongmatchSelfcheckChunks
+                                                     : kLongmatchChunks)) {
             return 1;
         }
     } else if (files.empty()) {
@@ -437,11 +629,11 @@ int main(int argc, char** argv) {
             return 1;
         }
     }
-    /* The worst-case corpus already carries its hand-built streams; the
-     * standard compressor would replace them with a single long match (the
-     * best case), defeating the point. Every other corpus is compressed by
-     * the oracle here. */
-    if (!worst4b) {
+    /* The worst-case and longmatch corpora already carry their hand-built
+     * streams; the standard compressor would replace them (a single long
+     * match, or a fixed-offset run collapsed into one match), defeating the
+     * point. Every other corpus is compressed by the oracle here. */
+    if (!worst4b && !longmatch) {
         CompressAll(&corpus);
     }
 

--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -49,8 +49,8 @@ constexpr size_t kLongmatchChunks = 3200;
 constexpr size_t kLongmatchSelfcheckChunks = 4;
 
 /* The block's shape: an initial literal seed the length of the match offset
- * (so the first match's source is in-bounds), then back-to-back maximum-
- * length matches at that fixed offset, then a literal tail. The offset is
+ * (so the first match's source is in-bounds), then back-to-back 255-byte
+ * matches at that fixed offset, then a literal tail. The offset is
  * held >= the match length so EVERY match is non-overlapping - the exact,
  * and only, case the fast path targets; the static_assert locks that. */
 constexpr size_t kLongmatchOffset = 512;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -151,11 +151,14 @@ binaries built from the same tree and A/B-interleaved in one session (two full
 passes, 3 warmup + 30 CUDA-event-timed runs each; all twelve ctest gates —
 oracle parity, determinism — green on the patched kernel first):
 
-| Corpus                    | Baseline p50 (2 passes) | Fast path p50 (2 passes) | Delta       |
-| ------------------------- | ----------------------- | ------------------------ | ----------- |
-| Silesia `--gpu`           | 11.979 / 12.859 ms      | 10.872 / 11.822 ms       | **+8–9%**   |
-| `--worst4b --gpu`         | 25.502 / 26.256 ms      | 27.938 / 27.654 ms       | **−6–9%**   |
-| `--longmatch --gpu` (new) | 1.277 / 1.278 ms        | 0.922 / 0.898 ms         | **+39–42%** |
+The Delta column is throughput speedup (`baseline_ms / fast_path_ms − 1`,
+per-pass), one basis for all three rows so they compare on one scale:
+
+| Corpus                    | Baseline p50 (2 passes) | Fast path p50 (2 passes) | Delta (throughput speedup) |
+| ------------------------- | ----------------------- | ------------------------ | -------------------------- |
+| Silesia `--gpu`           | 11.979 / 12.859 ms      | 10.872 / 11.822 ms       | **+10.2% / +8.8%**         |
+| `--worst4b --gpu`         | 25.502 / 26.256 ms      | 27.938 / 27.654 ms       | **−8.7% / −5.1%**          |
+| `--longmatch --gpu` (new) | 1.277 / 1.278 ms        | 0.922 / 0.898 ms         | **+38.5% / +42.3%**        |
 
 The gain is real — but so is the regression, and it lands exactly where this
 project refuses to pay: the adversarial worst case. `--worst4b` is offset-1
@@ -164,7 +167,8 @@ the added per-match predicate and the second copy loop's code in the hottest
 per-sequence path of the maximum-sequence-density input (one match per 4
 bytes). The plan's prediction that this would be "one free warp-uniform
 compare" is refuted by measurement — five independent patched `--worst4b`
-sessions all landed at 26.8–27.9 ms against a 25.1–26.3 ms baseline.
+sessions all landed at 26.8–27.9 ms against a 25.1–26.3 ms baseline (a 5–9%
+throughput regression against the 25.1–26.3 ms baseline pair).
 
 **Rejected under the pre-registered accept rule** (issue #36: improvement on
 at least one corpus with zero regression on the others) and under the
@@ -173,7 +177,7 @@ margin (issue #19), and trading it for average-case throughput inverts the
 project's hostile-input-first ordering. No kernel code shipped; the
 `--longmatch` harness corpus and its `bench_longmatch_selfcheck` ctest stay,
 so the regime is one flag away for any future attempt (a formulation that
-recovers the Silesia +8% without touching the worst case would be accepted —
+recovers the Silesia +9–10% without touching the worst case would be accepted —
 none is known under the single-loop structure, since the predicate is
 inherently per-match).
 
@@ -205,7 +209,8 @@ same container and RTX 3080. `--longmatch --gpu`.
 At 165 GB/s the copy-dominated best case runs ~9x the Silesia average and
 within ~4.6x of the ~760 GB/s output-bandwidth ceiling — the modular gather,
 not bandwidth, is the limiter in this regime (the rejected fast path reached
-~257 GB/s here), consistent with the ~250–400 GB/s redundant-parse family
+~228–234 GB/s here, from its 0.922 / 0.898 ms A/B passes above over the
+209.72 MB corpus), consistent with the ~250–400 GB/s redundant-parse family
 ceiling published in the masterplan.
 
 ### Worst case: the worst-4Bmatch adversarial-but-valid corpus (issue #19)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -137,6 +137,77 @@ two levers issue #21 named, the register-reduction lever is measured and
 rejected here; the warp-specialization lever is scoped as a larger design
 change deferred behind the format ladder.
 
+### Perf pass 3 (issue #36): the non-overlap match fast path is rejected by the worst case
+
+The last untried match-copy lever: when `offset >= match_len` the closed-form
+modular gather `dst[m+i] = dst[m-off + (i mod off)]` degenerates to a straight
+copy (`i mod off == i` for every `i < match_len <= off`, and the ranges are
+disjoint, so the copy is bit-identical, hazard-free, and the branch is
+warp-uniform). The fast path elides the per-byte 64-bit modulo on every
+non-overlapping match — the common case in real data.
+
+Measured 2026-07-18, same pinned container and RTX 3080, baseline and patched
+binaries built from the same tree and A/B-interleaved in one session (two full
+passes, 3 warmup + 30 CUDA-event-timed runs each; all twelve ctest gates —
+oracle parity, determinism — green on the patched kernel first):
+
+| Corpus                    | Baseline p50 (2 passes) | Fast path p50 (2 passes) | Delta       |
+| ------------------------- | ----------------------- | ------------------------ | ----------- |
+| Silesia `--gpu`           | 11.979 / 12.859 ms      | 10.872 / 11.822 ms       | **+8–9%**   |
+| `--worst4b --gpu`         | 25.502 / 26.256 ms      | 27.938 / 27.654 ms       | **−6–9%**   |
+| `--longmatch --gpu` (new) | 1.277 / 1.278 ms        | 0.922 / 0.898 ms         | **+39–42%** |
+
+The gain is real — but so is the regression, and it lands exactly where this
+project refuses to pay: the adversarial worst case. `--worst4b` is offset-1
+minmatch, always overlapping, so the fast-path arm is never taken; the cost is
+the added per-match predicate and the second copy loop's code in the hottest
+per-sequence path of the maximum-sequence-density input (one match per 4
+bytes). The plan's prediction that this would be "one free warp-uniform
+compare" is refuted by measurement — five independent patched `--worst4b`
+sessions all landed at 26.8–27.9 ms against a 25.1–26.3 ms baseline.
+
+**Rejected under the pre-registered accept rule** (issue #36: improvement on
+at least one corpus with zero regression on the others) and under the
+security posture behind it: the worst-case number is the DoS-resistance
+margin (issue #19), and trading it for average-case throughput inverts the
+project's hostile-input-first ordering. No kernel code shipped; the
+`--longmatch` harness corpus and its `bench_longmatch_selfcheck` ctest stay,
+so the regime is one flag away for any future attempt (a formulation that
+recovers the Silesia +8% without touching the worst case would be accepted —
+none is known under the single-loop structure, since the predicate is
+inherently per-match).
+
+### Best case: the longmatch corpus (issue #36)
+
+The shipped kernel's baseline on the new `--longmatch` corpus — long
+non-overlapping matches (match length 255 at offset 512), the copy-dominated
+regime that maximally exposes the per-byte modular gather. Hand-constructed
+like `--worst4b` (the standard compressor emits long matches but this shape
+pins `offset >= match_len` on every match), oracle-validated in-harness,
+shape-locked by the `bench_longmatch_selfcheck` ctest. Recorded 2026-07-18,
+same container and RTX 3080. `--longmatch --gpu`.
+
+```
+## bench_lz4 report
+- decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
+- cudec: 1 (the CPU rows time the liblz4 oracle baseline; the GPU rows below, when --gpu is set, time cudec's decoder)
+- corpus: longmatch, 3200 chunks, 209.72 MB original, 5.72 MB compressed (ratio 0.027), hand-constructed long non-overlapping matches (offset 512 >= match length 255; oracle-validated; LZ4_compress_default never emits it)
+- chunk sizes: min 65536 / median 65536 / max 65536 bytes
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
+- wall per run: p50 5.783 ms / p90 5.847 ms / p99 5.932 ms
+- decode throughput: p50 36.265 GB/s / p90 35.868 GB/s / p99 35.351 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs): p50 1.271 ms, 165.0 GB/s
+- GPU parse-only ceiling (copies elided): p50 0.265 ms, 790.7 GB/s - ceilings this design AND any two-phase phase-1 (shared parse)
+```
+
+At 165 GB/s the copy-dominated best case runs ~9x the Silesia average and
+within ~4.6x of the ~760 GB/s output-bandwidth ceiling — the modular gather,
+not bandwidth, is the limiter in this regime (the rejected fast path reached
+~257 GB/s here), consistent with the ~250–400 GB/s redundant-parse family
+ceiling published in the masterplan.
+
 ### Worst case: the worst-4Bmatch adversarial-but-valid corpus (issue #19)
 
 A security-posture number. The Silesia rows are an average; the worst case

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -323,6 +323,20 @@ the redundant-lockstep-parse invariant (its own design panel), which under
 "formats over percentage points" ranks below the next format. Recorded in
 [docs/BENCHMARKS.md](BENCHMARKS.md).
 
+**Perf pass 3 outcome (issue #36): the non-overlap match fast path is
+rejected by the worst case.** Splitting the match copy on the warp-uniform
+`offset >= match_len` predicate (straight copy instead of the modular gather
+when the match cannot wrap — bit-identical by construction, all oracle/
+determinism gates green) measured +8–9% on Silesia and +39–42% on the new
+copy-dominated `--longmatch` corpus, but a consistent −6–9% on `--worst4b`:
+the per-match predicate lands in the hottest path of exactly the
+maximum-sequence-density adversarial input. Rejected under the
+pre-registered zero-regression rule — the worst-case number is the
+DoS-resistance margin, and average-case gains do not buy it back. No kernel
+code shipped; the `--longmatch` corpus and its selfcheck ctest shipped so
+the regime stays measurable. Recorded in
+[docs/BENCHMARKS.md](BENCHMARKS.md).
+
 **Known limits, published:** the redundant-parse family ceiling is roughly
 250–400 GB/s after perf passes — deliberately accepted under "formats over
 percentage points"; batches under ~2,000 chunks underfill the machine and

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -327,8 +327,9 @@ the redundant-lockstep-parse invariant (its own design panel), which under
 rejected by the worst case.** Splitting the match copy on the warp-uniform
 `offset >= match_len` predicate (straight copy instead of the modular gather
 when the match cannot wrap — bit-identical by construction, all oracle/
-determinism gates green) measured +8–9% on Silesia and +39–42% on the new
-copy-dominated `--longmatch` corpus, but a consistent −6–9% on `--worst4b`:
+determinism gates green) measured +9–10% on Silesia and +38–42% on the new
+copy-dominated `--longmatch` corpus (throughput speedup), but a consistent
+−5–9% on `--worst4b`:
 the per-match predicate lands in the hottest path of exactly the
 maximum-sequence-density adversarial input. Rejected under the
 pre-registered zero-regression rule — the worst-case number is the


### PR DESCRIPTION
# What & why

Closes #36.

The last untried match-copy lever: when `offset >= match_len` the closed-form
modular gather `dst[m+i] = dst[m-off + (i mod off)]` degenerates to a straight
copy (`i mod off == i` for every `i < match_len <= off`; source and
destination ranges are disjoint, the predicate is warp-uniform from the
lockstep parse), so the per-byte 64-bit modulo can be elided on every
non-overlapping match. I implemented it, proved it bit-identical (all twelve
ctest gates green on the patched kernel, including the `gpu_fixture` /
`stream_twin` oracle-parity and determinism gates), and measured it, **and
the measurement rejects it**, per the accept rule pre-registered on the
issue before any numbers existed (improvement on at least one corpus with
zero regression on the others).

What ships instead is the measurement infrastructure and the record:

- the new `--longmatch` generated corpus (match length 255 at offset 512,
  oracle-validated in-harness exactly like `--worst4b`, compile-time
  non-overlap assert, shape-locked by a new `bench_longmatch_selfcheck`
  ctest), the copy-dominated regime that exposes this lever, kept one flag
  away for any future attempt;
- the longmatch baseline (165 GB/s device-resident) and the full A/B table
  in docs/BENCHMARKS.md ("Perf pass 3"), plus the masterplan outcome note
  alongside perf passes 1 (#16) and 2 (#21).

No kernel code ships; `src/lz4_decode.cuh` is untouched on this branch.

## The measurement that decided

RTX 3080 (sm_86), driver 12.6, runtime 12.6, digest-pinned
`nvidia/cuda:12.6.2-devel-ubuntu24.04` container; baseline and patched
binaries built from the same tree, A/B-interleaved in one container session,
two full passes, 3 warmup + 30 CUDA-event-timed runs, device-resident,
percentiles nearest-rank. Corpora: Silesia (3239 chunks, 211.94 MB, median
chunk 64 KB), `--worst4b` (3200 x 64 KB, offset-1 minmatch), `--longmatch`
(3200 x 64 KB, len-255 matches at offset 512).

Delta is throughput speedup (`baseline_ms / fast_path_ms − 1`, per pass), one
basis across all three rows:

| Corpus              | Baseline p50 (pass 1 / 2) | Fast path p50 (pass 1 / 2) | Delta (throughput) |
| ------------------- | ------------------------- | -------------------------- | ------------------ |
| Silesia `--gpu`     | 11.979 / 12.859 ms        | 10.872 / 11.822 ms         | **+10.2% / +8.8%** |
| `--worst4b --gpu`   | 25.502 / 26.256 ms        | 27.938 / 27.654 ms         | **−8.7% / −5.1%**  |
| `--longmatch --gpu` | 1.277 / 1.278 ms          | 0.922 / 0.898 ms           | **+38.5% / +42.3%** |

The worst-case regression is real, not jitter: five independent patched
`--worst4b` sessions all landed at 26.8-27.9 ms against a 25.1-26.3 ms
baseline. `--worst4b` is always-overlapping (offset 1), so the fast-path arm
is never taken there, the cost is the added per-match predicate and second
loop body in the hottest per-sequence path of the maximum-sequence-density
input. The plan's prediction that the compare would be free was refuted by
the hardware; that is what the measurement gate is for.

**Why the trade is refused:** the `--worst4b` number is the DoS-resistance
margin (#19), the throughput floor an attacker can force. Trading the
worst case for average-case gains inverts the hostile-input-first posture,
and the pre-registered rule said so before the numbers came in. A
formulation that recovers the Silesia +8% without touching the worst case
would be accepted; none is known under the single-loop structure (the
predicate is inherently per-match). The rejected fast path peaked at
~228-234 GB/s on longmatch (0.922 / 0.898 ms), against the shipped kernel's
165 GB/s baseline there.

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [x] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: no decode path is touched; the new corpus
      builder is harness-side, oracle-validated before any timing, and its
      construction is negative-locked by the selfcheck ctest.
- [x] Oracle coverage: the longmatch corpus round-trips through
      `LZ4_decompress_safe` in-harness before timing; the patched-kernel
      candidate passed the full `gpu_fixture`/`stream_twin` oracle diff
      before being measured (and then rejected on performance, not
      correctness).
- [x] Determinism preserved: no shipped decode-path change.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI
      (bench-side additions follow the existing harness error handling).
- [ ] Adversarial review: bench harness + docs change (no kernel, format,
      ABI, build-tool, or workflow code ships); flagged for the maintainers'
      panel decision on whether the gate applies to `bench/`.

## Performance checklist

- [x] The claim is measured, not reasoned: full A/B table above with GPU,
      driver, CUDA version, corpus, and chunk-size distribution; the
      rejected candidate's numbers are recorded in docs/BENCHMARKS.md.
- [x] No regression against the recorded baselines: no decoder code
      changes; the shipped tree re-measures at the recorded baselines
      (longmatch 165.0 GB/s recorded as the new baseline row).

## Quality checklist

- [x] Minimal: one corpus builder + one selfcheck ctest + the record; the
      rejected kernel edit is dropped, not #ifdef'd.
- [x] Self-documenting: the corpus builder states why the shape pins
      `offset >= match_len`; comments explain why.
- [x] Conformance tests pass; the new structural property (longmatch corpus
      shape: ratio band + non-overlap) is locked by
      `bench_longmatch_selfcheck` and a compile-time assert.

## Verification

- [x] `cmake --build build-cuda -j` - builds clean (`-Werror`), nvcc 12.6.77,
      sm_80+sm_86, in the digest-pinned container.
- [x] `ctest --test-dir build-cuda` - **12/12 passed** on the shipped tree
      (oracle diffs, negative tests, determinism, conformance, all four GPU
      gates on the RTX 3080); the rejected candidate also passed 12/12
      before its measurement, so the rejection is performance-only.
- [x] Prettier (`**/*.{md,yml,yaml}`), clean.
- [x] Docs synced: BENCHMARKS.md carries perf pass 3 + the longmatch
      baseline; MASTERPLAN carries the outcome note.

## Notes

- Same shape as #16 and #21: a designed optimization is implemented,
  measured honestly, and the code is dropped while the knowledge and the
  measurement infrastructure ship. Three for three now, the minimal-correct
  kernel keeps defending its local optimum.
- The longmatch corpus doubles as the best-case bound: 165 GB/s
  copy-dominated versus 8.2 GB/s worst-case and ~18 GB/s Silesia, the
  spread is now measured at both ends.
- GPU results pasted above because CI has no GPU; the build + host-side
  tests gate in CI.
