### PR TITLE
The em dash leaves the documentation and the two comment lines [#254]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Dependabot — weekly maintenance for the GitHub Actions SHA pins.
+# Dependabot - weekly maintenance for the GitHub Actions SHA pins.
 
 version: 2
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@
 - [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
       __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
       reproduction was produced). Every finding of either kind carries a
-      disposition — FIX, a reasoned DECLINE, or DEFER as its own issue.
+      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
 
 ## Performance checklist
 
@@ -52,10 +52,10 @@ Fill in for any change on the hot path.
 
 Paste the local gate results (or confirm CI is green).
 
-- [ ] `cmake --build build` — builds clean.
-- [ ] `ctest --test-dir build` — green (oracle diffs, negative tests,
+- [ ] `cmake --build build` - builds clean.
+- [ ] `ctest --test-dir build` - green (oracle diffs, negative tests,
       conformance tests).
-- [ ] Prettier (`**/*.{md,yml,yaml}`) — clean.
+- [ ] Prettier (`**/*.{md,yml,yaml}`) - clean.
 - [ ] Docs synced: MASTERPLAN / README / BENCHMARKS reflect any behavior,
       API, or performance change.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# CI — the fail-closed pull-request gate.
+# CI - the fail-closed pull-request gate.
 #
 # Runs only on pull requests to `main`, so the mainline scaffolding push does
 # not trigger it. Every PR must build both configurations, pass the host-side

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Issue-driven, gate-driven:
 
-1. Every change — feature, fix, perf work, docs — starts as a **GitHub issue**
+1. Every change - feature, fix, perf work, docs - starts as a **GitHub issue**
    with a type, `area:` and `priority:` label and a milestone.
 2. Work happens on a short-lived branch off `main`:
    `feature/…`, `fix/…`, `perf/…`, `harden/…`, `chore/…`, `refactor/…`.
@@ -17,15 +17,15 @@ Issue-driven, gate-driven:
   defined error code, never an out-of-bounds access, never a partial guess.
   Every reject path carries an explicit negative test.
 - **The oracles decide.** Decode output is diff-tested on real and fuzzed
-  corpora against the reference implementations — liblz4 today, with zlib and
+  corpora against the reference implementations - liblz4 today, with zlib and
   libzstd joining as the DEFLATE and Zstd formats land.
 - **Format provenance.** Every format is implemented from its public
-  specification only — the LZ4 block/frame spec, Snappy, DEFLATE (RFC 1951),
+  specification only - the LZ4 block/frame spec, Snappy, DEFLATE (RFC 1951),
   the GDeflate spec, Zstd (RFC 8878). The reference decoders (liblz4, zlib,
   libzstd) are test oracles, never a source to copy from: they ship under their
   own BSD/zlib licenses and pasted code would muddy the provenance of an
   Apache-2.0 tree. "The oracles decide" means the reference settles
-  _correctness by differential test_ — not that its code may be _derived from_.
+  _correctness by differential test_ - not that its code may be _derived from_.
   nvCOMP is proprietary: never copy its headers or source, and cudec claims no
   compatibility with it (nominative references and CPU-only benchmark
   comparisons are fine).
@@ -36,17 +36,17 @@ Issue-driven, gate-driven:
   the build on a fuel-free loop in the decode path, and every ctest entry has a
   finite `TIMEOUT`.
 - **Warp collectives.** Four points, checked on every kernel review:
-  1. **Mask provenance** — a collective's mask is the full-warp constant or
+  1. **Mask provenance** - a collective's mask is the full-warp constant or
      `__activemask()`, never a value computed from the bitstream.
-  2. **All participants reach it** — every lane the mask names arrives at the
+  2. **All participants reach it** - every lane the mask names arrives at the
      collective; loop bounds and branches around one stay lane-uniform.
-  3. **No source lane or predicate from unvalidated input** — a shuffle's
+  3. **No source lane or predicate from unvalidated input** - a shuffle's
      source lane and a vote's predicate are program constants or validated
      quantities, never a parsed length, offset, or token.
-  4. **No legacy intrinsics** — `__shfl`, `__ballot`, `__any`, `__all`,
+  4. **No legacy intrinsics** - `__shfl`, `__ballot`, `__any`, `__all`,
      `__match_any` and friends are banned; only the `_sync` forms are used.
 - **Determinism**: same input → bit-identical output, on every path and in
-  every supported launch configuration — the `gpu_to_gpu` level in NVIDIA's
+  every supported launch configuration - the `gpu_to_gpu` level in NVIDIA's
   CCCL vocabulary. A kernel that maps work onto lanes states which geometries
   it supports and refuses the rest, rather than assuming its caller. The scope,
   the qualifiers, and the tested axes are in
@@ -58,7 +58,7 @@ Issue-driven, gate-driven:
   intention-revealing names; comments explain _why_, never _what_. Every
   CUDA API call's error is checked; no exceptions cross the C ABI.
 - **Minimal.** The least code that does the job; structural rules are locked
-  in by conformance tests — do not weaken them.
+  in by conformance tests - do not weaken them.
 
 ## Building & testing
 
@@ -67,9 +67,9 @@ cmake -B build && cmake --build build   # host-only; needs just a C compiler
 ```
 
 The CUDA engine and its on-device tests are opt-in (`-DCUDEC_ENABLE_CUDA=ON`)
-and need a CUDA 12.x toolchain plus a GPU for the tests — see the README's
+and need a CUDA 12.x toolchain plus a GPU for the tests - see the README's
 container command for the maintained path (build directory `build-cuda`,
 `ctest --test-dir build-cuda`).
 
-All repo artifacts — code, comments, commits, PRs, issues — are written in
+All repo artifacts - code, comments, commits, PRs, issues - are written in
 English.

--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@
 Open-source GPU decompression for the standard formats.
 
 **Goal: batch-decode LZ4, Snappy, GDeflate and Zstd on an NVIDIA GPU at
-memory-bandwidth speed — auditable, fail-closed, and fuzz-tested.**
+memory-bandwidth speed - auditable, fail-closed, and fuzz-tested.**
 
 ## Why
 
 GPU decompression matters wherever decode throughput is the bottleneck:
 asset streaming, analytics scans, ML data loading, checkpoint restore. The
 only production-grade library in this space, NVIDIA's nvCOMP, has been
-proprietary since v2.3 — there is no maintained open-source library that
+proprietary since v2.3 - there is no maintained open-source library that
 decodes the standard formats on the GPU. Meta's dietgpu is open but uses its
 own rANS format; the GDeflate reference implementation is CPU-only; the
 academic prototypes are unmaintained.
 
-cudec fills that gap. Not on price — nvCOMP is free to use — but on the
+cudec fills that gap. Not on price - nvCOMP is free to use - but on the
 properties a closed binary cannot offer:
 
 - **Auditability.** Decompressors are classic attack surface. Every bounds
   check in cudec is readable, tested, and fuzz-diffed against the reference
-  implementation — liblz4 today, with zlib and libzstd joining as the DEFLATE
+  implementation - liblz4 today, with zlib and libzstd joining as the DEFLATE
   and Zstd formats land.
 - **Portability.** CUDA first; a HIP port is a planned milestone. A
   vendor-locked binary can never follow.
@@ -31,14 +31,14 @@ properties a closed binary cannot offer:
 
 Decode-only, batch-oriented. Compression stays on the CPU where it belongs;
 the GPU wins when thousands of independent chunks decode in parallel. A
-single small file on a cold PCIe bus is not the use case — the CPU wins that
+single small file on a cold PCIe bus is not the use case - the CPU wins that
 one, and this README will never claim otherwise.
 
 ## Status
 
 **M0 and M1 are complete; M2 is in progress.** cudec decodes real LZ4 on an
-NVIDIA GPU today — batch block decode, the `.lz4` frame format
-(block-independent subset), and a pinned-host streaming path — all fail-closed
+NVIDIA GPU today - batch block decode, the `.lz4` frame format
+(block-independent subset), and a pinned-host streaming path - all fail-closed
 and fuzz-diffed against liblz4. The design record is
 [docs/MASTERPLAN.md](docs/MASTERPLAN.md); the measured LZ4 block and streaming
 baselines, each carrying its full methodology, are in
@@ -48,21 +48,21 @@ milestones:
 
 | Milestone        | Deliverable                                         | Status      |
 | ---------------- | --------------------------------------------------- | ----------- |
-| M0 — Foundation  | Toolchain, CMake+CUDA skeleton, CI, test harness    | done        |
-| M1 — LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed      | done        |
-| M2 — LZ4 batch   | Frame format, batch API, streaming path, benchmarks | in progress |
-| M3 — Snappy      | Snappy decode on the same kernel family             | planned     |
-| M4 — GDeflate    | The first open GPU GDeflate decoder                 | planned     |
-| M5 — Zstd        | Zstd decode (FSE/Huffman sequences)                 | planned     |
-| M6 — Portability | HIP port                                            | planned     |
+| M0 - Foundation  | Toolchain, CMake+CUDA skeleton, CI, test harness    | done        |
+| M1 - LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed      | done        |
+| M2 - LZ4 batch   | Frame format, batch API, streaming path, benchmarks | in progress |
+| M3 - Snappy      | Snappy decode on the same kernel family             | planned     |
+| M4 - GDeflate    | The first open GPU GDeflate decoder                 | planned     |
+| M5 - Zstd        | Zstd decode (FSE/Huffman sequences)                 | planned     |
+| M6 - Portability | HIP port                                            | planned     |
 
 ## Principles
 
 - **Fail-closed.** A malformed or hostile bitstream produces a defined error,
-  never an out-of-bounds access and never a guess — and never a hang: every
+  never an out-of-bounds access and never a guess - and never a hang: every
   loop driven by a value read from the stream is capped, and termination is a
   tested invariant. Every reject path has a negative test.
-- **Deterministic.** Same input, same output — bit-exact on every code path,
+- **Deterministic.** Same input, same output - bit-exact on every code path,
   in every supported launch configuration, on every supported GPU. The scope,
   the qualifiers, and the tested axes:
   [docs/DETERMINISM.md](docs/DETERMINISM.md).
@@ -76,7 +76,7 @@ milestones:
 ## Building
 
 Two builds. The host-only build needs just a C compiler and compiles the ABI
-and version surface — not the decoder — so CI has a real build gate without a
+and version surface - not the decoder - so CI has a real build gate without a
 CUDA toolchain (CMake ≥ 3.24):
 
 ```sh
@@ -84,7 +84,7 @@ cmake -B build && cmake --build build
 ```
 
 The CUDA build is the decoder (CUDA 12.x toolchain; the maintained path is the
-pinned dev container — a GPU is required only for the gpu-labeled tests, not
+pinned dev container - a GPU is required only for the gpu-labeled tests, not
 the build: without a GPU, drop `--gpus all` and add `-LE gpu` to the ctest line
 to build everything and run the host-side subset):
 
@@ -99,21 +99,21 @@ docker run --rm --gpus all -v "$PWD:/w" -w /w \
 
 ## Contributing
 
-Issue-driven: every change starts as an issue and lands as a gated PR — see
+Issue-driven: every change starts as an issue and lands as a gated PR - see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 🤝 AI-assisted, human-owned
 
 Development here is AI-assisted. Claude (Anthropic) helps with individual
-process steps — generating and analysing code, running the adversarial
+process steps - generating and analysing code, running the adversarial
 security reviews, and translating documentation and comments into English. It
 never hands over finished, unreviewed work: each step is only a proposal. A
 human maintainer reviews, understands, edits where needed, and signs off on
-every one — the AI proposes, a person decides, and a human stays responsible
+every one - the AI proposes, a person decides, and a human stays responsible
 for every line that ships, at all times. The review discipline is modelled,
 as far as is practical for a volunteer project, on the change-control
 expected of TÜV/BSI-certified software in a critical sector such as
-healthcare — with no claim to actual certification. In short: nothing lands
+healthcare - with no claim to actual certification. In short: nothing lands
 because a tool suggested it; it lands because a person verified it.
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security policy
 
-cudec decodes untrusted input by design — compressed bitstreams are classic
+cudec decodes untrusted input by design - compressed bitstreams are classic
 attack surface, and a GPU decoder that trusts its input is a vulnerability
 with a very wide blast radius. The security posture is therefore central,
 not incidental:

--- a/docs/BENCHMARK-METHODOLOGY.md
+++ b/docs/BENCHMARK-METHODOLOGY.md
@@ -2,8 +2,8 @@
 
 The performance write-up for cudec's LZ4 decode path: what is measured, on
 what hardware, how to reproduce it, and how to read the numbers honestly.
-The raw baseline record — every number with the full methodology block the
-harness emits — lives in [BENCHMARKS.md](BENCHMARKS.md); this page is the
+The raw baseline record - every number with the full methodology block the
+harness emits - lives in [BENCHMARKS.md](BENCHMARKS.md); this page is the
 narrative around those recorded numbers and adds nothing that was not
 measured. A performance claim without its measurement is not a claim
 ([MASTERPLAN](MASTERPLAN.md) section 5).
@@ -16,11 +16,11 @@ cudec exists to be the auditable, fail-closed, fuzz-tested open alternative,
 not a cheaper one (nvCOMP is free to use). This document therefore measures
 cudec against two references that can be published in full:
 
-- **The CPU oracle** — `LZ4_decompress_safe` from liblz4 1.10.0, single
+- **The CPU oracle** - `LZ4_decompress_safe` from liblz4 1.10.0, single
   thread. This is the same reference implementation cudec is diff-tested
   against, so it is both the correctness oracle and the throughput baseline.
-- **cudec's own internal ceilings** — the parse-only ceiling and the
-  ~760 GB/s output-bandwidth ceiling of the GPU — which bound what any decode
+- **cudec's own internal ceilings** - the parse-only ceiling and the
+  ~760 GB/s output-bandwidth ceiling of the GPU - which bound what any decode
   on this hardware can achieve.
 
 No cudec-vs-nvCOMP performance numbers appear here or anywhere in the repo;
@@ -54,25 +54,25 @@ clears). Every reported figure is the median (p50) of 30 measured runs after
 ## Corpora
 
 Fetched hash-pinned by [`bench/get-corpora.sh`](../bench/get-corpora.sh)
-(SHA-256, fail-closed on any mismatch) and never committed — the supply-chain
+(SHA-256, fail-closed on any mismatch) and never committed - the supply-chain
 rule applied to test data. The harness splits each input file into 64 KB
 (65536-byte) chunks and compresses each chunk in-harness with
 `LZ4_compress_default`, so the batch is many independent chunks, which is the
 workload the GPU path is built for.
 
-- **Silesia** — the standard 12-file mixed corpus (dickens, mozilla, mr, nci,
+- **Silesia** - the standard 12-file mixed corpus (dickens, mozilla, mr, nci,
   ooffice, osdb, reymont, samba, sao, webster, x-ray, xml). 3239 chunks,
   211.94 MB original, 102.44 MB compressed (ratio 0.483). Chunk sizes:
   min 8066 / median 65536 / max 65536 bytes. This is the representative
   average-case number.
-- **worst-4Bmatch** — an adversarial-but-valid corpus constructed in-harness
+- **worst-4Bmatch** - an adversarial-but-valid corpus constructed in-harness
   (`--worst4b`): back-to-back minimum matches (length 4, offset 1), the
   maximum sequence density a valid LZ4 block can carry. 3200 identical 64 KB
   chunks (~210 MB). The standard compressor never emits this shape (it would
   extend the offset-1 run into one long match), so the harness builds the
   block directly and the oracle validates it (round-trips through
   `LZ4_decompress_safe`) before any timing. This is the throughput worst case.
-- **enwik8** — fetched and hash-pinned by the harness for completeness, but
+- **enwik8** - fetched and hash-pinned by the harness for completeness, but
   **not yet recorded with a GPU row**; when an enwik8 GPU number is published
   it will carry its own full methodology block. It is listed here so the
   corpus set is stated honestly, not to imply a measurement that does not
@@ -96,7 +96,7 @@ The device-resident kernel decodes Silesia at **~18 GB/s**, roughly 5× the
 single-thread CPU baseline. The **parse-only ceiling is ~35 GB/s** (~10× CPU):
 the serial per-lane parse and the match/literal copies each cost roughly half
 the wall time. Both numbers sit well under the ~760 GB/s output-bandwidth
-ceiling — LZ4 decode on this design is bound by the redundant lockstep parse,
+ceiling - LZ4 decode on this design is bound by the redundant lockstep parse,
 not by memory bandwidth. Why that is a deliberate design choice, not a defect,
 is covered in [The design rationale](#the-design-rationale-single-pass).
 
@@ -111,7 +111,7 @@ is covered in [The design rationale](#the-design-rationale-single-pass).
 The worst case matters because it is the security-posture number: it is what
 an attacker who fully controls a valid input can force. The honest findings:
 
-- **The degradation is uniform and bounded, ~2.2–2.3× across every path** —
+- **The degradation is uniform and bounded, ~2.2–2.3× across every path** -
   CPU, GPU decode, and GPU parse-only all slow by the same factor. That factor
   is the sequence density (one sequence per 4 decoded bytes here, versus
   Silesia's longer average matches): the cost is linear in the number of
@@ -121,8 +121,8 @@ an attacker who fully controls a valid input can force. The honest findings:
 - **No size amplification.** The block barely compresses (ratio 0.750,
   ~1.33× expansion) and each chunk decodes to exactly 65536 bytes, capped by
   the caller's destination capacity. The throughput worst case and a
-  decompression bomb are mutually exclusive for LZ4 — a bomb is one long
-  match (a single fast sequence), the opposite shape — and cudec's fixed
+  decompression bomb are mutually exclusive for LZ4 - a bomb is one long
+  match (a single fast sequence), the opposite shape - and cudec's fixed
   per-chunk output cap fail-closes the size axis regardless.
 - **The GPU advantage holds under the worst input:** 8.1 GB/s worst-case GPU
   is still ~5.4× the CPU worst case and ~2.3× the CPU's Silesia _average_.
@@ -131,16 +131,16 @@ an attacker who fully controls a valid input can force. The honest findings:
 
 The device-resident rows above exclude transfers; the streaming path
 (`cudec_stream_ctx_create` / `cudec_lz4_decompress_stream_ctx` /
-`cudec_stream_ctx_destroy`) measures the whole synchronous decode call —
+`cudec_stream_ctx_destroy`) measures the whole synchronous decode call -
 pinned staging, host-to-device copy, decode, and, for host output, the
-device-to-host readback — wall-clocked. On Silesia, reusing a warmed context:
+device-to-host readback - wall-clocked. On Silesia, reusing a warmed context:
 
 | Output target            | Steady-state (reused ctx) | Cold (fresh ctx) |
 | ------------------------ | ------------------------- | ---------------- |
 | Device out               | ~0.92 GB/s (229.5 ms)     | ~0.89 GB/s       |
 | Host out (sync readback) | ~0.58 GB/s (365.2 ms)     | ~0.57 GB/s       |
 
-This is a different, honest metric — not a regression of the ~18 GB/s
+This is a different, honest metric - not a regression of the ~18 GB/s
 device-resident kernel throughput. Read it plainly:
 
 - **The streaming wall is submission-bound, not compute-bound.** Against a
@@ -158,7 +158,7 @@ device-resident kernel throughput. Read it plainly:
   (~12 ms), so overlapping input transfer against the kernel saves ~4 ms at
   best (~25% ceiling) and was never worth its complexity. The genuine overlap
   lever for the higher-ratio formats to come (Zstd, GDeflate) is overlapping
-  decode against the decoded-**output** readback, not the input — a change
+  decode against the decoded-**output** readback, not the input - a change
   for those milestones, with its own test when it lands.
 
 ## The design rationale (single-pass)
@@ -172,7 +172,7 @@ by the #15 measurement:
 - The parse-only number (~35 GB/s on Silesia) ceilings **both** single-pass
   and any two-phase design, because a two-phase phase-1 runs the identical
   serial parse and so cannot exceed it either. Two-phase's only lever is a
-  faster phase-2 copy — but single-pass's copy is equally optimizable, with no
+  faster phase-2 copy - but single-pass's copy is equally optimizable, with no
   table, no barrier, and no extra memory traffic. The decomposition question
   is therefore settled for single-pass.
 - Two subsequent measured perf passes (issues #16 and #21) confirmed the
@@ -182,7 +182,7 @@ by the #15 measurement:
   occupancy regressed the decode ~5% because the only way to reach it under
   the fail-closed 64-bit-arithmetic invariant is a register spill. The
   remaining structural lever is a warp-specialization rewrite that abandons
-  the redundant-parse invariant — its own design change, deferred behind the
+  the redundant-parse invariant - its own design change, deferred behind the
   format ladder ("formats over percentage points").
 
 The full derivations, the profile readout, and the falsification-trigger
@@ -192,7 +192,7 @@ verdicts are recorded in [BENCHMARKS.md](BENCHMARKS.md) and
 ## When the GPU wins, and when it does not
 
 The honest framing, consistent with the README: the GPU wins when thousands
-of independent chunks decode in parallel — batch asset streaming, analytics
+of independent chunks decode in parallel - batch asset streaming, analytics
 scans, ML data loading, checkpoint restore. The device-resident numbers above
 are that case. A single small file on a cold PCIe bus is **not** the GPU's
 case: the transfer and per-submission latency dominate (visible directly in
@@ -202,7 +202,7 @@ claim otherwise.
 ## Reproducing the numbers
 
 Everything needed to reproduce every figure is in the tree. A third party
-runs the same measurements — including any nvCOMP comparison — as follows.
+runs the same measurements - including any nvCOMP comparison - as follows.
 
 1. **Fetch the corpora** (hash-pinned, fail-closed; needs `curl` and
    `unzip`):
@@ -249,19 +249,19 @@ runner, so the adversarial number cannot silently drift.
 ## The nvCOMP comparison (not published)
 
 The one comparison this document deliberately does **not** publish is
-cudec-vs-nvCOMP. **§8.9 of the NVIDIA Software License Agreement** — the EULA
-governing the nvCOMP binary — restricts the customer from distributing or
+cudec-vs-nvCOMP. **§8.9 of the NVIDIA Software License Agreement** - the EULA
+governing the nvCOMP binary - restricts the customer from distributing or
 disclosing to third parties the results of benchmarking, competitive analysis,
 or regression/performance testing of the software without NVIDIA's prior
 written permission (a "DeWitt clause"). cudec therefore publishes **no**
 cudec-vs-nvCOMP throughput numbers, quotes no nvCOMP figures, and builds no
-head-to-head table — by policy, not oversight. nvCOMP is referenced only
+head-to-head table - by policy, not oversight. nvCOMP is referenced only
 nominatively, as the proprietary incumbent this project offers an auditable
 open alternative to.
 
 This is why the reproducible harness above matters: a third party can build
 cudec and nvCOMP on their own hardware, run both over the same hash-pinned
 corpora, and draw their own head-to-head conclusion under their own
-acceptance of the nvCOMP EULA. cudec ships the honest, published half — its
-own measured numbers and the CPU baseline — and the tooling to complete the
+acceptance of the nvCOMP EULA. cudec ships the honest, published half - its
+own measured numbers and the CPU baseline - and the tooling to complete the
 picture privately.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,11 +1,11 @@
 # Benchmarks
 
-The narrative write-up — how these numbers are read, reproduced, and
-positioned — is [BENCHMARK-METHODOLOGY.md](BENCHMARK-METHODOLOGY.md). This
+The narrative write-up - how these numbers are read, reproduced, and
+positioned - is [BENCHMARK-METHODOLOGY.md](BENCHMARK-METHODOLOGY.md). This
 file is the raw baseline record it is built on.
 
 The baseline record. Every entry carries the full methodology block as
-emitted by the harness (`bench/bench_lz4`, `--gpu` for the device path) — a
+emitted by the harness (`bench/bench_lz4`, `--gpu` for the device path) - a
 number without its methodology cannot be produced, by construction.
 Regressions against the recorded baselines block merges unless explicitly
 justified ([MASTERPLAN](MASTERPLAN.md) section 5). Corpora are fetched
@@ -42,7 +42,7 @@ gather is the prime suspect).
 
 The parse-only number ceilings **both** single-pass and any two-phase
 design (a two-phase phase-1 runs the identical serial parse, so it cannot
-exceed ~35 GB/s either). Two-phase's only lever is a faster phase-2 copy —
+exceed ~35 GB/s either). Two-phase's only lever is a faster phase-2 copy -
 but single-pass's copy is equally optimizable, and doing so needs no table,
 no barrier, and no extra memory traffic. **The decomposition question is
 therefore settled for single-pass.** Perf pass 1 (#16) then measured the
@@ -66,32 +66,32 @@ improvement):
 | `__syncwarp` elision on zero-literal sequences | neutral         | the barriers are not the bottleneck                                                                                                  |
 
 The empirical conclusion: the minimal-correct byte-per-lane kernel is at a
-local optimum for this workload. The bottleneck is **structural** — the
+local optimum for this workload. The bottleneck is **structural** - the
 redundant 32-lane parse sets the ~34 GB/s ceiling, and the copies are
 latency-bound on the short literal/match runs typical of real data, where
 neither a cheaper modulo nor wider copies help. Meaningful gains require
 raising the parse ceiling itself (higher occupancy via register reduction,
-or warp-specialization), which is larger than a micro-op pass — tracked as
+or warp-specialization), which is larger than a micro-op pass - tracked as
 a follow-up (issue #21).
 
 **Falsification-trigger verdict (masterplan section 9).** The shipped
 kernel is ~5× CPU (below the ~15× reopen threshold), but two-phase stays
 **ruled out**: the parse-only ceiling (~10× CPU) bounds any two-phase
 phase-1, which shares the identical serial parse, so two-phase cannot reach
-~15× either. The trigger's numeric condition is met while its purpose — does
-two-phase help? — is answered NO by the arithmetic. The path to higher
+~15× either. The trigger's numeric condition is met while its purpose - does
+two-phase help? - is answered NO by the arithmetic. The path to higher
 throughput is structural single-pass work, not a decomposition change.
 
 ### Perf pass 2 (issue #21): the occupancy lever does not help either
 
-Perf pass 1 named the remaining structural lever — raise the ~34 GB/s parse
+Perf pass 1 named the remaining structural lever - raise the ~34 GB/s parse
 ceiling through higher occupancy. This pass profiled the kernel and measured
 that lever directly; it too is rejected by measurement.
 
 **Profile (pinned container, RTX 3080 sm_86, `nvcc -Xptxas -v`).** The shipped
 `lz4_decode_batch` (Full) uses **46 registers/thread** on sm_86 (48 on sm_80).
-On sm_86 — 65536 registers/SM, 256-register warp allocation granularity,
-128-thread blocks — 46 rounds up to 1536 registers/warp, giving 10 resident
+On sm_86 - 65536 registers/SM, 256-register warp allocation granularity,
+128-thread blocks - 46 rounds up to 1536 registers/warp, giving 10 resident
 blocks → **40 warps/SM (~83% occupancy)**. Register granularity is the wall:
 41–48 registers/thread all fall in the same 1536-register/warp bucket and all
 yield 40 warps; the next occupancy step (48 warps/SM, 100%) requires
@@ -99,9 +99,9 @@ yield 40 warps; the next occupancy step (48 warps/SM, 100%) requires
 
 **The only reachable path forces a spill.** The parser's live state is
 dominated by the 64-bit stream cursors and the six-field `Lz4Sequence`. The
-anti-pattern rule (masterplan section 9) forbids narrowing any of it to 32-bit
-— the ABI's `size_t` capacities admit values above 2^32, pinned by the
-`SIZE_MAX` and beyond-convention capacity tests — so a legitimate drop to 40
+anti-pattern rule (masterplan section 9) forbids narrowing any of it to 32-bit -
+the ABI's `size_t` capacities admit values above 2^32, pinned by the
+`SIZE_MAX` and beyond-convention capacity tests - so a legitimate drop to 40
 registers is not available. `__launch_bounds__(kBlockThreads, 12)` caps ptxas
 at 40 registers only by **spilling to local memory** (sm_86: 16-byte stack
 frame, 20 bytes spill stores, 20 bytes spill loads).
@@ -117,12 +117,12 @@ state is shared):
 
 Forcing 100% occupancy **regresses** the full decode ~5%. Parse-only (still 28
 registers, no spill, so unaffected by the register cap) stays flat across the
-same runs — an internal control that attributes the regression to the spill,
+same runs - an internal control that attributes the regression to the spill,
 not to run-to-run variance; the CPU oracle baseline was in fact slightly faster
 during the variant run. The extra local-memory traffic in the already
 latency-bound parse loop costs more than the eight added warps hide. All ten
 ctest gates (`parser_twin` and `gpu_fixture` oracle parity, `stream_twin`
-determinism, and the rest) stay green on the variant — the change is
+determinism, and the rest) stay green on the variant - the change is
 measurement-rejected, not correctness-rejected. No code shipped; the kernel is
 unchanged.
 
@@ -130,8 +130,8 @@ unchanged.
 current fail-closed architecture: more warps need ≤ 40 registers/thread; ≤ 40
 registers needs either a forbidden 64-bit narrowing or a spill; and the spill
 regresses. Raising the parse ceiling therefore requires the warp-specialization
-rewrite that abandons the load-bearing redundant-lockstep-parse invariant — its
-own design panel, not a measured micro-pass — and under "formats over
+rewrite that abandons the load-bearing redundant-lockstep-parse invariant - its
+own design panel, not a measured micro-pass - and under "formats over
 percentage points" (masterplan section 2) the next format outranks it. Of the
 two levers issue #21 named, the register-reduction lever is measured and
 rejected here; the warp-specialization lever is scoped as a larger design
@@ -144,12 +144,12 @@ modular gather `dst[m+i] = dst[m-off + (i mod off)]` degenerates to a straight
 copy (`i mod off == i` for every `i < match_len <= off`, and the ranges are
 disjoint, so the copy is bit-identical, hazard-free, and the branch is
 warp-uniform). The fast path elides the per-byte 64-bit modulo on every
-non-overlapping match — the common case in real data.
+non-overlapping match - the common case in real data.
 
 Measured 2026-07-18, same pinned container and RTX 3080, baseline and patched
 binaries built from the same tree and A/B-interleaved in one session (two full
-passes, 3 warmup + 30 CUDA-event-timed runs each; all twelve ctest gates —
-oracle parity, determinism — green on the patched kernel first):
+passes, 3 warmup + 30 CUDA-event-timed runs each; all twelve ctest gates -
+oracle parity, determinism - green on the patched kernel first):
 
 The Delta column is throughput speedup (`baseline_ms / fast_path_ms − 1`,
 per-pass), one basis for all three rows so they compare on one scale:
@@ -160,13 +160,13 @@ per-pass), one basis for all three rows so they compare on one scale:
 | `--worst4b --gpu`         | 25.502 / 26.256 ms      | 27.938 / 27.654 ms       | **−8.7% / −5.1%**          |
 | `--longmatch --gpu` (new) | 1.277 / 1.278 ms        | 0.922 / 0.898 ms         | **+38.5% / +42.3%**        |
 
-The gain is real — but so is the regression, and it lands exactly where this
+The gain is real - but so is the regression, and it lands exactly where this
 project refuses to pay: the adversarial worst case. `--worst4b` is offset-1
 minmatch, always overlapping, so the fast-path arm is never taken; the cost is
 the added per-match predicate and the second copy loop's code in the hottest
 per-sequence path of the maximum-sequence-density input (one match per 4
 bytes). The plan's prediction that this would be "one free warp-uniform
-compare" is refuted by measurement — five independent patched `--worst4b`
+compare" is refuted by measurement - five independent patched `--worst4b`
 sessions all landed at 26.8–27.9 ms against a 25.1–26.3 ms baseline (a 5–9%
 throughput regression against the 25.1–26.3 ms baseline pair).
 
@@ -177,13 +177,13 @@ margin (issue #19), and trading it for average-case throughput inverts the
 project's hostile-input-first ordering. No kernel code shipped; the
 `--longmatch` harness corpus and its `bench_longmatch_selfcheck` ctest stay,
 so the regime is one flag away for any future attempt (a formulation that
-recovers the Silesia +9–10% without touching the worst case would be accepted —
+recovers the Silesia +9–10% without touching the worst case would be accepted -
 none is known under the single-loop structure, since the predicate is
 inherently per-match).
 
 ### Best case: the longmatch corpus (issue #36)
 
-The shipped kernel's baseline on the new `--longmatch` corpus — long
+The shipped kernel's baseline on the new `--longmatch` corpus - long
 non-overlapping matches (match length 255 at offset 512), the copy-dominated
 regime that maximally exposes the per-byte modular gather. Hand-constructed
 like `--worst4b` (the standard compressor emits long matches but this shape
@@ -207,7 +207,7 @@ same container and RTX 3080. `--longmatch --gpu`.
 ```
 
 At 165 GB/s the copy-dominated best case runs ~9x the Silesia average and
-within ~4.6x of the ~760 GB/s output-bandwidth ceiling — the modular gather,
+within ~4.6x of the ~760 GB/s output-bandwidth ceiling - the modular gather,
 not bandwidth, is the limiter in this regime (the rejected fast path reached
 ~228–234 GB/s here, from its 0.922 / 0.898 ms A/B passes above over the
 209.72 MB corpus), consistent with the ~250–400 GB/s redundant-parse family
@@ -217,7 +217,7 @@ ceiling published in the masterplan.
 
 A security-posture number. The Silesia rows are an average; the worst case
 for this kernel's throughput is an adversarial-but-valid block of
-back-to-back minimum matches (match length 4, offset 1) — the maximum
+back-to-back minimum matches (match length 4, offset 1) - the maximum
 sequence density a valid LZ4 block can carry, one parsed sequence per 4
 decoded bytes, which drives the redundant 32-lane lockstep parse and the
 closed-form modular gather on every match byte. The standard compressor
@@ -244,22 +244,22 @@ the device and sit at the Silesia scale for a direct comparison.
 - GPU parse-only ceiling (copies elided): p50 13.710 ms, 15.3 GB/s - ceilings this design AND any two-phase phase-1 (shared parse)
 ```
 
-**The degradation is linear and bounded — not an amplification vector.**
+**The degradation is linear and bounded - not an amplification vector.**
 
 - Every path degrades by the same ~2.2–2.3× against the Silesia average:
   CPU 3.41 → 1.49 GB/s, GPU decode 18.1 → 8.1 GB/s, GPU parse-only ceiling
   34.6 → 15.3 GB/s. The uniform factor is the sequence density (one
   sequence per 4 bytes here versus Silesia's longer average matches): the
-  cost is linear in the number of sequences — exactly the redundant parse
+  cost is linear in the number of sequences - exactly the redundant parse
   the kernel design accepts, no super-linear blow-up. This is below the
   issue's pessimistic ~4× estimate.
 - No size amplification. The block barely compresses (ratio 0.750, 157 MB →
   210 MB, ~1.33× expansion) and each chunk decodes to exactly 65536 bytes,
-  capped by the caller's destination capacity — never more. The two
+  capped by the caller's destination capacity - never more. The two
   adversarial axes are mutually exclusive for LZ4: a decompression bomb is
-  one long match — LZ4's length encoding costs ~1 input byte per 255 output
+  one long match - LZ4's length encoding costs ~1 input byte per 255 output
   bytes, so a full-64 KB single-match block is ~260 bytes (~250× expansion,
-  and single-match amplification is capped near 255×) — a single fast
+  and single-match amplification is capped near 255×) - a single fast
   sequence, the opposite of this throughput worst case, and cudec's fixed
   per-chunk output cap fail-closes the size axis regardless.
 - The GPU advantage holds under the worst input: 8.1 GB/s worst-case GPU is
@@ -289,7 +289,7 @@ so the spread is visible rather than averaged away.
 The methodology block below is **one standalone run of the "after" build**,
 pasted whole because the rule here is that a number ships with its
 methodology. Its GPU decode p50 is 12.427 ms, inside that build's observed
-run-to-run range but not identical to the paired mean in the table — the same
+run-to-run range but not identical to the paired mean in the table - the same
 build measured twice, not a discrepancy. The paired means are what the claim
 rests on.
 
@@ -318,8 +318,8 @@ rests on.
 The shipped decode path pays **+2.0% on Silesia**; on the worst case the
 difference (+1.3%) is smaller than the "after" side's own pass-to-pass spread
 (25.285 / 26.661 ms), so it is **not a measurement**, only an upper bound. The
-parse-only ceiling — a diagnostic kernel with the copies elided, never shipped
-— pays 14–17% on both corpora, tightly and reproducibly, which is where the
+parse-only ceiling - a diagnostic kernel with the copies elided, never shipped -
+pays 14–17% on both corpora, tightly and reproducibly, which is where the
 per-sequence cost shows up undiluted by memory stalls.
 
 #### Occupancy is the constraint, and it bounds what the guard may cost
@@ -342,7 +342,7 @@ on the last rung before an occupancy cliff, and that was measured, not assumed:
 The last three rows are why the kernel's 32-bit `warp_in_grid` is **left
 32-bit and documented as a limit rather than enforced**. Three spellings of the
 2^32-thread bound were measured, including one that touches no 64-bit value at
-all and compares two values already live in registers — nvcc 12.6 allocates the
+all and compares two values already live in registers - nvcc 12.6 allocates the
 same four extra registers for all three, so neither "widening is free" nor
 "there must be a cheaper spelling" survives contact with the compiler. Only the
 first was timed; the other two share its register count and therefore its
@@ -353,7 +353,7 @@ already forces `blockDim.x` to a multiple of the warp size, so a wrapped index
 stays warp-aligned: an aliased block recomputes the **same** `warp_in_grid`
 values with a full 0–31 lane range, decodes the same chunks, and writes
 byte-identical values to the same addresses. Exceeding the documented bound
-therefore costs duplicated work — not missing bytes, not a hang, and the output
+therefore costs duplicated work - not missing bytes, not a hang, and the output
 stays bit-identical. That is categorically unlike the two refused geometries,
 where bytes really do go unwritten or the kernel really does spin. Paying an
 occupancy step on every launch to prevent redundant-but-correct output, on a
@@ -376,15 +376,15 @@ taken, across sessions:
 | `while (fuel-- != 0)` at the top of the loop   | 12.744 / 12.822                                              |
 
 Only the first two rows were measured under the paired interleaved protocol,
-and only they separate by more than the shipped build's own run-to-run range
-— so the with/without-cap difference is real and the between-formulation
+and only they separate by more than the shipped build's own run-to-run range -
+so the with/without-cap difference is real and the between-formulation
 differences are **not established**. The shipped formulation was chosen on a
 structural argument, not a measured one: folding the test into the loop's
 existing exit branch adds no branch at the top of the loop. The 32-bit counter
-was dropped on correctness, not speed — keeping its budget unreachable would
+was dropped on correctness, not speed - keeping its budget unreachable would
 need a 4 GiB per-chunk limit, an accept-set change.
 
-The regression is accepted deliberately under the prime-directive ordering —
+The regression is accepted deliberately under the prime-directive ordering -
 **correctness > measured performance**. A decoder that hangs on hostile input
 has failed open in the availability direction; nvCOMP 5.3's release notes
 record shipping exactly that bug class in its Snappy decoder. Recovering the
@@ -397,7 +397,7 @@ The streaming decode path is now a reusable context
 (`cudec_stream_ctx_create` / `cudec_lz4_decompress_stream_ctx` /
 `cudec_stream_ctx_destroy`, issue #29) that owns one CUDA stream and grow-only
 pinned/device staging, created once and reused across decodes. It replaces the
-per-call N-stream ring of #24 (dropped — the overlap it provided is not worth
+per-call N-stream ring of #24 (dropped - the overlap it provided is not worth
 its complexity for LZ4; see below). The wall is CPU-clocked around the whole
 synchronous decode call (pinned staging + H2D + decode +, for host output,
 D2H). Recorded 2026-07-17, same container and RTX 3080 as the M1 rows.
@@ -419,41 +419,41 @@ NOT the dominant cost.** #24 could not account for ~233 ms of its ~249 ms
 one-shot wall, named the per-call `cudaHostAlloc`/`cudaMalloc` of the ring as
 the prime suspect, and declared a reusable context "required, not optional." A
 reusable context that allocates nothing in steady state now measures the
-allocation directly — and it is only **~8 ms** (cold − steady), not ~233 ms.
+allocation directly - and it is only **~8 ms** (cold − steady), not ~233 ms.
 The steady-state device wall is still **~230 ms**, against a ~12 ms
 device-resident decode (one launch over all 3239 chunks) and a ~4 ms compressed
 H2D (M1/#24). The ~213 ms residual is therefore neither allocation (excluded:
-steady == cold to within 8 ms) nor copy/decode (~16 ms together) — it is the
+steady == cold to within 8 ms) nor copy/decode (~16 ms together) - it is the
 **per-wave serial submission** of the batch in 64-chunk waves (~51 waves for
 Silesia), one H2D + launch + event-gated reuse + result D2H per wave on this
 WSL2/WDDM setup where each submission flush costs milliseconds. The
 device-resident path is ~12 ms precisely because it submits **once**; the
 streaming path submits ~51 times. Not separately isolated, but attributed by
 exclusion. Raising the wave granularity so the path submits once is the real
-lever, out of this change's scope — **issue #33**.
+lever, out of this change's scope - **issue #33**.
 
 **So the reusable context is a simplification, not the speedup #24
-anticipated** — and it still earns its place under correctness > measured
+anticipated** - and it still earns its place under correctness > measured
 performance > minimal code: it deletes the entire N-stream ring (the overlap
 machinery the analysis below shows LZ4 does not benefit from), removes a
 `streams` ABI parameter the #24 measurement proved only degraded throughput,
 and is the correct primitive issue #33 builds on. The `stream_twin` conformance
 property now locks the reuse guarantee: the same input decoded on a reused
-context — after any number of prior decodes, including one that grew the
-staging — is bit-identical to a fresh-context decode.
+context - after any number of prior decodes, including one that grew the
+staging - is bit-identical to a fresh-context decode.
 
-**Why dropping the N-stream overlap was right — a better compression ratio
+**Why dropping the N-stream overlap was right - a better compression ratio
 makes input-H2D overlap LESS valuable.** #24's overlap premise was that a
 caller serializes copy-then-decode; but for LZ4 the compressed H2D is only
 ~4 ms against a ~12 ms decode (LZ4's ~2:1 ratio keeps the input small), so
 perfect input-side overlap saves `16 − max(4, 12) = 4 ms` at best (~25 %
 ceiling) and was never realized. The better a format compresses, the smaller
-its input half relative to decode, and the less input-H2D overlap can ever pay
-— LZ4's ratio is exactly why it does not. The genuine overlap lever for the
+its input half relative to decode, and the less input-H2D overlap can ever pay -
+LZ4's ratio is exactly why it does not. The genuine overlap lever for the
 high-ratio M3+ formats (Zstd, GDeflate), where decode dwarfs the input
 transfer, is overlapping decode against the decoded-**output** D2H (an output
 ring on the host-output path), NOT the input H2D. That is the change that would
-reverse this simplification, and it needs its own test when it lands — the
+reverse this simplification, and it needs its own test when it lands - the
 removed `stream_overlap` test locked the input-H2D‖kernel capability LZ4 no
 longer uses, so it was removed rather than left as an orphaned lock.
 

--- a/docs/DETERMINISM.md
+++ b/docs/DETERMINISM.md
@@ -26,14 +26,14 @@ per-chunk status, and `bytes_written` are identical:
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Run to run            | Identical, same process or a fresh one.                                                                                                                                                               |
 | Launch configuration  | Identical for any grid size, any block size that is a whole number of warps, any chunk-to-warp mapping, and any number of concurrent streams. Other block sizes are refused, not decoded differently. |
-| Batch composition     | Identical whether the chunk is decoded alone, in a batch, or in a differently ordered batch — chunks are independent.                                                                                 |
+| Batch composition     | Identical whether the chunk is decoded alone, in a batch, or in a differently ordered batch - chunks are independent.                                                                                 |
 | Entry point           | Identical through the batch entry, the frame decoder, and the streaming context, fresh or reused.                                                                                                     |
 | GPU to GPU            | Identical on any device the library supports (`sm_80` baseline and newer).                                                                                                                            |
 | Driver / CUDA version | Identical: the arithmetic is integer and the output-byte mapping is fixed at the source level, not at the ISA level.                                                                                  |
 
 ## Why it holds
 
-The reason is structural, not statistical — the pipeline has nothing
+The reason is structural, not statistical - the pipeline has nothing
 non-deterministic in it to control:
 
 - **No floating point.** A lossless decompressor has no use for it. There is no
@@ -42,7 +42,7 @@ non-deterministic in it to control:
   A configure-time check in `tests/CMakeLists.txt` reds the build if any FP type
   or FP atomic appears in the sources.
 - **Every output byte is written exactly once**, by a statically determined
-  lane — given a supported launch geometry, which the kernel enforces rather
+  lane - given a supported launch geometry, which the kernel enforces rather
   than assumes: the copy loops stride by the warp size, so a block that is not
   a whole number of warps would leave a fixed slice of every destination
   written by nobody. That geometry returns without decoding instead. An
@@ -60,7 +60,7 @@ non-deterministic in it to control:
 ## What the level does not promise
 
 - **Nothing about rejected chunks' destination contents.** On any non-OK status
-  `bytes_written` is 0 and the destination is explicitly unspecified — the
+  `bytes_written` is 0 and the destination is explicitly unspecified - the
   decoder never presents partial output as success, and the bytes it happened to
   write before rejecting are not part of the contract. The _status_ for a given
   input is deterministic; the leftover bytes are not.
@@ -68,19 +68,19 @@ non-deterministic in it to control:
   whole number of warps, or a grid holding less than one whole warp, is refused
   by the kernel: it returns without touching the destinations or the result
   records, so the caller sees whatever it primed them with. That is a defined
-  refusal, not a decode — and it is only reachable through the internal kernel
+  refusal, not a decode - and it is only reachable through the internal kernel
   header, never through the public ABI, which always launches `kBlockThreads`.
   `tests/termination_gpu.cu` covers `<<<1, 16>>>`, `<<<2, 16>>>`, and
   `<<<2, 48>>>`. One further geometry bound is **documented rather than
   enforced**: the kernel's thread index is 32-bit, so it requires
   `gridDim.x * blockDim.x <= 2^32`. Exceeding it does **not** break this
-  promise — because a block is already forced to be a whole number of warps,
+  promise - because a block is already forced to be a whole number of warps,
   the wrapped index stays warp-aligned, so an aliased block recomputes the
   same chunks with a full lane range and writes byte-identical values to the
   same addresses. The output is unchanged; the work is done twice. That
   asymmetry is why this one is documented and the other two are refused:
   enforcing it costs a real sm_86 occupancy step on every launch (three
-  spellings measured, all 48 → 52 registers — [BENCHMARKS.md](BENCHMARKS.md)),
+  spellings measured, all 48 → 52 registers - [BENCHMARKS.md](BENCHMARKS.md)),
   the shipped grid is capped at 8192 blocks, and no public entry point can
   approach it.
 - **Nothing about timing.** Throughput varies with geometry, occupancy, clocks,
@@ -94,7 +94,7 @@ non-deterministic in it to control:
 
 ## How it is tested
 
-- `tests/determinism_gpu.cu` — the launch-geometry axis. One corpus of pristine
+- `tests/determinism_gpu.cu` - the launch-geometry axis. One corpus of pristine
   and mutated chunks, one reference decode, then five runs each across five
   grid/block geometries (a single warp walking the whole batch through the
   grid-stride loop, block sizes of 32/64/96/128, a grid far larger than the
@@ -102,18 +102,18 @@ non-deterministic in it to control:
   Every geometry here is a supported one; the refused geometries are covered by
   `tests/termination_gpu.cu` instead.
   The whole destination arena is re-poisoned before every run and compared in
-  full — decoded bytes and the untouched poison beyond `bytes_written` — along
+  full - decoded bytes and the untouched poison beyond `bytes_written` - along
   with every per-chunk result record.
-- `tests/stream_twin.cu` — the entry-point and context-reuse axes: the streaming
+- `tests/stream_twin.cu` - the entry-point and context-reuse axes: the streaming
   decoder's output is bit-identical to a single-stream reference decode, on a
   fresh context and on a reused one whose staging has grown.
-- `tests/gpu_fixture.cu` and `tests/frame_twin.cu` — the oracle axis: decoded
+- `tests/gpu_fixture.cu` and `tests/frame_twin.cu` - the oracle axis: decoded
   bytes match liblz4's own output for every accepted stream.
-- `tests/CMakeLists.txt` — the structural axis: the floating-point ban above,
+- `tests/CMakeLists.txt` - the structural axis: the floating-point ban above,
   checked at configure time, with probes that prove the check still bites.
 
 The GPU-to-GPU axis is **reasoned, not measured**: the maintainer's gate runs one
 device (an RTX 3080, `sm_86`). It rests on the integer-only argument above rather
-than on a two-GPU comparison, and it is stated that way deliberately — a claim
+than on a two-GPU comparison, and it is stated that way deliberately - a claim
 without a measurement is not a measurement. A second device joins the gate when
 one is available.

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1,4 +1,4 @@
-# cudec — masterplan
+# cudec - masterplan
 
 The design record: what is being built, why it is shaped this way, and in
 which order. Settled decisions live here with their rationale; open questions
@@ -8,7 +8,7 @@ that depends on them is written.
 ## 1. Positioning
 
 cudec is an open-source CUDA library that batch-decodes the standard
-compression formats — LZ4, Snappy, GDeflate/DEFLATE, and eventually Zstd —
+compression formats - LZ4, Snappy, GDeflate/DEFLATE, and eventually Zstd -
 on the GPU.
 
 The field today:
@@ -16,7 +16,7 @@ The field today:
 | Existing work              | Why it does not fill the gap                              |
 | -------------------------- | --------------------------------------------------------- |
 | nvCOMP / nvCOMPDx (NVIDIA) | Proprietary since v2.3; NVIDIA-only; not auditable        |
-| dietgpu (Meta)             | Open, but its own rANS format — not format-compatible     |
+| dietgpu (Meta)             | Open, but its own rANS format - not format-compatible     |
 | GDeflate reference (MS/NV) | Open spec + CPU codec; the GPU decoder is Windows-runtime |
 | Academic prototypes        | Unmaintained research code                                |
 
@@ -24,7 +24,7 @@ There is no maintained open-source library that decodes the standard formats
 on the GPU. The value proposition is not price (nvCOMP is free to use) but
 **auditability** (decompressors are classic attack surface; every bounds
 check here is readable, tested, and fuzzed), **portability** (a HIP port is
-a planned milestone — a vendor binary can never follow), and **hackability**.
+a planned milestone - a vendor binary can never follow), and **hackability**.
 
 ## 2. Scope
 
@@ -32,7 +32,7 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
   the tooling, and the flexibility live, and encode throughput is rarely the
   bottleneck. Decode is.
 - **Batch-oriented.** The GPU wins when many independent chunks decode in
-  parallel — asset streaming, analytics scans, ML data loading. A single
+  parallel - asset streaming, analytics scans, ML data loading. A single
   small file over a cold PCIe bus loses to the CPU and always will; the
   documentation says so.
 - **Formats over percentage points.** The library's value is format
@@ -41,25 +41,25 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
 
 ## 3. Format ladder (and why this order)
 
-1. **LZ4** (M1/M2) — byte-oriented, no entropy coding: token/literal/match
+1. **LZ4** (M1/M2) - byte-oriented, no entropy coding: token/literal/match
    sequences only. The simplest correct GPU decode, the fastest path to an
    honest benchmark, and the kernel-family foundation everything else
    reuses. Block format first, then the frame format and the batch API.
-2. **Snappy** (M3) — structurally close to LZ4 (varint-length literals and
+2. **Snappy** (M3) - structurally close to LZ4 (varint-length literals and
    copies, no entropy stage); a cheap second format that proves the kernel
    family generalizes.
-3. **GDeflate** (M4) — the strategic differentiator. The format is designed
+3. **GDeflate** (M4) - the strategic differentiator. The format is designed
    for GPU decode (the DEFLATE bitstream is split into 32 interleaved
    sub-streams so a full warp reads Huffman codes in parallel), the spec is
    open, and the reference implementation is CPU-only: the only shipping GPU
    decoder lives inside the Windows DirectStorage runtime. An open CUDA
-   GDeflate decoder — usable on Linux, in HPC, anywhere — does not exist
+   GDeflate decoder - usable on Linux, in HPC, anywhere - does not exist
    until cudec ships it.
-4. **Zstd decode** (M5) — the flagship and by far the hardest: FSE/Huffman
+4. **Zstd decode** (M5) - the flagship and by far the hardest: FSE/Huffman
    entropy stages feeding an LZ77 sequence executor with long-range matches.
    Attempted only once the kernel family, the oracle net, and the benchmark
    discipline are proven on 1–3.
-5. **HIP port** (M6) — portability as a moat. The kernels stay on warp-level
+5. **HIP port** (M6) - portability as a moat. The kernels stay on warp-level
    primitives available on both vendors to keep this tractable.
 
 ## 4. Architecture pillars
@@ -70,7 +70,7 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
   CUDA toolkit.
 - **Batch API.** The core entry point decodes N independent chunks described
   by device-side arrays (src pointers/sizes, dst pointers/capacities) on a
-  caller-provided stream, reporting per-chunk status — modeled on the shape
+  caller-provided stream, reporting per-chunk status - modeled on the shape
   proven by nvCOMP's batch interface, implemented independently.
 - **Kernel dispatch by chunk size.** The shipped M1 decoder is a single
   warp-per-chunk kernel with no dispatch heuristic, no shared memory, and no
@@ -78,18 +78,18 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
   (section 9), and the asynchronous batch ABI rules out host-side
   histogramming (section 8). A block-per-chunk path (a warp team sharing
   staged input via `cp.async`) and device-side chunk-size binning remain
-  deferred options for large-chunk or future-format workloads — not a
+  deferred options for large-chunk or future-format workloads - not a
   decision the current code took.
 - **Two memory paths.** Device-resident (caller already has the data on the
-  GPU) and a pinned-host streaming path that overlaps H2D copies with decode
-  — the asset-streaming shape.
+  GPU) and a pinned-host streaming path that overlaps H2D copies with decode -
+  the asset-streaming shape.
 - **Fail-closed decode contract.** Every value decoded from the bitstream is
   validated before it is used as an address, length, or offset; size
   arithmetic is overflow-checked; a chunk that fails validation reports a
   defined error and produces no partial output presented as success. Hostile
   input is the expected case, not the exception.
 - **Termination is part of fail-closed.** A decoder that hangs on hostile
-  input has failed open in the availability direction — nvCOMP 5.3's release
+  input has failed open in the availability direction - nvCOMP 5.3's release
   notes record fixing an indefinite Snappy-decompression hang on malformed
   input, so this is a demonstrated bug class in exactly this product
   category, not a theoretical one. Every loop whose exit depends on a value
@@ -104,8 +104,8 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
 - **Warp collective integrity.** Kernels use only the `_sync` warp
   primitives; the legacy non-`_sync` intrinsics are banned outright, because
   since Volta's independent thread scheduling they cannot express which lanes
-  participate at all. A collective's participation metadata — its mask, its
-  source lane, its predicate — is never derived from a value read out of the
+  participate at all. A collective's participation metadata - its mask, its
+  source lane, its predicate - is never derived from a value read out of the
   bitstream: it is the full-warp constant or `__activemask()`, and the loop
   bounds that decide which lanes reach a collective stay lane-uniform.
   Corrupting that metadata is a published attack on CUDA kernels
@@ -116,7 +116,7 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
   carries the four-point review checklist.
 - **Determinism.** Same input → bit-identical output on every path: the level
   is `gpu_to_gpu` in NVIDIA's CCCL vocabulary, held by construction rather
-  than by tuning — integer-only arithmetic, every output byte written exactly
+  than by tuning - integer-only arithmetic, every output byte written exactly
   once by a statically determined lane as a pure function of lower addresses,
   and no inter-chunk coupling. The scope, the reasoning, and the tested axes
   (including launch geometry and stream count, which a same-batch-twice
@@ -143,16 +143,16 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
 - **The harness is framework-less; ctest is the runner** (settled in the #4
   design review): one executable per test group over the small assertion
   header `tests/require.h`; discovery, labels, parallelism, and rerun come
-  from ctest; buffer diffs report first-mismatch offset plus a hex window —
+  from ctest; buffer diffs report first-mismatch offset plus a hex window -
   the one assertion domain a framework would not improve. Rationale:
   near-zero supply-chain surface for the security net itself, and
   early-abort semantics fit contract-sequence tests. Recorded reassessment
   trigger: if early-abort measurably masks failure clusters at M5 mutant
-  scale, or an outside contributor base emerges, migrate to Catch2 (pinned)
-  — the REQUIRE-shaped macros survive that move verbatim, and no framework
+  scale, or an outside contributor base emerges, migrate to Catch2 (pinned) -
+  the REQUIRE-shaped macros survive that move verbatim, and no framework
   headers are compiled through nvcc-only paths that would complicate it.
 - **A GPU test never self-skips** (banned pattern): no "no device, exit 0"
-  branches — skipping is exclusively the runner's decision via ctest labels
+  branches - skipping is exclusively the runner's decision via ctest labels
   (`-LE gpu` on the GPU-less CI runner; the full run on the local gate). A
   mislabeled GPU test in CI therefore fails loudly instead of passing
   vacuously; `--no-tests=error` closes the zero-tests-selected route; CI
@@ -165,7 +165,7 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
   their hashes moved). Where a project publishes no uploaded asset, the
   archive tarball is pinned and a future hash mismatch is treated as the
   invariant working, not as noise. FetchContent pins are invisible to
-  Dependabot — oracle bumps are deliberate manual PRs owned by the
+  Dependabot - oracle bumps are deliberate manual PRs owned by the
   supply-chain sweep. Third-party oracle code compiles with SYSTEM includes
   and without the project's strict flags; one translation unit per oracle,
   never its build system.
@@ -181,13 +181,13 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
 
 | Milestone        | Deliverable                                                                                                                  |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| M0 — Foundation  | Toolchain decision + GPU probe, CMake+CUDA skeleton, CI gate, test harness + LZ4 oracle, bench skeleton, masterplan complete |
-| M1 — LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed against liblz4, first honest numbers                                          |
-| M2 — LZ4 batch   | Frame format, batch API, pinned-host streaming path, published benchmark + methodology write-up                              |
-| M3 — Snappy      | Snappy decode on the shared kernel family                                                                                    |
-| M4 — GDeflate    | The first open GPU GDeflate decoder (32-substream warp decode)                                                               |
-| M5 — Zstd        | Zstd decode: FSE/Huffman stages + sequence execution                                                                         |
-| M6 — Portability | HIP port of the kernel family                                                                                                |
+| M0 - Foundation  | Toolchain decision + GPU probe, CMake+CUDA skeleton, CI gate, test harness + LZ4 oracle, bench skeleton, masterplan complete |
+| M1 - LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed against liblz4, first honest numbers                                          |
+| M2 - LZ4 batch   | Frame format, batch API, pinned-host streaming path, published benchmark + methodology write-up                              |
+| M3 - Snappy      | Snappy decode on the shared kernel family                                                                                    |
+| M4 - GDeflate    | The first open GPU GDeflate decoder (32-substream warp decode)                                                               |
+| M5 - Zstd        | Zstd decode: FSE/Huffman stages + sequence execution                                                                         |
+| M6 - Portability | HIP port of the kernel family                                                                                                |
 
 ## 7. Risks, named
 
@@ -202,16 +202,16 @@ a planned milestone — a vendor binary can never follow), and **hackability**.
 
 ## 8. Open design questions (settled via design issues before use)
 
-- Benchmark corpus set beyond Silesia/enwik (game-asset-like data) — M2.
-- Device-side chunk-size binning for mixed batches — M2 (see section 9:
+- Benchmark corpus set beyond Silesia/enwik (game-asset-like data) - M2.
+- Device-side chunk-size binning for mixed batches - M2 (see section 9:
   the async ABI rules out host-side histogramming, so the block-per-chunk /
   binning option in section 4 resolves to device-side binning or nothing;
   M1 ships without a dispatch heuristic).
 
 Settled: test framework and oracle vendoring (section 5, via the #4 design
-review); dev-container image and CI toolchain pinning (issues #1/#3 —
+review); dev-container image and CI toolchain pinning (issues #1/#3 -
 digest-pinned `nvidia/cuda` 12.6.2 in CI and the local gate); the LZ4
-kernel decomposition (section 9, via the #6 design panel — single-pass
+kernel decomposition (section 9, via the #6 design panel - single-pass
 warp-per-chunk, with a recorded measurement-based falsification trigger;
 the exact batch upper bound is pinned by the zero-visible-devices
 technique from the #4 harness once the geometry lands:
@@ -227,7 +227,7 @@ occupancy arithmetic. The convergent result:
 
 **One kernel. One warp per chunk over a grid-stride loop. All 32 lanes
 parse the sequence stream redundantly in lockstep** (identical bytes,
-identical arithmetic, identical registers in every lane — no leader lane,
+identical arithmetic, identical registers in every lane - no leader lane,
 no shuffles, no parse divergence), **and fan out by lane for every copy.
 No shared memory, no sequence table, no dispatch heuristic.**
 
@@ -235,7 +235,7 @@ Why the arithmetic forces this shape:
 
 - The kernel is parse-bound, not bandwidth-bound. The Silesia-shaped batch
   moves ~450–550 MB per run (src read + dst write + match-gather misses
-  against 5 MB L2) — a ~300–380 GB/s bandwidth ceiling — while the serial
+  against 5 MB L2) - a ~300–380 GB/s bandwidth ceiling - while the serial
   per-chunk parse chain (3–5 dependent L1 loads per sequence, ~3,300
   sequences per 64 KiB chunk) bounds a naive kernel to ~100–200 GB/s.
   Parallelism therefore comes from chunks: 3,239 Silesia chunks against
@@ -245,7 +245,7 @@ Why the arithmetic forces this shape:
   never the bottleneck.
 - Table-in-smem two-phase is dead on arithmetic alone, recorded here so
   nobody re-proposes it: a 64 KiB chunk admits up to 16,385 sequences;
-  at 16 B per table entry that is ~256 KiB — 2.6× an SM's usable shared
+  at 16 B per table entry that is ~256 KiB - 2.6× an SM's usable shared
   memory.
 
 **Overlap copy, closed form.** An overlapping match is not a copy that
@@ -253,19 +253,19 @@ chases itself; it is a modular gather from bytes already final:
 `dst[d + i] = dst[d - off + (i mod off)]` reads only `[d - off, d)`, which
 the `__syncwarp()` preceding every copy has frozen. Each output byte is
 written exactly once, by a statically determined lane, as a pure function
-of lower addresses — deterministic because no ordering exists to get
+of lower addresses - deterministic because no ordering exists to get
 wrong. "Exactly once" holds for a supported launch geometry, which the
 kernel enforces rather than assumes: the copy loops stride by the warp
 size, so a block that is not a whole number of warps would leave a fixed
 slice of every destination written by nobody, and that geometry returns
-without decoding ([DETERMINISM.md](DETERMINISM.md)). The shipped inner loop computes that `i mod off` directly — one
+without decoding ([DETERMINISM.md](DETERMINISM.md)). The shipped inner loop computes that `i mod off` directly - one
 64-bit modulo per output byte, so every lane pays a division per
 iteration (`dst[seq.match_dst + i] = dst[seq.match_src + (i % offset)]`
 in `src/lz4_decode.cuh`). Cutting that cost is deferred, measurement-gated
 perf work, not a present property: eliding the modulo when the match
 cannot wrap (`off >= len`, #36) and narrowing it to 32-bit (#58), neither
 merged. The fully incremental `r += step; if (r >= off) r -= off` scheme
-was itself tried and rejected by measurement — see perf pass 1 below.
+was itself tried and rejected by measurement - see perf pass 1 below.
 
 **The validation ladder** (fail-closed; every stream-decoded value checked
 before first use as address, length, or offset): token existence before
@@ -278,7 +278,7 @@ capacity; offset-field presence; `offset == 0` rejected;
 capacity; the LZ4 parsing restriction that a match may not end within the
 last `LASTLITERALS` (5) output bytes; success ONLY at exact stream
 consumption after a literals-only tail. Edge semantics (end-of-block rules, empty-block tokens) are settled
-empirically by oracle parity — whenever liblz4 rejects, cudec rejects; for
+empirically by oracle parity - whenever liblz4 rejects, cudec rejects; for
 accepted mutants the comparison is against the oracle's own output and
 size. One crafted negative fixture per ladder branch, its oracle verdict
 asserted in-test, keeps every reject path CI-covered.
@@ -287,13 +287,13 @@ asserted in-test, keeps every reject path CI-covered.
 status; dst contents up to the failure point are unspecified but are never
 presented as success. On success, writes touch exactly
 `dst[0, bytes_written)`. Check-before-load is batch isolation, not just
-parity: on a GPU an out-of-bounds read is not a per-chunk failure — it can
+parity: on a GPU an out-of-bounds read is not a per-chunk failure - it can
 fault the launch and poison the whole batch.
 
 **One deliberate divergence from liblz4 (settled empirically at ladder
 step 2):** a match offset of 0 is invalid per the LZ4 block spec, but
 liblz4 tolerates it as a defined self-referential copy (its decoder
-silences an msan warning there rather than erroring). cudec rejects it —
+silences an msan warning there rather than erroring). cudec rejects it -
 fail-closed on spec-invalid input (prime directive 1) outranks bug-for-bug
 parity with the reference. This makes cudec's accept set a strict subset
 of liblz4's: the twin test asserts the two security-critical directions
@@ -304,7 +304,7 @@ such point.
 
 **Anti-pattern rule (from the two-phase candidate's disproof):** no packed
 or narrowed field anywhere in the decoder unless its bound derives from an
-ABI-enforced invariant — the 64 KiB chunk cap is a project convention, not
+ABI-enforced invariant - the 64 KiB chunk cap is a project convention, not
 an ABI guarantee, and the frozen `size_t` capacities admit larger values.
 A crafted test (valid stream, `dst_capacity > 65536`) pins that the ladder
 stays correct beyond the convention.
@@ -317,7 +317,7 @@ unverified decoder are not numbers.
 
 **Occupancy plan:** target ≤ 64 registers/thread for ≥ 32 warps/SM,
 pinned with `__launch_bounds__`; achieved registers and occupancy are read
-out at the kernel PR and recorded — a 24-warp fallback is a measured
+out at the kernel PR and recorded - a 24-warp fallback is a measured
 choice, never an accident.
 
 **Measurement decision rule (recorded before the kernel lands):** the
@@ -331,21 +331,21 @@ profiling attributes the majority of stalls to copy starvation.
 
 **Measured outcome (issue #15, 2026-07-17): SETTLED for single-pass.** On
 Silesia the minimal-correct kernel decodes at ~18 GB/s (~5× CPU) and the
-parse-only ceiling is ~35 GB/s (~10× CPU) — so parse and copy each cost
+parse-only ceiling is ~35 GB/s (~10× CPU) - so parse and copy each cost
 roughly half the wall time. Since parse-only ceilings any two-phase phase-1
 (shared serial parse), two-phase cannot exceed ~35 GB/s; its only lever is
 a faster copy, which single-pass optimizes equally without a table or
 barrier. Recorded in [docs/BENCHMARKS.md](BENCHMARKS.md).
 
 **Perf pass 1 outcome (issue #16): the designed micro-optimizations were
-rejected by measurement** — the incremental-mod gather regressed 16% (its
+rejected by measurement** - the incremental-mod gather regressed 16% (its
 loop-carried dependency pipelines worse than the independent modulo the
 compiler overlaps) and the vectorized literal copy regressed 6% (real
 literal runs are too short for the wide path); a `__syncwarp` elision was
 neutral. The kernel is at a local optimum for its structure; the bottleneck
 is structural (the redundant 32-lane parse ceiling and latency-bound
 short-run copies), so raising throughput needs higher occupancy or
-warp-specialization — larger than a micro-op pass, tracked as issue #21. The
+warp-specialization - larger than a micro-op pass, tracked as issue #21. The
 falsification trigger does NOT reopen two-phase: it stays ruled out by the
 shared parse ceiling regardless of the numeric condition (see
 BENCHMARKS.md).
@@ -365,38 +365,38 @@ the redundant-lockstep-parse invariant (its own design panel), which under
 **Perf pass 3 outcome (issue #36): the non-overlap match fast path is
 rejected by the worst case.** Splitting the match copy on the warp-uniform
 `offset >= match_len` predicate (straight copy instead of the modular gather
-when the match cannot wrap — bit-identical by construction, all oracle/
+when the match cannot wrap - bit-identical by construction, all oracle/
 determinism gates green) measured +9–10% on Silesia and +38–42% on the new
 copy-dominated `--longmatch` corpus (throughput speedup), but a consistent
 −5–9% on `--worst4b`:
 the per-match predicate lands in the hottest path of exactly the
 maximum-sequence-density adversarial input. Rejected under the
-pre-registered zero-regression rule — the worst-case number is the
+pre-registered zero-regression rule - the worst-case number is the
 DoS-resistance margin, and average-case gains do not buy it back. No kernel
 code shipped; the `--longmatch` corpus and its selfcheck ctest shipped so
 the regime stays measurable. Recorded in
 [docs/BENCHMARKS.md](BENCHMARKS.md).
 
 **Known limits, published:** the redundant-parse family ceiling is roughly
-250–400 GB/s after perf passes — deliberately accepted under "formats over
+250–400 GB/s after perf passes - deliberately accepted under "formats over
 percentage points"; batches under ~2,000 chunks underfill the machine and
 land near CPU speed (documented, not hidden); warp-synchronous discipline
-is load-bearing — every `__syncwarp` is reviewed as such.
+is load-bearing - every `__syncwarp` is reviewed as such.
 
-**M3/M4 seam:** the chunk decoder is `template<class FormatParser>` —
+**M3/M4 seam:** the chunk decoder is `template<class FormatParser>` -
 Snappy (M3) swaps the parser and keeps everything else; GDeflate (M4)
 keeps the copy engine, validation posture, and result contract while
 bringing its format-native 32-substream parse model.
 
-**The M1 PR ladder** (each independently gated): (1) this design section —
+**The M1 PR ladder** (each independently gated): (1) this design section -
 closes the design issue; (2) the sequence parser + validation ladder as a
 single-source `__host__ __device__` header with a CPU-compiled twin test
 running the full mutant corpus and the crafted negatives on the GPU-less
-CI runner — the security heart of M1 lands under CI before any kernel;
-(3) the kernel, minimal-correct, behind the frozen batch ABI — the stub
+CI runner - the security heart of M1 lands under CI before any kernel;
+(3) the kernel, minimal-correct, behind the frozen batch ABI - the stub
 deleted, the gpu_fixture expectations flip, all mechanical gates recorded
 (security-review gated: decoder validation is this project's login path);
 (4) the bench GPU path + the split variants + the first recorded GPU
-baselines — numbers and kernel never move in the same PR; (5) a measured
+baselines - numbers and kernel never move in the same PR; (5) a measured
 perf pass (register-window parse staging, vectorized multi-byte lane
 copies), accepted only on recorded improvement with all gates green.


### PR DESCRIPTION
Sweeps the em dash out of this repository. I keep the marker as a rule
elsewhere: the literal `U+2014`, matched anywhere, in content rather than prose
only, scoped per repository. Tracked here as `#254`.

Closes #254.

## The count reproduces

The issue states its count at the revision it was written against. It is re-run
here at the reference a reader has, `origin/main` at `f3ac564`, and against the
branch this repository's roster record declares (`Mainline: main`) rather than
whatever branch a checkout sits on.

    $ git rev-parse origin/main
    f3ac56475be9f70ed420d11127caae4c9395ed4c
    $ git grep -o -h -P '\x{2014}' origin/main -- . | wc -l
    194
    $ git grep -l -P '\x{2014}' origin/main -- . | wc -l
    10
    $ git grep -o -n -P '\x{2014}' origin/main -- . | awk -F: '{print $2}' | sort | uniq -c | sort -rn
         59 docs/MASTERPLAN.md
         49 docs/BENCHMARKS.md
         27 docs/BENCHMARK-METHODOLOGY.md
         24 README.md
         14 docs/DETERMINISM.md
         14 CONTRIBUTING.md
          4 .github/pull_request_template.md
          1 SECURITY.md
          1 .github/workflows/ci.yml
          1 .github/dependabot.yml

| | issue, as stated | here, at `f3ac564` |
|---|---|---|
| occurrences | 194 | 194 |
| files | 10 | 10 |

Every per-file figure reproduces as well, in the same order. There is no
difference to report.

## The two configuration files, which are the named risk

The issue names these as where the sweep could refuse falsely: a replacement
reaching YAML content rather than YAML comments changes what the workflow does,
and no check in the operations tree runs against this tree.

Both occurrences sit on a leading `#` comment line, and each is the whole diff for
its file. Argued from the parse rather than from reading the diff, since "it is
only a comment" is a claim about lexing:

    $ python - <<'PY'
    import subprocess, yaml
    for f in ['.github/workflows/ci.yml', '.github/dependabot.yml']:
        before = subprocess.run(['git','show','origin/main:'+f],capture_output=True).stdout.decode('utf-8')
        after  = open(f,encoding='utf-8').read()
        print(f, '| loaded documents compare equal:', yaml.safe_load(before) == yaml.safe_load(after))
    PY
    .github/workflows/ci.yml | loaded documents compare equal: True
    .github/dependabot.yml | loaded documents compare equal: True

The loaded document is unchanged, so the workflow does what it did.

## The benchmark numbers did not move

The issue says a reviewer who sees a number move should reject this change.
Proven for every changed file rather than only for the two it worries about: strip
the marker, the ASCII hyphen and all whitespace from the blob at `origin/main` and
from the file on this branch, and compare what is left. A digit, a word or a
delimiter that moved shows up as a mismatch.

    $ perl invariant.pl origin/main $(git diff --name-only origin/main...HEAD)
    ok   .github/dependabot.yml
    ok   .github/pull_request_template.md
    ok   .github/workflows/ci.yml
    ok   CONTRIBUTING.md
    ok   README.md
    ok   SECURITY.md
    ok   docs/BENCHMARK-METHODOLOGY.md
    ok   docs/BENCHMARKS.md
    ok   docs/DETERMINISM.md
    ok   docs/MASTERPLAN.md
    all files: only the marker and surrounding whitespace changed
    exit 0

## How the replacement was made, including the case that is not mechanical

A spaced occurrence becomes a spaced hyphen. There is no unspaced occurrence in
this tree, checked rather than assumed:

    $ git grep -n -P '\S\x{2014}\S' origin/main -- .
    (no output, exit 1)

SIX OCCURRENCES OPENED A WRAPPED LINE and are not a character-for-character
substitution. Four in `docs/BENCHMARKS.md` and two in `docs/MASTERPLAN.md` sit at
the start of a continuation line inside a paragraph or a list item. A hyphen there
is a markdown bullet, and it would have split the block:

    $ git grep -n -P '^\s*\x{2014}' origin/main -- . | awk -F: '{print $2":"$3}'
    docs/BENCHMARKS.md:103
    docs/BENCHMARKS.md:322
    docs/BENCHMARKS.md:380
    docs/BENCHMARKS.md:452
    docs/MASTERPLAN.md:85
    docs/MASTERPLAN.md:152

Each of those folds onto the end of the previous line, so the rendered sentence is
the one that was there:

    -anti-pattern rule (masterplan section 9) forbids narrowing any of it to 32-bit
    -[dash] the ABI's `size_t` capacities admit values above 2^32, pinned by the
    +anti-pattern rule (masterplan section 9) forbids narrowing any of it to 32-bit -
    +the ABI's `size_t` capacities admit values above 2^32, pinned by the

`[dash]` stands for the character in that quoted line, so this body does not carry
the thing it removes. That fold is the one part of the diff to read as prose rather
than as a substitution.

## What was left untouched, and why

Nothing was left as an occurrence. There is no vendored file, no third-party
quotation and no generated file in the changed set. `LICENSE` is the one licence
text in the tree and it carries no occurrence, which the ten-file histogram above
already says:

    $ git ls-files | grep -iE 'license|licence|vendor|third.?party|generated|\.min\.|COPYING|NOTICE'
    LICENSE

The en dash `U+2013` appears in this tree (`~2.2-2.3x`, `14-17%`, `+9-10%` are
written there with it) and is NOT this marker. The rule I keep declares one
codepoint, and by its own terms a second literal would owe its own
witness. Those are untouched and are not counted here.

The CP1252 mojibake rendering of the character is likewise not this marker, and
this tree carries none of it either way:

    $ git grep -o -h -P '\x{00e2}\x{20ac}' origin/main -- . | wc -l
    0

## What was run, and what could not be

    $ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
    Checking formatting...
    All matched files use Prettier code style!
    exit 0

That is the `format` job from `.github/workflows/ci.yml` run verbatim, and it is
the gate that reads every file this change touches.

THE `build` AND `sanitize` JOBS WERE NOT RUN. They need a CUDA toolchain, CMake
and Ninja inside the pinned container, and none of them exists on this machine:

    $ for t in cmake nvcc ninja clang-format; do printf '%-14s ' "$t"; $t --version 2>&1 | head -1; done
    cmake          command not found
    nvcc           command not found
    ninja          command not found
    clang-format   command not found

So this change is NOT shown to compile here, and nothing below turns that into a
positive statement. Two facts bound the gap rather than close it. No file under a
source extension is in the diff, because no source file in this repository carries
the character. And the `format` job's clang-format step reads C++ sources, which
are unchanged. This pull request's own CI run is the witness for the other two
jobs, and it has not been read into this body.

## What this change does not do

It does not add `cudec` to the marker's coverage in the rule I keep elsewhere.
That field lives in another repository and its change is not in this diff, so
the operations CI `fleet` job is unaffected by this branch either way. Until it
lands there, the marker still does not read this tree and the sweep is
unenforced here.

It settles nothing about the other four repositories on the roster. Each is judged
on its own contents and carries its own pull request.

This branch is not merged here. The merge is my act.


## THE CI RUN THIS BODY SAID IT HAD NOT READ, NOW READ

The section above says the `build` and `sanitize` jobs were not run here and that
this change is not shown to compile from this machine. Both statements stand. This
section reports what the runner did afterwards.

    $ gh pr checks 255 --repo iderex/cudec
    build      pass  1m50s
    format     pass     9s
    sanitize   pass  1m38s

THE TWO JOBS THAT NEEDED THE CUDA TOOLCHAIN RAN AND PASSED. Nothing above is
edited: the local run still could not compile this, and the negative statement
about what this machine did stays exactly as it was written.
