### PR TITLE
Add the four-tool Compute Sanitizer runner over discovered gpu tests [#125]

### DIFF
--- a/scripts/sanitize-gpu.sh
+++ b/scripts/sanitize-gpu.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+# Runs all four Compute Sanitizer tools over every gpu-labeled ctest target
+# and prints one paste-ready PASS/FAIL block naming the machine it ran on.
+#
+# It is fail-closed on a VACUOUS run: a sanitizer sweep that checked nothing
+# reads exactly like a clean one. An absent compute-sanitizer, an empty
+# discovery, a missing test binary, and a known GPU test gone from the
+# discovered set are hard errors here, never skips.
+#
+# Discovery is `ctest -L gpu -N`, never a list in this file, so a GPU test is
+# covered the moment it is registered with the label.
+#
+# Usage, from the repository root, inside the pinned container (the image
+# ships no cmake and no git, hence the apt-get and CUDEC_COMMIT):
+#
+#   docker run --rm --gpus all -v "$PWD:/w" -w /w \
+#     nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8 \
+#     sh -c "apt-get update -q >/dev/null && \
+#            apt-get install -yq cmake >/dev/null 2>&1 && \
+#            cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && \
+#            cmake --build build-cuda -j && \
+#            CUDEC_COMMIT=<sha> scripts/sanitize-gpu.sh build-cuda"
+#
+# The tool flags are pinned against `compute-sanitizer --help` of the version
+# in that image, 2024.3.0.0 (build 34841621). Two flags named while this
+# script was specified do not exist there, and the substitutes are stated
+# rather than assumed:
+#
+#   - memcheck has no --report-device-side-allocation-failure. Device heap
+#     allocation is covered by --check-device-heap, passed explicitly below
+#     although it already defaults to yes, so the run states the option
+#     instead of implying it.
+#   - initcheck has no --initcheck-address-space. Its own help calls it
+#     "Global memory initialization checking", so in this version the tool
+#     has no shared-memory address space to switch on; shared memory is
+#     racecheck's subject ("Shared memory hazard checking") and racecheck
+#     runs below. initcheck's remaining knob, --track-unused-memory, reports
+#     unused allocations rather than uninitialised reads and is left off.
+#
+# Re-confirm both against --help on any toolkit bump. A flag this script
+# passes that the tool does not know is a hard error from compute-sanitizer
+# itself rather than a silent skip.
+set -eu
+
+build="${1:-build-cuda}"
+
+die() {
+    echo "sanitize-gpu: $1" >&2
+    exit 1
+}
+
+command -v compute-sanitizer >/dev/null 2>&1 ||
+    die "compute-sanitizer is not on PATH - this must run inside the pinned
+CUDA container (see the header). A sweep that ran no tool is refused."
+command -v ctest >/dev/null 2>&1 ||
+    die "ctest is not on PATH - discovery is impossible, so the run would
+cover nothing."
+command -v nvidia-smi >/dev/null 2>&1 ||
+    die "nvidia-smi is not on PATH - the summary must name the GPU and driver
+it ran against, so an unattributable run is refused."
+command -v nvcc >/dev/null 2>&1 ||
+    die "nvcc is not on PATH - the summary must name the CUDA version it ran
+against, so an unattributable run is refused."
+
+[ -d "$build" ] || die "build directory '$build' does not exist"
+
+# The commit is part of the evidence: a pasted block naming no commit cannot
+# be checked against anything. The container ships no git, and a git
+# worktree's .git is a file naming a host path that does not resolve inside
+# the container, so the sha is passed in and derived from git only as a
+# convenience for a host-side run.
+commit="${CUDEC_COMMIT:-}"
+if [ -z "$commit" ]; then
+    commit="$(git -C "$(dirname "$0")/.." rev-parse HEAD 2>/dev/null || true)"
+fi
+[ -n "$commit" ] ||
+    die "no tested commit: set CUDEC_COMMIT=\$(git rev-parse HEAD) on the
+host, where git can read the repository."
+
+# Discovery, in the shape .github/workflows/ci.yml lists the deferred GPU
+# tests with. ctest prints "  Test #3: smoke"; anything else on a line is not
+# a test name.
+listing="$(ctest --test-dir "$build" -L gpu -N)" ||
+    die "ctest discovery failed in '$build'"
+tests="$(printf '%s\n' "$listing" |
+    sed -n 's/^ *Test *#[0-9][0-9]*: *\([^ ][^ ]*\) *$/\1/p')"
+[ -n "$tests" ] ||
+    die "zero gpu-labeled tests discovered in '$build' - a sweep over nothing
+is not a clean sweep. Configure with -DCUDEC_ENABLE_CUDA=ON."
+
+# The cross-check .github/workflows/ci.yml already makes on the same
+# listing, by name: a known GPU test quietly leaving the discovered set (a
+# dropped label, a renamed target, a registration lost in a merge) would
+# otherwise shrink this sweep and still print PASS. The names are that job's,
+# so the two gates cannot drift apart unnoticed.
+for known in smoke gpu_fixture frame_twin stream_twin termination_gpu \
+    determinism_gpu; do
+    printf '%s\n' "$tests" | grep -qx "$known" ||
+        die "gpu test '$known' is absent from the discovered set - the sweep
+would cover less than the CI job's own cross-check demands."
+done
+
+# Name to binary, searched rather than assumed at tests/<name>: a moved
+# output directory becomes a hard error here instead of a wrong path later,
+# and two matches are as unusable as none.
+binary_of() {
+    matches="$(find "$build" -type f -perm -u+x -name "$1" 2>/dev/null ||
+        true)"
+    count="$(printf '%s' "$matches" | grep -c . || true)"
+    [ "$count" = "1" ] ||
+        die "expected exactly one executable named '$1' under '$build', found
+$count - discovery and the build tree disagree."
+    printf '%s\n' "$matches"
+}
+
+# The tool's own flags; --error-exitcode 1 is appended to every invocation,
+# because a sanitizer that reports an error and still exits 0 is the vacuous
+# run in another shape.
+flags_of() {
+    case "$1" in
+    memcheck) echo "--tool memcheck --leak-check full --check-device-heap yes" ;;
+    racecheck) echo "--tool racecheck" ;;
+    initcheck) echo "--tool initcheck --check-api-memory-access yes" ;;
+    synccheck) echo "--tool synccheck" ;;
+    *) die "unknown tool '$1'" ;;
+    esac
+}
+
+# The summary is accumulated in a file rather than a variable: every line is
+# written the moment its tool exits, so an interrupted run still leaves the
+# results of what did run.
+results="$(mktemp)"
+trap 'rm -f "$results"' EXIT
+
+report() {
+    echo
+    echo "=== Compute Sanitizer summary ==="
+    echo "commit:    $commit"
+    echo "gpu:       $(nvidia-smi --query-gpu=name,driver_version \
+        --format=csv,noheader)"
+    echo "cuda:      $(nvcc --version | sed -n \
+        's/^.*release \([0-9][0-9.]*\).*$/\1/p')"
+    echo "sanitizer: $(compute-sanitizer --version |
+        sed -n 's/^Version //p')"
+    echo "build:     $build"
+    echo
+    cat "$results"
+    echo
+}
+
+failed=""
+for name in $tests; do
+    bin="$(binary_of "$name")" || exit 1
+    for tool in memcheck racecheck initcheck synccheck; do
+        flags="$(flags_of "$tool")"
+        echo "=== $name : $tool ==="
+        # Unquoted on purpose: $flags is this file's own constant list.
+        if compute-sanitizer $flags --error-exitcode 1 "$bin"; then
+            printf '  %-16s %-10s PASS\n' "$name" "$tool" >>"$results"
+        else
+            printf '  %-16s %-10s FAIL\n' "$name" "$tool" >>"$results"
+            failed="$name/$tool"
+            break
+        fi
+    done
+    [ -z "$failed" ] || break
+done
+
+report
+
+if [ -n "$failed" ]; then
+    echo "sanitize-gpu: FAILED at $failed" >&2
+    exit 1
+fi
+echo "sanitize-gpu: clean over $(printf '%s\n' "$tests" | grep -c .) gpu \
+tests, four tools each"


### PR DESCRIPTION
﻿Closes nothing yet. Issue #125, and two of its five done-when boxes are NOTmet on this machine. The reason is in "What could not be demonstrated" belowand it is the finding this branch mostly produced.## What this adds`scripts/sanitize-gpu.sh`, executable, and nothing else. One path in thediff:    git diff --name-only origin/main...HEAD    scripts/sanitize-gpu.shIt runs memcheck, racecheck, initcheck and synccheck over every gpu-labeledctest target, discovers those targets with `ctest --test-dir <build> -L gpu-N` rather than from a list inside the script, passes `--error-exitcode 1` toevery invocation, stops at the first nonzero tool exit, and prints onepaste-ready block naming the GPU, the driver, the CUDA version, the sanitizerversion and the tested commit.The failure it exists to prevent is the vacuous run: a sweep that checkednothing prints the same green as a clean one. Four conditions are hard errorsrather than skips.- `compute-sanitizer` not on PATH.- Zero gpu-labeled tests discovered.- A discovered name that does not resolve to exactly one executable under the  build tree.- Any of `smoke`, `gpu_fixture`, `frame_twin`, `stream_twin`,  `termination_gpu`, `determinism_gpu` missing from the discovered set. The  issue names four; the list here is the six that  `.github/workflows/ci.yml` already greps for by name in its  "Deferred to the local GPU gate" step, so the two gates cannot drift apart  unnoticed. That is a superset of what the issue asked for and it is stated  rather than assumed.`nvidia-smi` and `nvcc` are required too, for the same reason: the summaryblock is evidence, and a block that cannot name the GPU or the CUDA versionit ran against is not evidence.The means is POSIX `sh`, matching `bench/get-corpora.sh`, the only otherscript in the tree. It adds no language, no runtime and no dependency, it isthe forced means for a thing whose whole job is to launch subprocesses andread their exit codes, and every claim it makes is a command it ran.## Two flags in the issue do not exist in the pinned sanitizerConfirmed against `--help` inside the pinned image, as the issue asked, atversion 2024.3.0.0 (build 34841621):    docker exec <container> compute-sanitizer --help    Initcheck-specific options:      --check-api-memory-access arg (=yes)  Check cudaMemcpy/cudaMemset for accesses to device memory      --check-optix                         Track OptiX kernel launches.      --track-unused-memory                 Check for unused memory allocations.      --unused-memory-threshold arg (=0)    Threshold for unused memory reporting.    Memcheck-specific options:      --check-cache-control      --detect-missing-module-unload      --leak-check arg (=no)      --padding arg (=0)      --report-api-errors arg (=explicit)      --track-stream-ordered-races arg (=no)There is no `--initcheck-address-space` and no`--report-device-side-allocation-failure`. This version's initcheck is"Global memory initialization checking" and has no shared-memory addressspace to switch on; shared memory is racecheck's subject here ("Shared memoryhazard checking") and racecheck runs. The device heap is covered by thegeneral `--check-device-heap`, which the script passes explicitly although italready defaults to yes, so the run states the option instead of implying it.`--track-unused-memory` reports unused allocations rather than uninitialisedreads and is left off. All of this is in the script's header, to bere-confirmed on any toolkit bump.## The three vacuous-run refusals, demonstratedRun at the pushed commit `9bb1e0a6370738105d8094df29ccad6a5c2733c0`, insidethe pinned container against the local RTX 3080. The container was startedonce, detached, and the legs below ran through `docker exec` into it, becauseonly one container may hold the GPU on this machine at a time:    docker run -d --name <container> --gpus all -v "<repo>:/w" -w /w \      nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8 \      sh -c "sleep 5400"    docker exec <container> sh -c "apt-get update -q && apt-get install -yq cmake && \      cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j"**1. `compute-sanitizer` absent.** PATH cut to the base system, so the CUDAbin directory is gone:    docker exec <container> sh -c 'PATH=/usr/bin:/bin CUDEC_COMMIT=9bb1e0a scripts/sanitize-gpu.sh build-cuda'    sanitize-gpu: compute-sanitizer is not on PATH - this must run inside the pinned    CUDA container (see the header). A sweep that ran no tool is refused.    EXIT=1**2. Zero discovered gpu tests.** A host-only configuration registers none:    docker exec <container> sh -c 'cmake -B build-hostonly && ctest --test-dir build-hostonly -L gpu -N | tail -n 2 && CUDEC_COMMIT=9bb1e0a scripts/sanitize-gpu.sh build-hostonly'    configure exit=0    Total Tests: 0    sanitize-gpu: zero gpu-labeled tests discovered in 'build-hostonly' - a sweep over nothing    is not a clean sweep. Configure with -DCUDEC_ENABLE_CUDA=ON.    EXIT=1**3. A cross-check target missing from discovery.** The `stream_twin`registration in `tests/CMakeLists.txt` commented out in the working tree,configured into a separate build directory, then reverted. That edit is NOTin this branch:    docker exec <container> sh -c 'cmake -B build-miss -DCUDEC_ENABLE_CUDA=ON; CUDEC_COMMIT=9bb1e0a scripts/sanitize-gpu.sh build-miss'    code=1    sanitize-gpu: gpu test 'stream_twin' is absent from the discovered set - the sweep    would cover less than the CI job's own cross-check demands.Discovery in that build directory found 5 tests, and the four other nameswere all present, so the refusal came from the missing one rather than froman empty listing.## What could not be demonstrated, and why**Compute Sanitizer cannot attach to the device on this machine.** Every oneof the four tools fails to initialize the WDDM debugger interface through theWSL2 GPU passthrough, reports two errors before the program starts, and exitsnonzero on a program with no fault at all:    docker exec <container> sh -c 'nvcc -arch=sm_86 -o /tmp/p/clean /tmp/p/clean.cu'    # clean.cu: __global__ void k(int* p) { p[0] = 7; }  with a 4-byte cudaMalloc    memcheck exit=1 | ========= ERROR SUMMARY: 2 errors    ========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator    ========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation    racecheck exit=1 | ========= RACECHECK SUMMARY: 2 hazards displayed (2 errors, 0 warnings)    ========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator    ========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation    initcheck exit=1 | ========= ERROR SUMMARY: 2 errors    ========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator    ========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation    synccheck exit=1 | ========= ERROR SUMMARY: 2 errors    ========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator    ========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentationTwo consequences follow, and both are load-bearing.**No PASS is obtainable here.** Every invocation reports those two errors, sowith `--error-exitcode 1` every tool on every binary FAILs regardless of thecode under it. The summary block in this pull request therefore shows no PASSline anywhere, and none of the pasted FAILs says anything about the tree.**The seeded out-of-bounds read was not caught by memcheck.** A throwawaydevice kernel reading 1 KiB past a 16-byte allocation was added to`tests/smoke.cu` in the working tree, built, and run through the script. Thescript did produce a memcheck FAIL and a nonzero exit:    docker exec <container> sh -c 'cmake --build build-cuda --target smoke -j; CUDEC_COMMIT=9bb1e0a... scripts/sanitize-gpu.sh build-cuda'    code=1    === smoke : memcheck ===    ========= COMPUTE-SANITIZER    ========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator    ========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation    ========= Program hit cudaErrorInvalidDevice (error 101) due to "invalid device ordinal" on CUDA API call to cudaSetDevice.    ...    ========= Target application returned an error    ========= LEAK SUMMARY: 0 bytes leaked in 0 allocations    ========= ERROR SUMMARY: 6 errors    === Compute Sanitizer summary ===    commit:    9bb1e0a6370738105d8094df29ccad6a5c2733c0    gpu:       NVIDIA GeForce RTX 3080, 560.94    cuda:      12.6    sanitizer: 2024.3.0.0 (build 34841621) (public-release)    build:     build-cuda      smoke            memcheck   FAIL    sanitize-gpu: FAILED at smoke/memcheckbut the FAIL is not attributable to the seeded fault. There is no`Invalid __global__ read` line and no device backtrace anywhere in thatoutput; the six errors are the two initialization errors plus API-errorreports of the `cudaSetDevice(12345)` that `tests/smoke.cu` plants onpurpose. Without the sanitizer, the same seeded binary exits 0 and prints itsPASS line, so the fault is real and simply went unseen:    docker exec <container> sh -c 'cd /w/build-cuda/tests; ./smoke'    plain_exit=0    PASS: version + fail-closed validation + 257-chunk empty-block decode on deviceA separate minimal program confirms the same on hardware rather than throughthe test suite: a kernel writing 4 MiB past a 4-byte allocation is reportedonly as the runtime's own `cudaErrorIllegalAddress` on`cudaDeviceSynchronize`, never as a device-side memcheck error.So the fourth done-when box is NOT ticked. A memcheck FAIL and a nonzero exithappened; the demonstration that memcheck detects the seeded out-of-boundsread did not, and this paragraph is not to be read as the demonstration inweaker words. The seeded fault is not committed: `git status` is cleanagainst the branch and the diff holds one path.The same limitation blocks issue #127, which is the first clean run: on thismachine there can be no clean run of anything under any of these four tools,and there is a second problem waiting behind it, because `tests/smoke.cu`deliberately plants CUDA API errors that memcheck reports by default(`--report-api-errors arg (=explicit)`). Whether the runner should pass`--report-api-errors no` is a decision for that issue rather than a flag thischange picks unmeasured, and it is written into #125.## Gates- Prettier, host leg, run although the diff carries no `md`, `yml` or `yaml`  file:      npx prettier@3 --check "**/*.{md,yml,yaml}"      Checking formatting...      All matched files use Prettier code style!- CI build, sanitize and format, at the pushed commit:      gh pr checks 257      build     pass  1m26s      format    pass  11s      sanitize  pass  1m24s  None of the three runs a gpu-labeled test, and none of them runs this  script: the CI runner has no GPU. They prove the tree still builds in both  configurations and stays formatted, and nothing about the sweep.- The gpu-labeled ctest suite itself was not run for this change and this  change does not touch it.## Territory    git diff --name-only origin/main...HEAD    scripts/sanitize-gpu.shNothing outside the assignment. The two working-tree edits used fordemonstrations, in `tests/CMakeLists.txt` and `tests/smoke.cu`, were revertedand are absent from the branch.

## Landing re-run, 2026-08-05

This section was produced by an automated re-run, not by a second person.

Every number above was re-executed at `9bb1e0a6370738105d8094df29ccad6a5c2733c0`,
the head of this branch, before merging. The branch sits directly on the
mainline, so nothing was merged into it:

    git rev-parse origin/main
    972fac1bb5d769c72ef2024bc0fdaa409047909c
    git merge-base origin/main HEAD
    972fac1bb5d769c72ef2024bc0fdaa409047909c

Territory is unchanged, one path:

    git diff --name-only origin/main...HEAD
    scripts/sanitize-gpu.sh

Same machine and same pinned image as the original run: RTX 3080, driver
560.94, nvcc V12.6.77, cmake 3.28.3, image
`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`,
compute-sanitizer 2024.3.0.0 (build 34841621).

### The two absent flags, re-confirmed

    compute-sanitizer --help | grep -c 'initcheck-address-space'
    0
    compute-sanitizer --help | grep -c 'report-device-side-allocation-failure'
    0

Both flags are still absent at this version, and the substitutes the header
names are present:

    --check-device-heap arg (=yes)        Check allocation on the device heap.
    --leak-check arg (=no)                <full|no> Print leak information for CUDA allocations.
    --check-api-memory-access arg (=yes)  Check cudaMemcpy/cudaMemset for accesses to device memory
    --track-unused-memory                 Check for unused memory allocations.

### The three refusals, re-run

    PATH=/usr/bin:/bin CUDEC_COMMIT=9bb1e0a... scripts/sanitize-gpu.sh build-cuda
    sanitize-gpu: compute-sanitizer is not on PATH - this must run inside the pinned
    CUDA container (see the header). A sweep that ran no tool is refused.
    EXIT=1

    cmake -B build-hostonly && ctest --test-dir build-hostonly -L gpu -N | tail -1
    Total Tests: 0
    CUDEC_COMMIT=9bb1e0a... scripts/sanitize-gpu.sh build-hostonly
    sanitize-gpu: zero gpu-labeled tests discovered in 'build-hostonly' - a sweep over nothing
    is not a clean sweep. Configure with -DCUDEC_ENABLE_CUDA=ON.
    EXIT=1

The third refusal was re-run against a build directory that was configured
**and built**, which the original run's was not. That matters: an unbuilt tree
reaches the same nonzero exit through the missing-binary refusal instead, so
the original run does not separate the two. Built, it does. The `stream_twin`
registration was commented out in the working tree, the tree configured and
built into `build-miss`, and `tests/CMakeLists.txt` restored immediately after.
That edit is not in this branch and `git status` is clean against it.

    discovered: smoke gpu_fixture frame_twin termination_gpu determinism_gpu
    CUDEC_COMMIT=9bb1e0a... scripts/sanitize-gpu.sh build-miss
    sanitize-gpu: gpu test 'stream_twin' is absent from the discovered set - the sweep
    would cover less than the CI job's own cross-check demands.
    EXIT=1
    sweep entered? headers=0

Five tests discovered, the other four cross-check names all present, no tool
invocation reached.

### Each guard deleted in turn

A refusal that fires is not yet a guard that bites: the run has to be shown
doing the wrong thing once the guard is gone. Each was cut from a copy of the
script and the same condition presented again.

    D1  the cross-check loop cut, same built build-miss
        refusal lines=0, sweep entered? headers=1
        === Compute Sanitizer summary ===
        build:     build-miss
          smoke            memcheck   FAIL

With the loop gone the run enters the sweep over the shrunken set instead of
refusing it, which is the vacuous-run shape the guard exists against. Nothing
else in the script covers that case.

    D2  the empty-discovery guard cut, same build-hostonly
        sanitize-gpu: gpu test 'smoke' is absent from the discovered set - the sweep
        would cover less than the CI job's own cross-check demands.

D2 is still refused with its guard gone, by the cross-check loop below it,
which reaches the same conclusion from the same empty listing. So that guard is
not the only thing standing between an empty discovery and a sweep, and its own
deletion opens no hole. It is recorded that way rather than as a fifth guard
shown biting alone.

The `FAIL` in D1 is the WDDM attach failure below, not a finding about the
tree.

### The WDDM limitation, reproduced

    === smoke : memcheck ===
    ========= COMPUTE-SANITIZER
    ========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator
    ========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation
    ========= Program hit cudaErrorInvalidDevice (error 101) due to "invalid device ordinal" on CUDA API call to cudaSetDevice.

Unchanged from what this body already reports. No PASS is obtainable on this
machine, the seeded out-of-bounds demonstration remains undone, and the two
done-when boxes on #125 stay unticked. Nothing in this re-run makes them
tickable and none of it is to be read as making them so. #125 stays open and
this pull request closes nothing.

### Gates

- `cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j`,
  fresh directory, both green.
- `ctest --test-dir build-cuda --output-on-failure`:

      100% tests passed, 0 tests failed out of 15

      Label Time Summary:
      gpu    =   4.72 sec*proc (6 tests)

  The gpu-labeled suite was not run for the original push and is run here. It
  is green, and this change does not touch it, so what it says is that the
  tree this lands on is sound rather than anything about the script.

- Prettier over the eleven tracked `md`/`yml`/`yaml` files: "All matched files
  use Prettier code style!". The diff carries no such file.
- CI build, sanitize and format are green on this head. Those runs have no GPU,
  so none of them runs this script.

What lands is one new file that no gate in the tree executes yet. It is a
runner a person invokes by hand, and until #127 there is no route that fails
when it fails.
