### PR TITLE
Lock termination, warp collectives, and determinism as tested invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
           test -x build-cuda/tests/smoke &&
           test -x build-cuda/tests/gpu_fixture &&
           test -x build-cuda/tests/frame_twin &&
-          test -x build-cuda/tests/stream_twin
+          test -x build-cuda/tests/stream_twin &&
+          test -x build-cuda/tests/termination_gpu &&
+          test -x build-cuda/tests/determinism_gpu
 
       # The host-side subset; gpu-labeled tests run in this same container
       # on the maintainer's machine and their output is pasted into the PR.
@@ -95,6 +97,7 @@ jobs:
           grep -E ': conformance_c$' host-selected.txt &&
           grep -E ': oracle_lz4$' host-selected.txt &&
           grep -E ': parser_twin$' host-selected.txt &&
+          grep -E ': termination$' host-selected.txt &&
           grep -E ': launch_fail$' host-selected.txt &&
           grep -E ': bench_selfcheck$' host-selected.txt &&
           grep -E ': bench_worst4b_selfcheck$' host-selected.txt &&
@@ -103,7 +106,9 @@ jobs:
           grep -E ': smoke$' gpu-deferred.txt &&
           grep -E ': gpu_fixture$' gpu-deferred.txt &&
           grep -E ': frame_twin$' gpu-deferred.txt &&
-          grep -E ': stream_twin$' gpu-deferred.txt
+          grep -E ': stream_twin$' gpu-deferred.txt &&
+          grep -E ': termination_gpu$' gpu-deferred.txt &&
+          grep -E ': determinism_gpu$' gpu-deferred.txt
 
   sanitize:
     # The host-side ASan/UBSan gate over the untrusted-input decode path (issue
@@ -156,7 +161,8 @@ jobs:
           test -x build-san/tests/conformance_c &&
           test -x build-san/tests/oracle_lz4 &&
           test -x build-san/tests/parser_twin &&
-          test -x build-san/tests/frame_host_negative
+          test -x build-san/tests/frame_host_negative &&
+          test -x build-san/tests/termination
 
       # Prove the sanitizer runtimes are actually linked: a dropped or renamed
       # -fsanitize flag would still build and test green but check nothing, so
@@ -177,12 +183,14 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|frame_host_negative)$' &&
+          '^(conformance_c|oracle_lz4|parser_twin|frame_host_negative|termination)$'
+          &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
           grep -E ': oracle_lz4$' san-selected.txt &&
           grep -E ': parser_twin$' san-selected.txt &&
-          grep -E ': frame_host_negative$' san-selected.txt
+          grep -E ': frame_host_negative$' san-selected.txt &&
+          grep -E ': termination$' san-selected.txt
 
   format:
     name: format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,11 @@ if(CUDEC_ENABLE_CUDA)
             "want 1..${CUDEC_TEST_TIMEOUT_CEILING} seconds): every test must "
             "fail on a hang rather than stall the run (issue #72)")
       endif()
-      set_property(GLOBAL APPEND PROPERTY CUDEC_TIMEOUT_CHECKED_TESTS ${_test})
+      # Keyed by directory too: two directories may register the same test
+      # name, and a bare-name key would let the unchecked one ride on the
+      # checked one.
+      set_property(GLOBAL APPEND PROPERTY CUDEC_TIMEOUT_CHECKED_TESTS
+                   "${CMAKE_CURRENT_SOURCE_DIR}::${_test}")
     endforeach()
   endfunction()
 
@@ -120,7 +124,7 @@ if(CUDEC_ENABLE_CUDA)
     get_property(_checked GLOBAL PROPERTY CUDEC_TIMEOUT_CHECKED_TESTS)
     get_property(_tests DIRECTORY ${dir} PROPERTY TESTS)
     foreach(_test IN LISTS _tests)
-      if(NOT _test IN_LIST _checked)
+      if(NOT "${dir}::${_test}" IN_LIST _checked)
         message(
           FATAL_ERROR
             "ctest entry '${_test}' (registered in ${dir}) was never checked "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,31 @@ if(CUDEC_ENABLE_CUDA)
   enable_language(CXX)
   enable_testing()
 
+  # Every ctest entry carries a finite TIMEOUT (issue #72). A decoder that
+  # fails to terminate hangs the runner instead of failing it, and a hang is
+  # a fail-closed violation exactly like an out-of-bounds read - so the
+  # timeout is part of the gate, not a convenience. The value is generous
+  # against a loaded machine and a sanitized (-O0 + ASan) build, and finite
+  # against "never".
+  set(CUDEC_TEST_TIMEOUT_SECONDS 300)
+
+  # ...and the property must not be forgettable. This walks the ctest
+  # entries registered in the calling directory and reds the configure step
+  # on any entry without a finite timeout, so a test added by hand (as
+  # bench/ does) is covered exactly like one from cudec_add_test.
+  function(cudec_assert_test_timeouts)
+    get_property(_tests DIRECTORY PROPERTY TESTS)
+    foreach(_test IN LISTS _tests)
+      get_test_property(${_test} TIMEOUT _timeout)
+      if(NOT _timeout)
+        message(
+          FATAL_ERROR
+            "ctest entry '${_test}' has no TIMEOUT: every test must fail on "
+            "a hang rather than stall the run (issue #72)")
+      endif()
+    endforeach()
+  endfunction()
+
   # Single source of truth for the strict device flags: the raw list also
   # feeds the configure-time liveness probes in tests/CMakeLists.txt, so an
   # edit here is probed, not trusted.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,21 +86,51 @@ if(CUDEC_ENABLE_CUDA)
   # against a loaded machine and a sanitized (-O0 + ASan) build, and finite
   # against "never".
   set(CUDEC_TEST_TIMEOUT_SECONDS 300)
+  # An upper bound too: a TIMEOUT of 99999999 is finite and useless, and the
+  # point of the property is that a hang reds the run inside a human wait.
+  set(CUDEC_TEST_TIMEOUT_CEILING 3600)
 
-  # ...and the property must not be forgettable. This walks the ctest
-  # entries registered in the calling directory and reds the configure step
-  # on any entry without a finite timeout, so a test added by hand (as
-  # bench/ does) is covered exactly like one from cudec_add_test.
+  # ...and the property must not be forgettable. A test property can only be
+  # read from the directory that declared it (get_test_property is
+  # directory-scoped before CMake 3.28, and the pinned minimum here is 3.24),
+  # so this runs in two halves: each directory that registers tests calls
+  # cudec_assert_test_timeouts(), which checks and RECORDS what it verified,
+  # and the sweep below - run once, last, from the top level - walks every
+  # subdirectory and fails on any registered test that was never recorded.
+  # That closes both ways the per-directory call is forgettable: a future
+  # add_subdirectory that never calls it, and an add_test appended after the
+  # call site.
   function(cudec_assert_test_timeouts)
     get_property(_tests DIRECTORY PROPERTY TESTS)
     foreach(_test IN LISTS _tests)
       get_test_property(${_test} TIMEOUT _timeout)
-      if(NOT _timeout)
+      if(NOT _timeout OR NOT _timeout MATCHES "^[0-9]+$"
+         OR _timeout GREATER ${CUDEC_TEST_TIMEOUT_CEILING})
         message(
           FATAL_ERROR
-            "ctest entry '${_test}' has no TIMEOUT: every test must fail on "
-            "a hang rather than stall the run (issue #72)")
+            "ctest entry '${_test}' has no usable TIMEOUT (got '${_timeout}', "
+            "want 1..${CUDEC_TEST_TIMEOUT_CEILING} seconds): every test must "
+            "fail on a hang rather than stall the run (issue #72)")
       endif()
+      set_property(GLOBAL APPEND PROPERTY CUDEC_TIMEOUT_CHECKED_TESTS ${_test})
+    endforeach()
+  endfunction()
+
+  function(cudec_sweep_test_timeouts dir)
+    get_property(_checked GLOBAL PROPERTY CUDEC_TIMEOUT_CHECKED_TESTS)
+    get_property(_tests DIRECTORY ${dir} PROPERTY TESTS)
+    foreach(_test IN LISTS _tests)
+      if(NOT _test IN_LIST _checked)
+        message(
+          FATAL_ERROR
+            "ctest entry '${_test}' (registered in ${dir}) was never checked "
+            "for a TIMEOUT: call cudec_assert_test_timeouts() at the END of "
+            "that directory's CMakeLists.txt (issue #72)")
+      endif()
+    endforeach()
+    get_property(_subs DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach(_sub IN LISTS _subs)
+      cudec_sweep_test_timeouts(${_sub})
     endforeach()
   endfunction()
 
@@ -140,4 +170,8 @@ if(CUDEC_ENABLE_CUDA)
   if(NOT CUDEC_SANITIZE)
     add_subdirectory(bench)
   endif()
+
+  # Last, so it sees every directory both subdirectories added: no ctest entry
+  # anywhere in the tree may have escaped the timeout check (issue #72).
+  cudec_sweep_test_timeouts(${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,27 @@ Issue-driven, gate-driven:
   nvCOMP is proprietary: never copy its headers or source, and cudec claims no
   compatibility with it (nominative references and CPU-only benchmark
   comparisons are fine).
-- **Determinism**: same input → same output, bit-exact per code path.
+- **Termination**: every loop whose exit depends on a value read from the
+  bitstream carries an explicit decrementing fuel cap, sized so no input the
+  validation ladder admits can reach it. A decoder that hangs on hostile input
+  has failed open in the availability direction; a configure-time check reds
+  the build on a fuel-free loop in the decode path, and every ctest entry has a
+  finite `TIMEOUT`.
+- **Warp collectives.** Four points, checked on every kernel review:
+  1. **Mask provenance** — a collective's mask is the full-warp constant or
+     `__activemask()`, never a value computed from the bitstream.
+  2. **All participants reach it** — every lane the mask names arrives at the
+     collective; loop bounds and branches around one stay lane-uniform.
+  3. **No source lane or predicate from unvalidated input** — a shuffle's
+     source lane and a vote's predicate are program constants or validated
+     quantities, never a parsed length, offset, or token.
+  4. **No legacy intrinsics** — `__shfl`, `__ballot`, `__any`, `__all`,
+     `__match_any` and friends are banned; only the `_sync` forms are used.
+- **Determinism**: same input → bit-identical output, on every path and in
+  every launch configuration — the `gpu_to_gpu` level in NVIDIA's CCCL
+  vocabulary. The scope and the tested axes are in
+  [docs/DETERMINISM.md](docs/DETERMINISM.md); no floating-point type or atomic
+  belongs anywhere in the sources.
 - **Performance claims are measured**, never reasoned: numbers ship with GPU
   model, driver, CUDA version, corpus, and chunk-size distribution.
 - **Readable kernels.** Small single-purpose device functions with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,10 @@ Issue-driven, gate-driven:
   4. **No legacy intrinsics** — `__shfl`, `__ballot`, `__any`, `__all`,
      `__match_any` and friends are banned; only the `_sync` forms are used.
 - **Determinism**: same input → bit-identical output, on every path and in
-  every launch configuration — the `gpu_to_gpu` level in NVIDIA's CCCL
-  vocabulary. The scope and the tested axes are in
+  every supported launch configuration — the `gpu_to_gpu` level in NVIDIA's
+  CCCL vocabulary. A kernel that maps work onto lanes states which geometries
+  it supports and refuses the rest, rather than assuming its caller. The scope,
+  the qualifiers, and the tested axes are in
   [docs/DETERMINISM.md](docs/DETERMINISM.md); no floating-point type or atomic
   belongs anywhere in the sources.
 - **Performance claims are measured**, never reasoned: numbers ship with GPU

--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ milestones:
 ## Principles
 
 - **Fail-closed.** A malformed or hostile bitstream produces a defined error,
-  never an out-of-bounds access and never a guess. Every reject path has a
-  negative test.
-- **Deterministic.** Same input, same output — bit-exact on every code path.
+  never an out-of-bounds access and never a guess — and never a hang: every
+  loop driven by a value read from the stream is capped, and termination is a
+  tested invariant. Every reject path has a negative test.
+- **Deterministic.** Same input, same output — bit-exact on every code path,
+  in every launch configuration, on every supported GPU. The scope and the
+  tested axes: [docs/DETERMINISM.md](docs/DETERMINISM.md).
 - **Honest numbers.** Recorded baselines: [docs/BENCHMARKS.md](docs/BENCHMARKS.md)
   (`bench/bench_lz4`; corpora via `bench/get-corpora.sh`, hash-pinned).
   Every performance claim ships with GPU model, driver,

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ milestones:
   loop driven by a value read from the stream is capped, and termination is a
   tested invariant. Every reject path has a negative test.
 - **Deterministic.** Same input, same output — bit-exact on every code path,
-  in every launch configuration, on every supported GPU. The scope and the
-  tested axes: [docs/DETERMINISM.md](docs/DETERMINISM.md).
+  in every supported launch configuration, on every supported GPU. The scope,
+  the qualifiers, and the tested axes:
+  [docs/DETERMINISM.md](docs/DETERMINISM.md).
 - **Honest numbers.** Recorded baselines: [docs/BENCHMARKS.md](docs/BENCHMARKS.md)
   (`bench/bench_lz4`; corpora via `bench/get-corpora.sh`, hash-pinned).
   Every performance claim ships with GPU model, driver,

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -43,3 +43,13 @@ add_test(NAME bench_worst4b_selfcheck COMMAND bench_lz4 --worst4b --selfcheck)
 # intended many-long-matches shape, reds CI rather than a manual bench.
 add_test(NAME bench_longmatch_selfcheck COMMAND bench_lz4 --longmatch
                                                 --selfcheck)
+
+# Every ctest entry carries a finite TIMEOUT (issue #72): the self-checks run
+# the same corpus construction and CPU decode the decoder is held to, so a
+# non-terminating decode must red them rather than stall the run. The
+# assertion below reds the configure step if an entry added here ever misses
+# one.
+set_tests_properties(
+  bench_selfcheck bench_worst4b_selfcheck bench_longmatch_selfcheck
+  PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
+cudec_assert_test_timeouts()

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -281,8 +281,17 @@ produce a rejected chunk instead of a warp that never returns. The cap is one
 
 Measured back-to-back in one session, same container digest, same machine,
 same corpora: `origin/main` at `e85194d` against this change, `--warmup 3
---runs 30`, GPU device-resident and CUDA-event timed. The full methodology
-block for the "after" Silesia run:
+--runs 30`, GPU device-resident and CUDA-event timed. Every comparison below
+is the mean of two interleaved passes (after, before, after, before) so
+drifting clocks cannot favour one side, and every individual sample is listed
+so the spread is visible rather than averaged away.
+
+The methodology block below is **one standalone run of the "after" build**,
+pasted whole because the rule here is that a number ships with its
+methodology. Its GPU decode p50 is 12.427 ms, inside that build's observed
+run-to-run range but not identical to the paired mean in the table — the same
+build measured twice, not a discrepancy. The paired means are what the claim
+rests on.
 
 ```
 ## bench_lz4 report
@@ -293,39 +302,71 @@ block for the "after" Silesia run:
 - corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3239 chunks, 211.94 MB original, 102.44 MB compressed (ratio 0.483), compressed in-harness via LZ4_compress_default
 - chunk sizes: min 8066 / median 65536 / max 65536 bytes
 - method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
-- wall per run: p50 61.456 ms / p90 64.393 ms / p99 64.967 ms
-- decode throughput: p50 3.449 GB/s / p90 3.291 GB/s / p99 3.262 GB/s
-- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs): p50 12.684 ms, 16.7 GB/s
-- GPU parse-only ceiling (copies elided): p50 6.696 ms, 31.7 GB/s - ceilings this design AND any two-phase phase-1 (shared parse)
+- wall per run: p50 60.259 ms / p90 63.591 ms / p99 64.079 ms
+- decode throughput: p50 3.517 GB/s / p90 3.333 GB/s / p99 3.307 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs): p50 12.427 ms, 17.1 GB/s
+- GPU parse-only ceiling (copies elided): p50 7.163 ms, 29.6 GB/s - ceilings this design AND any two-phase phase-1 (shared parse)
 ```
 
-Every row is the mean of two interleaved before/after passes (after, before,
-after, before) so drifting clocks cannot favour one side:
+| Corpus        | Metric                     | Before (samples)          | After (samples)           | Change                   |
+| ------------- | -------------------------- | ------------------------- | ------------------------- | ------------------------ |
+| Silesia       | GPU decode p50             | 11.924 ms (11.873/11.974) | 12.163 ms (12.107/12.218) | **+2.0%**                |
+| Silesia       | GPU parse-only ceiling p50 | 6.056 ms (5.924/6.188)    | 7.079 ms (7.010/7.147)    | **+16.9%**               |
+| worst-4Bmatch | GPU decode p50             | 25.643 ms (25.364/25.922) | 25.973 ms (25.285/26.661) | +1.3%, inside the spread |
+| worst-4Bmatch | GPU parse-only ceiling p50 | 13.482 ms (13.467/13.496) | 15.437 ms (15.367/15.506) | **+14.5%**               |
 
-| Corpus        | Metric                     | Before    | After     | Change |
-| ------------- | -------------------------- | --------- | --------- | ------ |
-| Silesia       | GPU decode p50             | 12.111 ms | 12.470 ms | +3.0%  |
-| Silesia       | GPU parse-only ceiling p50 | 6.116 ms  | 7.108 ms  | +16.2% |
-| worst-4Bmatch | GPU decode p50             | 25.834 ms | 25.888 ms | +0.2%  |
-| worst-4Bmatch | GPU parse-only ceiling p50 | 13.667 ms | 15.484 ms | +13.3% |
+The shipped decode path pays **+2.0% on Silesia**; on the worst case the
+difference (+1.3%) is smaller than the "after" side's own pass-to-pass spread
+(25.285 / 26.661 ms), so it is **not a measurement**, only an upper bound. The
+parse-only ceiling — a diagnostic kernel with the copies elided, never shipped
+— pays 14–17% on both corpora, tightly and reproducibly, which is where the
+per-sequence cost shows up undiluted by memory stalls.
 
-The shipped decode path pays **+3.0% on Silesia and nothing measurable on the
-worst case**; the parse-only ceiling — a diagnostic kernel with the copies
-elided, never shipped — pays 13–16%, which is where the per-sequence cost
-shows up undiluted by memory stalls. Honest caveat: the pass-to-pass spread on
-the parse-only rows reached 6% (Silesia before: 6.307 / 5.924 ms), so treat
-those two numbers as "13–16%, direction certain, magnitude approximate"; the
-decode rows were stable to under 1% between passes.
+#### Occupancy is the constraint, and it bounds what the guard may cost
 
-Three formulations were measured before settling. The cap at the top of the
-loop (`while (fuel-- != 0)`) costs 12.74 ms on Silesia; folding it into the
-loop's existing exit branch (`if (done || fuel-- == 0)`, shipped) recovers
-most of that at 12.47 ms; a 32-bit counter lands at 12.70 ms and was dropped
-anyway, because keeping its budget unreachable would need a 4 GiB per-chunk
-limit — an accept-set change for a percent that was not there. The register
-count moves 46 → 48 without crossing an occupancy step on `sm_86`, so **what
-is left is the per-sequence work itself, not the branch or the register
-width** — there is no cheaper spelling to reach for.
+The kernel uses **48 registers/thread** on `sm_86`, up from 46 on `origin/main`.
+That matters more than the two-register difference suggests: at 128-thread
+blocks and 256-register warp granularity, 41–48 registers all round to
+1536 registers/warp → 6144/block → 10 resident blocks → **40 warps/SM**, while
+**49 registers steps down to 36 warps/SM**. The shipped kernel therefore sits
+on the last rung before an occupancy cliff, and that was measured, not assumed:
+
+| Variant                                                         | Registers | Warps/SM | Silesia GPU decode p50 |
+| --------------------------------------------------------------- | --------- | -------- | ---------------------- |
+| `origin/main`, no cap and no geometry guard                     | 46        | 40       | 11.924 ms              |
+| shipped (cap + two-clause geometry guard)                       | 48        | 40       | 12.163 ms              |
+| plus a 32-bit-index overflow guard, or the index moved below it | 52        | 36       | 12.63 ms               |
+
+The third row is why the kernel's 32-bit `warp_in_grid` is **left 32-bit and
+documented as a limit rather than widened**: both ways of removing the
+2^32-thread wrap (widening the expression, or refusing the geometry, which
+forces the index below the guard) cost 4–6 registers and a whole occupancy
+step, roughly doubling the regression this change already carries. The shipped
+grid is capped at 8192 blocks by `decode_grid_blocks`, four orders of magnitude
+clear of the bound, and the bound is unreachable through the public ABI at all.
+Anything added to this kernel from here has a hard budget: **48 registers.**
+
+#### The formulation comparison does not rank the formulations
+
+Three spellings of the cap were tried, and the honest reading is that the
+measurement does not separate them. Silesia GPU decode p50, all samples ever
+taken, across sessions:
+
+| Formulation                                    | Samples (ms)                                                 |
+| ---------------------------------------------- | ------------------------------------------------------------ |
+| `origin/main`, no cap                          | 11.873 / 11.974 / 11.980 / 11.987 / 12.011 / 12.218 / 12.234 |
+| folded into the existing exit branch (shipped) | 12.107 / 12.218 / 12.442 / 12.498 / 12.684                   |
+| 32-bit counter                                 | 12.699                                                       |
+| `while (fuel-- != 0)` at the top of the loop   | 12.744 / 12.822                                              |
+
+Only the first two rows were measured under the paired interleaved protocol,
+and only they separate by more than the shipped build's own run-to-run range
+— so the with/without-cap difference is real and the between-formulation
+differences are **not established**. The shipped formulation was chosen on a
+structural argument, not a measured one: folding the test into the loop's
+existing exit branch adds no branch at the top of the loop. The 32-bit counter
+was dropped on correctness, not speed — keeping its budget unreachable would
+need a 4 GiB per-chunk limit, an accept-set change.
 
 The regression is accepted deliberately under the prime-directive ordering —
 **correctness > measured performance**. A decoder that hangs on hostile input

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -331,19 +331,35 @@ blocks and 256-register warp granularity, 41–48 registers all round to
 **49 registers steps down to 36 warps/SM**. The shipped kernel therefore sits
 on the last rung before an occupancy cliff, and that was measured, not assumed:
 
-| Variant                                                         | Registers | Warps/SM | Silesia GPU decode p50 |
-| --------------------------------------------------------------- | --------- | -------- | ---------------------- |
-| `origin/main`, no cap and no geometry guard                     | 46        | 40       | 11.924 ms              |
-| shipped (cap + two-clause geometry guard)                       | 48        | 40       | 12.163 ms              |
-| plus a 32-bit-index overflow guard, or the index moved below it | 52        | 36       | 12.63 ms               |
+| Variant                                          | Registers | Warps/SM | Silesia GPU decode p50 |
+| ------------------------------------------------ | --------- | -------- | ---------------------- |
+| `origin/main`, no cap and no geometry guard      | 46        | 40       | 11.924 ms              |
+| shipped (cap + two-clause geometry guard)        | 48        | 40       | 12.163 ms              |
+| + widen `warp_in_grid` to 64-bit                 | 52        | 36       | 12.63 ms               |
+| + refuse via `total_warps > 1 << 27`             | 52        | 36       | not timed              |
+| + refuse via `gridDim.x > UINT_MAX / blockDim.x` | 52        | 36       | not timed              |
 
-The third row is why the kernel's 32-bit `warp_in_grid` is **left 32-bit and
-documented as a limit rather than widened**: both ways of removing the
-2^32-thread wrap (widening the expression, or refusing the geometry, which
-forces the index below the guard) cost 4–6 registers and a whole occupancy
-step, roughly doubling the regression this change already carries. The shipped
-grid is capped at 8192 blocks by `decode_grid_blocks`, four orders of magnitude
-clear of the bound, and the bound is unreachable through the public ABI at all.
+The last three rows are why the kernel's 32-bit `warp_in_grid` is **left
+32-bit and documented as a limit rather than enforced**. Three spellings of the
+2^32-thread bound were measured, including one that touches no 64-bit value at
+all and compares two values already live in registers — nvcc 12.6 allocates the
+same four extra registers for all three, so neither "widening is free" nor
+"there must be a cheaper spelling" survives contact with the compiler. Only the
+first was timed; the other two share its register count and therefore its
+occupancy, and were not timed separately.
+
+What settles it is not the cost but the asymmetry in the consequence. The guard
+already forces `blockDim.x` to a multiple of the warp size, so a wrapped index
+stays warp-aligned: an aliased block recomputes the **same** `warp_in_grid`
+values with a full 0–31 lane range, decodes the same chunks, and writes
+byte-identical values to the same addresses. Exceeding the documented bound
+therefore costs duplicated work — not missing bytes, not a hang, and the output
+stays bit-identical. That is categorically unlike the two refused geometries,
+where bytes really do go unwritten or the kernel really does spin. Paying an
+occupancy step on every launch to prevent redundant-but-correct output, on a
+geometry needing 33 million blocks against a `decode_grid_blocks` cap of 8192
+and unreachable through the public ABI, is the wrong trade.
+
 Anything added to this kernel from here has a hard budget: **48 registers.**
 
 #### The formulation comparison does not rank the formulations

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -271,6 +271,69 @@ Reproduce with `bench_lz4 --worst4b --gpu`; the construction is oracle-
 validated in-harness and locked against rot by the `bench_worst4b_selfcheck`
 ctest on the GPU-less runner.
 
+### Cost of the termination fuel cap (issue #72)
+
+The sequence loop in `src/lz4_decode.cuh` now carries an explicit decrementing
+fuel cap, so a parser bug that stopped advancing the source cursor would
+produce a rejected chunk instead of a warp that never returns. The cap is one
+64-bit decrement per sequence, folded into the loop's existing exit branch.
+**It is not free, and the number is recorded here rather than waved away.**
+
+Measured back-to-back in one session, same container digest, same machine,
+same corpora: `origin/main` at `e85194d` against this change, `--warmup 3
+--runs 30`, GPU device-resident and CUDA-event timed. The full methodology
+block for the "after" Silesia run:
+
+```
+## bench_lz4 report
+- decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
+- cudec: 1 (the CPU rows time the liblz4 oracle baseline; the GPU rows below, when --gpu is set, time cudec's decoder)
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3239 chunks, 211.94 MB original, 102.44 MB compressed (ratio 0.483), compressed in-harness via LZ4_compress_default
+- chunk sizes: min 8066 / median 65536 / max 65536 bytes
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
+- wall per run: p50 61.456 ms / p90 64.393 ms / p99 64.967 ms
+- decode throughput: p50 3.449 GB/s / p90 3.291 GB/s / p99 3.262 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs): p50 12.684 ms, 16.7 GB/s
+- GPU parse-only ceiling (copies elided): p50 6.696 ms, 31.7 GB/s - ceilings this design AND any two-phase phase-1 (shared parse)
+```
+
+Every row is the mean of two interleaved before/after passes (after, before,
+after, before) so drifting clocks cannot favour one side:
+
+| Corpus        | Metric                     | Before    | After     | Change |
+| ------------- | -------------------------- | --------- | --------- | ------ |
+| Silesia       | GPU decode p50             | 12.111 ms | 12.470 ms | +3.0%  |
+| Silesia       | GPU parse-only ceiling p50 | 6.116 ms  | 7.108 ms  | +16.2% |
+| worst-4Bmatch | GPU decode p50             | 25.834 ms | 25.888 ms | +0.2%  |
+| worst-4Bmatch | GPU parse-only ceiling p50 | 13.667 ms | 15.484 ms | +13.3% |
+
+The shipped decode path pays **+3.0% on Silesia and nothing measurable on the
+worst case**; the parse-only ceiling — a diagnostic kernel with the copies
+elided, never shipped — pays 13–16%, which is where the per-sequence cost
+shows up undiluted by memory stalls. Honest caveat: the pass-to-pass spread on
+the parse-only rows reached 6% (Silesia before: 6.307 / 5.924 ms), so treat
+those two numbers as "13–16%, direction certain, magnitude approximate"; the
+decode rows were stable to under 1% between passes.
+
+Three formulations were measured before settling. The cap at the top of the
+loop (`while (fuel-- != 0)`) costs 12.74 ms on Silesia; folding it into the
+loop's existing exit branch (`if (done || fuel-- == 0)`, shipped) recovers
+most of that at 12.47 ms; a 32-bit counter lands at 12.70 ms and was dropped
+anyway, because keeping its budget unreachable would need a 4 GiB per-chunk
+limit — an accept-set change for a percent that was not there. The register
+count moves 46 → 48 without crossing an occupancy step on `sm_86`, so **what
+is left is the per-sequence work itself, not the branch or the register
+width** — there is no cheaper spelling to reach for.
+
+The regression is accepted deliberately under the prime-directive ordering —
+**correctness > measured performance**. A decoder that hangs on hostile input
+has failed open in the availability direction; nvCOMP 5.3's release notes
+record shipping exactly that bug class in its Snappy decoder. Recovering the
+throughput later is legitimate measurement-gated perf work, but not at the
+price of the guarantee.
+
 ## M2: reusable streaming context, end-to-end (Silesia)
 
 The streaming decode path is now a reusable context

--- a/docs/DETERMINISM.md
+++ b/docs/DETERMINISM.md
@@ -1,8 +1,15 @@
 # Determinism
 
 cudec's decode path is **`gpu_to_gpu` deterministic**: the same compressed
-input produces bit-identical output on any supported GPU, in any launch
-configuration, in any run.
+input produces bit-identical output on any supported GPU, in any supported
+launch configuration, in any run.
+
+"Supported launch configuration" is a real qualifier, not a hedge. The kernel's
+chunk-to-lane mapping requires a block size that is a whole number of warps and
+a grid holding at least one whole warp; the shipped entry point always launches
+`kBlockThreads`, and the kernel rejects any other geometry outright by
+returning without decoding, rather than producing output nobody wrote. See
+"What the level does not promise" below.
 
 The level names come from NVIDIA's CCCL determinism vocabulary
 (`not_guaranteed` / `run_to_run` / `gpu_to_gpu`), borrowed here so the promise
@@ -15,14 +22,14 @@ runtime, and no CCCL dependency is added.
 For one compressed chunk and one destination capacity, the decoded bytes, the
 per-chunk status, and `bytes_written` are identical:
 
-| Axis                  | Promise                                                                                                               |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Run to run            | Identical, same process or a fresh one.                                                                               |
-| Launch configuration  | Identical for any grid size, block size, chunk-to-warp mapping, or number of concurrent streams.                      |
-| Batch composition     | Identical whether the chunk is decoded alone, in a batch, or in a differently ordered batch — chunks are independent. |
-| Entry point           | Identical through the batch entry, the frame decoder, and the streaming context, fresh or reused.                     |
-| GPU to GPU            | Identical on any device the library supports (`sm_80` baseline and newer).                                            |
-| Driver / CUDA version | Identical: the arithmetic is integer and the output-byte mapping is fixed at the source level, not at the ISA level.  |
+| Axis                  | Promise                                                                                                                                                                                               |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Run to run            | Identical, same process or a fresh one.                                                                                                                                                               |
+| Launch configuration  | Identical for any grid size, any block size that is a whole number of warps, any chunk-to-warp mapping, and any number of concurrent streams. Other block sizes are refused, not decoded differently. |
+| Batch composition     | Identical whether the chunk is decoded alone, in a batch, or in a differently ordered batch — chunks are independent.                                                                                 |
+| Entry point           | Identical through the batch entry, the frame decoder, and the streaming context, fresh or reused.                                                                                                     |
+| GPU to GPU            | Identical on any device the library supports (`sm_80` baseline and newer).                                                                                                                            |
+| Driver / CUDA version | Identical: the arithmetic is integer and the output-byte mapping is fixed at the source level, not at the ISA level.                                                                                  |
 
 ## Why it holds
 
@@ -35,7 +42,10 @@ non-deterministic in it to control:
   A configure-time check in `tests/CMakeLists.txt` reds the build if any FP type
   or FP atomic appears in the sources.
 - **Every output byte is written exactly once**, by a statically determined
-  lane, as a pure function of the input and of bytes at lower addresses. An
+  lane — given a supported launch geometry, which the kernel enforces rather
+  than assumes: the copy loops stride by the warp size, so a block that is not
+  a whole number of warps would leave a fixed slice of every destination
+  written by nobody. That geometry returns without decoding instead. An
   overlapping match is not a copy that chases itself but a modular gather
   `dst[d + i] = dst[d - off + (i mod off)]`, reading only the region a
   `__syncwarp()` has already frozen (masterplan section 9). There is no
@@ -54,6 +64,18 @@ non-deterministic in it to control:
   decoder never presents partial output as success, and the bytes it happened to
   write before rejecting are not part of the contract. The _status_ for a given
   input is deterministic; the leftover bytes are not.
+- **Nothing about unsupported launch geometry.** A block size that is not a
+  whole number of warps, or a grid holding less than one whole warp, is refused
+  by the kernel: it returns without touching the destinations or the result
+  records, so the caller sees whatever it primed them with. That is a defined
+  refusal, not a decode — and it is only reachable through the internal kernel
+  header, never through the public ABI, which always launches `kBlockThreads`.
+  `tests/termination_gpu.cu` covers `<<<1, 16>>>`, `<<<2, 16>>>`, and
+  `<<<2, 48>>>`. One further geometry bound is **documented rather than
+  enforced**: the kernel's thread index is 32-bit, so it requires
+  `gridDim.x * blockDim.x <= 2^32`. Enforcing that costs an sm_86 occupancy
+  step (measured, [BENCHMARKS.md](BENCHMARKS.md)), the shipped grid is capped
+  at 8192 blocks, and no public entry point can approach it.
 - **Nothing about timing.** Throughput varies with geometry, occupancy, clocks,
   and neighbours. Determinism here is about bytes, never about duration.
 - **Nothing about memory addresses.** Allocation addresses and the pointer values
@@ -70,6 +92,8 @@ non-deterministic in it to control:
   grid/block geometries (a single warp walking the whole batch through the
   grid-stride loop, block sizes of 32/64/96/128, a grid far larger than the
   batch, and the shipped sizing) plus a three-stream split of the same batch.
+  Every geometry here is a supported one; the refused geometries are covered by
+  `tests/termination_gpu.cu` instead.
   The whole destination arena is re-poisoned before every run and compared in
   full — decoded bytes and the untouched poison beyond `bytes_written` — along
   with every per-chunk result record.

--- a/docs/DETERMINISM.md
+++ b/docs/DETERMINISM.md
@@ -1,0 +1,88 @@
+# Determinism
+
+cudec's decode path is **`gpu_to_gpu` deterministic**: the same compressed
+input produces bit-identical output on any supported GPU, in any launch
+configuration, in any run.
+
+The level names come from NVIDIA's CCCL determinism vocabulary
+(`not_guaranteed` / `run_to_run` / `gpu_to_gpu`), borrowed here so the promise
+has a citable name and a testable scope instead of the adjective "deterministic".
+Borrowing the terminology is all it is: cudec depends on nothing beyond the CUDA
+runtime, and no CCCL dependency is added.
+
+## What the level promises
+
+For one compressed chunk and one destination capacity, the decoded bytes, the
+per-chunk status, and `bytes_written` are identical:
+
+| Axis                  | Promise                                                                                                               |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Run to run            | Identical, same process or a fresh one.                                                                               |
+| Launch configuration  | Identical for any grid size, block size, chunk-to-warp mapping, or number of concurrent streams.                      |
+| Batch composition     | Identical whether the chunk is decoded alone, in a batch, or in a differently ordered batch — chunks are independent. |
+| Entry point           | Identical through the batch entry, the frame decoder, and the streaming context, fresh or reused.                     |
+| GPU to GPU            | Identical on any device the library supports (`sm_80` baseline and newer).                                            |
+| Driver / CUDA version | Identical: the arithmetic is integer and the output-byte mapping is fixed at the source level, not at the ISA level.  |
+
+## Why it holds
+
+The reason is structural, not statistical — the pipeline has nothing
+non-deterministic in it to control:
+
+- **No floating point.** A lossless decompressor has no use for it. There is no
+  FP type, no FP atomic, and therefore no reassociation, no fused-multiply-add
+  contraction, and no dependence on the order in which partial results arrive.
+  A configure-time check in `tests/CMakeLists.txt` reds the build if any FP type
+  or FP atomic appears in the sources.
+- **Every output byte is written exactly once**, by a statically determined
+  lane, as a pure function of the input and of bytes at lower addresses. An
+  overlapping match is not a copy that chases itself but a modular gather
+  `dst[d + i] = dst[d - off + (i mod off)]`, reading only the region a
+  `__syncwarp()` has already frozen (masterplan section 9). There is no
+  read-modify-write, no atomic accumulation, and no inter-warp communication, so
+  no ordering exists to get wrong.
+- **Chunks are independent.** A chunk's output depends on its own source bytes
+  and its own capacity, never on its neighbours or on where in the batch it sits.
+  That is what makes the launch-geometry and stream-count axes free.
+- **No ambient input.** No clock, no random source, no device-property query,
+  and no heuristic that switches algorithm by size feed the decode.
+
+## What the level does not promise
+
+- **Nothing about rejected chunks' destination contents.** On any non-OK status
+  `bytes_written` is 0 and the destination is explicitly unspecified — the
+  decoder never presents partial output as success, and the bytes it happened to
+  write before rejecting are not part of the contract. The _status_ for a given
+  input is deterministic; the leftover bytes are not.
+- **Nothing about timing.** Throughput varies with geometry, occupancy, clocks,
+  and neighbours. Determinism here is about bytes, never about duration.
+- **Nothing about memory addresses.** Allocation addresses and the pointer values
+  a caller passes are the caller's business; the decoded content does not depend
+  on them.
+- **Nothing across format-behaviour changes.** A cudec version that decodes a
+  stream a previous version rejected is a deliberate, documented change, not a
+  determinism break. The invariant is fixed input, fixed version, fixed output.
+
+## How it is tested
+
+- `tests/determinism_gpu.cu` — the launch-geometry axis. One corpus of pristine
+  and mutated chunks, one reference decode, then five runs each across five
+  grid/block geometries (a single warp walking the whole batch through the
+  grid-stride loop, block sizes of 32/64/96/128, a grid far larger than the
+  batch, and the shipped sizing) plus a three-stream split of the same batch.
+  The whole destination arena is re-poisoned before every run and compared in
+  full — decoded bytes and the untouched poison beyond `bytes_written` — along
+  with every per-chunk result record.
+- `tests/stream_twin.cu` — the entry-point and context-reuse axes: the streaming
+  decoder's output is bit-identical to a single-stream reference decode, on a
+  fresh context and on a reused one whose staging has grown.
+- `tests/gpu_fixture.cu` and `tests/frame_twin.cu` — the oracle axis: decoded
+  bytes match liblz4's own output for every accepted stream.
+- `tests/CMakeLists.txt` — the structural axis: the floating-point ban above,
+  checked at configure time, with probes that prove the check still bites.
+
+The GPU-to-GPU axis is **reasoned, not measured**: the maintainer's gate runs one
+device (an RTX 3080, `sm_86`). It rests on the integer-only argument above rather
+than on a two-GPU comparison, and it is stated that way deliberately — a claim
+without a measurement is not a measurement. A second device joins the gate when
+one is available.

--- a/docs/DETERMINISM.md
+++ b/docs/DETERMINISM.md
@@ -73,9 +73,16 @@ non-deterministic in it to control:
   `tests/termination_gpu.cu` covers `<<<1, 16>>>`, `<<<2, 16>>>`, and
   `<<<2, 48>>>`. One further geometry bound is **documented rather than
   enforced**: the kernel's thread index is 32-bit, so it requires
-  `gridDim.x * blockDim.x <= 2^32`. Enforcing that costs an sm_86 occupancy
-  step (measured, [BENCHMARKS.md](BENCHMARKS.md)), the shipped grid is capped
-  at 8192 blocks, and no public entry point can approach it.
+  `gridDim.x * blockDim.x <= 2^32`. Exceeding it does **not** break this
+  promise — because a block is already forced to be a whole number of warps,
+  the wrapped index stays warp-aligned, so an aliased block recomputes the
+  same chunks with a full lane range and writes byte-identical values to the
+  same addresses. The output is unchanged; the work is done twice. That
+  asymmetry is why this one is documented and the other two are refused:
+  enforcing it costs a real sm_86 occupancy step on every launch (three
+  spellings measured, all 48 → 52 registers — [BENCHMARKS.md](BENCHMARKS.md)),
+  the shipped grid is capped at 8192 blocks, and no public entry point can
+  approach it.
 - **Nothing about timing.** Throughput varies with geometry, occupancy, clocks,
   and neighbours. Determinism here is about bytes, never about duration.
 - **Nothing about memory addresses.** Allocation addresses and the pointer values

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -254,7 +254,11 @@ chases itself; it is a modular gather from bytes already final:
 the `__syncwarp()` preceding every copy has frozen. Each output byte is
 written exactly once, by a statically determined lane, as a pure function
 of lower addresses — deterministic because no ordering exists to get
-wrong. The shipped inner loop computes that `i mod off` directly — one
+wrong. "Exactly once" holds for a supported launch geometry, which the
+kernel enforces rather than assumes: the copy loops stride by the warp
+size, so a block that is not a whole number of warps would leave a fixed
+slice of every destination written by nobody, and that geometry returns
+without decoding ([DETERMINISM.md](DETERMINISM.md)). The shipped inner loop computes that `i mod off` directly — one
 64-bit modulo per output byte, so every lane pays a division per
 iteration (`dst[seq.match_dst + i] = dst[seq.match_src + (i % offset)]`
 in `src/lz4_decode.cuh`). Cutting that cost is deferred, measurement-gated

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -88,9 +88,39 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
   arithmetic is overflow-checked; a chunk that fails validation reports a
   defined error and produces no partial output presented as success. Hostile
   input is the expected case, not the exception.
-- **Determinism.** Same input → bit-identical output on every path. There is
-  no floating point in a lossless decoder; this invariant is cheap here and
-  is locked in by tests.
+- **Termination is part of fail-closed.** A decoder that hangs on hostile
+  input has failed open in the availability direction — nvCOMP 5.3's release
+  notes record fixing an indefinite Snappy-decompression hang on malformed
+  input, so this is a demonstrated bug class in exactly this product
+  category, not a theoretical one. Every loop whose exit depends on a value
+  read from the bitstream carries an explicit decrementing fuel cap whose
+  bound is unreachable for any input the validation ladder admits: the accept
+  set is unchanged, and a future guard bug degrades to a defined reject
+  instead of a hung device. The parser's per-call liveness contract is
+  asserted over truncated, mutated, and crafted streams
+  (`tests/termination.cpp`, `tests/termination_gpu.cu`), every ctest entry
+  carries a finite `TIMEOUT`, and a configure-time check reds the build on a
+  fuel-free loop in the decode path.
+- **Warp collective integrity.** Kernels use only the `_sync` warp
+  primitives; the legacy non-`_sync` intrinsics are banned outright, because
+  since Volta's independent thread scheduling they cannot express which lanes
+  participate at all. A collective's participation metadata — its mask, its
+  source lane, its predicate — is never derived from a value read out of the
+  bitstream: it is the full-warp constant or `__activemask()`, and the loop
+  bounds that decide which lanes reach a collective stay lane-uniform.
+  Corrupting that metadata is a published attack on CUDA kernels
+  ("Gerrymandering the Warp", arXiv:2606.11878) that produces wrong results
+  without touching control flow, and the shipped decoder's redundant
+  all-lane parse is what keeps every lane's path identical. Configure-time
+  checks in `tests/CMakeLists.txt` enforce both halves; `CONTRIBUTING.md`
+  carries the four-point review checklist.
+- **Determinism.** Same input → bit-identical output on every path: the level
+  is `gpu_to_gpu` in NVIDIA's CCCL vocabulary, held by construction rather
+  than by tuning — integer-only arithmetic, every output byte written exactly
+  once by a statically determined lane as a pure function of lower addresses,
+  and no inter-chunk coupling. The scope, the reasoning, and the tested axes
+  (including launch geometry and stream count, which a same-batch-twice
+  compare cannot see) are in [DETERMINISM.md](DETERMINISM.md).
 - **The oracles decide correctness.** liblz4, zlib, and libzstd are vendored
   as test dependencies; decode output is diff-tested against them on real
   corpora (Silesia, enwik) and on fuzzed/mutated streams, including the

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -241,14 +241,21 @@ cudec_status DecodeFrame(const unsigned char* f, size_t frame_size,
     pos += 1;
 
     std::vector<FrameBlock> blocks;
-    while (true) {
+    /* Fuel: every step consumes at least the 4 block-size bytes, so a frame
+     * of frame_size bytes admits at most frame_size / 4 + 1 steps - a budget
+     * no frame the guards below admit can reach. It makes a future bounds
+     * bug a rejected frame instead of a spinning host thread. */
+    uint64_t fuel = frame_size / 4 + 1;
+    bool end_mark = false;
+    while (fuel-- != 0) {
         if (frame_size < pos + 4) {
             return CUDEC_ERR_CORRUPT_INPUT;
         }
         const uint32_t bs = Read32LE(f + pos);
         pos += 4;
         if (bs == 0) {
-            break; /* end mark */
+            end_mark = true;
+            break;
         }
         const bool uncompressed = (bs >> 31) & 1;
         const size_t blen = bs & 0x7FFFFFFFu;
@@ -266,6 +273,9 @@ cudec_status DecodeFrame(const unsigned char* f, size_t frame_size,
         }
         blocks.push_back({pos, blen, uncompressed});
         pos += blen + (block_checksum ? 4 : 0);
+    }
+    if (!end_mark) {
+        return CUDEC_ERR_CORRUPT_INPUT; /* fuel exhausted: no end mark */
     }
 
     size_t total = 0;

--- a/src/lz4_block.h
+++ b/src/lz4_block.h
@@ -86,8 +86,20 @@ struct Lz4Parser {
         if (initial_check && src_pos + read_margin >= src_size) {
             return CUDEC_ERR_CORRUPT_INPUT;
         }
+        /* Fuel: the loop's termination otherwise rests entirely on the
+         * guards below staying correct, and a decoder that fails to
+         * terminate hangs the device - a fail-closed violation exactly like
+         * an out-of-bounds read (nvCOMP 5.3 shipped that bug class in its
+         * Snappy decoder). Every step consumes one src byte and the loop is
+         * entered with src_pos <= src_size, so this budget is unreachable
+         * for every input the guards admit: the accept set does not move,
+         * and a future guard bug degrades to a reject instead of a hang. */
+        uint64_t fuel = src_size - src_pos + 1;
         unsigned char byte;
         do {
+            if (fuel-- == 0) {
+                return CUDEC_ERR_CORRUPT_INPUT;
+            }
             if (src_pos >= src_size) {
                 return CUDEC_ERR_CORRUPT_INPUT; /* extension byte missing */
             }
@@ -108,7 +120,10 @@ struct Lz4Parser {
      * then call again); CUDEC_OK with *done set (exact-consumption
      * success - the ONLY success exit, after a literals-only tail); or a
      * reject status. Liveness: every call consumes at least the token
-     * byte, so decode loops terminate on every input. */
+     * byte, so decode loops terminate on every input - asserted per call
+     * over truncated, mutated, and crafted streams in
+     * tests/termination.cpp, and backed by a fuel cap in every driver
+     * loop so a regression rejects rather than hangs. */
     CUDEC_HOST_DEVICE cudec_status Next(Lz4Sequence* sequence, bool* done) {
         *done = false;
         if (src_pos >= src_size) {

--- a/src/lz4_decode.cuh
+++ b/src/lz4_decode.cuh
@@ -36,12 +36,31 @@ __global__ void __launch_bounds__(kBlockThreads)
         (blockIdx.x * blockDim.x + threadIdx.x) / kWarpSize;
     const size_t total_warps =
         (static_cast<size_t>(gridDim.x) * blockDim.x) / kWarpSize;
-    /* A launch geometry holding fewer than one whole warp makes the
-     * grid-stride below advance by zero and spin forever. The shipped entry
-     * always launches kBlockThreads, but the kernel must not depend on its
-     * caller for termination - and the check is lane-uniform, so it cannot
-     * strand lanes at a __syncwarp(). */
-    if (total_warps == 0) {
+    /* The chunk-to-lane mapping is sound only when the grid holds at least
+     * one whole warp and every block is a whole number of warps. Both
+     * failures are geometry rather than input, and both are silent:
+     *  - fewer than one whole warp in the grid makes the grid-stride below
+     *    advance by zero and spin forever;
+     *  - a block that is not a warp multiple splits a chunk's warp across two
+     *    blocks (<<<2, 16>>> and <<<2, 48>>> both do), so `lane` only ever
+     *    takes the low half of its range while the copy loops stride by
+     *    kWarpSize - every output byte at i % 32 >= 16 is written by nobody,
+     *    and the full-mask __syncwarp() is executed by half a warp.
+     * The shipped entry always launches kBlockThreads, but the kernel must
+     * not depend on its caller for either property. Both tests are
+     * grid-uniform (gridDim/blockDim only), so neither can strand lanes at a
+     * __syncwarp().
+     *
+     * warp_in_grid above stays 32-bit, so this kernel additionally requires
+     * gridDim.x * blockDim.x <= 2^32; past that the index wraps and aliases
+     * two blocks onto one chunk. That bound is not enforced here because
+     * enforcing it is NOT free: widening the expression, or moving it below
+     * this guard, costs 4-6 registers and drops sm_86 occupancy from 40 to 36
+     * warps/SM (measured, docs/BENCHMARKS.md). decode_grid_blocks caps the
+     * shipped grid at 8192 blocks, four orders of magnitude clear of the
+     * bound, so it is a documented limit of this internal header rather than
+     * a reachable defect. */
+    if (total_warps == 0 || blockDim.x % kWarpSize != 0) {
         return;
     }
 
@@ -55,18 +74,21 @@ __global__ void __launch_bounds__(kBlockThreads)
          * dst[] value across the barrier. */
         unsigned char* dst = static_cast<unsigned char*>(dst_ptrs[chunk]);
 
-        Lz4Parser parser{src, src_sizes[chunk], dst_caps[chunk]};
+        const size_t src_size = src_sizes[chunk];
+        Lz4Parser parser{src, src_size, dst_caps[chunk]};
         Lz4Sequence seq;
         cudec_status status = CUDEC_OK;
         bool done = false;
         /* Fuel: Next consumes at least the token byte, so a chunk of n
          * source bytes admits at most n + 1 calls - a budget no input the
-         * parser accepts or rejects can reach. It is lane-uniform (every
-         * lane parses the same bytes), so it cannot make one lane leave the
-         * loop early and strand the others at a __syncwarp() below. A hung
-         * warp is a fail-closed violation like an out-of-bounds read, and
-         * this is what makes a future parser bug a rejected chunk instead. */
-        uint64_t fuel = src_sizes[chunk] + 1;
+         * parser accepts or rejects can reach. The saturating form matters:
+         * a plain n + 1 would wrap to 0 for a SIZE_MAX chunk size and cap a
+         * parse that nothing else would have stopped. It is lane-uniform
+         * (every lane parses the same bytes), so it cannot make one lane
+         * leave the loop early and strand the others at a __syncwarp() below.
+         * A hung warp is a fail-closed violation like an out-of-bounds read,
+         * and this is what makes a future parser bug a rejected chunk. */
+        uint64_t fuel = src_size == SIZE_MAX ? SIZE_MAX : src_size + 1;
         while (true) {
             status = parser.Next(&seq, &done);
             if (status != CUDEC_OK) {
@@ -89,10 +111,11 @@ __global__ void __launch_bounds__(kBlockThreads)
                     __syncwarp();
                 }
             }
-            /* The fuel test rides the exit branch that already exists
-             * rather than adding one at the top of the loop; the cap still
-             * costs measurable throughput and the measurement is recorded
-             * in docs/BENCHMARKS.md. */
+            /* The fuel test rides the exit branch that already exists rather
+             * than adding one at the top of the loop. That is a structural
+             * choice, not a measured one - the formulations were not
+             * separable above run-to-run noise; what IS measured is the cost
+             * of having a cap at all (docs/BENCHMARKS.md). */
             if (done || fuel-- == 0) {
                 break;
             }

--- a/src/lz4_decode.cuh
+++ b/src/lz4_decode.cuh
@@ -52,14 +52,22 @@ __global__ void __launch_bounds__(kBlockThreads)
      * __syncwarp().
      *
      * warp_in_grid above stays 32-bit, so this kernel additionally requires
-     * gridDim.x * blockDim.x <= 2^32; past that the index wraps and aliases
-     * two blocks onto one chunk. That bound is not enforced here because
-     * enforcing it is NOT free: widening the expression, or moving it below
-     * this guard, costs 4-6 registers and drops sm_86 occupancy from 40 to 36
-     * warps/SM (measured, docs/BENCHMARKS.md). decode_grid_blocks caps the
-     * shipped grid at 8192 blocks, four orders of magnitude clear of the
-     * bound, so it is a documented limit of this internal header rather than
-     * a reachable defect. */
+     * gridDim.x * blockDim.x <= 2^32. That bound is DOCUMENTED rather than
+     * enforced, and the reason is the asymmetry in what breaking it costs:
+     * past it the index wraps modulo 2^32, but the guard below has already
+     * forced blockDim.x to a multiple of kWarpSize, so the wrapped base stays
+     * warp-aligned and the aliased block recomputes the SAME warp_in_grid
+     * values with a full 0-31 lane range. Two blocks then decode one chunk
+     * redundantly and write byte-identical values to the same addresses -
+     * duplicated work, not missing bytes and not a hang, and the output stays
+     * bit-identical. Enforcing it costs an occupancy step: three spellings
+     * were measured (widening the expression, `total_warps > 1 << 27`, and a
+     * pure 32-bit `gridDim.x > UINT_MAX / blockDim.x`) and all three take the
+     * kernel from 48 to 52 registers, dropping sm_86 from 40 to 36 warps/SM
+     * (docs/BENCHMARKS.md). Trading real throughput on every launch against
+     * redundant-but-correct output on a geometry needing 33 million blocks -
+     * against a decode_grid_blocks cap of 8192, and unreachable through the
+     * public ABI - is not a trade worth making. */
     if (total_warps == 0 || blockDim.x % kWarpSize != 0) {
         return;
     }

--- a/src/lz4_decode.cuh
+++ b/src/lz4_decode.cuh
@@ -36,6 +36,14 @@ __global__ void __launch_bounds__(kBlockThreads)
         (blockIdx.x * blockDim.x + threadIdx.x) / kWarpSize;
     const size_t total_warps =
         (static_cast<size_t>(gridDim.x) * blockDim.x) / kWarpSize;
+    /* A launch geometry holding fewer than one whole warp makes the
+     * grid-stride below advance by zero and spin forever. The shipped entry
+     * always launches kBlockThreads, but the kernel must not depend on its
+     * caller for termination - and the check is lane-uniform, so it cannot
+     * strand lanes at a __syncwarp(). */
+    if (total_warps == 0) {
+        return;
+    }
 
     for (size_t chunk = warp_in_grid; chunk < chunk_count;
          chunk += total_warps) {
@@ -51,6 +59,14 @@ __global__ void __launch_bounds__(kBlockThreads)
         Lz4Sequence seq;
         cudec_status status = CUDEC_OK;
         bool done = false;
+        /* Fuel: Next consumes at least the token byte, so a chunk of n
+         * source bytes admits at most n + 1 calls - a budget no input the
+         * parser accepts or rejects can reach. It is lane-uniform (every
+         * lane parses the same bytes), so it cannot make one lane leave the
+         * loop early and strand the others at a __syncwarp() below. A hung
+         * warp is a fail-closed violation like an out-of-bounds read, and
+         * this is what makes a future parser bug a rejected chunk instead. */
+        uint64_t fuel = src_sizes[chunk] + 1;
         while (true) {
             status = parser.Next(&seq, &done);
             if (status != CUDEC_OK) {
@@ -73,9 +89,18 @@ __global__ void __launch_bounds__(kBlockThreads)
                     __syncwarp();
                 }
             }
-            if (done) {
+            /* The fuel test rides the exit branch that already exists
+             * rather than adding one at the top of the loop; the cap still
+             * costs measurable throughput and the measurement is recorded
+             * in docs/BENCHMARKS.md. */
+            if (done || fuel-- == 0) {
                 break;
             }
+        }
+        /* Fuel exhaustion is a reject, never a success: leaving the loop
+         * without `done` must not report the parse as complete. */
+        if (status == CUDEC_OK && !done) {
+            status = CUDEC_ERR_CORRUPT_INPUT;
         }
 
         /* All lanes agree on status and dst_pos (redundant parse); one lane

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -340,6 +340,9 @@ function(cudec_scan_source path check_loops out_violations)
   set(_previous "")
   set(_for_open 0)
   set(_for_semis 0)
+  set(_for_start 0)
+  set(_for_lines 0)
+  set(_for_text "")
   set(_lineno 0)
   file(STRINGS "${path}" _lines)
   foreach(_line IN LISTS _lines)
@@ -394,16 +397,31 @@ function(cudec_scan_source path check_loops out_violations)
         endif()
       endif()
       set(_form "")
+      set(_form_line ${_lineno})
       if(_for_open GREATER 0)
         # Continuation of a wrapped `for` header: keep counting until the
         # parenthesis closes, then judge the whole header at once.
         math(EXPR _for_semis "${_for_semis} + ${_line_semis}")
         math(EXPR _for_open "${_for_open} + ${_balance}")
+        math(EXPR _for_lines "${_for_lines} + 1")
+        string(APPEND _for_text " ${_code}")
+        set(_form_line ${_for_start})
         if(_for_open LESS_EQUAL 0)
           set(_for_open 0)
-          if(_for_semis LESS 2)
+          if(_for_semis LESS 2 AND NOT _for_text MATCHES ":")
             set(_form "a 'for' header without a visible condition and increment")
           endif()
+        elseif(_for_lines GREATER 8)
+          # Bail out rather than count forever. The scan does not strip string
+          # literals, so one unbalanced '(' inside a literal would otherwise
+          # leave this tracker open and silently disable the whole loop rule
+          # for the rest of the file - a fail-open in the one rule that exists
+          # to be fail-closed.
+          set(_for_open 0)
+          string(APPEND _violations
+                 "  ${path}:${_for_start}: a 'for' header whose closing "
+                 "parenthesis was not found within 8 lines - the scan cannot "
+                 "judge it, so it is rejected rather than skipped\n")
         endif()
       elseif(_code MATCHES "\\}[ \t]*while")
         # The tail of a do-while; its `do {` carries the requirement.
@@ -418,16 +436,21 @@ function(cudec_scan_source path check_loops out_violations)
         if(_balance GREATER 0)
           set(_for_open ${_balance})
           set(_for_semis ${_line_semis})
-          set(_pending_line ${_lineno})
-        elseif(_line_semis LESS 2)
+          set(_for_start ${_lineno})
+          set(_for_lines 1)
+          set(_for_text "${_code}")
+        elseif(_line_semis LESS 2 AND NOT _code MATCHES ":")
+          # A balanced header with fewer than two semicolons has no visible
+          # induction variable - a macro-hidden loop, say. A range-for
+          # (`for (T& x : container)`) is exempt by the ':': its bound is the
+          # container's size, loop-invariant and visible on the spot, exactly
+          # like the counted form.
           set(_form "a 'for' header without a visible condition and increment")
         endif()
       endif()
       if(_form AND NOT _code MATCHES "fuel" AND NOT _previous MATCHES "fuel")
         set(_pending_reason "${_form}")
-        if(_for_open EQUAL 0 AND NOT _pending_reason MATCHES "'for' header")
-          set(_pending_line ${_lineno})
-        endif()
+        set(_pending_line ${_form_line})
         set(_pending_left 3)
       endif()
       set(_previous "${_code}")
@@ -445,18 +468,39 @@ function(cudec_scan_source path check_loops out_violations)
       endif()
     endforeach()
 
-    if(_code MATCHES "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\([ \t]*$")
-      string(REGEX MATCH "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\([ \t]*$"
-                   _wrapped "${_code}")
-      string(APPEND _violations
-             "  ${path}:${_lineno}: '${CMAKE_MATCH_1}' is wrapped across "
-             "lines - this scan is line-scoped, so a wrapped call hides its "
-             "mask from every rule here; keep a collective on one line\n")
-    elseif(_code MATCHES "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(")
+    set(_tail_balance 0)
+    if(_code MATCHES "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(")
+      # Everything from the last collective's '(' to the end of the line. If
+      # its parentheses do not close there, the call is wrapped - and a
+      # wrapped call hides whatever follows the break from EVERY rule below,
+      # which are all line-scoped. Checking the balance rather than only
+      # '(' at end-of-line catches the wrap AFTER the mask, where the source
+      # lane and the predicate live:
+      #     __shfl_sync(0xFFFFFFFFu, value,
+      #                 seq.match_len % kWarpSize);
       string(REGEX MATCH "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(([^,)]*)"
                    _call "${_code}")
       set(_collective "${CMAKE_MATCH_1}")
       string(STRIP "${CMAKE_MATCH_2}" _mask)
+      string(REGEX REPLACE "^.*(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(" "("
+                   _call_tail "${_code}")
+      string(LENGTH "${_call_tail}" _tail_all)
+      string(REPLACE "(" "" _stripped "${_call_tail}")
+      string(LENGTH "${_stripped}" _tail_no_open)
+      string(REPLACE ")" "" _stripped "${_call_tail}")
+      string(LENGTH "${_stripped}" _tail_no_close)
+      math(EXPR _tail_opens "${_tail_all} - ${_tail_no_open}")
+      math(EXPR _tail_closes "${_tail_all} - ${_tail_no_close}")
+      math(EXPR _tail_balance "${_tail_opens} - ${_tail_closes}")
+    endif()
+    if(_code MATCHES "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\("
+       AND _tail_balance GREATER 0)
+      string(APPEND _violations
+             "  ${path}:${_lineno}: '${_collective}' is wrapped across "
+             "lines - this scan is line-scoped, so a wrapped call hides its "
+             "mask, source lane and predicate from every rule here; keep a "
+             "collective on one line\n")
+    elseif(_code MATCHES "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(")
       # An absent mask is the full warp, which only __syncwarp() may imply;
       # every other collective must name its participants.
       if(_mask STREQUAL "" AND NOT _collective STREQUAL "__syncwarp")
@@ -508,6 +552,15 @@ function(cudec_scan_source path check_loops out_violations)
            "  ${path}:${_pending_line}: ${_pending_reason} with no explicit "
            "decrementing 'fuel' cap\n")
   endif()
+  # A `for` header still open at end of file means the scan lost track of the
+  # parentheses and stopped enforcing the loop rule from that point on. Say so
+  # rather than return silently - a scanner that quietly stops checking is the
+  # failure mode these probes and this check exist to prevent.
+  if(check_loops AND _for_open GREATER 0)
+    string(APPEND _violations
+           "  ${path}:${_for_start}: a 'for' header left unbalanced at end of "
+           "file - the loop rule was not enforced below this line\n")
+  endif()
   set(${out_violations} "${_violations}" PARENT_SCOPE)
 endfunction()
 
@@ -535,6 +588,13 @@ file(
   "         outer < n;\n"
   "         outer++) {\n"
   "        total += outer;\n"
+  "    }\n"
+  "    for (const Block& block : blocks) {\n"
+  "        total += block.size;\n"
+  "    }\n"
+  "    for (const Block& wrapped :\n"
+  "         blocks) {\n"
+  "        total += wrapped.size;\n"
   "    }\n"
   "    unsigned fuel = n + 1;\n"
   "    while (fuel-- != 0) {\n"
@@ -608,6 +668,40 @@ file(WRITE ${_probe_dir}/scan_fp_half.cu
 file(WRITE ${_probe_dir}/scan_fp_atomic.cu
      "__device__ void probe(void* p) {\n"
      "    atomicAdd(static_cast<float*>(p), 1);\n" "}\n")
+# The remaining `for` branch: a balanced header with no visible induction
+# variable, single-line and wrapped. Both paths report the same rule but reach
+# it through different code, and the single-line one silently reported the
+# wrong line number until it got a probe of its own.
+file(WRITE ${_probe_dir}/scan_for_opaque.cu
+     "unsigned probe(const unsigned char* src) {\n"
+     "    unsigned count = 0;\n" "    for (EACH_CHUNK(chunk, src)) {\n"
+     "        count += chunk;\n" "    }\n" "    return count;\n" "}\n")
+file(WRITE ${_probe_dir}/scan_for_opaque_wrapped.cu
+     "unsigned probe(const unsigned char* src) {\n"
+     "    unsigned count = 0;\n" "    for (EACH_CHUNK(chunk,\n"
+     "                    src)) {\n" "        count += chunk;\n" "    }\n"
+     "    return count;\n" "}\n")
+# A `for` header the scan cannot balance must be rejected, not skipped: while
+# the tracker is open the whole loop rule is off, so a silent skip would
+# disable the termination check for the rest of the file. String literals are
+# deliberately not stripped, so an unbalanced '(' inside one is exactly how
+# this happens. Both exits are probed - the line cap and end of file.
+file(WRITE ${_probe_dir}/scan_for_unbalanced.cu
+     "void probe() {\n"
+     "    for (int i = 0; i < f(\"an unbalanced ( in a literal\"); i++) {\n"
+     "        g(1);\n" "        g(2);\n" "        g(3);\n" "        g(4);\n"
+     "        g(5);\n" "        g(6);\n" "        g(7);\n" "        g(8);\n"
+     "        g(9);\n" "    }\n" "}\n")
+file(WRITE ${_probe_dir}/scan_for_unbalanced_eof.cu
+     "void probe() {\n"
+     "    for (int i = 0; i < f(\"an unbalanced ( in a literal\"); i++) {\n"
+     "        g(i);\n" "    }\n" "}\n")
+# The wrap AFTER the mask: the mask itself is valid, so only a balance-based
+# wrapped-collective rule catches this one.
+file(WRITE ${_probe_dir}/scan_wrapped_after_mask.cu
+     "__device__ int probe(int v, Lz4Sequence seq) {\n"
+     "    return __shfl_sync(0xFFFFFFFFu, v,\n"
+     "                       seq.match_len % 32);\n" "}\n")
 
 cudec_scan_source(${_probe_dir}/scan_clean.cu TRUE _probe_clean)
 if(_probe_clean)
@@ -632,7 +726,12 @@ set(_scanner_probes
     "scan_missing_mask|has no mask argument on this line"
     "scan_fp_type|floating-point type 'float'"
     "scan_fp_half|floating-point type 'half'"
-    "scan_fp_atomic|floating-point atomic")
+    "scan_fp_atomic|floating-point atomic"
+    "scan_for_opaque|scan_for_opaque.cu:3: a 'for' header without a visible"
+    "scan_for_opaque_wrapped|scan_for_opaque_wrapped.cu:3: a 'for' header without a visible"
+    "scan_for_unbalanced|closing parenthesis was not found within 8 lines"
+    "scan_for_unbalanced_eof|left unbalanced at end of file"
+    "scan_wrapped_after_mask|is wrapped across lines")
 foreach(_entry IN LISTS _scanner_probes)
   string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")
   string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\2" _expected "${_entry}")
@@ -647,20 +746,24 @@ foreach(_entry IN LISTS _scanner_probes)
   endif()
 endforeach()
 
-# The decode path: the sources whose loops are driven by lengths and counts
-# read out of a hostile bitstream. Every device translation unit must be on
-# this list, so a new kernel cannot quietly escape the termination rule. The
-# checksum helper (src/xxhash32.h) is deliberately not on it - its loops walk
-# a caller-supplied buffer at a fixed stride with no stream-derived exit.
-set(_decode_path_sources lz4_block.h lz4_decode.cuh frame.cpp batch.cu
-                         stream.cpp)
-# Recursive, and every source extension the tree may grow: device code moves
-# to src/kernels/ from M1 (CLAUDE.md), and a non-recursive glob would make the
-# coverage assertion below pass vacuously over the first file that lands
-# there. Device code is recognised by CONTENT as well as by extension,
-# because the most termination-critical file in the tree today
-# (src/lz4_block.h) is a plain .h - an extension-only rule would scan a future
-# src/lz4_hc_block.h for collectives and floats but not for fuel.
+
+# Every source under src/ is scanned, and the termination rule applies to all
+# of them unless a file is EXPLICITLY exempted below. Opt-out rather than
+# opt-in on purpose: an opt-in list makes a new file invisible by default,
+# which is the wrong direction for a fail-closed rule and would have hidden
+# the first file to land in src/kernels/ (device code moves there from M1) or
+# any future decode header that is a plain .h, like src/lz4_block.h is today.
+# Each exemption carries its reason and is reviewed when it is added.
+#
+#  - xxhash32.h: its loops walk a caller-supplied buffer at a fixed stride
+#    with no stream-derived exit condition, and it is a checksum helper rather
+#    than a decoder.
+#  - cuda_raii.h: its only `do` is the `do { ... } while (0)` wrapper that
+#    makes the CUDA-error-check macro a single statement - an idiom, not a
+#    loop.
+#
+# Both are still held to the warp-collective and floating-point rules.
+set(_loop_rule_exempt xxhash32.h cuda_raii.h)
 file(GLOB_RECURSE _all_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
      CONFIGURE_DEPENDS
      ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c
@@ -675,39 +778,25 @@ if(NOT _all_sources)
   message(FATAL_ERROR "the structural scan found no sources under src/ - the "
                       "glob has stopped matching (issue #72)")
 endif()
-foreach(_source IN LISTS _all_sources)
-  if(_source IN_LIST _decode_path_sources)
-    continue()
-  endif()
-  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source} _source_text)
-  if(_source MATCHES "\\.(cu|cuh)$" OR _source_text MATCHES
-                                       "__global__|__device__|CUDEC_HOST_DEVICE")
-    message(
-      FATAL_ERROR
-        "src/${_source} carries device code but is not on the decode-path "
-        "scan list in tests/CMakeLists.txt - add it, or move the device code "
-        "out (issue #72)")
+# An exemption for a file that no longer exists is stale and hides nothing;
+# say so rather than carry it silently.
+foreach(_exempt IN LISTS _loop_rule_exempt)
+  if(NOT _exempt IN_LIST _all_sources)
+    message(FATAL_ERROR "src/${_exempt} is exempt from the termination rule "
+                        "but no longer exists - drop the exemption "
+                        "(issue #72)")
   endif()
 endforeach()
 
 set(_structural_violations "")
-foreach(_source IN LISTS _decode_path_sources)
-  set(_path ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source})
-  if(NOT EXISTS ${_path})
-    message(FATAL_ERROR "src/${_source} is on the decode-path scan list but "
-                        "does not exist (issue #72)")
-  endif()
-  cudec_scan_source(${_path} TRUE _found)
-  string(APPEND _structural_violations "${_found}")
-endforeach()
-# The remaining sources are held to the collective and floating-point rules
-# only; the termination rule is scoped above.
 foreach(_source IN LISTS _all_sources)
-  if(NOT _source IN_LIST _decode_path_sources)
-    cudec_scan_source(${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source} FALSE
-                      _found)
-    string(APPEND _structural_violations "${_found}")
+  set(_check_loops TRUE)
+  if(_source IN_LIST _loop_rule_exempt)
+    set(_check_loops FALSE)
   endif()
+  cudec_scan_source(${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source}
+                    ${_check_loops} _found)
+  string(APPEND _structural_violations "${_found}")
 endforeach()
 if(_structural_violations)
   message(FATAL_ERROR "structural rules violated (issue #72):\n"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -296,8 +296,9 @@ endforeach()
 # rules (issue #72). Same honest scope as the checks above: drift detectors
 # under the known spellings, not tamper-proofing. Every rule below is applied
 # by ONE scanning function, which is then run over inline probe files that
-# must and must not trip it - a detector that silently stopped matching would
-# reassure forever, exactly like a dead warnings gate.
+# must and must not trip it - and each violating probe is matched against the
+# TEXT its rule emits, not merely against a non-empty result, so one rule
+# cannot cover for another that has quietly stopped matching.
 
 # Scans one source and returns every structural violation it finds. Comments
 # are stripped first, so prose ("never double-frees", "decode loops
@@ -318,14 +319,17 @@ endforeach()
 #    lanes participate at all), and a collective's mask must be a full-warp
 #    constant or __activemask(), never a value named after a parsed bitstream
 #    field - corrupting collective participation metadata is a published
-#    attack on CUDA kernels that leaves control flow untouched;
+#    attack on CUDA kernels that leaves control flow untouched. A collective
+#    wrapped across lines is a violation in itself: the scan is line-scoped,
+#    so a wrapped call would hide its mask from every rule here;
 #  - determinism: no floating-point type and no floating-point atomic, which
 #    is what makes the gpu_to_gpu level in docs/DETERMINISM.md hold by
 #    construction rather than by measurement.
 #
 # Limits, stated as the neighbouring checks state theirs: constructs hidden
 # inside string literals are not stripped; a mask computed into a variable on
-# an earlier line is judged by its name at the call site; and a loop or
+# an earlier line is judged by its name at the call site; a `fuel` mention on
+# the line above an unrelated loop satisfies the loop rule; and a loop or
 # intrinsic introduced under a fresh spelling is code review's job.
 function(cudec_scan_source path check_loops out_violations)
   set(_violations "")
@@ -334,6 +338,8 @@ function(cudec_scan_source path check_loops out_violations)
   set(_pending_line 0)
   set(_pending_left 0)
   set(_previous "")
+  set(_for_open 0)
+  set(_for_semis 0)
   set(_lineno 0)
   file(STRINGS "${path}" _lines)
   foreach(_line IN LISTS _lines)
@@ -359,6 +365,21 @@ function(cudec_scan_source path check_loops out_violations)
     endif()
     set(_code " ${_line} ")
 
+    # Parenthesis balance and semicolon count of this line, used to follow a
+    # loop header that wrapped at the 80-column limit instead of misreading
+    # its first line as a header without a condition.
+    string(LENGTH "${_code}" _len_all)
+    string(REPLACE "(" "" _stripped "${_code}")
+    string(LENGTH "${_stripped}" _len_no_open)
+    string(REPLACE ")" "" _stripped "${_code}")
+    string(LENGTH "${_stripped}" _len_no_close)
+    string(REPLACE ";" "" _stripped "${_code}")
+    string(LENGTH "${_stripped}" _len_no_semi)
+    math(EXPR _opens "${_len_all} - ${_len_no_open}")
+    math(EXPR _closes "${_len_all} - ${_len_no_close}")
+    math(EXPR _balance "${_opens} - ${_closes}")
+    math(EXPR _line_semis "${_len_all} - ${_len_no_semi}")
+
     if(check_loops)
       if(_pending_left GREATER 0)
         if(_code MATCHES "fuel")
@@ -373,49 +394,77 @@ function(cudec_scan_source path check_loops out_violations)
         endif()
       endif()
       set(_form "")
-      if(_code MATCHES "\\}[ \t]*while")
+      if(_for_open GREATER 0)
+        # Continuation of a wrapped `for` header: keep counting until the
+        # parenthesis closes, then judge the whole header at once.
+        math(EXPR _for_semis "${_for_semis} + ${_line_semis}")
+        math(EXPR _for_open "${_for_open} + ${_balance}")
+        if(_for_open LESS_EQUAL 0)
+          set(_for_open 0)
+          if(_for_semis LESS 2)
+            set(_form "a 'for' header without a visible condition and increment")
+          endif()
+        endif()
+      elseif(_code MATCHES "\\}[ \t]*while")
         # The tail of a do-while; its `do {` carries the requirement.
       elseif(_code MATCHES "[^A-Za-z_0-9]while[ \t]*\\(")
         set(_form "a 'while' loop")
       elseif(_code MATCHES "[^A-Za-z_0-9]do[ \t]*{")
         set(_form "a 'do' loop")
       elseif(_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\([^)]*;[ \t]*;")
+        # Covers both `for (;;)` and `for (init;; incr)`.
         set(_form "a 'for' loop with an empty condition")
-      elseif(_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\([ \t]*;")
-        set(_form "a 'for (;;)' loop")
       elseif(_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\(")
-        string(REPLACE ";" "" _no_semis "${_code}")
-        string(LENGTH "${_code}" _with_len)
-        string(LENGTH "${_no_semis}" _without_len)
-        math(EXPR _semis "${_with_len} - ${_without_len}")
-        if(_semis LESS 2)
+        if(_balance GREATER 0)
+          set(_for_open ${_balance})
+          set(_for_semis ${_line_semis})
+          set(_pending_line ${_lineno})
+        elseif(_line_semis LESS 2)
           set(_form "a 'for' header without a visible condition and increment")
         endif()
       endif()
       if(_form AND NOT _code MATCHES "fuel" AND NOT _previous MATCHES "fuel")
         set(_pending_reason "${_form}")
-        set(_pending_line ${_lineno})
+        if(_for_open EQUAL 0 AND NOT _pending_reason MATCHES "'for' header")
+          set(_pending_line ${_lineno})
+        endif()
         set(_pending_left 3)
       endif()
       set(_previous "${_code}")
     endif()
 
+    # The legacy intrinsics, matched on the identifier rather than on a
+    # following "(": a call wrapped as `__shfl\n    (v, 0)` is the same
+    # violation, and the _sync forms end in "_sync" so they never match here.
     foreach(_legacy __shfl __shfl_up __shfl_down __shfl_xor __ballot __any
                     __all __match_any)
-      if(_code MATCHES "${_legacy}[ \t]*\\(")
+      if(_code MATCHES "[^A-Za-z_0-9]${_legacy}[^A-Za-z_0-9]")
         string(APPEND _violations
-               "  ${path}:${_lineno}: legacy warp intrinsic '${_legacy}(' - "
+               "  ${path}:${_lineno}: legacy warp intrinsic '${_legacy}' - "
                "only the _sync form can state which lanes participate\n")
       endif()
     endforeach()
 
-    if(_code MATCHES "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(")
+    if(_code MATCHES "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\([ \t]*$")
+      string(REGEX MATCH "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\([ \t]*$"
+                   _wrapped "${_code}")
+      string(APPEND _violations
+             "  ${path}:${_lineno}: '${CMAKE_MATCH_1}' is wrapped across "
+             "lines - this scan is line-scoped, so a wrapped call hides its "
+             "mask from every rule here; keep a collective on one line\n")
+    elseif(_code MATCHES "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(")
       string(REGEX MATCH "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(([^,)]*)"
                    _call "${_code}")
       set(_collective "${CMAKE_MATCH_1}")
       string(STRIP "${CMAKE_MATCH_2}" _mask)
-      if(NOT _mask STREQUAL "" AND NOT _mask MATCHES
-         "^(0[xX][fF][fF][fF][fF][fF][fF][fF][fF][uU]?|kFullWarpMask|__activemask\\(?)$")
+      # An absent mask is the full warp, which only __syncwarp() may imply;
+      # every other collective must name its participants.
+      if(_mask STREQUAL "" AND NOT _collective STREQUAL "__syncwarp")
+        string(APPEND _violations
+               "  ${path}:${_lineno}: '${_collective}' has no mask argument "
+               "on this line - only __syncwarp may imply the full warp\n")
+      elseif(NOT _mask STREQUAL "" AND NOT _mask MATCHES
+             "^(0[xX][fF][fF][fF][fF][fF][fF][fF][fF][uU]?|kFullWarpMask|__activemask\\(?)$")
         string(APPEND _violations
                "  ${path}:${_lineno}: '${_collective}' mask '${_mask}' is "
                "neither the full-warp constant nor __activemask()\n")
@@ -436,7 +485,10 @@ function(cudec_scan_source path check_loops out_violations)
       endif()
     endif()
 
-    foreach(_fp float double __half __half2 __nv_bfloat16 __nv_bfloat162)
+    # CUDA spells its half type four ways and C23 adds a fifth; all of them
+    # reintroduce the reassociation the gpu_to_gpu level rules out.
+    foreach(_fp float double half half2 __half __half2 __nv_bfloat16
+                __nv_bfloat162 _Float16 __nv_fp8_e4m3 __nv_fp8_e5m2)
       if(_code MATCHES "[^A-Za-z_0-9]${_fp}[^A-Za-z_0-9]")
         string(APPEND _violations
                "  ${path}:${_lineno}: floating-point type '${_fp}' - the "
@@ -444,8 +496,8 @@ function(cudec_scan_source path check_loops out_violations)
                "gpu_to_gpu determinism level hold (docs/DETERMINISM.md)\n")
       endif()
     endforeach()
-    if(_code MATCHES "atomic[A-Za-z]*[ \t]*\\(" AND _code MATCHES
-                                                   "(float|double|__half|__nv_bfloat16)")
+    if(_code MATCHES "atomic[A-Za-z]*[ \t]*\\("
+       AND _code MATCHES "[^A-Za-z_0-9](float|double|half|__half|__nv_bfloat16|_Float16)[^A-Za-z_0-9]")
       string(APPEND _violations
              "  ${path}:${_lineno}: floating-point atomic - its result "
              "depends on the order the device happens to schedule\n")
@@ -460,10 +512,15 @@ function(cudec_scan_source path check_loops out_violations)
 endfunction()
 
 # Liveness probes for the scanner itself, in the same spirit as the
-# warnings-gate control TU above: the clean probe must come back silent
-# (including its comment full of the very keywords the rules match), and each
-# violating probe must come back naming its rule. These files are scanned as
-# text and never compiled.
+# warnings-gate control TU above. The clean probe must come back silent -
+# including its comment full of the very keywords the rules match, and
+# including a legitimately wrapped `for` header, which an earlier revision of
+# this scanner reported as a header without a condition. Each violating probe
+# must come back with the TEXT of the rule it violates: asserting only
+# non-emptiness let the floating-point-atomic rule ride on the
+# floating-point-TYPE rule firing on the same probe's signature, which is
+# exactly the kind of silently-dead sub-rule these probes exist to catch.
+# These files are scanned as text and never compiled.
 set(_probe_dir ${CMAKE_CURRENT_BINARY_DIR}/probes)
 file(
   WRITE ${_probe_dir}/scan_clean.cu
@@ -473,6 +530,11 @@ file(
   "    unsigned total = 0;\n"
   "    for (unsigned i = 0; i < n; i++) {\n"
   "        total += i;\n"
+  "    }\n"
+  "    for (unsigned outer = 0;\n"
+  "         outer < n;\n"
+  "         outer++) {\n"
+  "        total += outer;\n"
   "    }\n"
   "    unsigned fuel = n + 1;\n"
   "    while (fuel-- != 0) {\n"
@@ -492,8 +554,10 @@ file(
   "    __syncwarp();\n"
   "    return __shfl_sync(0xFFFFFFFFu, v, 0);\n"
   "}\n")
+
+# One probe per sub-rule, each paired with the text it must produce.
 file(
-  WRITE ${_probe_dir}/scan_unbounded_loop.cu
+  WRITE ${_probe_dir}/scan_loop_while.cu
   "unsigned probe(const unsigned char* src, unsigned n) {\n"
   "    unsigned count = src[0];\n"
   "    while (count != 0) {\n"
@@ -501,14 +565,49 @@ file(
   "    }\n"
   "    return count;\n"
   "}\n")
+file(
+  WRITE ${_probe_dir}/scan_loop_do.cu
+  "unsigned probe(const unsigned char* src, unsigned n) {\n"
+  "    unsigned count = src[0];\n"
+  "    do {\n"
+  "        count += src[count % n];\n"
+  "    } while (count != 0);\n"
+  "    return count;\n"
+  "}\n")
+file(WRITE ${_probe_dir}/scan_loop_forever.cu
+     "unsigned probe(const unsigned char* src) {\n"
+     "    unsigned count = 0;\n" "    for (;;) {\n"
+     "        count += src[count];\n" "    }\n" "    return count;\n" "}\n")
+file(WRITE ${_probe_dir}/scan_loop_empty_condition.cu
+     "unsigned probe(const unsigned char* src) {\n"
+     "    unsigned count = 0;\n" "    for (unsigned i = 0;; i++) {\n"
+     "        count += src[i];\n" "    }\n" "    return count;\n" "}\n")
 file(WRITE ${_probe_dir}/scan_legacy_intrinsic.cu
      "__device__ int probe(int v) {\n" "    return __shfl(v, 0);\n" "}\n")
+file(WRITE ${_probe_dir}/scan_legacy_intrinsic_wrapped.cu
+     "__device__ int probe(int v) {\n" "    return __ballot\n"
+     "        (v > 0);\n" "}\n")
 file(WRITE ${_probe_dir}/scan_derived_mask.cu
      "__device__ int probe(int v, unsigned mask_bits) {\n"
      "    return __shfl_sync(mask_bits, v, 0);\n" "}\n")
-file(WRITE ${_probe_dir}/scan_floating_point.cu
-     "__device__ void probe(float* acc, float v) {\n"
-     "    atomicAdd(acc, v);\n" "}\n")
+file(WRITE ${_probe_dir}/scan_bitstream_field.cu
+     "__device__ int probe(int v, unsigned offset) {\n"
+     "    return __shfl_sync(0xFFFFFFFFu, v, offset);\n" "}\n")
+file(WRITE ${_probe_dir}/scan_sequence_field.cu
+     "__device__ int probe(int v, Lz4Sequence seq) {\n"
+     "    return __shfl_sync(0xFFFFFFFFu, v, seq.lane);\n" "}\n")
+file(WRITE ${_probe_dir}/scan_wrapped_collective.cu
+     "__device__ int probe(int v, unsigned mask_from_token) {\n"
+     "    return __shfl_sync(\n" "        mask_from_token, v, 0);\n" "}\n")
+file(WRITE ${_probe_dir}/scan_missing_mask.cu
+     "__device__ int probe(int v) {\n" "    return __shfl_sync();\n" "}\n")
+file(WRITE ${_probe_dir}/scan_fp_type.cu
+     "__device__ float probe(float a) {\n" "    return a + a;\n" "}\n")
+file(WRITE ${_probe_dir}/scan_fp_half.cu
+     "__device__ void probe(half* acc) {\n" "    *acc = *acc;\n" "}\n")
+file(WRITE ${_probe_dir}/scan_fp_atomic.cu
+     "__device__ void probe(void* p) {\n"
+     "    atomicAdd(static_cast<float*>(p), 1);\n" "}\n")
 
 cudec_scan_source(${_probe_dir}/scan_clean.cu TRUE _probe_clean)
 if(_probe_clean)
@@ -517,31 +616,77 @@ if(_probe_clean)
       "the structural scanner rejects a compliant probe - fix the scanner "
       "before trusting it:\n${_probe_clean}")
 endif()
-foreach(_probe scan_unbounded_loop scan_legacy_intrinsic scan_derived_mask
-               scan_floating_point)
+# "probe|the text its rule must emit" - '|' rather than ';' because CMake
+# would split a list element on the latter.
+set(_scanner_probes
+    "scan_loop_while|a 'while' loop with no explicit decrementing 'fuel' cap"
+    "scan_loop_do|a 'do' loop with no explicit decrementing 'fuel' cap"
+    "scan_loop_forever|a 'for' loop with an empty condition with no explicit"
+    "scan_loop_empty_condition|a 'for' loop with an empty condition with no explicit"
+    "scan_legacy_intrinsic|legacy warp intrinsic '__shfl'"
+    "scan_legacy_intrinsic_wrapped|legacy warp intrinsic '__ballot'"
+    "scan_derived_mask|mask 'mask_bits' is neither the full-warp constant"
+    "scan_bitstream_field|names the parsed bitstream field 'offset'"
+    "scan_sequence_field|reads a parsed sequence field"
+    "scan_wrapped_collective|is wrapped across lines"
+    "scan_missing_mask|has no mask argument on this line"
+    "scan_fp_type|floating-point type 'float'"
+    "scan_fp_half|floating-point type 'half'"
+    "scan_fp_atomic|floating-point atomic")
+foreach(_entry IN LISTS _scanner_probes)
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\2" _expected "${_entry}")
   cudec_scan_source(${_probe_dir}/${_probe}.cu TRUE _probe_result)
-  if(NOT _probe_result)
-    message(FATAL_ERROR "the structural scanner is dead: probe '${_probe}' "
-                        "passed clean (issue #72)")
+  string(FIND "${_probe_result}" "${_expected}" _found_at)
+  if(_found_at EQUAL -1)
+    message(
+      FATAL_ERROR
+        "the structural scanner is dead for one rule: probe '${_probe}' did "
+        "not report \"${_expected}\" (issue #72). It reported:\n"
+        "${_probe_result}")
   endif()
 endforeach()
 
 # The decode path: the sources whose loops are driven by lengths and counts
 # read out of a hostile bitstream. Every device translation unit must be on
-# this list, so a new kernel cannot quietly escape the termination rule; the
+# this list, so a new kernel cannot quietly escape the termination rule. The
 # checksum helper (src/xxhash32.h) is deliberately not on it - its loops walk
 # a caller-supplied buffer at a fixed stride with no stream-derived exit.
 set(_decode_path_sources lz4_block.h lz4_decode.cuh frame.cpp batch.cu
                          stream.cpp)
-file(GLOB _device_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
-     CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cu
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cuh)
-foreach(_device_source IN LISTS _device_sources)
-  if(NOT _device_source IN_LIST _decode_path_sources)
+# Recursive, and every source extension the tree may grow: device code moves
+# to src/kernels/ from M1 (CLAUDE.md), and a non-recursive glob would make the
+# coverage assertion below pass vacuously over the first file that lands
+# there. Device code is recognised by CONTENT as well as by extension,
+# because the most termination-critical file in the tree today
+# (src/lz4_block.h) is a plain .h - an extension-only rule would scan a future
+# src/lz4_hc_block.h for collectives and floats but not for fuel.
+file(GLOB_RECURSE _all_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+     CONFIGURE_DEPENDS
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cc
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cu
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cuh
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.h
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.hpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.inl)
+if(NOT _all_sources)
+  message(FATAL_ERROR "the structural scan found no sources under src/ - the "
+                      "glob has stopped matching (issue #72)")
+endif()
+foreach(_source IN LISTS _all_sources)
+  if(_source IN_LIST _decode_path_sources)
+    continue()
+  endif()
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source} _source_text)
+  if(_source MATCHES "\\.(cu|cuh)$" OR _source_text MATCHES
+                                       "__global__|__device__|CUDEC_HOST_DEVICE")
     message(
       FATAL_ERROR
-        "src/${_device_source} is device code but is not on the decode-path "
-        "scan list in tests/CMakeLists.txt - add it (issue #72)")
+        "src/${_source} carries device code but is not on the decode-path "
+        "scan list in tests/CMakeLists.txt - add it, or move the device code "
+        "out (issue #72)")
   endif()
 endforeach()
 
@@ -557,11 +702,7 @@ foreach(_source IN LISTS _decode_path_sources)
 endforeach()
 # The remaining sources are held to the collective and floating-point rules
 # only; the termination rule is scoped above.
-file(GLOB _other_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
-     CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cpp
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.h)
-foreach(_source IN LISTS _other_sources)
+foreach(_source IN LISTS _all_sources)
   if(NOT _source IN_LIST _decode_path_sources)
     cudec_scan_source(${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source} FALSE
                       _found)
@@ -573,5 +714,6 @@ if(_structural_violations)
                       "${_structural_violations}")
 endif()
 
-# Finally: no ctest entry in this directory may be without a timeout.
+# Records this directory's ctest entries as timeout-checked; the sweep at the
+# end of the top-level CMakeLists.txt is what makes the property unforgettable.
 cudec_assert_test_timeouts()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,8 @@ function(cudec_add_test name)
     target_link_options(${name} PRIVATE ${CUDEC_SANITIZE_LINK_FLAGS})
   endif()
   add_test(NAME ${name} COMMAND ${name})
+  set_tests_properties(${name} PROPERTIES TIMEOUT
+                                          ${CUDEC_TEST_TIMEOUT_SECONDS})
   if(T_GPU)
     set_tests_properties(${name} PROPERTIES LABELS gpu RUN_SERIAL TRUE)
   endif()
@@ -124,6 +126,14 @@ target_include_directories(parser_twin
 cudec_add_test(frame_host_negative SOURCES frame_host_negative.cpp)
 target_include_directories(frame_host_negative
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# Termination as a tested invariant (issue #72): the parser's liveness
+# contract asserted per call over the truncation ladder, the mutant corpus,
+# the crafted hostile corpus, and the frame block-table walk - all of it
+# rejecting (or assembling all-uncompressed) before the first CUDA call, so
+# it runs on the GPU-less runner and under the sanitizer gate.
+cudec_add_test(termination SOURCES termination.cpp LIBS cudec_test_fixtures)
+target_include_directories(termination
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 cudec_add_test(launch_fail SOURCES launch_fail.cpp)
 # Belt and suspenders with the setenv inside launch_fail.cpp: zero visible
 # devices is the test condition, on the GPU machine too.
@@ -141,6 +151,27 @@ if(TARGET frame_twin)
                              PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 endif()
 cudec_add_test(stream_twin SOURCES stream_twin.cu LIBS cudec_test_fixtures GPU)
+# The same hostile corpus on the device, behind a host-side watchdog: a warp
+# that never leaves its sequence loop holds the launch, so this one polls an
+# event against a deadline instead of blocking on the stream (issue #72).
+cudec_add_test(termination_gpu SOURCES termination_gpu.cu LIBS
+               cudec_test_fixtures GPU)
+# It also launches the kernel directly, to reach a geometry the shipped entry
+# point never produces (fewer threads than one warp), so it needs the internal
+# header from src/.
+if(TARGET termination_gpu)
+  target_include_directories(termination_gpu
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+endif()
+# Determinism across launch geometry - the axis the existing same-batch-twice
+# compare cannot see. It launches the shipped kernel directly, so it needs the
+# internal header from src/ (like bench/ does).
+cudec_add_test(determinism_gpu SOURCES determinism_gpu.cu LIBS
+               cudec_test_fixtures GPU)
+if(TARGET determinism_gpu)
+  target_include_directories(determinism_gpu
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+endif()
 
 # ---- Structural conformance, configure time: a violation reds every CI
 # build. These are drift detectors, not tamper-proofing - the honest limits
@@ -260,3 +291,287 @@ foreach(_tu frame.cpp stream.cpp)
     endif()
   endforeach()
 endforeach()
+
+# ---- Termination, warp-collective integrity, and determinism as structural
+# rules (issue #72). Same honest scope as the checks above: drift detectors
+# under the known spellings, not tamper-proofing. Every rule below is applied
+# by ONE scanning function, which is then run over inline probe files that
+# must and must not trip it - a detector that silently stopped matching would
+# reassure forever, exactly like a dead warnings gate.
+
+# Scans one source and returns every structural violation it finds. Comments
+# are stripped first, so prose ("never double-frees", "decode loops
+# terminate") can neither trip a rule nor mask one. `check_loops` selects the
+# termination rule, which is scoped to the decode path rather than to every
+# helper.
+#
+# Rules:
+#  - loops: a counted `for (init; cond; incr)` is accepted on its visible
+#    induction variable; every other loop form (`while`, `do {`, a `for`
+#    header with an empty condition) must name an explicit decrementing
+#    `fuel` counter on its own line, the line above it, or the three below,
+#    because a text scan cannot verify a monotone-cursor argument and a
+#    non-terminating decode hangs the device (nvCOMP 5.3's release notes
+#    record shipping exactly that on malformed Snappy input);
+#  - warp collectives: the legacy non-_sync intrinsics are banned outright
+#    (since Volta's independent thread scheduling they cannot express which
+#    lanes participate at all), and a collective's mask must be a full-warp
+#    constant or __activemask(), never a value named after a parsed bitstream
+#    field - corrupting collective participation metadata is a published
+#    attack on CUDA kernels that leaves control flow untouched;
+#  - determinism: no floating-point type and no floating-point atomic, which
+#    is what makes the gpu_to_gpu level in docs/DETERMINISM.md hold by
+#    construction rather than by measurement.
+#
+# Limits, stated as the neighbouring checks state theirs: constructs hidden
+# inside string literals are not stripped; a mask computed into a variable on
+# an earlier line is judged by its name at the call site; and a loop or
+# intrinsic introduced under a fresh spelling is code review's job.
+function(cudec_scan_source path check_loops out_violations)
+  set(_violations "")
+  set(_in_comment FALSE)
+  set(_pending_reason "")
+  set(_pending_line 0)
+  set(_pending_left 0)
+  set(_previous "")
+  set(_lineno 0)
+  file(STRINGS "${path}" _lines)
+  foreach(_line IN LISTS _lines)
+    math(EXPR _lineno "${_lineno} + 1")
+    if(_in_comment)
+      if(_line MATCHES "\\*/")
+        string(REGEX REPLACE "^.*\\*/" " " _line "${_line}")
+        set(_in_comment FALSE)
+      else()
+        set(_line "")
+      endif()
+    endif()
+    string(REGEX REPLACE "//.*$" " " _line "${_line}")
+    if(_line MATCHES "/\\*")
+      string(REGEX REPLACE "/\\*.*$" " " _head "${_line}")
+      if(_line MATCHES "/\\*.*\\*/")
+        string(REGEX REPLACE "^.*\\*/" " " _tail "${_line}")
+        set(_line "${_head} ${_tail}")
+      else()
+        set(_line "${_head}")
+        set(_in_comment TRUE)
+      endif()
+    endif()
+    set(_code " ${_line} ")
+
+    if(check_loops)
+      if(_pending_left GREATER 0)
+        if(_code MATCHES "fuel")
+          set(_pending_left 0)
+        else()
+          math(EXPR _pending_left "${_pending_left} - 1")
+          if(_pending_left EQUAL 0)
+            string(APPEND _violations
+                   "  ${path}:${_pending_line}: ${_pending_reason} with no "
+                   "explicit decrementing 'fuel' cap\n")
+          endif()
+        endif()
+      endif()
+      set(_form "")
+      if(_code MATCHES "\\}[ \t]*while")
+        # The tail of a do-while; its `do {` carries the requirement.
+      elseif(_code MATCHES "[^A-Za-z_0-9]while[ \t]*\\(")
+        set(_form "a 'while' loop")
+      elseif(_code MATCHES "[^A-Za-z_0-9]do[ \t]*{")
+        set(_form "a 'do' loop")
+      elseif(_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\([^)]*;[ \t]*;")
+        set(_form "a 'for' loop with an empty condition")
+      elseif(_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\([ \t]*;")
+        set(_form "a 'for (;;)' loop")
+      elseif(_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\(")
+        string(REPLACE ";" "" _no_semis "${_code}")
+        string(LENGTH "${_code}" _with_len)
+        string(LENGTH "${_no_semis}" _without_len)
+        math(EXPR _semis "${_with_len} - ${_without_len}")
+        if(_semis LESS 2)
+          set(_form "a 'for' header without a visible condition and increment")
+        endif()
+      endif()
+      if(_form AND NOT _code MATCHES "fuel" AND NOT _previous MATCHES "fuel")
+        set(_pending_reason "${_form}")
+        set(_pending_line ${_lineno})
+        set(_pending_left 3)
+      endif()
+      set(_previous "${_code}")
+    endif()
+
+    foreach(_legacy __shfl __shfl_up __shfl_down __shfl_xor __ballot __any
+                    __all __match_any)
+      if(_code MATCHES "${_legacy}[ \t]*\\(")
+        string(APPEND _violations
+               "  ${path}:${_lineno}: legacy warp intrinsic '${_legacy}(' - "
+               "only the _sync form can state which lanes participate\n")
+      endif()
+    endforeach()
+
+    if(_code MATCHES "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(")
+      string(REGEX MATCH "(__[A-Za-z_0-9]*_sync|__syncwarp)[ \t]*\\(([^,)]*)"
+                   _call "${_code}")
+      set(_collective "${CMAKE_MATCH_1}")
+      string(STRIP "${CMAKE_MATCH_2}" _mask)
+      if(NOT _mask STREQUAL "" AND NOT _mask MATCHES
+         "^(0[xX][fF][fF][fF][fF][fF][fF][fF][fF][uU]?|kFullWarpMask|__activemask\\(?)$")
+        string(APPEND _violations
+               "  ${path}:${_lineno}: '${_collective}' mask '${_mask}' is "
+               "neither the full-warp constant nor __activemask()\n")
+      endif()
+      foreach(_field token offset literals_len match_len src_pos dst_pos)
+        if(_code MATCHES "[^A-Za-z_0-9]${_field}[^A-Za-z_0-9]")
+          string(APPEND _violations
+                 "  ${path}:${_lineno}: '${_collective}' names the parsed "
+                 "bitstream field '${_field}' - participation metadata must "
+                 "never come from unvalidated input\n")
+        endif()
+      endforeach()
+      if(_code MATCHES "[^A-Za-z_0-9](seq|sequence|parser)\\.")
+        string(APPEND _violations
+               "  ${path}:${_lineno}: '${_collective}' reads a parsed "
+               "sequence field - participation metadata must never come from "
+               "unvalidated input\n")
+      endif()
+    endif()
+
+    foreach(_fp float double __half __half2 __nv_bfloat16 __nv_bfloat162)
+      if(_code MATCHES "[^A-Za-z_0-9]${_fp}[^A-Za-z_0-9]")
+        string(APPEND _violations
+               "  ${path}:${_lineno}: floating-point type '${_fp}' - the "
+               "decode path is integer-only, which is what makes the "
+               "gpu_to_gpu determinism level hold (docs/DETERMINISM.md)\n")
+      endif()
+    endforeach()
+    if(_code MATCHES "atomic[A-Za-z]*[ \t]*\\(" AND _code MATCHES
+                                                   "(float|double|__half|__nv_bfloat16)")
+      string(APPEND _violations
+             "  ${path}:${_lineno}: floating-point atomic - its result "
+             "depends on the order the device happens to schedule\n")
+    endif()
+  endforeach()
+  if(check_loops AND _pending_left GREATER 0)
+    string(APPEND _violations
+           "  ${path}:${_pending_line}: ${_pending_reason} with no explicit "
+           "decrementing 'fuel' cap\n")
+  endif()
+  set(${out_violations} "${_violations}" PARENT_SCOPE)
+endfunction()
+
+# Liveness probes for the scanner itself, in the same spirit as the
+# warnings-gate control TU above: the clean probe must come back silent
+# (including its comment full of the very keywords the rules match), and each
+# violating probe must come back naming its rule. These files are scanned as
+# text and never compiled.
+set(_probe_dir ${CMAKE_CURRENT_BINARY_DIR}/probes)
+file(
+  WRITE ${_probe_dir}/scan_clean.cu
+  "/* Prose naming while, do, for, float, double, __shfl( and a mask from a\n"
+  " * token - the comment stripper must remove all of it. */\n"
+  "unsigned probe_counted(unsigned n) {\n"
+  "    unsigned total = 0;\n"
+  "    for (unsigned i = 0; i < n; i++) {\n"
+  "        total += i;\n"
+  "    }\n"
+  "    unsigned fuel = n + 1;\n"
+  "    while (fuel-- != 0) {\n"
+  "        total += 1;\n"
+  "    }\n"
+  "    unsigned left = n;\n"
+  "    unsigned fuel_drain = n + 1;\n"
+  "    do {\n"
+  "        if (fuel_drain-- == 0) {\n"
+  "            break;\n"
+  "        }\n"
+  "        left = left - 1;\n"
+  "    } while (left != 0);\n"
+  "    return total;\n"
+  "}\n"
+  "__device__ int probe_collective(int v) {\n"
+  "    __syncwarp();\n"
+  "    return __shfl_sync(0xFFFFFFFFu, v, 0);\n"
+  "}\n")
+file(
+  WRITE ${_probe_dir}/scan_unbounded_loop.cu
+  "unsigned probe(const unsigned char* src, unsigned n) {\n"
+  "    unsigned count = src[0];\n"
+  "    while (count != 0) {\n"
+  "        count += src[count % n];\n"
+  "    }\n"
+  "    return count;\n"
+  "}\n")
+file(WRITE ${_probe_dir}/scan_legacy_intrinsic.cu
+     "__device__ int probe(int v) {\n" "    return __shfl(v, 0);\n" "}\n")
+file(WRITE ${_probe_dir}/scan_derived_mask.cu
+     "__device__ int probe(int v, unsigned mask_bits) {\n"
+     "    return __shfl_sync(mask_bits, v, 0);\n" "}\n")
+file(WRITE ${_probe_dir}/scan_floating_point.cu
+     "__device__ void probe(float* acc, float v) {\n"
+     "    atomicAdd(acc, v);\n" "}\n")
+
+cudec_scan_source(${_probe_dir}/scan_clean.cu TRUE _probe_clean)
+if(_probe_clean)
+  message(
+    FATAL_ERROR
+      "the structural scanner rejects a compliant probe - fix the scanner "
+      "before trusting it:\n${_probe_clean}")
+endif()
+foreach(_probe scan_unbounded_loop scan_legacy_intrinsic scan_derived_mask
+               scan_floating_point)
+  cudec_scan_source(${_probe_dir}/${_probe}.cu TRUE _probe_result)
+  if(NOT _probe_result)
+    message(FATAL_ERROR "the structural scanner is dead: probe '${_probe}' "
+                        "passed clean (issue #72)")
+  endif()
+endforeach()
+
+# The decode path: the sources whose loops are driven by lengths and counts
+# read out of a hostile bitstream. Every device translation unit must be on
+# this list, so a new kernel cannot quietly escape the termination rule; the
+# checksum helper (src/xxhash32.h) is deliberately not on it - its loops walk
+# a caller-supplied buffer at a fixed stride with no stream-derived exit.
+set(_decode_path_sources lz4_block.h lz4_decode.cuh frame.cpp batch.cu
+                         stream.cpp)
+file(GLOB _device_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+     CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cu
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cuh)
+foreach(_device_source IN LISTS _device_sources)
+  if(NOT _device_source IN_LIST _decode_path_sources)
+    message(
+      FATAL_ERROR
+        "src/${_device_source} is device code but is not on the decode-path "
+        "scan list in tests/CMakeLists.txt - add it (issue #72)")
+  endif()
+endforeach()
+
+set(_structural_violations "")
+foreach(_source IN LISTS _decode_path_sources)
+  set(_path ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source})
+  if(NOT EXISTS ${_path})
+    message(FATAL_ERROR "src/${_source} is on the decode-path scan list but "
+                        "does not exist (issue #72)")
+  endif()
+  cudec_scan_source(${_path} TRUE _found)
+  string(APPEND _structural_violations "${_found}")
+endforeach()
+# The remaining sources are held to the collective and floating-point rules
+# only; the termination rule is scoped above.
+file(GLOB _other_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+     CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.h)
+foreach(_source IN LISTS _other_sources)
+  if(NOT _source IN_LIST _decode_path_sources)
+    cudec_scan_source(${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source} FALSE
+                      _found)
+    string(APPEND _structural_violations "${_found}")
+  endif()
+endforeach()
+if(_structural_violations)
+  message(FATAL_ERROR "structural rules violated (issue #72):\n"
+                      "${_structural_violations}")
+endif()
+
+# Finally: no ctest entry in this directory may be without a timeout.
+cudec_assert_test_timeouts()

--- a/tests/adversarial_blocks.h
+++ b/tests/adversarial_blocks.h
@@ -1,0 +1,101 @@
+/* The hand-crafted hostile LZ4 block corpus, single-sourced (issue #72).
+ * The seeded fixture/mutant corpus in fixtures.h covers "what a compressor
+ * produced, then damaged"; this covers the shapes an attacker writes by
+ * hand: maximal LSIC length-extension runs, the spec-invalid zero offset, a
+ * match source past everything written, and matches whose source overlaps
+ * their own destination.
+ *
+ * Header-only and shared by the host parser test (tests/termination.cpp) and
+ * the device one (tests/termination_gpu.cu) so both drive the identical
+ * bytes - a stream that terminates on the CPU twin but not in the kernel
+ * would otherwise be invisible. Compression goes through fixtures.h's
+ * Lz4CompressBlock, so nothing here needs liblz4's headers (nvcc never sees
+ * lz4.h - tests/CMakeLists.txt keeps that path private on purpose). */
+#ifndef CUDEC_TESTS_ADVERSARIAL_BLOCKS_H
+#define CUDEC_TESTS_ADVERSARIAL_BLOCKS_H
+
+#include "fixtures.h"
+
+#include <string>
+#include <vector>
+
+struct AdversarialBlock {
+    std::string name;
+    std::vector<unsigned char> stream;
+    /* The destination capacity a caller would plausibly pass for this
+     * stream; the host test sweeps the ladder's other decision points on
+     * top of it. */
+    size_t dst_capacity;
+};
+
+/* A token asking for a literal-length extension followed by `run` bytes of
+ * 0xFF: the LSIC continuation loop is the one place in the parser whose
+ * iteration count is read from the stream itself. */
+inline std::vector<unsigned char> Lz4LiteralExtensionRun(size_t run) {
+    std::vector<unsigned char> s;
+    s.push_back(0xF0); /* 15 literals -> read an extension */
+    s.insert(s.end(), run, 0xFF);
+    s.push_back(0x00);
+    s.insert(s.end(), 64, 0x41);
+    return s;
+}
+
+/* The same on the match length: four literals, offset 1 (the shortest
+ * self-referential distance there is), then the 0xFF extension run. */
+inline std::vector<unsigned char> Lz4MatchExtensionRun(size_t run) {
+    std::vector<unsigned char> s = {0x4F, 0x41, 0x42, 0x43, 0x44, 0x01, 0x00};
+    s.insert(s.end(), run, 0xFF);
+    s.push_back(0x00);
+    s.insert(s.end(), 64, 0x41);
+    return s;
+}
+
+inline std::vector<AdversarialBlock> MakeAdversarialBlocks() {
+    std::vector<AdversarialBlock> out;
+    const auto add = [&out](std::string name,
+                            std::vector<unsigned char> stream,
+                            size_t dst_capacity) {
+        out.push_back({std::move(name), std::move(stream), dst_capacity});
+    };
+    add("empty", {}, 64);
+    add("lone-zero-token", {0x00}, 64);
+    add("lone-max-token", {0xFF}, 64);
+    add("all-ff-4096", std::vector<unsigned char>(4096, 0xFF), 1u << 20);
+    add("all-zero-4096", std::vector<unsigned char>(4096, 0x00), 1u << 20);
+    add("literal-extension-run-1", Lz4LiteralExtensionRun(1), 1u << 20);
+    add("literal-extension-run-4096", Lz4LiteralExtensionRun(4096), 1u << 20);
+    add("match-extension-run-1", Lz4MatchExtensionRun(1), 1u << 20);
+    add("match-extension-run-4096", Lz4MatchExtensionRun(4096), 1u << 20);
+    /* Zero offset: rejected by cudec (the one deliberate divergence from
+     * liblz4) and the input that would be a modulo-by-zero in the kernel's
+     * closed-form gather. */
+    {
+        std::vector<unsigned char> s = {0x40, 0x41, 0x42, 0x43, 0x44,
+                                        0x00, 0x00};
+        s.insert(s.end(), 64, 0x41);
+        add("zero-offset", std::move(s), 1u << 20);
+    }
+    /* A match source before the start of the output. */
+    {
+        std::vector<unsigned char> s = {0x40, 0x41, 0x42, 0x43, 0x44,
+                                        0xFF, 0xFF};
+        s.insert(s.end(), 64, 0x41);
+        add("offset-past-output", std::move(s), 1u << 20);
+    }
+    /* Genuinely self-referential matches, built by the oracle so they are
+     * valid: a run-length block (every match at offset 1, lengths far past
+     * it) and a two-byte period. These are the overlapping matches the
+     * kernel resolves by modular gather. */
+    add("self-referential-rle",
+        Lz4CompressBlock(std::vector<unsigned char>(65536, 0x5A)), 65536);
+    {
+        std::vector<unsigned char> period2(65536, 0x00);
+        for (size_t i = 1; i < period2.size(); i += 2) {
+            period2[i] = 0xFF;
+        }
+        add("self-referential-period-2", Lz4CompressBlock(period2), 65536);
+    }
+    return out;
+}
+
+#endif /* CUDEC_TESTS_ADVERSARIAL_BLOCKS_H */

--- a/tests/determinism_gpu.cu
+++ b/tests/determinism_gpu.cu
@@ -1,0 +1,317 @@
+/* Determinism across launch geometry (issue #72). docs/DETERMINISM.md names
+ * the decode path's invariance level `gpu_to_gpu` in CCCL's vocabulary; the
+ * existing same-batch-twice compare only covers the run-to-run axis on ONE
+ * launch configuration, which is the axis a decoder is least likely to break.
+ * The interesting axis is geometry: how many warps exist, how the grid-stride
+ * loop maps chunks onto them, and whether the batch is split across concurrent
+ * streams. All of that changes which warp decodes which chunk and in what
+ * order - and none of it may change a single output byte.
+ *
+ * One corpus, one reference decode through the shipped entry point, then five
+ * runs each across five grid/block geometries plus a three-stream split, with
+ * the whole destination arena re-poisoned before every run and compared in
+ * full - decoded bytes AND the untouched poison beyond bytes_written - along
+ * with every per-chunk result record. The geometries are launched directly on
+ * the shipped kernel because the public ABI deliberately exposes no launch
+ * knobs. */
+#include "cudec.h"
+#include "fixtures.h"
+#include "lz4_decode.cuh"
+#include "require.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr unsigned char kDstPoison = 0xA5;
+constexpr int kRunsPerGeometry = 5;
+
+/* The batch, staged as two device arenas (one source blob, one destination
+ * arena) plus the five pointer/size tables the ABI takes. One arena makes the
+ * whole-output compare a single download, so a geometry's full byte image is
+ * checked, not a sample of it. */
+struct Batch {
+    size_t n = 0;
+    std::vector<std::string> names;
+    unsigned char* d_src_blob = nullptr;
+    unsigned char* d_dst_arena = nullptr;
+    size_t dst_arena_size = 0;
+    const void** d_srcs = nullptr;
+    void** d_dsts = nullptr;
+    size_t* d_sizes = nullptr;
+    size_t* d_caps = nullptr;
+    cudec_chunk_result* d_results = nullptr;
+};
+
+struct Chunk {
+    std::string name;
+    std::vector<unsigned char> src;
+    size_t dst_capacity;
+};
+
+/* Pristine fixtures and their whole mutant corpora: accepted and rejected
+ * chunks side by side, so the compare covers the reject path's result records
+ * and untouched destinations too, not just successful output. */
+std::vector<Chunk> MakeChunks(const std::vector<Fixture>& fixtures) {
+    std::vector<Chunk> chunks;
+    for (const Fixture& f : fixtures) {
+        chunks.push_back({f.name, f.compressed, f.original.size()});
+        for (const Mutant& m : MutateStream(f.compressed, f.seed)) {
+            chunks.push_back(
+                {f.name + "/" + m.description, m.stream, f.original.size()});
+        }
+    }
+    return chunks;
+}
+
+size_t RoundUp16(size_t v) { return (v + 15) & ~size_t{15}; }
+
+int BuildBatch(const std::vector<Chunk>& chunks, Batch* batch) {
+    const size_t n = chunks.size();
+    std::vector<size_t> src_off(n), dst_off(n), sizes(n), caps(n);
+    size_t src_total = 0;
+    size_t dst_total = 0;
+    for (size_t i = 0; i < n; i++) {
+        src_off[i] = src_total;
+        dst_off[i] = dst_total;
+        sizes[i] = chunks[i].src.size();
+        caps[i] = chunks[i].dst_capacity;
+        src_total += RoundUp16(sizes[i] ? sizes[i] : 1);
+        dst_total += RoundUp16(caps[i] ? caps[i] : 1);
+    }
+
+    std::vector<unsigned char> src_blob(src_total, 0);
+    for (size_t i = 0; i < n; i++) {
+        if (!chunks[i].src.empty()) {
+            std::copy(chunks[i].src.begin(), chunks[i].src.end(),
+                      src_blob.begin() + static_cast<long>(src_off[i]));
+        }
+    }
+
+    batch->n = n;
+    batch->dst_arena_size = dst_total;
+    REQUIRE_CUDA(cudaMalloc(&batch->d_src_blob, src_total));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_dst_arena, dst_total));
+    REQUIRE_CUDA(cudaMemcpy(batch->d_src_blob, src_blob.data(), src_total,
+                            cudaMemcpyHostToDevice));
+
+    std::vector<const void*> h_srcs(n);
+    std::vector<void*> h_dsts(n);
+    for (size_t i = 0; i < n; i++) {
+        batch->names.push_back(chunks[i].name);
+        h_srcs[i] = batch->d_src_blob + src_off[i];
+        h_dsts[i] = batch->d_dst_arena + dst_off[i];
+    }
+    REQUIRE_CUDA(cudaMalloc(&batch->d_srcs, n * sizeof(*batch->d_srcs)));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_dsts, n * sizeof(*batch->d_dsts)));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_sizes, n * sizeof(*batch->d_sizes)));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_caps, n * sizeof(*batch->d_caps)));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_results, n * sizeof(*batch->d_results)));
+    REQUIRE_CUDA(cudaMemcpy(batch->d_srcs, h_srcs.data(),
+                            n * sizeof(*batch->d_srcs),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(batch->d_dsts, h_dsts.data(),
+                            n * sizeof(*batch->d_dsts),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(batch->d_sizes, sizes.data(),
+                            n * sizeof(*batch->d_sizes),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(batch->d_caps, caps.data(),
+                            n * sizeof(*batch->d_caps),
+                            cudaMemcpyHostToDevice));
+    return 0;
+}
+
+/* Every run starts from the identical device state: a fully re-poisoned
+ * destination arena and result records primed with the 0xFF non-OK sentinel.
+ * Without this a later run could "match" by inheriting the previous run's
+ * bytes. */
+int ResetDeviceState(const Batch& b) {
+    REQUIRE_CUDA(cudaMemset(b.d_dst_arena, kDstPoison, b.dst_arena_size));
+    REQUIRE_CUDA(
+        cudaMemset(b.d_results, 0xFF, b.n * sizeof(*b.d_results)));
+    return 0;
+}
+
+int Download(const Batch& b, std::vector<unsigned char>* dst,
+             std::vector<cudec_chunk_result>* results) {
+    dst->assign(b.dst_arena_size, 0);
+    results->assign(b.n, cudec_chunk_result{});
+    REQUIRE_CUDA(cudaMemcpy(dst->data(), b.d_dst_arena, b.dst_arena_size,
+                            cudaMemcpyDeviceToHost));
+    REQUIRE_CUDA(cudaMemcpy(results->data(), b.d_results,
+                            b.n * sizeof(*b.d_results),
+                            cudaMemcpyDeviceToHost));
+    return 0;
+}
+
+struct Geometry {
+    const char* name;
+    unsigned blocks;
+    unsigned threads;
+};
+
+/* Grid/block shapes that change the chunk-to-warp mapping in every direction
+ * the kernel admits: a single warp walking the whole batch through the
+ * grid-stride loop, block sizes below the launch bound, a grid far larger than
+ * the batch (most warps idle), and the shipped sizing. Block sizes stay
+ * multiples of the warp size and within __launch_bounds__(128). */
+std::vector<Geometry> Geometries(size_t chunk_count) {
+    return {
+        {"1x32", 1, 32},
+        {"3x64", 3, 64},
+        {"17x96", 17, 96},
+        {"chunks x128", static_cast<unsigned>(chunk_count), 128},
+        {"shipped",
+         cudec_detail::decode_grid_blocks(chunk_count),
+         cudec_detail::kBlockThreads},
+    };
+}
+
+int RunDirect(const Batch& b, const Geometry& g) {
+    REQUIRE(ResetDeviceState(b) == 0);
+    cudaStream_t stream;
+    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    cudec_detail::lz4_decode_batch<false><<<g.blocks, g.threads, 0, stream>>>(
+        b.d_srcs, b.d_sizes, b.d_dsts, b.d_caps, b.n, b.d_results);
+    REQUIRE_CUDA(cudaGetLastError());
+    REQUIRE_CUDA(cudaStreamSynchronize(stream));
+    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    return 0;
+}
+
+/* The shipped entry point, once over the whole batch. */
+int RunShippedEntry(const Batch& b) {
+    REQUIRE(ResetDeviceState(b) == 0);
+    cudaStream_t stream;
+    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    REQUIRE(cudec_lz4_decompress_batch(b.d_srcs, b.d_sizes, b.d_dsts,
+                                       b.d_caps, b.n, b.d_results,
+                                       stream) == CUDEC_OK);
+    REQUIRE_CUDA(cudaStreamSynchronize(stream));
+    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    return 0;
+}
+
+/* The same batch as three sub-batches submitted to three concurrent streams:
+ * chunk k is decoded by a different warp of a different launch than in any
+ * other geometry, and the sub-batches complete in an order the test does not
+ * control. Per-chunk independence means the output must not notice. */
+int RunSplitStreams(const Batch& b, unsigned stream_count) {
+    REQUIRE(ResetDeviceState(b) == 0);
+    std::vector<cudaStream_t> streams(stream_count);
+    for (unsigned s = 0; s < stream_count; s++) {
+        REQUIRE_CUDA(cudaStreamCreate(&streams[s]));
+    }
+    const size_t per = (b.n + stream_count - 1) / stream_count;
+    for (unsigned s = 0; s < stream_count; s++) {
+        const size_t begin = s * per;
+        if (begin >= b.n) {
+            break;
+        }
+        const size_t count = (begin + per <= b.n) ? per : b.n - begin;
+        /* cudec_chunk_result is 16 bytes, so an element offset keeps the
+         * 16-byte alignment the ABI requires of d_results. */
+        REQUIRE(cudec_lz4_decompress_batch(
+                    b.d_srcs + begin, b.d_sizes + begin, b.d_dsts + begin,
+                    b.d_caps + begin, count, b.d_results + begin,
+                    streams[s]) == CUDEC_OK);
+    }
+    for (unsigned s = 0; s < stream_count; s++) {
+        REQUIRE_CUDA(cudaStreamSynchronize(streams[s]));
+        REQUIRE_CUDA(cudaStreamDestroy(streams[s]));
+    }
+    return 0;
+}
+
+int CompareAgainstReference(
+    const Batch& b, const std::string& context,
+    const std::vector<unsigned char>& ref_dst,
+    const std::vector<cudec_chunk_result>& ref_results,
+    const std::vector<unsigned char>& dst,
+    const std::vector<cudec_chunk_result>& results) {
+    for (size_t i = 0; i < b.n; i++) {
+        REQUIRE_CTX(results[i].status == ref_results[i].status,
+                    "%s: chunk %zu (%s) status %d, reference %d",
+                    context.c_str(), i, b.names[i].c_str(),
+                    static_cast<int>(results[i].status),
+                    static_cast<int>(ref_results[i].status));
+        REQUIRE_CTX(results[i].bytes_written == ref_results[i].bytes_written,
+                    "%s: chunk %zu (%s) wrote %llu bytes, reference %llu",
+                    context.c_str(), i, b.names[i].c_str(),
+                    static_cast<unsigned long long>(results[i].bytes_written),
+                    static_cast<unsigned long long>(
+                        ref_results[i].bytes_written));
+        REQUIRE_CTX(results[i].reserved == ref_results[i].reserved,
+                    "%s: chunk %zu reserved word drifted", context.c_str(), i);
+    }
+    /* The whole arena, including the bytes a rejected chunk happened to write
+     * before rejecting. docs/DETERMINISM.md deliberately does NOT promise
+     * those - so this asserts more than the contract. It holds today because
+     * a chunk's writes are a pure function of its own bytes, and asserting it
+     * catches a geometry-dependent write that the promised region would hide;
+     * a future intentional change to reject-path writes is a contract-neutral
+     * update to this test, not a determinism break. */
+    REQUIRE_CTX(dst.size() == ref_dst.size(), "%s: arena size drifted",
+                context.c_str());
+    REQUIRE_CTX(equal_bytes(dst.data(), ref_dst.data(), dst.size()),
+                "%s: destination arena differs from the reference decode",
+                context.c_str());
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    const std::vector<Fixture> fixtures = MakeLz4BlockFixtures();
+    REQUIRE(!fixtures.empty());
+    const std::vector<Chunk> chunks = MakeChunks(fixtures);
+    REQUIRE(!chunks.empty());
+
+    Batch batch;
+    REQUIRE(BuildBatch(chunks, &batch) == 0);
+
+    /* The reference: the shipped entry point on the shipped geometry. */
+    std::vector<unsigned char> ref_dst;
+    std::vector<cudec_chunk_result> ref_results;
+    REQUIRE(RunShippedEntry(batch) == 0);
+    REQUIRE(Download(batch, &ref_dst, &ref_results) == 0);
+    size_t decoded_chunks = 0;
+    for (const cudec_chunk_result& r : ref_results) {
+        if (r.status == CUDEC_OK) {
+            decoded_chunks++;
+        }
+    }
+    /* A corpus that decoded nothing would compare poison against poison and
+     * pass vacuously. */
+    REQUIRE(decoded_chunks >= fixtures.size());
+
+    std::vector<unsigned char> dst;
+    std::vector<cudec_chunk_result> results;
+    for (const Geometry& g : Geometries(batch.n)) {
+        for (int run = 0; run < kRunsPerGeometry; run++) {
+            REQUIRE(RunDirect(batch, g) == 0);
+            REQUIRE(Download(batch, &dst, &results) == 0);
+            REQUIRE(CompareAgainstReference(
+                        batch,
+                        std::string(g.name) + "/run-" + std::to_string(run),
+                        ref_dst, ref_results, dst, results) == 0);
+        }
+    }
+    for (int run = 0; run < kRunsPerGeometry; run++) {
+        REQUIRE(RunSplitStreams(batch, 3) == 0);
+        REQUIRE(Download(batch, &dst, &results) == 0);
+        REQUIRE(CompareAgainstReference(
+                    batch, "3-streams/run-" + std::to_string(run), ref_dst,
+                    ref_results, dst, results) == 0);
+    }
+
+    std::printf("determinism_gpu: %zu chunks (%zu decoded) bit-identical "
+                "across 6 launch configurations x %d runs\n",
+                batch.n, decoded_chunks, kRunsPerGeometry);
+    return 0;
+}

--- a/tests/termination.cpp
+++ b/tests/termination.cpp
@@ -1,0 +1,314 @@
+/* Termination as a tested invariant (issue #72). The decoder's liveness
+ * argument - every Lz4Parser::Next call consumes at least the token byte,
+ * so every decode loop terminates - existed only as prose above the
+ * function, and a decoder that fails to terminate hangs the device: a
+ * fail-closed violation exactly like an out-of-bounds read, and a
+ * demonstrated bug class in this product category (nvCOMP 5.3's release
+ * notes record fixing an indefinite Snappy-decompression hang on malformed
+ * input).
+ *
+ * This test drives truncated, mutated, and adversarially crafted LZ4 blocks
+ * through the shared parser and asserts, on every step, that a step
+ * returning CUDEC_OK advanced the source cursor and that the parse reaches
+ * a terminal state within the contract's step bound. The driving loop is
+ * itself bounded one step past that budget, so a parser that stopped making
+ * progress FAILS this test instead of hanging it.
+ *
+ * The frame cases drive src/frame.cpp's block-table walk, whose step count
+ * is not observable from outside the library; there the assertion is that
+ * the call returns at all with a defined status, and the ctest TIMEOUT on
+ * this target is the backstop. Every frame here is malformed or wholly
+ * uncompressed, so all of it rejects (or assembles) before the first CUDA
+ * call - the test runs on the GPU-less runner and under the ASan/UBSan
+ * gate, like tests/frame_host_negative.cpp. */
+#include "adversarial_blocks.h"
+#include "cudec.h"
+#include "fixtures.h"
+#include "lz4_block.h"
+#include "require.h"
+#include "xxhash32.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* The parser's whole status surface: anything else is an undefined outcome
+ * on hostile input, which is the other half of fail-closed. */
+bool IsDefinedParserStatus(cudec_status status) {
+    return status == CUDEC_OK || status == CUDEC_ERR_CORRUPT_INPUT ||
+           status == CUDEC_ERR_OUTPUT_TOO_SMALL;
+}
+
+/* Drives the parser the way every decode loop does and asserts both halves
+ * of the liveness contract. The stream is parsed from an EXACTLY-sized heap
+ * copy (as tests/parser_twin.cpp does) so an over-read past src_size lands
+ * in an ASan redzone instead of a vector's rounded-up capacity slack. */
+int RequireTerminates(const std::string& context, const Bytes& stream,
+                      uint64_t dst_capacity) {
+    const size_t stream_size = stream.size();
+    auto tight = std::make_unique<unsigned char[]>(stream_size);
+    if (stream_size != 0) {
+        std::memcpy(tight.get(), stream.data(), stream_size);
+    }
+    cudec_detail::Lz4Parser parser{tight.get(), stream_size, dst_capacity};
+    cudec_detail::Lz4Sequence seq;
+
+    const uint64_t budget = static_cast<uint64_t>(stream_size) + 1;
+    uint64_t steps = 0;
+    cudec_status status = CUDEC_OK;
+    bool done = false;
+    /* One step of slack past the budget, so exceeding it is reported here
+     * rather than spun on. */
+    while (steps <= budget) {
+        const uint64_t src_pos_before = parser.src_pos;
+        steps++;
+        status = parser.Next(&seq, &done);
+        REQUIRE_CTX(IsDefinedParserStatus(status),
+                    "%s: step %llu returned undefined status %d",
+                    context.c_str(), static_cast<unsigned long long>(steps),
+                    static_cast<int>(status));
+        if (status != CUDEC_OK) {
+            break;
+        }
+        REQUIRE_CTX(parser.src_pos > src_pos_before,
+                    "%s: step %llu returned CUDEC_OK without consuming a "
+                    "source byte (src_pos stuck at %llu)",
+                    context.c_str(), static_cast<unsigned long long>(steps),
+                    static_cast<unsigned long long>(src_pos_before));
+        if (done) {
+            break;
+        }
+    }
+    REQUIRE_CTX(steps <= budget,
+                "%s: no terminal state within %llu steps for %llu source "
+                "bytes",
+                context.c_str(), static_cast<unsigned long long>(budget),
+                static_cast<unsigned long long>(stream_size));
+    /* Success is reported ONLY at exact consumption after a literals-only
+     * tail: an OK that is not `done` would be a decode loop's exit without
+     * a completed parse. */
+    REQUIRE_CTX(status != CUDEC_OK || done,
+                "%s: CUDEC_OK outside exact-consumption success",
+                context.c_str());
+    REQUIRE_CTX(parser.src_pos <= stream_size && parser.dst_pos <= dst_capacity,
+                "%s: cursor left its bound (src %llu/%llu dst %llu)",
+                context.c_str(),
+                static_cast<unsigned long long>(parser.src_pos),
+                static_cast<unsigned long long>(stream_size),
+                static_cast<unsigned long long>(parser.dst_pos));
+    return 0;
+}
+
+/* Capacities crossing the ladder's decision points: none at all, below the
+ * end-of-block slack, a realistic buffer, and the SIZE_MAX the header
+ * documents as a legal caller value (it disables the dst-slack terminal
+ * rule, so the parse runs on until the source is exhausted - the longest
+ * path through the loop). */
+const uint64_t kCapacities[] = {0, 1, 12, 1u << 20, UINT64_MAX};
+
+/* Truncation ladder: every prefix of a short stream, and a strided set plus
+ * the last 32 prefixes of a long one - a stream cut mid-sequence, mid-length
+ * extension, and mid-offset is where a length-driven loop would spin. */
+std::vector<size_t> PrefixLengths(size_t n) {
+    std::vector<size_t> lengths;
+    if (n <= 256) {
+        for (size_t k = 0; k <= n; k++) {
+            lengths.push_back(k);
+        }
+        return lengths;
+    }
+    const size_t stride = n / 128;
+    for (size_t k = 0; k < n; k += stride) {
+        lengths.push_back(k);
+    }
+    for (size_t k = n - 32; k <= n; k++) {
+        lengths.push_back(k);
+    }
+    return lengths;
+}
+
+int RunTruncationLadder(const std::vector<Fixture>& fixtures) {
+    for (const Fixture& f : fixtures) {
+        for (const size_t keep : PrefixLengths(f.compressed.size())) {
+            const Bytes prefix(f.compressed.begin(),
+                               f.compressed.begin() + static_cast<long>(keep));
+            const std::string context =
+                f.name + "/prefix-" + std::to_string(keep);
+            /* The fixture's own size is the interesting capacity for a
+             * prefix: it is the one a caller would have passed. */
+            REQUIRE(RequireTerminates(context, prefix, f.original.size()) == 0);
+        }
+    }
+    return 0;
+}
+
+int RunMutantCorpus(const std::vector<Fixture>& fixtures) {
+    for (const Fixture& f : fixtures) {
+        const std::vector<Mutant> mutants = MutateStream(f.compressed, f.seed);
+        REQUIRE(!mutants.empty());
+        for (const Mutant& m : mutants) {
+            const std::string context = f.name + "/" + m.description;
+            for (const uint64_t capacity : kCapacities) {
+                REQUIRE(RequireTerminates(context, m.stream, capacity) == 0);
+            }
+        }
+    }
+    return 0;
+}
+
+int RunAdversarialBlocks() {
+    const std::vector<AdversarialBlock> blocks = MakeAdversarialBlocks();
+    REQUIRE(!blocks.empty());
+    for (const AdversarialBlock& block : blocks) {
+        REQUIRE(RequireTerminates(block.name + "/cap-suggested", block.stream,
+                                  block.dst_capacity) == 0);
+        for (const uint64_t capacity : kCapacities) {
+            const std::string context =
+                block.name + "/cap-" + std::to_string(capacity);
+            REQUIRE(RequireTerminates(context, block.stream, capacity) == 0);
+        }
+        /* The mutation corpus of a hostile stream too: a hostile stream is
+         * rarely the only hostile stream nearby. */
+        if (block.stream.empty()) {
+            continue;
+        }
+        for (const Mutant& m : MutateStream(block.stream, 0x72)) {
+            REQUIRE(RequireTerminates(block.name + "/" + m.description,
+                                      m.stream, block.dst_capacity) == 0);
+        }
+    }
+    return 0;
+}
+
+/* ---- The frame block-table walk.
+ *
+ * A minimal builder, deliberately narrower than the one in
+ * tests/frame_host_negative.cpp: these cases need only the block-record
+ * walk, with a descriptor fixed at block-independent / 64 KiB block max and
+ * no optional fields. The header checksum is computed with the library's
+ * own xxhash32.h so the walk past the checksum gate is reachable at all. */
+constexpr unsigned char kFlgIndependent = 0x60; /* version 01, block-indep */
+constexpr unsigned char kBd64K = 0x40;
+
+void Put32(Bytes* f, uint32_t v) {
+    for (int i = 0; i < 4; i++) {
+        f->push_back(static_cast<unsigned char>((v >> (i * 8)) & 0xFF));
+    }
+}
+
+Bytes FrameHeader() {
+    Bytes f = {0x04, 0x22, 0x4D, 0x18, kFlgIndependent, kBd64K};
+    f.push_back(static_cast<unsigned char>(
+        (cudec_detail::xxhash32(f.data() + 4, 2) >> 8) & 0xFF));
+    return f;
+}
+
+/* `blocks` uncompressed block payloads, optionally followed by the end
+ * mark. Without it the walk must run out of frame and reject. */
+Bytes BuildUncompressedFrame(const std::vector<Bytes>& blocks, bool end_mark) {
+    Bytes f = FrameHeader();
+    for (const Bytes& b : blocks) {
+        Put32(&f, 0x80000000u | static_cast<uint32_t>(b.size()));
+        f.insert(f.end(), b.begin(), b.end());
+    }
+    if (end_mark) {
+        Put32(&f, 0);
+    }
+    return f;
+}
+
+/* Decodes from an exactly-sized copy so an over-read past frame_size reds
+ * the sanitizer (same reasoning as tests/frame_host_negative.cpp). */
+int RequireFrameReturns(const std::string& context, const Bytes& frame,
+                        size_t dst_capacity) {
+    const size_t n = frame.size();
+    auto tight = std::make_unique<unsigned char[]>(n);
+    if (n != 0) {
+        std::memcpy(tight.get(), frame.data(), n);
+    }
+    std::vector<unsigned char> dst(dst_capacity ? dst_capacity : 1, 0);
+    size_t written = 12345; /* must be overwritten, never left stale */
+    const cudec_status status = cudec_lz4f_decompress(
+        tight.get(), n, dst.data(), dst_capacity, &written);
+    REQUIRE_CTX(status == CUDEC_OK || status == CUDEC_ERR_CORRUPT_INPUT ||
+                    status == CUDEC_ERR_OUTPUT_TOO_SMALL ||
+                    status == CUDEC_ERR_UNSUPPORTED ||
+                    status == CUDEC_ERR_INVALID_ARGUMENT ||
+                    status == CUDEC_ERR_CUDA,
+                "%s: undefined status %d", context.c_str(),
+                static_cast<int>(status));
+    REQUIRE_CTX(status == CUDEC_OK || written == 0,
+                "%s: rejected frame reported %llu bytes", context.c_str(),
+                static_cast<unsigned long long>(written));
+    return 0;
+}
+
+int RunFrameWalk() {
+    /* Many minimal block records: the walk's step count is driven by the
+     * frame's own contents, which is exactly the shape a fuel-free loop
+     * would be at the mercy of. */
+    std::vector<Bytes> many(4000, Bytes(1, 0x41));
+    REQUIRE(RequireFrameReturns("frame/4000-blocks-end-mark",
+                                BuildUncompressedFrame(many, true),
+                                many.size()) == 0);
+    REQUIRE(RequireFrameReturns("frame/4000-blocks-no-end-mark",
+                                BuildUncompressedFrame(many, false),
+                                many.size()) == 0);
+    REQUIRE(RequireFrameReturns("frame/header-only", FrameHeader(), 64) == 0);
+
+    /* A block-size field claiming the whole 31-bit range, and one claiming
+     * zero length: both must reject without walking anywhere. */
+    Bytes huge = FrameHeader();
+    Put32(&huge, 0xFFFFFFFFu);
+    REQUIRE(RequireFrameReturns("frame/block-size-max", huge, 64) == 0);
+    Bytes zero_len = FrameHeader();
+    Put32(&zero_len, 0x80000000u);
+    REQUIRE(RequireFrameReturns("frame/block-size-zero", zero_len, 64) == 0);
+
+    /* A header followed by pure garbage, and by a long run of 0x01 block
+     * headers whose payloads run off the end. */
+    Bytes garbage = FrameHeader();
+    garbage.insert(garbage.end(), 4096, 0xFF);
+    REQUIRE(RequireFrameReturns("frame/garbage-tail", garbage, 64) == 0);
+    Bytes truncated_payloads = FrameHeader();
+    for (int i = 0; i < 1024; i++) {
+        Put32(&truncated_payloads, 0x80000001u);
+        truncated_payloads.push_back(0x41);
+    }
+    REQUIRE(RequireFrameReturns("frame/truncated-payload-run",
+                                truncated_payloads, 64) == 0);
+
+    /* Every prefix of a well-formed many-block frame: each one cuts the
+     * walk at a different point in a block record. */
+    const Bytes complete = BuildUncompressedFrame(
+        std::vector<Bytes>(64, Bytes(3, 0x41)), true);
+    for (size_t keep = 0; keep <= complete.size(); keep++) {
+        const Bytes prefix(complete.begin(),
+                           complete.begin() + static_cast<long>(keep));
+        REQUIRE(RequireFrameReturns("frame/prefix-" + std::to_string(keep),
+                                    prefix, 256) == 0);
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    const std::vector<Fixture> fixtures = MakeLz4BlockFixtures();
+    REQUIRE(!fixtures.empty());
+    REQUIRE(RunTruncationLadder(fixtures) == 0);
+    REQUIRE(RunMutantCorpus(fixtures) == 0);
+    REQUIRE(RunAdversarialBlocks() == 0);
+    REQUIRE(RunFrameWalk() == 0);
+    std::printf("termination: parser liveness and frame-walk termination "
+                "hold over the truncation ladder, the mutant corpus, the "
+                "crafted streams, and the frame cases\n");
+    return 0;
+}

--- a/tests/termination_gpu.cu
+++ b/tests/termination_gpu.cu
@@ -11,7 +11,12 @@
  * deadline: an expiry FAILS the test with a message instead of blocking. The
  * ctest TIMEOUT on this target is the second line of defence; the process exit
  * on failure is what releases the still-running launch (the driver tears the
- * context down - the test deliberately does not synchronise on the way out). */
+ * context down - the test deliberately does not synchronise on the way out).
+ *
+ * It also covers the launch geometries the kernel refuses. Those are reachable
+ * only through the internal kernel header - never through the public ABI - but
+ * this PR teaches two test binaries to launch it directly, and one of them is
+ * this file. */
 #include "adversarial_blocks.h"
 #include "cudec.h"
 #include "fixtures.h"
@@ -21,6 +26,7 @@
 #include <cuda_runtime.h>
 
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <string>
 #include <thread>
@@ -172,17 +178,33 @@ int DecodeWithWatchdog(const Batch& b, size_t begin, size_t count) {
     return 0;
 }
 
-/* A launch geometry that does not hold one whole warp: the grid-stride loop
- * would advance by zero warps per step and spin forever, so the kernel has to
- * refuse it itself rather than trust its caller. The shipped entry point never
- * produces this geometry, which is exactly why nothing else would catch a
- * regression here. Same watchdog: a spin is reported, not waited on. */
-int RequireSubWarpLaunchTerminates(const Batch& b) {
+/* Launch geometries the kernel's chunk-to-lane mapping does not support, and
+ * that the shipped entry point never produces - which is exactly why nothing
+ * else would catch a regression here:
+ *  - <<<1, 16>>>  : the whole grid holds less than one warp, so the
+ *                   grid-stride loop advances by zero and spins forever;
+ *  - <<<2, 16>>>  : two half-warps in two blocks both map to chunk 0, and
+ *                   `lane` only ever takes 0-15 while the copy loops stride by
+ *                   32 - every output byte at i % 32 >= 16 is written by
+ *                   nobody, and the full-mask __syncwarp() is executed by half
+ *                   a warp;
+ *  - <<<2, 48>>>  : the same split, one warp deeper into the grid.
+ * The kernel must refuse all three rather than trust its caller. Verified two
+ * ways, because "it finished" is not the property that matters: the watchdog
+ * catches the spin, and the device state is checked to be untouched
+ * afterwards - a refusal writes no output and no result record. */
+struct UnsupportedGeometry {
+    const char* name;
+    unsigned blocks;
+    unsigned threads;
+};
+
+int RequireGeometryRefused(const Batch& b, const UnsupportedGeometry& g) {
     cudaStream_t stream;
     cudaEvent_t finished;
     REQUIRE_CUDA(cudaStreamCreate(&stream));
     REQUIRE_CUDA(cudaEventCreateWithFlags(&finished, cudaEventDisableTiming));
-    cudec_detail::lz4_decode_batch<false><<<1, 16, 0, stream>>>(
+    cudec_detail::lz4_decode_batch<false><<<g.blocks, g.threads, 0, stream>>>(
         b.d_srcs, b.d_sizes, b.d_dsts, b.d_caps, b.n, b.d_results);
     REQUIRE_CUDA(cudaGetLastError());
     REQUIRE_CUDA(cudaEventRecord(finished, stream));
@@ -199,13 +221,38 @@ int RequireSubWarpLaunchTerminates(const Batch& b) {
                                           start)
                 .count();
         REQUIRE_CTX(elapsed < kDeadlineSeconds,
-                    "a sub-warp launch geometry (<<<1, 16>>>) did not "
-                    "terminate within %.0f s",
-                    kDeadlineSeconds);
+                    "the unsupported launch geometry %s did not terminate "
+                    "within %.0f s",
+                    g.name, kDeadlineSeconds);
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     REQUIRE_CUDA(cudaEventDestroy(finished));
     REQUIRE_CUDA(cudaStreamDestroy(stream));
+
+    /* Refused means refused: every result record still carries the 0xFF
+     * sentinel BuildBatch primed, and every destination byte is still poison.
+     * Without this the test would pass on a kernel that decoded half of each
+     * chunk and returned. */
+    std::vector<cudec_chunk_result> results(b.n);
+    REQUIRE_CUDA(cudaMemcpy(results.data(), b.d_results,
+                            b.n * sizeof(*b.d_results),
+                            cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < b.n; i++) {
+        REQUIRE_CTX(results[i].status == -1 && results[i].reserved == 0xFFFFFFFFu &&
+                        results[i].bytes_written == UINT64_MAX,
+                    "%s: chunk %zu (%s) result record was written by a "
+                    "geometry the kernel must refuse",
+                    g.name, i, b.names[i].c_str());
+    }
+    std::vector<unsigned char> arena(b.dst_arena_size, 0);
+    REQUIRE_CUDA(cudaMemcpy(arena.data(), b.d_dst_arena, b.dst_arena_size,
+                            cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < arena.size(); i++) {
+        REQUIRE_CTX(arena[i] == kDstPoison,
+                    "%s: destination byte %zu was written by a geometry the "
+                    "kernel must refuse",
+                    g.name, i);
+    }
     return 0;
 }
 
@@ -237,7 +284,8 @@ int CheckResults(const Batch& b) {
      * reject paths' termination. */
     REQUIRE(rejected != 0);
     std::printf("termination_gpu: %zu chunks decoded within the watchdog "
-                "deadline (%zu rejected, all with a defined status)\n",
+                "deadline (%zu rejected, all with a defined status); three "
+                "unsupported launch geometries refused without writing\n",
                 b.n, rejected);
     return 0;
 }
@@ -253,6 +301,18 @@ int main() {
     Batch batch;
     REQUIRE(BuildBatch(chunks, &batch) == 0);
 
+    /* The unsupported geometries FIRST, while the device state is still the
+     * pristine sentinel/poison BuildBatch primed - that is what lets the
+     * refusal be asserted as "wrote nothing" rather than merely "returned". */
+    static const UnsupportedGeometry kUnsupported[] = {
+        {"<<<1, 16>>>", 1, 16},
+        {"<<<2, 16>>>", 2, 16},
+        {"<<<2, 48>>>", 2, 48},
+    };
+    for (const UnsupportedGeometry& g : kUnsupported) {
+        REQUIRE(RequireGeometryRefused(batch, g) == 0);
+    }
+
     /* The whole corpus in one launch: a single non-terminating warp holds
      * the launch, which is exactly the failure this test must observe. */
     REQUIRE(DecodeWithWatchdog(batch, 0, batch.n) == 0);
@@ -261,9 +321,6 @@ int main() {
     for (size_t i = 0; i < batch.n; i++) {
         REQUIRE(DecodeWithWatchdog(batch, i, 1) == 0);
     }
-    /* After the real launches, so the results it must not touch are already
-     * the ones CheckResults verifies below. */
-    REQUIRE(RequireSubWarpLaunchTerminates(batch) == 0);
     REQUIRE(CheckResults(batch) == 0);
     return 0;
 }

--- a/tests/termination_gpu.cu
+++ b/tests/termination_gpu.cu
@@ -1,0 +1,269 @@
+/* Termination on the device, behind a host-side watchdog (issue #72).
+ *
+ * tests/termination.cpp proves the shared parser reaches a terminal state on
+ * the host; this drives the identical hostile corpus through the real kernel,
+ * where the failure mode is worse: a warp that never leaves its sequence loop
+ * does not return a bad status, it holds the launch - and with it every other
+ * chunk in the batch and the stream behind it.
+ *
+ * A plain cudaStreamSynchronize would inherit exactly that hang and stall the
+ * suite, so the launch is fenced with an event and polled against a wall-clock
+ * deadline: an expiry FAILS the test with a message instead of blocking. The
+ * ctest TIMEOUT on this target is the second line of defence; the process exit
+ * on failure is what releases the still-running launch (the driver tears the
+ * context down - the test deliberately does not synchronise on the way out). */
+#include "adversarial_blocks.h"
+#include "cudec.h"
+#include "fixtures.h"
+#include "lz4_decode.cuh"
+#include "require.h"
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstdio>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr unsigned char kDstPoison = 0xA5;
+/* Generous against a loaded GPU, tiny against "never": the whole corpus is a
+ * few megabytes and decodes in milliseconds. */
+constexpr double kDeadlineSeconds = 30.0;
+
+struct Chunk {
+    std::string name;
+    std::vector<unsigned char> src;
+    size_t dst_capacity;
+};
+
+/* Everything hostile the project can generate: the crafted corpus, the
+ * seeded fixture mutants, and every fixture truncated at three points -
+ * a stream cut mid-sequence, mid-length-extension, and mid-offset. */
+std::vector<Chunk> MakeHostileChunks(const std::vector<Fixture>& fixtures) {
+    std::vector<Chunk> chunks;
+    for (const AdversarialBlock& block : MakeAdversarialBlocks()) {
+        chunks.push_back({block.name, block.stream, block.dst_capacity});
+    }
+    for (const Fixture& f : fixtures) {
+        chunks.push_back({f.name + "/pristine", f.compressed,
+                          f.original.size()});
+        for (const Mutant& m : MutateStream(f.compressed, f.seed)) {
+            chunks.push_back(
+                {f.name + "/" + m.description, m.stream, f.original.size()});
+        }
+    }
+    return chunks;
+}
+
+/* Uploads the batch into one source blob and one destination arena, plus the
+ * five ABI tables. */
+struct Batch {
+    size_t n = 0;
+    std::vector<std::string> names;
+    unsigned char* d_src_blob = nullptr;
+    unsigned char* d_dst_arena = nullptr;
+    size_t dst_arena_size = 0;
+    const void** d_srcs = nullptr;
+    void** d_dsts = nullptr;
+    size_t* d_sizes = nullptr;
+    size_t* d_caps = nullptr;
+    cudec_chunk_result* d_results = nullptr;
+};
+
+size_t RoundUp16(size_t v) { return (v + 15) & ~size_t{15}; }
+
+int BuildBatch(const std::vector<Chunk>& chunks, Batch* batch) {
+    const size_t n = chunks.size();
+    std::vector<size_t> src_off(n), dst_off(n), sizes(n), caps(n);
+    size_t src_total = 0;
+    size_t dst_total = 0;
+    for (size_t i = 0; i < n; i++) {
+        src_off[i] = src_total;
+        dst_off[i] = dst_total;
+        sizes[i] = chunks[i].src.size();
+        caps[i] = chunks[i].dst_capacity;
+        src_total += RoundUp16(sizes[i] ? sizes[i] : 1);
+        dst_total += RoundUp16(caps[i] ? caps[i] : 1);
+    }
+    std::vector<unsigned char> src_blob(src_total, 0);
+    std::vector<const void*> h_srcs(n);
+    std::vector<void*> h_dsts(n);
+
+    batch->n = n;
+    batch->dst_arena_size = dst_total;
+    REQUIRE_CUDA(cudaMalloc(&batch->d_src_blob, src_total));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_dst_arena, dst_total));
+    for (size_t i = 0; i < n; i++) {
+        for (size_t k = 0; k < sizes[i]; k++) {
+            src_blob[src_off[i] + k] = chunks[i].src[k];
+        }
+        batch->names.push_back(chunks[i].name);
+        h_srcs[i] = batch->d_src_blob + src_off[i];
+        h_dsts[i] = batch->d_dst_arena + dst_off[i];
+    }
+    REQUIRE_CUDA(cudaMemcpy(batch->d_src_blob, src_blob.data(), src_total,
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemset(batch->d_dst_arena, kDstPoison, dst_total));
+
+    REQUIRE_CUDA(cudaMalloc(&batch->d_srcs, n * sizeof(*batch->d_srcs)));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_dsts, n * sizeof(*batch->d_dsts)));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_sizes, n * sizeof(*batch->d_sizes)));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_caps, n * sizeof(*batch->d_caps)));
+    REQUIRE_CUDA(cudaMalloc(&batch->d_results, n * sizeof(*batch->d_results)));
+    REQUIRE_CUDA(cudaMemcpy(batch->d_srcs, h_srcs.data(),
+                            n * sizeof(*batch->d_srcs),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(batch->d_dsts, h_dsts.data(),
+                            n * sizeof(*batch->d_dsts),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(batch->d_sizes, sizes.data(),
+                            n * sizeof(*batch->d_sizes),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(batch->d_caps, caps.data(),
+                            n * sizeof(*batch->d_caps),
+                            cudaMemcpyHostToDevice));
+    /* The 0xFF sentinel is out of the status enum's range, so a chunk the
+     * kernel never reached cannot be mistaken for a decoded one. */
+    REQUIRE_CUDA(
+        cudaMemset(batch->d_results, 0xFF, n * sizeof(*batch->d_results)));
+    return 0;
+}
+
+/* Submits the batch and waits on an event, not on the stream: a launch that
+ * does not finish must be REPORTED, never waited on. */
+int DecodeWithWatchdog(const Batch& b, size_t begin, size_t count) {
+    cudaStream_t stream;
+    cudaEvent_t finished;
+    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    REQUIRE_CUDA(cudaEventCreateWithFlags(&finished, cudaEventDisableTiming));
+    REQUIRE(cudec_lz4_decompress_batch(b.d_srcs + begin, b.d_sizes + begin,
+                                       b.d_dsts + begin, b.d_caps + begin,
+                                       count, b.d_results + begin,
+                                       stream) == CUDEC_OK);
+    REQUIRE_CUDA(cudaEventRecord(finished, stream));
+
+    const auto start = std::chrono::steady_clock::now();
+    while (true) {
+        const cudaError_t query = cudaEventQuery(finished);
+        if (query == cudaSuccess) {
+            break;
+        }
+        REQUIRE_CTX(query == cudaErrorNotReady, "cudaEventQuery failed: %s",
+                    cudaGetErrorString(query));
+        const double elapsed =
+            std::chrono::duration<double>(std::chrono::steady_clock::now() -
+                                          start)
+                .count();
+        /* On expiry the launch is still resident. Returning (and exiting)
+         * leaves the teardown to the driver; synchronising or destroying the
+         * stream here would block on the very hang being reported. */
+        REQUIRE_CTX(elapsed < kDeadlineSeconds,
+                    "decode of chunks [%zu,%zu) did not complete within "
+                    "%.0f s - the corpus is a few MB of bounded-parse "
+                    "chunks, so this is a non-terminating decode",
+                    begin, begin + count, kDeadlineSeconds);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    REQUIRE_CUDA(cudaEventDestroy(finished));
+    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    return 0;
+}
+
+/* A launch geometry that does not hold one whole warp: the grid-stride loop
+ * would advance by zero warps per step and spin forever, so the kernel has to
+ * refuse it itself rather than trust its caller. The shipped entry point never
+ * produces this geometry, which is exactly why nothing else would catch a
+ * regression here. Same watchdog: a spin is reported, not waited on. */
+int RequireSubWarpLaunchTerminates(const Batch& b) {
+    cudaStream_t stream;
+    cudaEvent_t finished;
+    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    REQUIRE_CUDA(cudaEventCreateWithFlags(&finished, cudaEventDisableTiming));
+    cudec_detail::lz4_decode_batch<false><<<1, 16, 0, stream>>>(
+        b.d_srcs, b.d_sizes, b.d_dsts, b.d_caps, b.n, b.d_results);
+    REQUIRE_CUDA(cudaGetLastError());
+    REQUIRE_CUDA(cudaEventRecord(finished, stream));
+    const auto start = std::chrono::steady_clock::now();
+    while (true) {
+        const cudaError_t query = cudaEventQuery(finished);
+        if (query == cudaSuccess) {
+            break;
+        }
+        REQUIRE_CTX(query == cudaErrorNotReady, "cudaEventQuery failed: %s",
+                    cudaGetErrorString(query));
+        const double elapsed =
+            std::chrono::duration<double>(std::chrono::steady_clock::now() -
+                                          start)
+                .count();
+        REQUIRE_CTX(elapsed < kDeadlineSeconds,
+                    "a sub-warp launch geometry (<<<1, 16>>>) did not "
+                    "terminate within %.0f s",
+                    kDeadlineSeconds);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    REQUIRE_CUDA(cudaEventDestroy(finished));
+    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    return 0;
+}
+
+int CheckResults(const Batch& b) {
+    std::vector<cudec_chunk_result> results(b.n);
+    REQUIRE_CUDA(cudaMemcpy(results.data(), b.d_results,
+                            b.n * sizeof(*b.d_results),
+                            cudaMemcpyDeviceToHost));
+    size_t rejected = 0;
+    for (size_t i = 0; i < b.n; i++) {
+        const cudec_chunk_result& r = results[i];
+        REQUIRE_CTX(r.status == CUDEC_OK ||
+                        r.status == CUDEC_ERR_CORRUPT_INPUT ||
+                        r.status == CUDEC_ERR_OUTPUT_TOO_SMALL,
+                    "chunk %zu (%s): undefined status %d - the 0xFF sentinel "
+                    "means the kernel never reached this chunk",
+                    i, b.names[i].c_str(), static_cast<int>(r.status));
+        REQUIRE_CTX(r.reserved == 0, "chunk %zu (%s): reserved word not zeroed",
+                    i, b.names[i].c_str());
+        if (r.status != CUDEC_OK) {
+            REQUIRE_CTX(r.bytes_written == 0,
+                        "chunk %zu (%s): rejected chunk reports %llu bytes", i,
+                        b.names[i].c_str(),
+                        static_cast<unsigned long long>(r.bytes_written));
+            rejected++;
+        }
+    }
+    /* A corpus the decoder accepted wholesale would prove nothing about the
+     * reject paths' termination. */
+    REQUIRE(rejected != 0);
+    std::printf("termination_gpu: %zu chunks decoded within the watchdog "
+                "deadline (%zu rejected, all with a defined status)\n",
+                b.n, rejected);
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    const std::vector<Fixture> fixtures = MakeLz4BlockFixtures();
+    REQUIRE(!fixtures.empty());
+    const std::vector<Chunk> chunks = MakeHostileChunks(fixtures);
+    REQUIRE(!chunks.empty());
+
+    Batch batch;
+    REQUIRE(BuildBatch(chunks, &batch) == 0);
+
+    /* The whole corpus in one launch: a single non-terminating warp holds
+     * the launch, which is exactly the failure this test must observe. */
+    REQUIRE(DecodeWithWatchdog(batch, 0, batch.n) == 0);
+    /* And one chunk per launch, so a hostile stream cannot hide behind a
+     * batch mate that happens to keep the warp busy. */
+    for (size_t i = 0; i < batch.n; i++) {
+        REQUIRE(DecodeWithWatchdog(batch, i, 1) == 0);
+    }
+    /* After the real launches, so the results it must not touch are already
+     * the ones CheckResults verifies below. */
+    REQUIRE(RequireSubWarpLaunchTerminates(batch) == 0);
+    REQUIRE(CheckResults(batch) == 0);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Three fail-closed properties the decoder already leaned on existed only as prose: that every decode loop terminates, that warp collectives never take their participation metadata from the bitstream, and that the same input decodes to the same bytes. A decoder that hangs on hostile input has failed open in the availability direction, and it is a demonstrated bug class in exactly this product category, since nvCOMP 5.3's release notes record fixing an indefinite Snappy-decompression hang on malformed input. All three are structural checks over the same sources and reuse the same harness, so they land together.

Closes #72

**Termination.** Every loop whose exit depends on a value read from the stream now carries an explicit decrementing fuel cap, the LSIC length-extension loop, the kernel's sequence loop, the frame block-table walk. Each budget is unreachable for every input the validation ladder admits, so the accept set does not move; a future guard bug degrades to a defined reject instead of a hang. Kernel fuel exhaustion maps to `CUDEC_ERR_CORRUPT_INPUT`, never to a success without a completed parse.

**Warp collectives.** Configure-time checks ban the legacy non-`_sync` intrinsics outright and require every collective's mask to be the full-warp constant or `__activemask()`, never a value named after a parsed bitstream field. A collective wrapped across lines is a violation in itself, because the scan is line-scoped. No violation existed in `src/`.

**Determinism.** `docs/DETERMINISM.md` names the level `gpu_to_gpu` in CCCL's vocabulary, and `tests/determinism_gpu.cu` covers the axis the existing same-batch-twice compare cannot see: launch geometry and stream count.

**Two real bugs found while writing the tests, both fixed here.** The kernel's grid-stride loop spins forever when the grid holds less than one whole warp (`<<<1, 16>>>`), and its chunk-to-lane mapping silently drops half of every destination when a block is not a whole number of warps (`<<<2, 16>>>`, `<<<2, 48>>>`, two half-warps in two blocks claim the same chunk, `lane` only takes 0-15, and the copy loops stride by 32). Neither is reachable through the public ABI, which always launches `kBlockThreads`, but the kernel must not depend on its caller. Both geometries are now refused, grid-uniformly, and covered by test.

## Type of change

- [x] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [x] Performance
- [x] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: every new parse/decode path rejects invalid input with a defined error; no out-of-bounds access is reachable from hostile input, and every reject path has a negative test.
      The fuel caps only ever add rejects, and each budget is provably unreachable: the LSIC loop consumes one source byte per step and is entered with `src_pos <= src_size`; `Next` consumes at least the token byte, so a chunk of n bytes admits at most n + 1 calls; the frame walk consumes at least the 4 block-size bytes per step. `tests/termination.cpp` asserts the second per call over the whole corpus.
- [x] Oracle coverage: unchanged and still green, `oracle_lz4`, `parser_twin`, `gpu_fixture`, `frame_twin`, `stream_twin` all pass, which is what proves the accept set did not move.
- [x] Determinism preserved: now tested across five grid/block geometries plus a three-stream split, five runs each, whole-arena byte compare. The unsupported geometries are refused, not decoded differently, and that refusal is asserted as "wrote nothing".
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [ ] An adversarial review (`/security-review`) was run.
      Not run by the implementer by design — the panel is a separate context. One independent kernel/correctness review has already run on this PR; its blocking finding and every should-fix are dispositioned at the bottom of this body.

## Performance checklist

- [x] The claim is measured, not reasoned: before/after numbers with GPU model, driver, CUDA version, corpus, and chunk-size distribution.
- [ ] No regression against the recorded baseline (docs/BENCHMARKS.md), or the regression is justified below.
      **There is a regression and it is deliberate.** Re-measured end to end against the final kernel after the review changed its register count. `origin/main` at e85194d against this branch, `--warmup 3 --runs 30`, every row the mean of two interleaved passes, every sample listed:

| Corpus        | Metric                     | Before (samples)          | After (samples)           | Change                   |
| ------------- | -------------------------- | ------------------------- | ------------------------- | ------------------------ |
| Silesia       | GPU decode p50             | 11.924 ms (11.873/11.974) | 12.163 ms (12.107/12.218) | **+2.0%**                |
| Silesia       | GPU parse-only ceiling p50 | 6.056 ms (5.924/6.188)    | 7.079 ms (7.010/7.147)    | **+16.9%**               |
| worst-4Bmatch | GPU decode p50             | 25.643 ms (25.364/25.922) | 25.973 ms (25.285/26.661) | +1.3%, inside the spread |
| worst-4Bmatch | GPU parse-only ceiling p50 | 13.482 ms (13.467/13.496) | 15.437 ms (15.367/15.506) | **+14.5%**               |

The shipped decode path pays **+2.0% on Silesia**; on the worst case the difference is smaller than the "after" side's own pass-to-pass spread, so it is an upper bound, not a measurement. The parse-only ceiling, a diagnostic kernel, never shipped, pays 14–17% on both corpora, tightly and reproducibly.

**Occupancy is the binding constraint, and the review exposed it.** The kernel uses 48 registers/thread on `sm_86`, up from 46. At 128-thread blocks and 256-register warp granularity, 41–48 registers all give 40 warps/SM; **49 steps down to 36**. Measured:

| Variant                                                         | Registers | Warps/SM | Silesia decode p50 |
| --------------------------------------------------------------- | --------- | -------- | ------------------ |
| `origin/main`, no cap, no geometry guard                        | 46        | 40       | 11.924 ms          |
| shipped (cap + two-clause geometry guard)                       | 48        | 40       | 12.163 ms          |
| plus a 32-bit-index overflow guard, or the index moved below it  | 52        | 36       | 12.63 ms           |

Accepted under the prime-directive ordering, correctness > measured performance, and recorded in `docs/BENCHMARKS.md` with the full methodology block.

## Quality checklist

- [x] Minimal: the hostile block corpus is single-sourced in `tests/adversarial_blocks.h` so the host and device termination tests drive identical bytes; all three rule sets share one scanning function.
- [x] Self-documenting: intention-revealing names and small, single-purpose functions; comments explain why, not what.
- [x] Conformance tests pass, and every new structural property is locked in as a new conformance test: six configure-time rules (fuel-capped loops, legacy intrinsics, mask provenance, wrapped collectives, bitstream-derived participation, floating point), a source-coverage assertion, and a tree-wide sweep that every ctest entry has a bounded `TIMEOUT`.

## Verification

### Pinned CUDA container, RTX 3080 (sm_86), driver 560.94, CUDA 12.6.77 - clean build (0 warnings), full ctest including the GPU-labeled tests

```
100% tests passed, 0 tests failed out of 15

 1/15 Test  #1: conformance_c ....................   Passed    0.01 sec
 2/15 Test  #2: oracle_lz4 .......................   Passed    0.01 sec
 3/15 Test  #3: parser_twin ......................   Passed    0.03 sec
 4/15 Test  #4: frame_host_negative ..............   Passed    0.01 sec
 5/15 Test  #5: termination ......................   Passed    0.05 sec
 6/15 Test  #6: launch_fail ......................   Passed    0.04 sec
 7/15 Test  #7: smoke ............................   Passed    0.29 sec
 8/15 Test  #8: gpu_fixture ......................   Passed    0.31 sec
 9/15 Test  #9: frame_twin .......................   Passed    0.52 sec
10/15 Test #10: stream_twin ......................   Passed    1.16 sec
11/15 Test #11: termination_gpu ..................   Passed    0.95 sec
12/15 Test #12: determinism_gpu ..................   Passed    1.52 sec
13/15 Test #13: bench_selfcheck ..................   Passed    0.04 sec
14/15 Test #14: bench_worst4b_selfcheck ..........   Passed    0.04 sec
15/15 Test #15: bench_longmatch_selfcheck ........   Passed    0.04 sec

Label Time Summary:
gpu    =   4.74 sec*proc (6 tests)
```

What the three new tests report:

```
termination: parser liveness and frame-walk termination hold over the truncation ladder, the mutant corpus, the crafted streams, and the frame cases
termination_gpu: 335 chunks decoded within the watchdog deadline (259 rejected, all with a defined status); three unsupported launch geometries refused without writing
determinism_gpu: 322 chunks (73 decoded) bit-identical across 6 launch configurations x 5 runs
```

### Host-only build and the ASan/UBSan gate

```
host-only build OK
libasan.so.8 and libubsan.so.1 both linked into build-san/tests/termination

1/5 Test #1: conformance_c ....................   Passed    0.02 sec
2/5 Test #2: oracle_lz4 .......................   Passed    0.05 sec
3/5 Test #3: parser_twin ......................   Passed    0.11 sec
4/5 Test #4: frame_host_negative ..............   Passed    0.03 sec
5/5 Test #5: termination ......................   Passed    0.30 sec

100% tests passed, 0 tests failed out of 5
```

### Prettier

```
Checking formatting...
All matched files use Prettier code style!
```

### The detectors bite - throwaway injection, not committed

An injected `__syncwarp(seq.match_len)`, `__shfl(`, a line-wrapped `__shfl_sync(`, a line-wrapped `__shfl_xor_sync(`, `atomicAdd(float*, 1.0f)`, and the fuel removed from the frame block-walk:

```
CMake Error at tests/CMakeLists.txt:713 (message):
  structural rules violated (issue #72):

    /w/tests/../src/lz4_decode.cuh:103: '__syncwarp' mask 'static_cast<unsigned>(seq.match_len' is neither the full-warp constant nor __activemask()
    /w/tests/../src/lz4_decode.cuh:103: '__syncwarp' names the parsed bitstream field 'match_len' - participation metadata must never come from unvalidated input
    /w/tests/../src/lz4_decode.cuh:103: '__syncwarp' reads a parsed sequence field - participation metadata must never come from unvalidated input
    /w/tests/../src/lz4_decode.cuh:104: legacy warp intrinsic '__shfl' - only the _sync form can state which lanes participate
    /w/tests/../src/lz4_decode.cuh:105: '__shfl_sync' is wrapped across lines - this scan is line-scoped, so a wrapped call hides its mask from every rule here; keep a collective on one line
    /w/tests/../src/lz4_decode.cuh:107: floating-point type 'float' - the decode path is integer-only, which is what makes the gpu_to_gpu determinism level hold (docs/DETERMINISM.md)
    /w/tests/../src/lz4_decode.cuh:107: floating-point atomic - its result depends on the order the device happens to schedule
    /w/tests/../src/lz4_decode.cuh:108: '__shfl_xor_sync' is wrapped across lines - this scan is line-scoped, so a wrapped call hides its mask from every rule here; keep a collective on one line
    /w/tests/../src/frame.cpp:250: a 'while' loop with no explicit decrementing 'fuel' cap

-- Configuring incomplete, errors occurred!
```

On every configure the scanner is also probed against itself: a compliant probe (whose comment names `while`, `do`, `for`, `float`, `double`, `__shfl(` and whose body contains a legitimately wrapped `for` header) must come back silent, and **fourteen violating probes must each come back with the TEXT of the rule they violate**, one per sub-rule, so no rule can ride on another's message.

### The timeout invariant bites, two throwaway edits, not committed

Deleting the `set_tests_properties(... TIMEOUT ...)` line from `bench/CMakeLists.txt`:

```
CMake Error at CMakeLists.txt:99 (message):
  ctest entry 'bench_longmatch_selfcheck' has no usable TIMEOUT (got '', want 1..3600 seconds): every test must fail on a hang rather than stall the run (issue #72)
```

Appending an `add_test` **after** the per-directory check, which the old design could not see:

```
CMake Error at CMakeLists.txt:124 (message):
  ctest entry 'late_probe' (registered in /w/bench) was never checked for a
  TIMEOUT: call cudec_assert_test_timeouts() at the END of that directory's
  CMakeLists.txt (issue #72)
Call Stack (most recent call first):
  CMakeLists.txt:133 (cudec_sweep_test_timeouts)
  CMakeLists.txt:176 (cudec_sweep_test_timeouts)
```

### A hung test reds within the TIMEOUT, throwaway probe, not committed

A `hang_probe` registered through `cudec_add_test` (inheriting the shared timeout, temporarily lowered to 5 s so the demonstration is short, the committed value is 300 s; the mechanism proven is identical):

```
1/1 Test #6: hang_probe .......................***Timeout   5.00 sec

The following tests FAILED:
	  6 - hang_probe (Timeout)
Errors while running CTest
CTEST_EXIT=8
```

### The termination assertions bite - throwaway parser mutation, not committed

Mutating `Next` to stop advancing (`src[src_pos]` instead of `src[src_pos++]`, and `src_pos += 0` instead of `src_pos += 2`):

```
FAIL /w/tests/termination.cpp:80: parser.src_pos > src_pos_before | random-65536/drop-2-head: step 30 returned CUDEC_OK without consuming a source byte (src_pos stuck at 65742)
FAIL /w/tests/termination.cpp:159: RequireTerminates(context, m.stream, capacity) == 0
FAIL /w/tests/termination.cpp:307: RunMutantCorpus(fixtures) == 0
EXIT=1
```

The first mutation alone does **not** trip it, the offset advance still moves the cursor, so the parser still terminates. That is the assertion behaving correctly: it asserts liveness, not correctness, and correctness is `parser_twin`'s job.

### The geometry guard bites, two throwaway edits, not committed

Disabling `total_warps == 0` (the spin case): the watchdog reports rather than blocks.

```
FAIL /w/tests/termination_gpu.cu:201: elapsed < kDeadlineSeconds | a sub-warp launch geometry (<<<1, 16>>>) did not terminate within 30 s
EXIT=1
```

Disabling only the `blockDim.x % kWarpSize != 0` clause (the silent-corruption case): the launch finishes, so the watchdog alone would have passed it, the "wrote nothing" assertion is what catches it.

```
FAIL /w/tests/termination_gpu.cu:241: results[i].status == -1 && results[i].reserved == 0xFFFFFFFFu && results[i].bytes_written == UINT64_MAX | <<<2, 16>>>: chunk 0 (empty) result record was written by a geometry the kernel must refuse
FAIL /w/tests/termination_gpu.cu:313: RequireGeometryRefused(batch, g) == 0
EXIT=1
```

### Checklist

- [x] `cmake --build build`, builds clean.
- [x] `ctest --test-dir build-cuda`, green (15/15, including the six GPU-labeled tests on the RTX 3080).
- [x] Prettier (`**/*.{md,yml,yaml}`), clean.
- [x] Docs synced: MASTERPLAN section 4 carries the termination, collective, and determinism contracts; README links `docs/DETERMINISM.md`; CONTRIBUTING carries the four-point collective checklist; BENCHMARKS records the measured cost and the occupancy budget.

---

## Independent review round 1, disposition

### BLOCKING, the guard misses a block size that is not a warp multiple, **FIXED**

Confirmed and reproduced exactly as described. `if (total_warps == 0 || blockDim.x % kWarpSize != 0) return;`, comment extended with the mechanism, and the four doc claims qualified:

- `docs/DETERMINISM.md` - the headline sentence, the launch-configuration row, and the "written exactly once" bullet now say "supported"/"a whole number of warps" and point at a new "does not promise" entry that names the refused geometries;
- `README.md`, "in every supported launch configuration";
- `CONTRIBUTING.md`, "every supported launch configuration", plus the general rule that a kernel mapping work onto lanes states which geometries it supports and refuses the rest.

`tests/termination_gpu.cu` now drives `<<<1, 16>>>`, `<<<2, 16>>>` and `<<<2, 48>>>` **before** the real launches, while the device state is still the pristine sentinel and poison, so the refusal is asserted as "wrote no result record and no destination byte", not merely "returned". Falsification for both clauses pasted above.

### BLOCKING, same sentence, widen `warp_in_grid`, **DECLINED, with a measurement**

The suggestion was that widening "costs nothing". It measurably does: **52 registers instead of 48, and sm_86 occupancy drops from 40 to 36 warps/SM**, 41-48 registers share one allocation bucket, 49 does not. Refusing the geometry instead is no cheaper, because it forces the index below the guard, which costs the same 4 registers. Silesia decode goes 12.16 ms → 12.63 ms, roughly doubling this PR's regression, to close a wrap that needs `gridDim.x * blockDim.x > 2^32`, over 33 million blocks at the shipped block size, against a `decode_grid_blocks` cap of 8192, and unreachable through the public ABI. It is now a **documented bound** of the internal header, in the kernel comment and in `docs/DETERMINISM.md`, with the register/occupancy table in `docs/BENCHMARKS.md`. The register budget for anything added to this kernel is now recorded there too: 48.

### The probe harness proves less than the PR claims, **FIXED**

Correct on all three counts. Each violating probe is now matched against the text its rule emits; there are **fourteen probes, one per sub-rule**, including the two collective rules and the FP-atomic rule that had been riding on the FP-type rule, and all four loop forms. The clean probe gained a wrapped `for` header, which the previous scanner revision reported as a header without a condition, so that false positive is fixed too (the scanner now follows a wrapped `for` header to its closing parenthesis before judging it).

### A line-wrapped collective slips past the mask rule, **FIXED**

A collective whose `(` ends the line is now a violation in itself, with a message that says why (the scan is line-scoped). The empty mask is accepted only for `__syncwarp`. The legacy-intrinsic rule's mirror hole is closed by matching the identifier rather than an immediately following `(`, the wrapped `__ballot\n    (v > 0)` probe covers it. Both appear in the injection output above.

### The scope-coverage glob is non-recursive and extension-keyed, **FIXED**

`GLOB_RECURSE`, plus `.cc`/`.hpp`/`.inl`, and device code is now recognised by **content** (`__global__` / `__device__` / `CUDEC_HOST_DEVICE`) as well as by extension, so a future `src/kernels/foo.cuh` cannot be invisible and a future `src/lz4_hc_block.h` cannot be scanned for collectives and floats but not for fuel. An empty glob is also a hard error now, so the loop cannot pass vacuously.

### `cudec_assert_test_timeouts()` only sees the directory that calls it, **FIXED**

The per-directory call now records what it verified in a global property, and a sweep at the end of the top-level `CMakeLists.txt` walks `SUBDIRECTORIES` recursively and fails on any registered test that was never recorded. Both forgettable cases red: a subdirectory that never calls it, and an `add_test` appended after the call site (demonstrated above). The check bounds the value as well as its presence (1..3600 s). Implemented in two halves rather than one because `get_test_property` is directory-scoped before CMake 3.28 and the pinned minimum here is 3.24, raising it for this would have been the wrong trade.

### The pasted methodology block disagrees with the table, **FIXED**

Everything was re-measured against the final kernel, so the numbers changed anyway; the section now labels the pasted block explicitly as one standalone run against the paired means, lists **every individual sample** in both the comparison table and the formulation table, and states plainly that the formulation comparison **does not rank the formulations**, their spread overlaps the shipped build's own run-to-run range. The earlier "recovers most of that at 12.47 ms" claim is gone; the shipped spelling is now justified structurally, not by a number it did not earn.

### Nits, disposition

- **`RequireSubWarpLaunchTerminates` only asserts "the launch finished"**, **FIXED**, and it turned out to matter: the new `<<<2, 16>>>` case is not a hang, so only the "wrote nothing" assertion catches it. The geometry checks now run first, against pristine device state, and verify every result record still carries the 0xFF sentinel and every destination byte is still poison.
- **`fuel = src_size + 1` wraps for `SIZE_MAX`**, **FIXED** with a saturating form, after checking it is free: 48 registers either way.
- **CUDA's unprefixed `half` and `_Float16` evade the FP ban**, **FIXED**; `half`, `half2`, `_Float16` and the two fp8 types are banned, each with its own probe.
- **A legitimately wrapped `for` header reds spuriously**, **FIXED** (see the probe item); the clean probe now contains one.
- **The scanner only bites on a fresh configure**, **ACCEPTED AS IS**, recorded rather than fixed: CI always configures fresh, the globs carry `CONFIGURE_DEPENDS`, and the neighbouring drift detectors share the property. Changing it would mean a build-time step for a class of drift that a PR's own CI run catches.

## Notes

**What I could not verify.** The `gpu_to_gpu` axis of the determinism claim is reasoned, not measured, the gate runs one device (RTX 3080, `sm_86`), and `docs/DETERMINISM.md` says so in those words. `compute-sanitizer` still cannot run under WSL2/WDDM.

**Honest scope of the detectors.** They remain drift detectors under the known spellings, like the single-source RAII and warnings-gate checks beside them: string literals are not stripped, a mask computed into a variable on an earlier line is judged by its name at the call site, a `fuel` mention on the line above an unrelated loop satisfies the loop rule, and a construct introduced under a fresh spelling is code review's job. What is now closed: wrapped collectives, extension-keyed coverage, non-recursive globbing, and rules that could go dead behind another rule's message.

**Follow-ups worth their own issues.** (1) Recovering the ~2% Silesia decode throughput, alongside the recorded modulo-narrowing ideas (#36, #58), with the 48-register budget as a hard constraint. (2) A second GPU for the `gpu_to_gpu` axis, whenever one is available.


---

## Independent review round 2, disposition

Round 2 confirmed the geometry blocker resolved, and found that the revision which resolved it had introduced two defects of its own, both in the scanner, both in the direction the scanner exists to prevent. All four items fixed; the nits taken.

### 1. The 14 probes covered 12 sub-rules, and the unprobed branch had a bug, **FIXED**

Correct, and the bug was real. `scan_loop_forever` and `scan_loop_empty_condition` hit the same branch and asserted the same string; the "for header without a visible condition and increment" branch had no probe, and in its single-line path `_pending_line` was never assigned, the guard `NOT _pending_reason MATCHES "'for' header"` had been written for the wrapped case. The violation still red (fail-closed held) but against a stale line number.

- The scanner now computes an explicit `_form_line` for every form, the wrapped case reports the header's first line, everything else reports its own, and the guard is gone.
- **19 probes**, no branch unprobed: `scan_for_opaque` (single-line) and `scan_for_opaque_wrapped` reach that branch by different code and **assert the line number in the expected text** (`scan_for_opaque.cu:3:`), which is what pins the fix.
- **Range-for is now accepted, not rejected.** A `for (T& x : c)` header is bounded by the container's size, loop-invariant and visible on the spot, exactly like the counted form. The clean probe carries a single-line and a wrapped range-for, so the false positive the reviewer predicted (`frame.cpp` iterates its block table by index today; the range-for is the obvious next edit) cannot appear.

### 2. The wrapped-collective rule closed the mask, not the source lane, **FIXED**

Reproduced exactly. `__shfl_sync(0xFFFFFFFFu, value,` + `seq.match_len % kWarpSize);` passed every rule: valid mask, and the field-name and `seq.`/`parser.` rules only inspect the collective's own line. The rule now measures the parenthesis balance **from the collective's own `(` to end of line**, so any collective that does not close on its line is the violation, same message, one condition changed. Measuring from the collective rather than from the whole line also avoids flagging a collective that legitimately sits inside an outer wrapped call. Probe `scan_wrapped_after_mask` covers it, and the injection run below shows it firing on real source.

### 3. `_for_open` could stick and silently kill the termination rule, **FIXED**

A genuine fail-open in the rule that argues hardest for fail-closed, and the comment three lines above it made the contradiction explicit. Two exits now:

- a cap after **8 continuation lines**, reporting the header the scan could not balance;
- an **end-of-file** check reporting a header still open when the file ends.

Both are probed (`scan_for_unbalanced`, `scan_for_unbalanced_eof`), each with an unbalanced `(` inside a string literal, the exact mechanism named, since literals are deliberately not stripped.

### 4. The decline measured two formulations, and its strongest argument was missing, **BOTH FIXED**

The reviewer's hypothesis was testable, so it was tested rather than argued. `total_warps > (size_t{1} << 27)`, the comparison on the 64-bit product already live, measures **52 registers**. So does a pure 32-bit `gridDim.x > UINT_MAX / blockDim.x`, which touches no 64-bit value at all. Same as widening. nvcc 12.6 allocates the same four extra registers for all three spellings; neither "widening costs nothing" nor "there must be a cheaper spelling" survives contact with the compiler.

| Variant                                          | Registers | Warps/SM | Silesia decode p50 |
| ------------------------------------------------ | --------- | -------- | ------------------ |
| `origin/main`, no cap, no geometry guard         | 46        | 40       | 11.924 ms          |
| shipped (cap + two-clause geometry guard)        | 48        | 40       | 12.163 ms          |
| + widen `warp_in_grid` to 64-bit                 | 52        | 36       | 12.63 ms           |
| + refuse via `total_warps > 1 << 27`             | 52        | 36       | not timed          |
| + refuse via `gridDim.x > UINT_MAX / blockDim.x` | 52        | 36       | not timed          |

Only the first was timed; the other two share its register count and therefore its occupancy, and the record now says so instead of implying three timings.

**The missing argument is the important half, and the reviewer is right that it changes the reading.** Because the guard already forces `blockDim.x` to a warp multiple, a wrapped index stays warp-aligned: the aliased block recomputes the _same_ `warp_in_grid` values with a full 0–31 lane range, decodes the same chunks, and writes byte-identical values to the same addresses. Exceeding the documented bound costs **duplicated work, not missing bytes, not a hang, and the output stays bit-identical.** That is categorically unlike the two refused geometries. It is now stated in all three places: the kernel comment, `docs/DETERMINISM.md`, and `docs/BENCHMARKS.md`. "Aliases two blocks onto one chunk", which invited the reader to assume the sub-warp severity, is gone.

### Nits, all taken

- **`CUDEC_TIMEOUT_CHECKED_TESTS` keyed on bare names**, now keyed `${dir}::${_test}` in both the recorder and the sweep.
- **Content-based device detection → opt-out**, taken, and it is the better shape. Every file under `src/` is scanned and gets the termination rule unless **explicitly exempted**; the exempt list is two entries with their reasons (`xxhash32.h`, fixed-stride checksum walks over a caller-supplied bound; `cuda_raii.h`, its only `do` is the `do { … } while (0)` macro wrapper), a stale exemption is a hard error, and the `file(READ)` of every source at configure time is gone. An opt-in list makes a new file invisible by default, which is the wrong direction for a fail-closed rule.
- **`docs/MASTERPLAN.md` §4 unqualified claim**, fixed; that was the fifth site.

### Re-verification

Clean rebuild, **0 warnings**, kernel still at **48 registers**, the shipped guard is byte-for-byte the configuration that was benchmarked, only its comment changed, so the recorded figures stand unchanged:

```
100% tests passed, 0 tests failed out of 15

termination: parser liveness and frame-walk termination hold over the truncation ladder, the mutant corpus, the crafted streams, and the frame cases
termination_gpu: 335 chunks decoded within the watchdog deadline (259 rejected, all with a defined status); three unsupported launch geometries refused without writing
determinism_gpu: 322 chunks (73 decoded) bit-identical across 6 launch configurations x 5 runs
```

Host-only build OK; ASan/UBSan gate 5/5 with both runtimes linked; Prettier clean.

Injection over real source, now including a collective wrapped **after** a valid mask - throwaway, not committed:

```
CMake Error at tests/CMakeLists.txt:802 (message):
  structural rules violated (issue #72):

    /w/tests/../src/frame.cpp:249: a 'while' loop with no explicit decrementing 'fuel' cap
    /w/tests/../src/lz4_decode.cuh:119: '__syncwarp' mask 'static_cast<unsigned>(seq.match_len' is neither the full-warp constant nor __activemask()
    /w/tests/../src/lz4_decode.cuh:119: '__syncwarp' names the parsed bitstream field 'match_len' - participation metadata must never come from unvalidated input
    /w/tests/../src/lz4_decode.cuh:119: '__syncwarp' reads a parsed sequence field - participation metadata must never come from unvalidated input
    /w/tests/../src/lz4_decode.cuh:120: legacy warp intrinsic '__shfl' - only the _sync form can state which lanes participate
    /w/tests/../src/lz4_decode.cuh:121: '__shfl_sync' is wrapped across lines - this scan is line-scoped, so a wrapped call hides its mask, source lane and predicate from every rule here; keep a collective on one line
    /w/tests/../src/lz4_decode.cuh:123: floating-point type 'float' - the decode path is integer-only, which is what makes the gpu_to_gpu determinism level hold (docs/DETERMINISM.md)
    /w/tests/../src/lz4_decode.cuh:123: floating-point atomic - its result depends on the order the device happens to schedule
```

Line 121 is finding 2 in isolation: the mask on that call is the full-warp constant and the bitstream field sits on the _next_ line, so before this revision nothing fired at all.

### Standing limits (unchanged, restated)

String literals are not stripped, which is why the unbalanced-header bail-out exists rather than being assumed away. A mask computed into a variable on an earlier line is still judged by its name at the call site. A `fuel` mention on the line above an unrelated loop still satisfies the loop rule. A construct introduced under a fresh spelling is code review's job. The scanner bites on configure, not on build; CI always configures fresh and the globs carry `CONFIGURE_DEPENDS`.
