### PR TITLE
Recognise the do/while(0) idiom, drop the cuda_raii.h exemption

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -313,7 +313,11 @@ endforeach()
 #    `fuel` counter on its own line, the line above it, or the three below,
 #    because a text scan cannot verify a monotone-cursor argument and a
 #    non-terminating decode hangs the device (nvCOMP 5.3's release notes
-#    record shipping exactly that on malformed Snappy input);
+#    record shipping exactly that on malformed Snappy input). The one
+#    forgiven form is `do { ... } while (0)`, the wrapper that makes a macro
+#    body a single statement: its body runs once, so there is no exit
+#    condition for a cap to bound. It is forgiven as an idiom rather than
+#    per file, so a real loop in the same header is still seen;
 #  - warp collectives: the legacy non-_sync intrinsics are banned outright
 #    (since Volta's independent thread scheduling they cannot express which
 #    lanes participate at all), and a collective's mask must be a full-warp
@@ -329,8 +333,11 @@ endforeach()
 # Limits, stated as the neighbouring checks state theirs: constructs hidden
 # inside string literals are not stripped; a mask computed into a variable on
 # an earlier line is judged by its name at the call site; a `fuel` mention on
-# the line above an unrelated loop satisfies the loop rule; and a loop or
-# intrinsic introduced under a fresh spelling is code review's job.
+# the line above an unrelated loop satisfies the loop rule; a `do { ... }
+# while (0)` written out rather than wrapped in a macro is reported once its
+# body passes two lines, because its tail is then outside the three-line
+# window the `fuel` mention gets and a macro's tail is never outside it; and a
+# loop or intrinsic introduced under a fresh spelling is code review's job.
 function(cudec_scan_source path check_loops out_violations)
   set(_violations "")
   set(_in_comment FALSE)
@@ -385,7 +392,13 @@ function(cudec_scan_source path check_loops out_violations)
 
     if(check_loops)
       if(_pending_left GREATER 0)
-        if(_code MATCHES "fuel")
+        # A `while (0)` below a pending `do` is that `do`'s tail: the idiom,
+        # not a loop. Only a pending `do` is cleared this way - a `while` or a
+        # `for` above an unrelated `while (0)` keeps its requirement, so the
+        # idiom clause cannot swallow the rule it sits inside.
+        if(_code MATCHES "fuel"
+           OR (_pending_reason STREQUAL "a 'do' loop"
+               AND _code MATCHES "while[ \t]*\\([ \t]*0[ \t]*\\)"))
           set(_pending_left 0)
         else()
           math(EXPR _pending_left "${_pending_left} - 1")
@@ -426,12 +439,22 @@ function(cudec_scan_source path check_loops out_violations)
                  "parenthesis was not found within 8 lines - the scan cannot "
                  "judge it, so it is rejected rather than skipped\n")
         endif()
+      elseif(_code MATCHES "[^A-Za-z_0-9]do[ \t]*{")
+        # Before the tail branch below, not after it, because a
+        # backslash-continued macro reaches this scan as ONE line:
+        # file(STRINGS) hands back the file as a list, and a trailing '\'
+        # escapes the separator that would have ended the element, so the
+        # whole macro body is joined into one. A macro-hidden
+        # `do { ... } while (cond)` therefore carries its own tail, and the
+        # tail branch below would take it for someone else's tail and let a
+        # real loop through.
+        if(NOT _code MATCHES "while[ \t]*\\([ \t]*0[ \t]*\\)")
+          set(_form "a 'do' loop")
+        endif()
       elseif(_code MATCHES "\\}[ \t]*while")
         # The tail of a do-while; its `do {` carries the requirement.
       elseif(_code MATCHES "[^A-Za-z_0-9]while[ \t]*\\(")
         set(_form "a 'while' loop")
-      elseif(_code MATCHES "[^A-Za-z_0-9]do[ \t]*{")
-        set(_form "a 'do' loop")
       elseif(_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\([^)]*;[ \t]*;")
         # Covers both `for (;;)` and `for (init;; incr)`.
         set(_form "a 'for' loop with an empty condition")
@@ -587,6 +610,12 @@ file(
   WRITE ${_probe_dir}/scan_clean.cu
   "/* Prose naming while, do, for, float, double, __shfl( and a mask from a\n"
   " * token - the comment stripper must remove all of it. */\n"
+  "#define PROBE_CHECK(call) \\\n"
+  "    do {                  \\\n"
+  "        if ((call) != 0) {\\\n"
+  "            return 0;     \\\n"
+  "        }                 \\\n"
+  "    } while (0)\n"
   "unsigned probe_counted(unsigned n) {\n"
   "    unsigned total = 0;\n"
   "    for (unsigned i = 0; i < n; i++) {\n"
@@ -623,6 +652,9 @@ file(
   "        }\n"
   "        left = left - 1;\n"
   "    } while (left != 0);\n"
+  "    do {\n"
+  "        total += 1;\n"
+  "    } while (0);\n"
   "    return total;\n"
   "}\n"
   "__device__ int probe_collective(int v) {\n"
@@ -647,6 +679,34 @@ file(
   "    do {\n"
   "        count += src[count % n];\n"
   "    } while (count != 0);\n"
+  "    return count;\n"
+  "}\n")
+# The same loop hidden in a macro, which the scan reads as a single line
+# because the continuations join it. The line number is asserted with the
+# text: `:1:` is the whole macro, and reporting it anywhere else would mean
+# the join stopped happening and the probe stopped covering the macro case.
+file(
+  WRITE ${_probe_dir}/scan_loop_do_macro.cu
+  "#define PROBE_RETRY(src, n) \\\n"
+  "    do {                    \\\n"
+  "        count += src[count % n];\\\n"
+  "    } while (count != 0)\n"
+  "unsigned probe(const unsigned char* src, unsigned n) {\n"
+  "    unsigned count = src[0];\n"
+  "    PROBE_RETRY(src, n);\n"
+  "    return count;\n"
+  "}\n")
+# The idiom clause is for a pending `do` and nothing else. Here a `while` loop
+# with no cap is followed, inside its window, by a `do { } while (0);` that has
+# nothing to do with it. The `while` must still be reported.
+file(
+  WRITE ${_probe_dir}/scan_loop_while_zero_below.cu
+  "unsigned probe(const unsigned char* src, unsigned n) {\n"
+  "    unsigned count = src[0];\n"
+  "    while (count != 0) {\n"
+  "        count += src[count % n];\n"
+  "    }\n"
+  "    do { } while (0);\n"
   "    return count;\n"
   "}\n")
 file(WRITE ${_probe_dir}/scan_loop_forever.cu
@@ -744,6 +804,8 @@ endif()
 set(_scanner_probes
     "scan_loop_while|a 'while' loop with no explicit decrementing 'fuel' cap"
     "scan_loop_do|a 'do' loop with no explicit decrementing 'fuel' cap"
+    "scan_loop_do_macro|scan_loop_do_macro.cu:1: a 'do' loop with no explicit"
+    "scan_loop_while_zero_below|scan_loop_while_zero_below.cu:3: a 'while' loop with no explicit"
     "scan_loop_forever|a 'for' loop with an empty condition with no explicit"
     "scan_loop_empty_condition|a 'for' loop with an empty condition with no explicit"
     "scan_legacy_intrinsic|legacy warp intrinsic '__shfl'"
@@ -789,12 +851,9 @@ endforeach()
 #  - xxhash32.h: its loops walk a caller-supplied buffer at a fixed stride
 #    with no stream-derived exit condition, and it is a checksum helper rather
 #    than a decoder.
-#  - cuda_raii.h: its only `do` is the `do { ... } while (0)` wrapper that
-#    makes the CUDA-error-check macro a single statement - an idiom, not a
-#    loop.
 #
-# Both are still held to the warp-collective and floating-point rules.
-set(_loop_rule_exempt xxhash32.h cuda_raii.h)
+# It is still held to the warp-collective and floating-point rules.
+set(_loop_rule_exempt xxhash32.h)
 file(GLOB_RECURSE _all_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
      CONFIGURE_DEPENDS
      ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c


### PR DESCRIPTION
﻿# What & whyThe termination rule was off for the whole of `src/cuda_raii.h` so that onemacro wrapper could pass. The file is under the rule now and the wrapper isforgiven as an idiom instead.The route there is not the one the issue describes, and that is the substanceof this change. The issue expects a pending violation that a `while (0)` clausethen clears. There is none: dropping the exemption and changing nothing elseconfigures green today, because `file(STRINGS)` joins a backslash-continuedmacro into ONE element and the existing tail branch (`} while`) matched thatline first and set no form. So it was never the idiom that was forgiven, itwas every `do` inside every macro, whatever its condition. The commit messagecarries the elements, the reproduction, and the mutation table.Closes #124**Not ready to merge, and held here on purpose.** The gate is green, everynumber below re-runs at the commit as it sits on origin, and the diagnosisholds. But the clause that replaces the file exemption has a fail-open of itsown, in the very file this brings under the rule - measured under "Openquestion, blocking". Settling it is a decision about what the termination ruleforgives, so it is put as a question rather than guessed at.## Type of change- [ ] Decode kernel / device code- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)- [ ] API surface- [ ] Performance- [x] Bug fix- [ ] Refactor / code quality- [x] Build / CI / supply chain- [ ] Docs## Engineering checklist- [ ] Fail-closed preserved: only partly. The change closes the fail-open the      file exemption was hiding - every `do` inside every macro, tree-wide -      and opens a narrower one: a real macro-hidden `do` loop on any of the      three lines above a `while (0)`. Measured under "Open question,      blocking". No parse or decode path is touched, no new input reaches any      bound.- [ ] Oracle coverage: not applicable, no format path is touched. The oracle      tests run unchanged and green (see Verification).- [x] Determinism preserved: no source under `src/` changes, so the built      artifacts are identical.- [x] Not applicable, no CUDA API call and no ABI boundary is touched.- [ ] An adversarial review by a person was NOT run over this surface. What was      run: the guard table was re-executed at the head commit and then extended      with the placement cases the table does not cover. This section was      produced by an automated re-run, not by a second person. The box stays      unticked because a re-run is not the thing the box asks about.- [x] One finding was confirmed and it is not fixed here. Its reproduction is      below. It is deferred rather than repaired, because the repair is a choice      between two rule scopes and that choice is not mechanical.## Performance checklistNot on the hot path. No source under `src/` or `bench/` changes.- [ ] The claim is measured, not reasoned: no performance claim is made.- [ ] No regression against the recorded baseline: not applicable.## Quality checklist- [x] Minimal: one branch moved and given a condition, one clause added to the      pending block, one entry removed from the exempt list, two probe files,      two entries in `_scanner_probes`, and two shapes added to the clean      probe.- [x] Self-documenting: the reason the `do` branch sits above the tail branch      is written where it sits, because it is not obvious from the code that a      macro arrives as one line.- [ ] Every guard is locked in by a probe: five of the six guards are. The      sixth, the idiom clause, is locked in only for the placement the probe      happens to use - see the re-run below and the open question.## VerificationThis section was produced by an automated re-run, not by a second person.Re-run at `e0e8cd1432817564929907c6df0a7b18b33418c6`, the head of `issue/124`,from a clean export. Its merge base with `main` equals `f3ac56475be9f70ed420d11127caae4c9395ed4c`,the current tip of `main`, so the branch sits directly on the mainline andthere is nothing to rebase. Build directories created fresh. GPU: NVIDIAGeForce RTX 3080, driver 560.94, nvcc V12.6.77, container image`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`.- [x] `cmake -B build && cmake --build build` (host-only) - builds clean.      [ 50%] Building C object CMakeFiles/cudec.dir/src/version.c.o      [100%] Linking C static library libcudec.a      [100%] Built target cudec- [x] `cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda      -j && ctest --test-dir build-cuda --output-on-failure` - green.      100% tests passed, 0 tests failed out of 15      Label Time Summary:      gpu    =   4.71 sec*proc (6 tests)      Total Test time (real) =   5.07 sec      The configure step is where the scanner probes run. A silent probe or a      probe reporting the wrong text is a `FATAL_ERROR`, so a successful      configure is the assertion that they passed and that `scan_clean.cu`      came back empty.- [x] The CI host subset, `ctest --test-dir build-cuda -LE gpu      --no-tests=error --output-on-failure`:      100% tests passed, 0 tests failed out of 9- [x] The CI sanitize job, `cmake -B build-san -DCUDEC_ENABLE_CUDA=ON      -DCUDEC_SANITIZE=address,undefined && cmake --build build-san -j &&      ctest --test-dir build-san --no-tests=error --output-on-failure -R      '^(conformance_c|oracle_lz4|parser_twin|frame_host_negative|termination)$'`:      100% tests passed, 0 tests failed out of 5      `ldd build-san/tests/parser_twin | grep -c 'libasan\|libubsan'` prints 2,      and all five sanitized binaries exist.- [x] Prettier: `npx --yes prettier@3 --check "**/*.{md,yml,yaml}"` - "All      matched files use Prettier code style!". No `.md`, `.yml` or `.yaml`      file changes in this PR anyway.- [x] Docs synced: nothing to sync. The rule's own explanation and its Limits      paragraph live beside it, and both are updated.### The guard table, re-runEach guard deleted in turn from a pristine export of the head commit,re-configuring each time with `cmake -B build-red -S <export>-DCUDEC_ENABLE_CUDA=ON`:    A0 unchanged                                    GREEN    A1 the do branch no longer tests for while (0)  RED scan_clean.cu:3    A2 the do branch back after the tail branch     RED scan_loop_do_macro    A3 idiom clause out of the pending block        RED scan_clean.cu:40    A4 idiom clause not restricted to a pending do  RED scan_loop_while_zero_below    A5 macro-hidden retry loop in src/cuda_raii.h   RED cuda_raii.h:32    A6 plain retry loop in src/cuda_raii.h          RED cuda_raii.h:64A6 reports one site rather than two because the loop was placed once, in`DevBuf::ensure()`. A5 reproduces, but only for the placement it uses - that isthe open question below.The mainline reference cases, same method, pristine export of`f3ac56475be9f70ed420d11127caae4c9395ed4c`:    B0 mainline, unchanged                                   GREEN    B1 mainline, exemption dropped, nothing else             GREEN    B2 mainline, exemption dropped, macro-hidden retry loop  GREEN    B3 mainline, exemption in place, plain retry loop        GREENB1 is the claim this change rests on, and it holds: the pending violation theissue expects is not there. B2 and B3 are the two fail-opens the exemption wascovering.## Open question, blocking**A5 depends on where the loop is put, and the placement that passes is theone directly above the existing macro.**The clause added to the pending block clears a pending `do` when any of thenext three lines carries `while (0)`. It cannot tell that `while (0)` from thepending `do`'s own tail, and `src/cuda_raii.h:36` is the only `while (0)`under `src/`. So the identical loop is reported below that macro and silentabove it. Both runs, same export, same command:    below CUDEC_CUDA_CHECK, no blank line :: RED    cuda_raii.h:32: a 'do' loop with no explicit decrementing 'fuel' cap    above CUDEC_CUDA_CHECK, no blank line :: GREEN  the loop is not reportedThe loop inserted in both:    #define CUDEC_RETRY(call, n) \        do {                     \            n = n + (call);      \        } while (n != 0)Sweeping the gap between that macro and `CUDEC_CUDA_CHECK` shows the blindwindow is exactly the three lines the pending counter allows:    gap 0 blank lines  GREEN    gap 1 blank line   GREEN    gap 2 blank lines  GREEN    gap 3 blank lines  RED  cuda_raii.h:31    gap 4 blank lines  RED  cuda_raii.h:31This is narrower than what it replaces: on the mainline a macro-hidden loop isinvisible anywhere in the file (B2), here only within three lines above a`while (0)`. It is still a loop with a stream-derived exit condition passingthe rule written to refuse it, in the file this change exists to bring underthat rule, next to the macro a new macro would be written beside.Breaking the idiom deliberately does fire, which is the other half worthchecking: replacing the wrapper's own `} while (0)` with`} while ((call) != cudaSuccess)` reports `cuda_raii.h:31`. The changesatisfies the check for the wrapper itself; it is the neighbourhood the clausecannot see.**The question: which spelling should the rule forgive?**1. Only the macro-joined one, which the same-line test in the `do` branch   already covers. The pending-block clause and the written-out shape added to   `scan_clean.cu` come out again; a written-out `do { ... } while (0)` then   needs a `fuel` mention or a macro wrapper. Nothing in the tree spells it   that way today, as the Notes below already record. This closes the hole   outright and makes the diff smaller than it is now.2. Both, and tie the clearing `while (0)` to its own `do` by brace depth. That   is a mechanism this scan does not have and has avoided throughout - it is   line-scoped by design, and the neighbouring Limits paragraph says so.Option 1 is smaller and closes it; option 2 preserves a spelling nothing inthe tree uses. Either changes what a contributor is allowed to write, which iswhy the choice is not taken here.## NotesResidual, written into the function's Limits paragraph rather than left for areader to find: a `do { ... } while (0)` written out instead of wrapped in amacro is reported once its body passes two lines, because its tail is thenoutside the three-line window the `fuel` mention gets. A macro's tail is neveroutside that window, since it is on the same joined line. Nothing in the treespells the idiom that way.Out of scope and filed as #251: the same join means a collective wrappedacross a macro's continuation lines is invisible to the wrapped-collectiverule, and every line number below a continuation is short by the number ofcontinuation lines above it. Both are measured there. Neither is reachable byanything in the tree today, and the second is why `scan_loop_do_macro` assertsa line number as well as a rule text: `:1:` is the whole macro, and reportingit anywhere else would mean the join stopped happening and the probe stoppedcovering the case it was written for. That shift is also why the line numbersin the tables above are element numbers, not source lines.The exempt list is down to `xxhash32.h`, and its stated reason still holds:fixed-stride loops over a caller-supplied buffer in a checksum helper, with nostream-derived exit condition.## Left open, and the reasonThe blocking question above is answered, on #124, and the answer is option 1.Only the macro-joined spelling is forgiven, which the same-line test in the `do`branch already covers. The pending-block clause and the written-out shape addedto `scan_clean.cu` come out. #124 now carries that surface and the done-whenthat goes with it, together with the reasoning and the measurement it rests on,which is this body's own.That answer deletes part of this branch, so this branch is not merged. Landingit would put the clause and the probe shape onto the mainline and take them offagain in the next change, and the clause is the one guard this body alreadyreports as locked in only for the placement its probe happens to use. Thesuccessor branch is smaller than this one and closes the hole outright.What this branch established is kept rather than repeated by accident. Thediagnosis that dropping the exemption alone configures green, because`file(STRINGS)` joins a backslash-continued macro into one element and the tailbranch matched it first; the placement of the `do` branch above the tail branchwith its reason written where it sits; the `scan_loop_do_macro` probe assertinga line number as well as a rule text; and the `scan_loop_while_zero_below`probe. All of it carries over to the successor.### The mainline has moved since the merge base recorded above    git fetch origin    git rev-parse origin/main    972fac1bb5d769c72ef2024bc0fdaa409047909c    git merge-base origin/main origin/issue/124    f3ac56475be9f70ed420d11127caae4c9395ed4c    git log --oneline f3ac564..972fac1    972fac1 Merge pull request #255 from iderex/voice/em-dash-254    bec8de8 The em dash leaves the documentation and the two comment lines [#254]Those two commits change comment and prose text only, in ten files, with nobuild step, no test and nothing under `src/` or `tests/` touched. So theVerification block above is still true of the commit it names and nothing wasmerged into this branch.Nothing was executed while this section was written. No cmake and no CUDAtoolchain were present, so no configure, build, ctest or probe run stands behindit, and the Verification block above is not restated as current on that account.It was measured at `e0e8cd1432817564929907c6df0a7b18b33418c6`. The executedevidence available here is the three CI checks on that commit, build, sanitizeand format, all green, and the rest of this section is a reading of`tests/CMakeLists.txt` at that commit.

## Pins refreshed, 2026-08-05, and this is not merged

This section was produced by an automated re-run, not by a second person.

This branch is not landed and is not going to be. #124 answered its blocking
question with option 1, the successor branch carries that surface, and it has
now merged as `1a77831049045d684adde92b507edd721a8beea6`. Everything this body
says about itself stands: the fail-open under "Open question, blocking" was
real, the clause and the probe shape it added are the part the answer deleted,
and none of that is retracted here.

What is refreshed is the pins. The mainline this body measures against no
longer exists on the mainline path, so the reference rows in it cannot be
reproduced as written, and the addendum says which ones and why rather than
leaving a reader to discover it.

### Where the pins now point

    git rev-parse origin/main
    1a77831049045d684adde92b507edd721a8beea6
    git log --oneline f3ac564..origin/main
    1a77831 Merge pull request #260 from iderex/issue/124-scanner
    d02a8e0 Merge mainline into issue/124-scanner
    b857dcb Merge pull request #259 from iderex/issue/57
    5471836 Merge mainline into issue/57
    1ff5369 Merge pull request #257 from iderex/issue/125
    0aded6c Bound the streaming host-output copy by the chunk's capacity [#57]
    9bb1e0a Add the four-tool Compute Sanitizer runner over discovered gpu tests [#125]
    4a19a5e Judge a macro-hidden do loop by the whole element [#124]
    d7e41d2 Extract the streaming host-output wave copy and drive it with a bad length [#57]
    972fac1 Merge pull request #255 from iderex/voice/em-dash-254
    bec8de8 The em dash leaves the documentation and the two comment lines [#254]

The blobs of the one file this branch and its successor both change:

    git rev-parse f3ac564:tests/CMakeLists.txt      8b8e4aa09da67e6d1d9a7340da1661b6a9361bdd   the base this body measured against
    git rev-parse e0e8cd1:tests/CMakeLists.txt      e49af9e826988ccf5ea56459a443bb2c5248bb95   this branch's head, unlanded
    git rev-parse 4a19a5e:tests/CMakeLists.txt      b147f57b73863a006ebeaea6aa6dfbed25700ca6   the successor's head
    git rev-parse origin/main:tests/CMakeLists.txt  b147f57b73863a006ebeaea6aa6dfbed25700ca6   what landed

The last two are the same blob, so the successor landed with no change made to
it on the way in.

### Which of this body's rows can still be reproduced

The A rows are rows about this branch's own head, `e0e8cd1`, and that commit
still exists, so they stand as measured.

The B rows do not. Every one of them starts from a mainline that exempts
`src/cuda_raii.h` from the loop rule, and the mainline no longer does:

    git show origin/main:tests/CMakeLists.txt | grep 'set(_loop_rule_exempt'
    set(_loop_rule_exempt xxhash32.h)

So B1, "mainline, exemption dropped, nothing else", is now the mainline
unchanged, and B3, "exemption in place, plain retry loop", cannot be set up at
this base without putting the exemption back. Both were true of `f3ac564` and
neither is a statement about the tree today.

B2 is the one worth re-measuring, because it is the fail-open this branch
exists to close. It was GREEN on the old mainline, meaning the loop went
unseen. Re-run at a pristine export of `1a77831`, one configure with
`cmake -B <build> -S <export> -DCUDEC_ENABLE_CUDA=ON`, planting the same
macro-hidden retry loop this body used, directly above `CUDEC_CUDA_CHECK`:

    the mainline as it now stands                          GREEN
    the same loop, same placement                          RED
      cuda_raii.h:31: a 'do' loop with no explicit decrementing 'fuel' cap

The hole is closed on the mainline, by the successor rather than by this
branch. The placement that is red there is the one this branch's own clause let
through, which is what the open question was about and why the route changed.

### Why this is closed rather than merged

Landing it would put the pending-block clause and the written-out probe shape
onto a mainline that has already taken the other route, and the next change
would take them straight back off. #124 recorded that decision before either
branch landed and is now closed by the successor. Nothing here is a finding
against this branch that was not already in its own body first.
