### PR TITLE
Hold a freshly published action for seven days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,9 @@ updates:
         update-types:
           - minor
           - patch
+    # A release must be seven days old before Dependabot may propose it.
+    # What the hold does not reach, why there is no semver tier key, and how
+    # the weekly schedule quantises it:
+    # https://github.com/iderex/cudec/issues/122#issuecomment-5106859665
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# What & why

Closes #230.

`.github/dependabot.yml` set no `cooldown`, so a release published an hour
ago could be proposed and land on green CI the same day. This adds
`cooldown: default-days: 7` to the `github-actions` entry, the repository's
only ecosystem.

The file gets one sentence and a pointer. The argument - what the hold does
not reach, why there is no `semver-*-days` key, how the weekly schedule
quantises the delay - stays in the comment on #122, where it can be dated
and corrected. That placement is #230's own instruction, not a shortcut
taken here.

No `semver-*-days` key: `github-actions` carries no SemVer-tier column in the
platform's cooldown table. That reading is dated 2026-07-28 in the referenced
comment and is not re-verified by this pull request.

## Type of change

- [x] Build / CI / supply chain

## Engineering checklist

Not applicable: no code, no parse path, no kernel, no ABI. The diff is six
lines of configuration and comment in `.github/dependabot.yml`.

- [x] An adversarial review is owed for workflow changes. `.github/` is
      audited below with zizmor at a pinned version; a human adversarial
      review was not run, see Notes.

## Verification

zizmor 1.16.0, pedantic persona, offline, over `.github/` at this commit:

```
$ zizmor --offline --persona=pedantic .github/
🌈 zizmor v1.16.0
 INFO audit: zizmor: 🌈 completed .github/dependabot.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/ci.yml
No findings to report. Good job!
```

The same audit against the file WITHOUT this change, so the clean run above
is not a run that checks nothing. Reverted to the parent commit's
`dependabot.yml` and re-run, same version and flags:

```
$ zizmor --offline --persona=pedantic .github/dependabot.yml
🌈 zizmor v1.16.0
 INFO audit: zizmor: 🌈 completed .github/dependabot.yml
warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
 --> .github/dependabot.yml:6:5
  |
6 |   - package-ecosystem: github-actions
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
  |
  = note: audit confidence → High
  = note: this finding has an auto-fix

1 findings (1 fixable): 0 informational, 0 low, 1 medium, 0 high
```

zizmor is not in `ci.yml` and this does not put it there; that is #131's
ground. The two runs above are local, at a pinned version, and are the whole
record.

```
$ npx --yes prettier@3 --check ".github/dependabot.yml"
Checking formatting...
All matched files use Prettier code style!
```

```
$ git diff --name-only origin/main...HEAD
.github/dependabot.yml
```

## Notes

Not proven here, and not claimed. Two gaps, both named in the issue:

- **The hold is in force.** A key sitting in the file is not evidence the
  platform accepted the file; a rejected Dependabot config fails silently.
  Nothing in this repository distinguishes the two today. That is #232, open
  and unlanded, and until it lands this pull request's claim is that the key
  is present and well-formed by zizmor's reading, not that the hold is
  running.
- **The observation.** That a fresh upstream release is not proposed before
  the hold elapses cannot be checked until a cycle passes. It stays open on
  #230 after the merge rather than being ticked here.

No second reader was available for this change. This body carries the
evidence in place of one, and that is a substitution rather than an
equivalent: zizmor checks for the key's presence and nothing about whether
seven days is the right number, or whether the pointer in the file points at
prose that is still true.
