### PR TITLE
Judge a macro-hidden do loop by the whole element [#124]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -331,6 +331,15 @@ endforeach()
 # an earlier line is judged by its name at the call site; a `fuel` mention on
 # the line above an unrelated loop satisfies the loop rule; and a loop or
 # intrinsic introduced under a fresh spelling is code review's job.
+#
+# The `do { ... } while (0)` idiom is forgiven only where it is joined into one
+# element, which is the macro spelling and the only one the tree uses. Two
+# things follow, and both are the price of a line-scoped scan. A written-out
+# `do { ... } while (0);` is reported, because its tail is a separate element
+# that clears nothing - wrap it in a macro or name a `fuel` cap. And a macro
+# carrying a real loop AND the idiom in the same element is forgiven whole,
+# since the element is judged by what it contains rather than by structure the
+# scan does not parse.
 function(cudec_scan_source path check_loops out_violations)
   set(_violations "")
   set(_in_comment FALSE)
@@ -426,12 +435,25 @@ function(cudec_scan_source path check_loops out_violations)
                  "parenthesis was not found within 8 lines - the scan cannot "
                  "judge it, so it is rejected rather than skipped\n")
         endif()
+      elseif(_code MATCHES "[^A-Za-z_0-9]do[ \t]*{")
+        # Ahead of the `} while` tail branch on purpose. A backslash-continued
+        # macro reaches this scan as ONE element - the trailing backslash
+        # escapes the list separator file(STRINGS) put there - so a macro's
+        # `do {` and its own tail arrive together. Judged after the tail branch
+        # they matched it first, which forgave every `do` inside every macro
+        # whatever its condition, the file exemption this replaced being what
+        # hid that. Judged here the element is read whole: only the
+        # `do { ... } while (0)` idiom, which makes a macro a single statement,
+        # is forgiven, and a macro-hidden loop with any other condition sets
+        # the form at the macro's own line.
+        if(NOT _code MATCHES "while[ \t]*\\([ \t]*0[ \t]*\\)")
+          set(_form "a 'do' loop")
+        endif()
       elseif(_code MATCHES "\\}[ \t]*while")
-        # The tail of a do-while; its `do {` carries the requirement.
+        # The tail of a do-while written out over several lines; its `do {`
+        # carries the requirement.
       elseif(_code MATCHES "[^A-Za-z_0-9]while[ \t]*\\(")
         set(_form "a 'while' loop")
-      elseif(_code MATCHES "[^A-Za-z_0-9]do[ \t]*{")
-        set(_form "a 'do' loop")
       elseif(_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\([^)]*;[ \t]*;")
         # Covers both `for (;;)` and `for (init;; incr)`.
         set(_form "a 'for' loop with an empty condition")
@@ -731,6 +753,31 @@ file(WRITE ${_probe_dir}/scan_wrapped_after_mask.cu
      "__device__ int probe(int v, Lz4Sequence seq) {\n"
      "    return __shfl_sync(0xFFFFFFFFu, v,\n"
      "                       seq.match_len % 32);\n" "}\n")
+# The two halves of the macro case, and they are one pair rather than two
+# probes: a backslash-continued macro arrives as a single element, so the same
+# element carries the loop and its condition. The idiom must come back silent
+# and a real loop wearing the same wrapper must not, or the clause that
+# forgives the wrapper has turned the rule off for every macro in the tree -
+# which is what the file exemption on src/cuda_raii.h was doing.
+#
+# Both put the #define on line 1, and the violating one asserts that line
+# number: the report lands on the macro's own line only while the join still
+# happens, so a scan that stopped joining would move it to line 2 and stop
+# covering the case these exist for.
+file(WRITE ${_probe_dir}/scan_loop_do_macro_idiom.cu
+     "#define PROBE_CHECK(call, on_failure) \\\n"
+     "    do {                              \\\n"
+     "        if ((call) != 0) {            \\\n"
+     "            on_failure;               \\\n"
+     "        }                             \\\n"
+     "    } while (0)\n"
+     "unsigned probe(unsigned n) {\n" "    PROBE_CHECK(n, n = 0);\n"
+     "    return n;\n" "}\n")
+file(WRITE ${_probe_dir}/scan_loop_do_macro.cu
+     "#define PROBE_RETRY(call, n) \\\n" "    do {                 \\\n"
+     "        n = n + (call);  \\\n" "    } while (n != 0)\n"
+     "unsigned probe(const unsigned char* src, unsigned n) {\n"
+     "    PROBE_RETRY(src[n], n);\n" "    return n;\n" "}\n")
 
 cudec_scan_source(${_probe_dir}/scan_clean.cu TRUE _probe_clean)
 if(_probe_clean)
@@ -740,7 +787,9 @@ if(_probe_clean)
       "before trusting it:\n${_probe_clean}")
 endif()
 # "probe|the text its rule must emit" - '|' rather than ';' because CMake
-# would split a list element on the latter.
+# would split a list element on the latter. An entry whose text is empty is a
+# probe that must come back SILENT, and the loop below spells that out as its
+# own branch.
 set(_scanner_probes
     "scan_loop_while|a 'while' loop with no explicit decrementing 'fuel' cap"
     "scan_loop_do|a 'do' loop with no explicit decrementing 'fuel' cap"
@@ -762,18 +811,33 @@ set(_scanner_probes
     "scan_for_opaque_qualified_wrapped|scan_for_opaque_qualified_wrapped.cu:3: a 'for' header without a visible"
     "scan_for_unbalanced|closing parenthesis was not found within 8 lines"
     "scan_for_unbalanced_eof|left unbalanced at end of file"
-    "scan_wrapped_after_mask|is wrapped across lines")
+    "scan_wrapped_after_mask|is wrapped across lines"
+    "scan_loop_do_macro_idiom|"
+    "scan_loop_do_macro|scan_loop_do_macro.cu:1: a 'do' loop with no explicit decrementing 'fuel' cap"
+)
 foreach(_entry IN LISTS _scanner_probes)
   string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")
   string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\2" _expected "${_entry}")
   cudec_scan_source(${_probe_dir}/${_probe}.cu TRUE _probe_result)
-  string(FIND "${_probe_result}" "${_expected}" _found_at)
-  if(_found_at EQUAL -1)
-    message(
-      FATAL_ERROR
-        "the structural scanner is dead for one rule: probe '${_probe}' did "
-        "not report \"${_expected}\" (issue #72). It reported:\n"
-        "${_probe_result}")
+  if(_expected STREQUAL "")
+    # A silent probe is checked here rather than through string(FIND): an
+    # empty needle is found at position 0 in every string, so routing it
+    # through the branch below would assert nothing at all.
+    if(_probe_result)
+      message(
+        FATAL_ERROR
+          "the structural scanner rejects a compliant probe: '${_probe}' must "
+          "come back silent (issue #72). It reported:\n${_probe_result}")
+    endif()
+  else()
+    string(FIND "${_probe_result}" "${_expected}" _found_at)
+    if(_found_at EQUAL -1)
+      message(
+        FATAL_ERROR
+          "the structural scanner is dead for one rule: probe '${_probe}' did "
+          "not report \"${_expected}\" (issue #72). It reported:\n"
+          "${_probe_result}")
+    endif()
   endif()
 endforeach()
 
@@ -789,12 +853,9 @@ endforeach()
 #  - xxhash32.h: its loops walk a caller-supplied buffer at a fixed stride
 #    with no stream-derived exit condition, and it is a checksum helper rather
 #    than a decoder.
-#  - cuda_raii.h: its only `do` is the `do { ... } while (0)` wrapper that
-#    makes the CUDA-error-check macro a single statement - an idiom, not a
-#    loop.
 #
-# Both are still held to the warp-collective and floating-point rules.
-set(_loop_rule_exempt xxhash32.h cuda_raii.h)
+# It is still held to the warp-collective and floating-point rules.
+set(_loop_rule_exempt xxhash32.h)
 file(GLOB_RECURSE _all_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
      CONFIGURE_DEPENDS
      ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c


### PR DESCRIPTION
﻿# What & whyThe termination rule was off for the whole of `src/cuda_raii.h` so that onemacro wrapper could pass. The file is under the rule now, and only the idiom isforgiven.A backslash-continued macro reaches the scan as ONE element, because thetrailing backslash escapes the list separator `file(STRINGS)` writes. So theelement carrying a macro's `do {` also carries the macro's own tail, the`} while` tail branch matched it first, and every `do` inside every macro wasforgiven whatever its condition. That diagnosis is #252's and it carries overunchanged.What changes is where the forgiving happens. The `do` branch moves above thetail branch and sets the form unless the same element also carries `while (0)`,so the element is judged whole. A macro-hidden loop with a stream-derived exitcondition is then reported at the macro's own line wherever in the file itsits, including directly above `CUDEC_CUDA_CHECK`, which is the case the branchon #252 lets through. Nothing is added to the pending block, so no clauseclears a pending violation on the strength of a `while (0)` belonging tosomething else.Closes #124. Supersedes #252, which carries the surface the issue's note tookback out; this branch does not build on it and nothing here was landed from it.The means is CMake because the scanner is CMake and runs at configure time, soa probe is asserted by the same configure that gates the build. Nothing else inthe tree could refuse this rule at that moment.## Type of change- [ ] Decode kernel / device code- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)- [ ] API surface- [ ] Performance- [x] Bug fix- [ ] Refactor / code quality- [x] Build / CI / supply chain- [ ] Docs## Engineering checklist- [x] Fail-closed preserved. The change closes the fail-open the file exemption      was hiding, every `do` inside every macro tree-wide, and opens none: the      element is judged on what it carries rather than on a neighbouring line.      Two residuals are stated in the function's Limits paragraph rather than      left for a reader to find, and both are listed under Notes below. No      parse or decode path is touched and no new input reaches any bound.- [ ] Oracle coverage: not applicable, no format path is touched. The oracle      tests run unchanged and green, see Verification.- [x] Determinism preserved: no source under `src/` changes, so the built      artifacts are identical.- [x] Not applicable, no CUDA API call and no ABI boundary is touched.- [ ] An adversarial review by a person was NOT run over this surface, and      neither was the lens review the repository asks for on this file. What      was run is the guard table below, each guard deleted in turn from a      pristine export. The box stays unticked because a guard table is not the      thing the box asks about. This section was produced by an automated      re-run, not by a second person.- [ ] Review record: none, because no review was run. Nothing is deferred and      no finding is declined.## Performance checklistNot on the hot path. No source under `src/` or `bench/` changes.- [ ] The claim is measured, not reasoned: no performance claim is made.- [ ] No regression against the recorded baseline: not applicable.## Quality checklist- [x] Minimal: one branch moved and given a condition, one entry removed from      the exempt list with its reason, two probe files, two entries in      `_scanner_probes`, and one branch in the probe loop for a probe that must      come back silent. No clause is added to the pending block.- [x] Self-documenting: the reason the `do` branch sits above the tail branch      is written where it sits, because a macro arriving as one element is not      visible from the code.- [x] Every guard the change ships is locked in by a probe or by a source in      the tree, and the table below shows each one biting.## VerificationThis section was produced by an automated re-run, not by a second person.Run at `4a19a5e0c3aab32fda425078ea3e8f986293c11c`, the head of`issue/124-scanner`, which sits directly on `main` at`972fac1bb5d769c72ef2024bc0fdaa409047909c` with nothing to rebase. Builddirectories created fresh. GPU: NVIDIA GeForce RTX 3080, nvcc V12.6.77,container image`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`,cmake 3.28.3. The GPU is shared with other work on this machine, so the runwaited about 21 minutes for the device to come free. The wait changed nothingabout what was run.- [x] `cmake -B build && cmake --build build` (host-only) builds clean.      [ 50%] Building C object CMakeFiles/cudec.dir/src/version.c.o      [100%] Linking C static library libcudec.a      [100%] Built target cudec- [x] `cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda      -j && ctest --test-dir build-cuda --output-on-failure` is green.      100% tests passed, 0 tests failed out of 15      Label Time Summary:      gpu    =   5.06 sec*proc (6 tests)      Total Test time (real) =   5.48 sec      The configure step is where the scanner probes run. Every probe is a      `FATAL_ERROR` on failure, so a successful configure asserts three things      and not one: `scan_clean.cu` came back empty, every probe with an      expected text reported it, and `scan_loop_do_macro_idiom.cu` came back      silent. It also asserts that `src/cuda_raii.h` was scanned under the loop      rule and produced nothing, since the file is no longer exempt.- [x] The CI host subset, `ctest --test-dir build-cuda -LE gpu      --no-tests=error --output-on-failure`:      100% tests passed, 0 tests failed out of 9- [x] The CI sanitize job, `cmake -B build-san -DCUDEC_ENABLE_CUDA=ON      -DCUDEC_SANITIZE=address,undefined && cmake --build build-san -j && ctest      --test-dir build-san --no-tests=error --output-on-failure -R      '^(conformance_c|oracle_lz4|parser_twin|frame_host_negative|termination)$'`:      100% tests passed, 0 tests failed out of 5      `ldd build-san/tests/parser_twin | grep -c 'libasan\|libubsan'` prints 2.- [x] Prettier: `npx --yes prettier@3 --check "**/*.{md,yml,yaml}"` reports      "All matched files use Prettier code style!". This branch changes no      `.md`, `.yml` or `.yaml` file, and the leg was run anyway.- [x] CI on this branch is green on all three checks: build 1m29s, sanitize 1m23s, format 6s, in run 30952052191.- [x] Docs synced: nothing to sync. The rule's own explanation, its Limits      paragraph and the exemption reasons live beside it, and all three are      updated.### The guard tableEach guard deleted in turn from a pristine export of the head commit, oneconfigure per row, `cmake -B <build> -S <export> -DCUDEC_ENABLE_CUDA=ON`:    A0  the change as it stands                            GREEN    A1  the while (0) test deleted from the do branch       RED    scan_loop_do_macro_idiom.cu:1    A2  the do branch moved back below the } while branch   RED    scan_loop_do_macro reports nothing    A3a a macro-hidden retry loop directly ABOVE the macro  RED    cuda_raii.h:31    A3b the same loop directly BELOW the macro              RED    cuda_raii.h:32    A3x the same loop with the file exemption put back      GREEN    A5  a written-out retry loop in DevBuf::ensure()        RED    cuda_raii.h:64A3a is the row the issue's note asks for and the one the branch on #252 letsthrough. A3b is the placement that already reported there. A3x is the guardthis change removes, deleted the only way it can be, by putting it back: thesame file and the same loop go silent again. The loop used in all three is theone #252 measured with, its exit condition derived from the call it wraps.The line number in A3b is 32 while the loop sits on source line 37. That is#251's element-numbering shift, five lines for the five continuation linesabove it, and it is not this change's to repair. A3a is unaffected, sittingabove the macro that does the joining.The near-miss, and it is the row worth the effort. The branch that asserts asilent probe cannot fail on its own, because deleting it routes the emptyexpectation into `string(FIND)`, which finds an empty needle in anything:    A4  the silent-probe branch routed through string(FIND)  GREEN    A4+ A4 together with A1                                  RED    cuda_raii.h:31    C1  A1 with src/cuda_raii.h exempt again                 RED    scan_loop_do_macro_idiom.cu:1    C2  C1 with the silent-probe branch routed through FIND   GREENA4 alone is green, and that is what the branch exists to prevent rather than anexcuse for it. A4+ is red, but from the source scan rather than from the probe,and only because `src/cuda_raii.h` happens to hold the idiom. C1 and C2 removethat cover: with the file exempt again, the probe is the only thing left thatcan see a broken idiom clause, and it sees it with the branch and misses itwithout.The mainline reference cases, same method, pristine export of`972fac1bb5d769c72ef2024bc0fdaa409047909c`:    M0  mainline, unchanged                                         GREEN    B1  mainline, exemption dropped, nothing else                   GREEN    B2  mainline, exemption dropped, macro-hidden loop above macro  GREENB1 confirms #252's finding at this base: dropping the exemption aloneconfigures green, so the pending violation the issue's first surface expecteddoes not exist. B2 is the fail-open the exemption was covering, and A3a is thesame case on this branch.## NotesThe probes are generated by `file(WRITE)` into the build directory beside theother twenty-one, rather than added as tracked `tests/scan_*.cu` files. That iswhere every scanner probe already lives, next to the text it must produce.Two residuals, both written into the function's Limits paragraph. A written-out`do { ... } while (0);` is now reported, because its tail is a separate elementthat clears nothing; it needs a `fuel` mention or a macro wrapper, and nothingin the tree spells it that way. A macro carrying a real loop and the idiom inone element is forgiven whole, because the element is judged by what itcontains and the scan parses no structure. Both are the price of a line-scopedscan, and neither depends on where a line sits relative to another.The exempt list is down to `xxhash32.h`, and its stated reason still holds:fixed-stride loops over a caller-supplied buffer in a checksum helper, with nostream-derived exit condition. `src/cuda_raii.h` is scanned under the loop rulenow, so a future retry loop in `DevBuf::ensure()` is seen, which A5 shows.#251 is untouched and still open. Nothing here reaches outside`tests/CMakeLists.txt`, and `git diff --name-only origin/main...HEAD` printsthat one path.

## Landing re-run, 2026-08-05

This section was produced by an automated re-run, not by a second person.

The mainline moved twice under this branch while it sat open. #257 landed as
`1ff5369` and #259 as `b857dcb61b573fd2366583b7778256af465156ed`. The mainline
was merged in rather than rebased, and the whole guard table was re-derived at
the result, `d02a8e0ea5247552fb419ee8d2d4a0fd0db807cc`:

    git rev-parse origin/main
    b857dcb61b573fd2366583b7778256af465156ed
    git merge origin/main
    Merge made by the 'ort' strategy.
     scripts/sanitize-gpu.sh | 176 ++++++++++++++++++++++++++++++++++++++++++++++++
     src/stream.cpp          |  71 ++++++++++++++-----
     tests/stream_twin.cu    |  88 +++++++++++++++++++++++-
    git rev-parse HEAD
    d02a8e0

Territory is unchanged, one path:

    git diff --name-only origin/main...HEAD
    tests/CMakeLists.txt

Same machine and pinned image as the run above: RTX 3080, driver 560.94, nvcc
V12.6.77, cmake 3.28.3, image
`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`.

### The guard table, re-derived at the merge commit

Same method as above: a pristine export of the merge commit per row, one guard
removed or one loop planted, one configure each with
`cmake -B <build> -S <export> -DCUDEC_ENABLE_CUDA=ON`.

    A0  the change as it stands                            GREEN
    A1  the while (0) test deleted from the do branch      RED    scan_loop_do_macro_idiom.cu:1, must come back silent
    A2  the do branch moved back below the } while branch  RED    scan_loop_do_macro did not report, "It reported:" is empty
    A3a a macro-hidden retry loop directly ABOVE the macro RED    cuda_raii.h:31: a 'do' loop with no explicit decrementing 'fuel' cap
    A3b the same loop directly BELOW the macro             RED    cuda_raii.h:32
    A3x the same loop with the file exemption put back     GREEN
    A5  a written-out retry loop in DevBuf::ensure()       RED    cuda_raii.h:64: a 'do' loop with no explicit decrementing 'fuel' cap
    A4  the silent-probe branch routed through string(FIND) GREEN
    A4+ A4 together with A1                                RED    cuda_raii.h:31
    C1  A1 with src/cuda_raii.h exempt again               RED    scan_loop_do_macro_idiom.cu:1, must come back silent
    C2  C1 with the silent-probe branch routed through FIND GREEN

Every row lands on the same verdict and the same location as the table this
body already carries. A2's exact text, which is the row that says the branch
order is the load-bearing part:

    CMake Error at tests/CMakeLists.txt:835 (message):
      the structural scanner is dead for one rule: probe 'scan_loop_do_macro' did
      not report "scan_loop_do_macro.cu:1: a 'do' loop with no explicit
      decrementing 'fuel' cap" (issue #72).  It reported:

Nothing follows "It reported:", so with the do branch below the tail branch the
macro-hidden loop is not seen at all.

A4 and C2 are green, and that is the near-miss rather than an excuse: routing
the empty expectation through `string(FIND)` asserts nothing, because an empty
needle is found at position 0 in anything. C1 and C2 are the pair that shows
it, with `src/cuda_raii.h` exempt again so the source scan cannot stand in for
the probe.

### The mainline reference cases, re-derived at the new mainline

The rows the body records were measured against `972fac1`. That is two merges
behind now, so they were re-run against a pristine export of
`b857dcb61b573fd2366583b7778256af465156ed`:

    M0  mainline, unchanged                                         GREEN
    B1  mainline, exemption dropped, nothing else                    GREEN
    B2  mainline, exemption dropped, macro-hidden loop above macro   GREEN

Unchanged at the new base. B1 still confirms that dropping the exemption alone
configures green, so the pending violation #124's first surface expected does
not exist here either, and B2 is still the fail-open the exemption was
covering. A3a is that same case on this branch and it is red.

### Gates at the merge commit

- `cmake -B build && cmake --build build`, host-only, fresh directory:

      [ 50%] Building C object CMakeFiles/cudec.dir/src/version.c.o
      [100%] Linking C static library libcudec.a
      [100%] Built target cudec

- `cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j &&
  ctest --test-dir build-cuda --output-on-failure`:

      100% tests passed, 0 tests failed out of 15

      Label Time Summary:
      gpu    =   4.80 sec*proc (6 tests)

  The configure is where the probes run, so a successful configure is what
  asserts them.

- The CI host subset, `-LE gpu --no-tests=error`: 9 of 9 passed.
- The CI sanitize job, the five-test selection under
  `-DCUDEC_SANITIZE=address,undefined`: 5 of 5 passed, and
  `ldd build-san/tests/parser_twin | grep -c 'libasan\|libubsan'` prints 2.
- Prettier over the eleven tracked `md`/`yml`/`yaml` files: all already
  formatted. The diff carries none.
- CI on this head is green on all three checks: build 1m30s, format 10s,
  sanitize 1m27s, run 30957679202.

### What is still not covered

No adversarial review by a person and no lens review was run over this file,
which the checklist above already records and this re-run does not change. The
two residuals in the Limits paragraph stand as written. #251 is untouched and
still open.
