### PR TITLE
Bound the streaming host-output copy by the chunk's capacity [#57]

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -51,6 +51,10 @@ inline bool MulOverflows(size_t a, size_t b) {
     return a != 0 && b > SIZE_MAX / a;
 }
 
+cudec_status CopyWaveToHost(cudec_chunk_result* wr, const unsigned char* d_dst,
+                            void* const* dst_ptrs, const size_t* dst_caps,
+                            size_t begin, size_t wn);
+
 }  // namespace cudec_stream_detail
 
 /* The opaque context (the header forward-declares `struct cudec_stream_ctx`).
@@ -77,6 +81,38 @@ struct cudec_stream_ctx {
     cudec_cuda::PinnedBuf p_results;
     bool poisoned = false;
 };
+
+namespace cudec_stream_detail {
+
+/* Copies one drained wave's decoded bytes out of the device staging into the
+ * caller's host destinations: exactly bytes_written per chunk, leaving the tail
+ * beyond it untouched, with the staging slots laid out at dst_caps strides.
+ * `wr` is the wave's slice of the pinned result mirror, `d_dst` its staging
+ * base, and `dst_ptrs`/`dst_caps` the caller's arrays indexed from `begin`.
+ * Returns CUDEC_ERR_CUDA on a fault, which fails the wave.
+ *
+ * Its own function with external linkage, rather than a block inside the wave
+ * loop, so the negative test can drive it with an injected result record: the
+ * lengths it acts on come from the device, and the current kernel cannot
+ * produce the ones this has to survive. */
+cudec_status CopyWaveToHost(cudec_chunk_result* wr, const unsigned char* d_dst,
+                            void* const* dst_ptrs, const size_t* dst_caps,
+                            size_t begin, size_t wn) {
+    size_t off = 0;
+    for (size_t j = 0; j < wn; j++) {
+        const size_t i = begin + j;
+        const size_t bw = static_cast<size_t>(wr[j].bytes_written);
+        if (bw != 0 && dst_ptrs[i] != nullptr &&
+            cudaMemcpy(dst_ptrs[i], d_dst + off, bw,
+                       cudaMemcpyDeviceToHost) != cudaSuccess) {
+            return CUDEC_ERR_CUDA;
+        }
+        off += dst_caps[i];
+    }
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_stream_detail
 
 namespace {
 
@@ -332,23 +368,12 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
             if (cudaStreamSynchronize(stream) != cudaSuccess) {
                 WAVE_FAIL(CUDEC_ERR_CUDA);
             }
-            const cudec_chunk_result* wr =
+            cudec_chunk_result* wr =
                 static_cast<cudec_chunk_result*>(ctx.p_results.p) + begin;
-            size_t off = 0;
-            bool copy_failed = false;
-            for (size_t j = 0; j < wn; j++) {
-                const size_t i = begin + j;
-                const size_t bw = static_cast<size_t>(wr[j].bytes_written);
-                if (bw != 0 && dst_ptrs[i] != nullptr &&
-                    cudaMemcpy(dst_ptrs[i], d_dst + off, bw,
-                               cudaMemcpyDeviceToHost) != cudaSuccess) {
-                    copy_failed = true;
-                    break;
-                }
-                off += dst_caps[i];
-            }
-            if (copy_failed) {
-                WAVE_FAIL(CUDEC_ERR_CUDA);
+            const cudec_status copied =
+                CopyWaveToHost(wr, d_dst, dst_ptrs, dst_caps, begin, wn);
+            if (copied != CUDEC_OK) {
+                WAVE_FAIL(copied);
             }
         }
     }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -91,6 +91,14 @@ namespace cudec_stream_detail {
  * base, and `dst_ptrs`/`dst_caps` the caller's arrays indexed from `begin`.
  * Returns CUDEC_ERR_CUDA on a fault, which fails the wave.
  *
+ * bytes_written is device-reported and it becomes a HOST write length here, so
+ * it is bounded by the chunk's own capacity before it is used, and a length
+ * past that capacity is treated as a device fault rather than trusted: the
+ * chunk is stamped non-OK with no claimed output and the wave fails, with
+ * nothing written to the caller's buffer. The frame path already bounds the
+ * same value against its internal block_max after its result readback; this is
+ * the streaming path's half of it.
+ *
  * Its own function with external linkage, rather than a block inside the wave
  * loop, so the negative test can drive it with an injected result record: the
  * lengths it acts on come from the device, and the current kernel cannot
@@ -102,6 +110,12 @@ cudec_status CopyWaveToHost(cudec_chunk_result* wr, const unsigned char* d_dst,
     for (size_t j = 0; j < wn; j++) {
         const size_t i = begin + j;
         const size_t bw = static_cast<size_t>(wr[j].bytes_written);
+        if (bw > dst_caps[i]) {
+            wr[j].status = static_cast<int32_t>(CUDEC_ERR_CUDA);
+            wr[j].reserved = 0;
+            wr[j].bytes_written = 0;
+            return CUDEC_ERR_CUDA;
+        }
         if (bw != 0 && dst_ptrs[i] != nullptr &&
             cudaMemcpy(dst_ptrs[i], d_dst + off, bw,
                        cudaMemcpyDeviceToHost) != cudaSuccess) {

--- a/tests/stream_twin.cu
+++ b/tests/stream_twin.cu
@@ -106,6 +106,17 @@ int RunFreshCtx(const std::vector<SChunk>& chunks, cudec_mem_space space,
 
 }  // namespace
 
+/* The streaming host-output wave copy, declared here because it is internal to
+ * src/stream.cpp and reaching it needs no public surface. It turns a
+ * device-reported bytes_written into a host write length, and the length it has
+ * to survive is one the current kernel cannot produce, so the negative below
+ * drives it directly with an injected result record (issue #57). */
+namespace cudec_stream_detail {
+cudec_status CopyWaveToHost(cudec_chunk_result* wr, const unsigned char* d_dst,
+                            void* const* dst_ptrs, const size_t* dst_caps,
+                            size_t begin, size_t wn);
+}  // namespace cudec_stream_detail
+
 int main() {
     const auto fixtures = MakeLz4BlockFixtures();
     REQUIRE(!fixtures.empty());
@@ -436,11 +447,86 @@ int main() {
         cudec_stream_ctx_destroy(ctx); /* still frees, no crash */
     }
 
+    /* A device-reported length longer than the chunk's capacity fails closed
+     * before it becomes a host write (issue #57). The host destination and the
+     * device staging both carry slack past the capacity the copy is told about:
+     * an unbounded copy therefore lands inside real allocations and shows up as
+     * poison bytes overwritten past the capacity, which is the tripwire, rather
+     * than as a fault that would mask it. The two lengths on either side of the
+     * bound run too, so a check that rejects at the capacity instead of past it
+     * is caught here as well. */
+    {
+        constexpr size_t kCap = 256;
+        constexpr size_t kSlack = 4096;
+        constexpr unsigned char kStage = 0x5C;
+
+        unsigned char* d_stage = nullptr;
+        REQUIRE_CUDA(cudaMalloc(&d_stage, kCap + kSlack));
+        REQUIRE_CUDA(cudaMemset(d_stage, kStage, kCap + kSlack));
+
+        std::vector<unsigned char> host(kCap + kSlack, kPoison);
+        void* dsts[1] = {host.data()};
+        size_t caps[1] = {kCap};
+        cudec_chunk_result wr[1];
+        wr[0].status = CUDEC_OK;
+        wr[0].reserved = 0;
+        wr[0].bytes_written = kCap + 64;
+
+        const cudec_status over = cudec_stream_detail::CopyWaveToHost(
+            wr, d_stage, dsts, caps, 0, 1);
+        /* Past the capacity: rejected, the chunk left with a defined non-OK
+         * status and no claimed output, and NOTHING written to the caller's
+         * buffer - the bytes past its capacity first. */
+        for (size_t j = kCap; j < host.size(); j++) {
+            REQUIRE_CTX(host[j] == kPoison, "overlong bw wrote past cap at %zu",
+                        j);
+        }
+        for (size_t j = 0; j < kCap; j++) {
+            REQUIRE_CTX(host[j] == kPoison, "overlong bw wrote at %zu", j);
+        }
+        REQUIRE_CTX(over == CUDEC_ERR_CUDA, "overlong bw status %d",
+                    static_cast<int>(over));
+        REQUIRE_CTX(wr[0].status == CUDEC_ERR_CUDA, "overlong bw chunk %d",
+                    static_cast<int>(wr[0].status));
+        REQUIRE_CTX(wr[0].bytes_written == 0, "overlong bw chunk bytes %llu",
+                    static_cast<unsigned long long>(wr[0].bytes_written));
+
+        /* Exactly the capacity is a legal decode and still copies, and the
+         * bytes past it stay untouched. */
+        wr[0].status = CUDEC_OK;
+        wr[0].reserved = 0;
+        wr[0].bytes_written = kCap;
+        REQUIRE(cudec_stream_detail::CopyWaveToHost(wr, d_stage, dsts, caps, 0,
+                                                    1) == CUDEC_OK);
+        for (size_t j = 0; j < kCap; j++) {
+            REQUIRE_CTX(host[j] == kStage, "at-cap bw not copied at %zu", j);
+        }
+        for (size_t j = kCap; j < host.size(); j++) {
+            REQUIRE_CTX(host[j] == kPoison, "at-cap bw wrote past cap at %zu",
+                        j);
+        }
+
+        /* And a short decode copies exactly its own length. */
+        host.assign(kCap + kSlack, kPoison);
+        wr[0].bytes_written = 16;
+        REQUIRE(cudec_stream_detail::CopyWaveToHost(wr, d_stage, dsts, caps, 0,
+                                                    1) == CUDEC_OK);
+        for (size_t j = 0; j < 16; j++) {
+            REQUIRE_CTX(host[j] == kStage, "short bw not copied at %zu", j);
+        }
+        for (size_t j = 16; j < host.size(); j++) {
+            REQUIRE_CTX(host[j] == kPoison, "short bw wrote past bw at %zu", j);
+        }
+        REQUIRE_CUDA(cudaFree(d_stage));
+    }
+
     std::printf("PASS: reused-context decode bit-identical to fresh across "
                 "{host,device} and a grow, over %zu chunks; grow, corrupt "
                 "isolation, undersized, zero-chunk, null-dst, null-ctx "
                 "fail-closed without poisoning; one-shot wrapper matches; "
-                "defined CUDA fault poisons and destroy still frees\n",
+                "defined CUDA fault poisons and destroy still frees; a "
+                "device-reported length past the chunk capacity fails the "
+                "host-output copy closed with no host write\n",
                 n);
     return 0;
 }


### PR DESCRIPTION
﻿Closes #57.The host-output branch of the streaming decode used the device-reported`bytes_written` as the length of a D2H copy into the caller's buffer, withoutbounding it by that chunk's `dst_caps[i]`. The same value was the read lengthfrom the internal staging slot and the write length into the caller's buffer,so a length past the capacity would have written device-produced bytes past theend of the caller's buffer.This is not a live bug on this tree, and the change does not make it one. Theblock parser holds `dst_pos <= dst_capacity` on every path and the kernelreports `dst_pos` only for a successful chunk, so under the current kernel thelength stays within the capacity. What is added is the local guarantee that adevice fault leaving a corrupt result record, or a later kernel change, cannotturn it into a caller-buffer overflow.## The change`src/stream.cpp` now bounds the value before it is used. A length past thechunk's capacity is treated as a device fault: the chunk is stamped`CUDEC_ERR_CUDA` with no claimed output, the wave fails, and nothing is writtento the caller's buffer at all. `src/frame.cpp` already bounds the same valueagainst its internal `block_max` after its result readback, so the streamingpath now matches the sibling path rather than trusting a length the frame pathchecks.The copy loop is lifted out of the wave loop into`cudec_stream_detail::CopyWaveToHost`, unchanged in what it does, so thenegative can call it with a result record of its own. That is the only way toreach the branch: the lengths it acts on come from the device, and the currentkernel cannot produce one past the capacity, which is the same sentence as thereachability paragraph above. The function has external linkage and nodeclaration in the public header, so the C ABI is unchanged; the test declaresit, and a signature that drifts fails to link.The normal path is untouched. Each chunk still copies exactly its reportedlength and leaves the tail beyond it alone, at the same `dst_caps` strides, sothe same input still decodes to the same bytes.## The test, and that it bites`tests/stream_twin.cu` drives `CopyWaveToHost` with `bytes_written` 64 bytespast a 256-byte capacity and asserts the caller's buffer is untouched, thebytes past the capacity first, then the ones below it, then that the callreturns `CUDEC_ERR_CUDA` and left the chunk non-OK with no claimed output. Thehost destination and the device staging both carry 4096 bytes of slack past thecapacity the copy is told about, so an unbounded copy lands inside realallocations and shows up as overwritten poison rather than as a fault thatwould mask what it did.Two more lengths run through the same call: exactly the capacity, which islegal and must still copy, and a short one, which must copy exactly its ownlength. A check that rejects at the capacity instead of past it fails the firstof those.The first commit adds the extraction and the test with the copy stillunbounded, which is what the code does today, and the second adds the bound.The two runs are the same command against those two commits.Against the unbounded copy, at d7e41d2:```    Start 10: stream_twin1/1 Test #10: stream_twin ......................***Failed    1.23 secFAIL /w/tests/stream_twin.cu:481: host[j] == kPoison | overlong bw wrote past cap at 2560% tests passed, 1 tests failed out of 1```The failing byte is at offset 256, which is the first byte past the capacity.With the bound, at 0aded6c, the whole suite:```10/15 Test #10: stream_twin ......................   Passed    1.28 sec11/15 Test #11: termination_gpu ..................   Passed    0.94 sec12/15 Test #12: determinism_gpu ..................   Passed    1.61 sec13/15 Test #13: bench_selfcheck ..................   Passed    0.08 sec14/15 Test #14: bench_worst4b_selfcheck ..........   Passed    0.05 sec15/15 Test #15: bench_longmatch_selfcheck ........   Passed    0.05 sec100% tests passed, 0 tests failed out of 15Label Time Summary:gpu    =   5.04 sec*proc (6 tests)```## What was runThe container gate, the documented invocation with the pinned image digest,`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`,nvcc 12.6.77, on the local RTX 3080. Build green, 15 of 15 tests passed. Thefailing run above used the same invocation with `-R stream_twin` on theselection, so what it proves is that one test against that commit and nothingabout the rest of the suite at that commit.The host-only leg, Prettier over `**/*.{md,yml,yaml}`, reports every matchedfile already formatted. No such file is in this diff.The machine's GPU was occupied by other work for most of this change. Thefailing run started after about 26 minutes of waiting for a free slot and thepassing run after a further 105 seconds; both ran with no other containeralive. Nothing was skipped for it.CI build, sanitize and format are the checks on this pull request and are notreported here as green by me; the run on this branch is what says so, and atthe time this was written all three of them report pass on its head. Thesanitize gate builds the host-only subset and skips the GPU targets, so it doesnot build or run this test, which is stated because the test is where the proofis.## The meansC++ in `src/stream.cpp` and CUDA C++ in `tests/stream_twin.cu`, because thedefect is in that translation unit and the check has to sit where the lengthbecomes a write bound. The test is a `.cu` file because it calls `cudaMalloc`and `cudaMemcpy` to build the staging the copy reads from, and it goes into the`stream_twin` binary that is already registered, so no new target and no buildchange. Nothing is added to the tree that was not already there.## Territory```$ git diff --name-only origin/main...HEADsrc/stream.cpptests/stream_twin.cu````tests/CMakeLists.txt` is untouched.

## Landing re-run, 2026-08-05

This section was produced by an automated re-run, not by a second person.

The mainline moved under this branch while it sat open. #257 landed as
`1ff536957052695613caa8a6bd3995a99bc34f2e`, so the branch is not the two
commits this body describes any more. The mainline was merged in rather than
rebased, and everything below was re-executed at the result:

    git rev-parse origin/main
    1ff536957052695613caa8a6bd3995a99bc34f2e
    git merge origin/main
    Merge made by the 'ort' strategy.
     scripts/sanitize-gpu.sh | 176 ++++++++++++++++++++++++++++++++++++++++++++++++
    git rev-parse HEAD
    5471836

The one file that arrived with it is a hand-invoked script that no gate runs,
and it touches nothing this change touches. Territory is unchanged:

    git diff --name-only origin/main...HEAD
    src/stream.cpp
    tests/stream_twin.cu

Same machine and same pinned image as the runs above: RTX 3080, driver 560.94,
nvcc V12.6.77, cmake 3.28.3, image
`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`.
Build directories created fresh.

### The suite at the merge commit

    cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
    ctest --test-dir build-cuda --output-on-failure

    100% tests passed, 0 tests failed out of 15

    Label Time Summary:
    gpu    =   5.43 sec*proc (6 tests)

The CI host subset, `ctest --test-dir build-cuda -LE gpu --no-tests=error
--output-on-failure`: 9 of 9 passed.

The CI sanitize job, `cmake -B build-san -DCUDEC_ENABLE_CUDA=ON
-DCUDEC_SANITIZE=address,undefined` then the five-test selection: 5 of 5
passed, and `ldd build-san/tests/parser_twin | grep -c 'libasan\|libubsan'`
prints 2.

Prettier over the eleven tracked `md`/`yml`/`yaml` files reports every one
already formatted. The diff carries none.

CI on this head is green on all three checks: build 1m32s, format 9s, sanitize
1m23s, run 30957310600.

### The bound deleted, at the merge commit

The red run this body records was made at `d7e41d2` before the bound existed.
It is reproduced here the other way round, by taking the bound back out of the
merged tree, which is the same question asked at the commit that will land:

    git checkout d7e41d2 -- src/stream.cpp     # the file without the bound
    cmake --build build-cuda --target stream_twin -j
    ctest --test-dir build-cuda -R stream_twin --output-on-failure

    Start 10: stream_twin
    1/1 Test #10: stream_twin ......................***Failed    1.17 sec
    FAIL /w/cudec-i57/tests/stream_twin.cu:481: host[j] == kPoison | overlong bw wrote past cap at 256
    0% tests passed, 1 tests failed out of 1

The same line, the same assertion and the same offset as the original red run:
256 is the first byte past the capacity, so what the test caught is the write
landing outside the caller's buffer rather than a length being rejected in the
wrong place.

Restored and rebuilt, the same command passes and the whole suite is green
again:

    git checkout HEAD -- src/stream.cpp
    1/1 Test #10: stream_twin ......................   Passed    1.18 sec
    100% tests passed, 0 tests failed out of 15

The working-tree edit is not in the branch. `git status` is clean against
`5471836`.

### What this does not say

The defect is still not reachable through the public API on this tree, exactly
as this body already states: the block parser holds `dst_pos <= dst_capacity`
and the kernel reports a length only for a successful chunk, so the red run
above reaches the branch through `CopyWaveToHost` directly and by no other
route. What landed is a local bound, not a fix for a live overflow, and the
test proves the bound rather than the absence of one elsewhere.
