### PR TITLE
Qualify the section-4 determinism claim by launch geometry

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -118,9 +118,11 @@ a planned milestone - a vendor binary can never follow), and **hackability**.
   is `gpu_to_gpu` in NVIDIA's CCCL vocabulary, held by construction rather
   than by tuning - integer-only arithmetic, every output byte written exactly
   once by a statically determined lane as a pure function of lower addresses,
-  and no inter-chunk coupling. The scope, the reasoning, and the tested axes
-  (including launch geometry and stream count, which a same-batch-twice
-  compare cannot see) are in [DETERMINISM.md](DETERMINISM.md).
+  and no inter-chunk coupling. "Exactly once" holds for a supported launch
+  geometry, which the kernel enforces rather than assumes. The scope, the
+  reasoning, and the tested axes (including launch geometry and stream count,
+  which a same-batch-twice compare cannot see) are in
+  [DETERMINISM.md](DETERMINISM.md).
 - **The oracles decide correctness.** liblz4, zlib, and libzstd are vendored
   as test dependencies; decode output is diff-tested against them on real
   corpora (Silesia, enwik) and on fuzzed/mutated streams, including the


### PR DESCRIPTION
# What & why

Closes #126.

`docs/MASTERPLAN.md` section 4 stated the determinism property as "every
output byte written exactly once by a statically determined lane" with no
launch-geometry qualifier. The property is conditional, and the other two
sites that state it already say so: the copy loops stride by the warp size,
so a block that is not a whole number of warps leaves a fixed slice of every
destination written by nobody, and the kernel returns without decoding on
that geometry rather than assuming its caller. A summary that drops the
condition teaches a reader the wrong contract.

The added sentence is taken verbatim from the section-9 overlap-copy passage
(line 259 before this change), so all three sites now say one thing.

## Type of change

- [x] Docs

## Engineering checklist

Not applicable: no code, no parse path, no kernel, no ABI. Nothing in this
diff can change decode behaviour.

- [x] Fail-closed preserved (vacuously: no code changed).
- [x] Determinism preserved (vacuously: no code changed). The change makes
      the document match the property the kernel already enforces; it does
      not relax or widen the claim.

## Quality checklist

- [x] Minimal: one sentence added, and the following sentence rewrapped
      because of it. No other edit.
- [x] Self-documenting: the wording is the existing wording, not a new
      formulation.

## Verification

Every site that states the property, and its qualifier, at this commit:

```
$ grep -rn -A3 "written exactly" docs/
docs/DETERMINISM.md:44:- **Every output byte is written exactly once**, by a statically determined
docs/DETERMINISM.md-45-  lane - given a supported launch geometry, which the kernel enforces rather
docs/DETERMINISM.md-46-  than assumes: the copy loops stride by the warp size, so a block that is not
docs/DETERMINISM.md-47-  a whole number of warps would leave a fixed slice of every destination
--
docs/MASTERPLAN.md:119:  than by tuning - integer-only arithmetic, every output byte written exactly
docs/MASTERPLAN.md-120-  once by a statically determined lane as a pure function of lower addresses,
docs/MASTERPLAN.md-121-  and no inter-chunk coupling. "Exactly once" holds for a supported launch
docs/MASTERPLAN.md-122-  geometry, which the kernel enforces rather than assumes. The scope, the
--
docs/MASTERPLAN.md:257:written exactly once, by a statically determined lane, as a pure function
docs/MASTERPLAN.md-258-of lower addresses - deterministic because no ordering exists to get
docs/MASTERPLAN.md-259-wrong. "Exactly once" holds for a supported launch geometry, which the
docs/MASTERPLAN.md-260-kernel enforces rather than assumes: the copy loops stride by the warp
```

That is the whole set: three sites, three qualifiers.

```
$ npx --yes prettier@3 --check "docs/MASTERPLAN.md"
Checking formatting...
All matched files use Prettier code style!
```

```
$ git diff --name-only origin/main...HEAD
docs/MASTERPLAN.md
```

Build and ctest were not run for this change and are not claimed: the diff
touches no file any build reads. CI's build, sanitize and format jobs run on
this pull request and are the record for that.

## Notes

No second reader was available for this change. This body carries the
evidence in place of one, and that is a substitution, not an equivalent: a
reviewer would have read whether the added sentence is the RIGHT
qualification, and no command here makes that judgement. What the commands
above show is narrower - that the sentence is the one already in use at the
other two sites, that the file is formatted, and that the branch touches one
file.
