### PR TITLE
Strip '::' before the range-for exemption test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -408,7 +408,10 @@ function(cudec_scan_source path check_loops out_violations)
         set(_form_line ${_for_start})
         if(_for_open LESS_EQUAL 0)
           set(_for_open 0)
-          if(_for_semis LESS 2 AND NOT _for_text MATCHES ":")
+          # '::' out first, for the reason spelled out at the single-line
+          # branch below: a qualified name is not a range-for.
+          string(REPLACE "::" "" _range_text "${_for_text}")
+          if(_for_semis LESS 2 AND NOT _range_text MATCHES ":")
             set(_form "a 'for' header without a visible condition and increment")
           endif()
         elseif(_for_lines GREATER 8)
@@ -433,13 +436,18 @@ function(cudec_scan_source path check_loops out_violations)
         # Covers both `for (;;)` and `for (init;; incr)`.
         set(_form "a 'for' loop with an empty condition")
       elseif(_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\(")
+        # The range-for test runs on the header with '::' removed: the colons
+        # of a qualified name (`cudec_detail::Foo`) carry none of the meaning
+        # the exemption rests on, and left in they would exempt any opaque
+        # header that happens to mention one.
+        string(REPLACE "::" "" _range_text "${_code}")
         if(_balance GREATER 0)
           set(_for_open ${_balance})
           set(_for_semis ${_line_semis})
           set(_for_start ${_lineno})
           set(_for_lines 1)
           set(_for_text "${_code}")
-        elseif(_line_semis LESS 2 AND NOT _code MATCHES ":")
+        elseif(_line_semis LESS 2 AND NOT _range_text MATCHES ":")
           # A balanced header with fewer than two semicolons has no visible
           # induction variable - a macro-hidden loop, say. A range-for
           # (`for (T& x : container)`) is exempt by the ':': its bound is the
@@ -596,6 +604,13 @@ file(
   "         blocks) {\n"
   "        total += wrapped.size;\n"
   "    }\n"
+  "    for (const cudec_detail::Block& scoped : blocks) {\n"
+  "        total += scoped.size;\n"
+  "    }\n"
+  "    for (const cudec_detail::Block& scoped_wrapped :\n"
+  "         blocks) {\n"
+  "        total += scoped_wrapped.size;\n"
+  "    }\n"
   "    unsigned fuel = n + 1;\n"
   "    while (fuel-- != 0) {\n"
   "        total += 1;\n"
@@ -681,6 +696,20 @@ file(WRITE ${_probe_dir}/scan_for_opaque_wrapped.cu
      "    unsigned count = 0;\n" "    for (EACH_CHUNK(chunk,\n"
      "                    src)) {\n" "        count += chunk;\n" "    }\n"
      "    return count;\n" "}\n")
+# The same opaque header carrying a qualified name. Its '::' is not a
+# range-for's ':' and must not exempt it - single-line, and wrapped with the
+# qualified name on the continuation line, where only the accumulated header
+# text can see it.
+file(WRITE ${_probe_dir}/scan_for_opaque_qualified.cu
+     "unsigned probe(const unsigned char* src) {\n"
+     "    unsigned count = 0;\n"
+     "    for (EACH_CHUNK(chunk, cudec_detail::chunks_of(src))) {\n"
+     "        count += chunk;\n" "    }\n" "    return count;\n" "}\n")
+file(WRITE ${_probe_dir}/scan_for_opaque_qualified_wrapped.cu
+     "unsigned probe(const unsigned char* src) {\n"
+     "    unsigned count = 0;\n" "    for (EACH_CHUNK(chunk,\n"
+     "                    cudec_detail::chunks_of(src))) {\n"
+     "        count += chunk;\n" "    }\n" "    return count;\n" "}\n")
 # A `for` header the scan cannot balance must be rejected, not skipped: while
 # the tracker is open the whole loop rule is off, so a silent skip would
 # disable the termination check for the rest of the file. String literals are
@@ -729,6 +758,8 @@ set(_scanner_probes
     "scan_fp_atomic|floating-point atomic"
     "scan_for_opaque|scan_for_opaque.cu:3: a 'for' header without a visible"
     "scan_for_opaque_wrapped|scan_for_opaque_wrapped.cu:3: a 'for' header without a visible"
+    "scan_for_opaque_qualified|scan_for_opaque_qualified.cu:3: a 'for' header without a visible"
+    "scan_for_opaque_qualified_wrapped|scan_for_opaque_qualified_wrapped.cu:3: a 'for' header without a visible"
     "scan_for_unbalanced|closing parenthesis was not found within 8 lines"
     "scan_for_unbalanced_eof|left unbalanced at end of file"
     "scan_wrapped_after_mask|is wrapped across lines")


### PR DESCRIPTION
# What & why

The opaque-`for` rule in `cudec_scan_source()` tested for any `:` in the
header, so `for (EACH_CHUNK(chunk, cudec_detail::Foo))` was exempted by its
`::` and escaped the termination rule entirely. Both `:` tests now run on the
header with `::` removed. A qualified name's colons carry none of the meaning
the exemption rests on: a range-for is exempt because its bound is the
container's size, loop-invariant and visible on the spot.

Closes #123

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [x] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: the change only makes a fail-closed structural
      rule refuse a case it was letting through. No parse or decode path is
      touched, no new input reaches any bound.
- [ ] Oracle coverage: not applicable, no format path is touched. The oracle
      tests run unchanged and green (see Verification).
- [x] Determinism preserved: no source under `src/` changes, so the built
      artifacts are unchanged.
- [x] Not applicable, no CUDA API call and no ABI boundary is touched.
- [ ] An adversarial review was NOT run by the author. The change is on a
      sensitive surface (`tests/CMakeLists.txt`) and the review belongs to the
      reviewing lane, not to me.
- [ ] Review record: none yet. This PR has not been reviewed.

## Performance checklist

Not on the hot path. No source under `src/` or `bench/` changes.

- [ ] The claim is measured, not reasoned: no performance claim is made.
- [ ] No regression against the recorded baseline: not applicable.

## Quality checklist

- [x] Minimal: two `string(REPLACE "::" "")` calls, two probe files, two
      entries in `_scanner_probes`, and two range-for loops in the clean probe.
- [x] Self-documenting: the reason for the strip sits at the single-line
      branch, and the wrapped branch points at it rather than repeating it.
- [x] The new property is locked in by the probes. Each of the two code
      branches was proven red on its own before the fix, so neither is riding
      on the other:

      With both probes added and the scanner untouched, `cmake -B build-red
      -DCUDEC_ENABLE_CUDA=ON` fails with

          CMake Error at tests/CMakeLists.txt:772 (message):
            the structural scanner is dead for one rule: probe
            'scan_for_opaque_qualified' did not report
            "scan_for_opaque_qualified.cu:3: a 'for' header without a visible"

      With only the single-line branch stripped, the same command fails on
      `scan_for_opaque_qualified_wrapped` instead.

## Verification

Run at `5b4f93e84a25d7b80d2070aa30094b52bf2fbac9` with a clean working tree
(`git status --porcelain` empty), build directories removed first. GPU:
NVIDIA GeForce RTX 3080, driver 560.94, nvcc V12.6.77, container image
`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`.

- [x] `cmake -B build && cmake --build build` (host-only) - builds clean.

      [ 50%] Building C object CMakeFiles/cudec.dir/src/version.c.o
      [100%] Linking C static library libcudec.a
      [100%] Built target cudec

- [x] `cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda
      -j && ctest --test-dir build-cuda --output-on-failure` - green.

      100% tests passed, 0 tests failed out of 15

      Label Time Summary:
      gpu    =   5.01 sec*proc (6 tests)

      Total Test time (real) =   5.38 sec

      The configure step is where the 21 scanner probes run. A silent probe or
      a probe reporting the wrong text is a `FATAL_ERROR`, so a successful
      configure is the assertion that all 21 passed and that `scan_clean.cu`
      came back empty.

- [x] The CI host subset, `ctest --test-dir build-cuda -LE gpu
      --no-tests=error --output-on-failure`:

      100% tests passed, 0 tests failed out of 9

- [x] The CI sanitize job, `cmake -B build-san -DCUDEC_ENABLE_CUDA=ON
      -DCUDEC_SANITIZE=address,undefined && cmake --build build-san -j &&
      ctest --test-dir build-san --no-tests=error --output-on-failure -R
      '^(conformance_c|oracle_lz4|parser_twin|frame_host_negative|termination)$'`:

      100% tests passed, 0 tests failed out of 5

- [x] Prettier: `npx --yes prettier@3 --check "**/*.{md,yml,yaml}"` -
      "All matched files use Prettier code style!". No `.md`, `.yml` or
      `.yaml` file changes in this PR anyway.
- [x] Docs synced: nothing to sync. The rule's own explanation lives in the
      comment beside it, and that comment is updated.

## Notes

Scope. The strip is `::` and only `::`. Other colons that are not a range-for
still exempt an opaque header: a ternary in the header, a bit-field width, a
label. No `for` header in the shipped sources contains a colon of any kind
today, so none of them is live:

    $ grep -rhn "for[ \t]*(" src/ include/ | sed 's/^[0-9]*://' | grep -c ":"
    0

Each would want its own probe and its own reasoning rather than a wider blind
strip, so they are left alone rather than guessed at.

The clean probe gains a plain and a wrapped genuine range-for whose element
type is qualified. Without them the strip could go the other way and start
rejecting the loops the exemption exists for, and nothing would say so.

---

## Independent verification

**This section was produced by an automated re-run, not by a second person.** It
re-executes the repository's own commands and reports what they printed. It is
evidence that the stated numbers reproduce, and it is not a human second opinion.

Every number below was produced
at `5b4f93e84a25d7b80d2070aa30094b52bf2fbac9` as it sits on the remote, on a
clean tree (`git status --porcelain` empty), in the pinned container.

### The gate, re-run rather than taken on trust

```
docker run --rm --gpus all -v "<worktree>:/w" -w /w \
  nvidia/cuda:12.6.2-devel-ubuntu24.04 sh -c \
  "apt-get update -q >/dev/null && apt-get install -yq cmake >/dev/null 2>&1 \
   && cmake -B build && cmake --build build \
   && cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j \
   && ctest --test-dir build-cuda --output-on-failure"
```

```
HOST-ONLY BUILD OK
CUDA BUILD OK
100% tests passed, 0 tests failed out of 15

Label Time Summary:
gpu    =   4.77 sec*proc (6 tests)

Total Test time (real) =   5.14 sec
```

GPU: NVIDIA GeForce RTX 3080, driver 560.94 (`nvidia-smi
--query-gpu=name,driver_version --format=csv` in the same image). Same result
at `2cea666` on `main` for comparison: 15/15, so nothing here rides on a test
that was already red.

The probe count the PR body asserts:

```
$ sed -n '/^set(_scanner_probes/,/^foreach/p' tests/CMakeLists.txt | grep -c '^    "'
21
```

The `Notes` grep reproduces:

```
$ grep -rhn "for[ \t]*(" src/ include/ | sed 's/^[0-9]*://' | grep -c ":"
0
```

### The attack: each guard deleted, the suite re-run

A guard whose removal leaves the gate green is not covered. Each mutation was
applied to a pristine export of the commit, configured with
`cmake -B build-red -DCUDEC_ENABLE_CUDA=ON`, then reverted.

| mutation | configure |
| --- | --- |
| none | GREEN |
| wrapped branch back to `_for_text MATCHES ":"` | RED on `scan_for_opaque_qualified_wrapped` |
| single-line branch back to `_code MATCHES ":"` | RED on `scan_for_opaque_qualified` |
| both back (the behaviour on `main`) | RED on `scan_for_opaque_qualified` |
| strip every `:`, not just `::` | RED, clean probe rejected at lines 13, 16, 20 |
| truncate the header from its first `::` | RED, clean probe rejected at line 20 |

The last row is the one worth naming: line 20 of `scan_clean.cu` is one of the
two range-for loops this PR adds. A strip that ate the range-for colon along
with the qualified name passes every probe that existed before this change and
is caught only by the loops added here, so those two loops are load-bearing,
not decoration.

Both code branches are held apart by their own probe, in both directions, so
neither is riding on the other.

### Checked and found nothing

- False positives on a genuine range-for: `for (const T& x : ns::items())`
  keeps its bare `:` after the strip, and a range-for cannot have `::` as its
  only colon, so the exemption cannot be stripped away from one.
- Scope: only `tests/CMakeLists.txt` changes, so no built artifact moves and
  the determinism and oracle claims in the PR body are true by construction
  (`git diff --stat 2cea666..5b4f93e` names one file).
- The three required checks are green on this head: build, sanitize, format.

### The residual is already written down

The `Notes` section is right that a ternary, a label or a colon inside a string
literal still buys an exemption, and right that each wants its own probe rather
than a wider blind strip. That residual is filed as #250 rather than left
unwritten, which is what makes the narrow scope here a decision instead of an
omission.
