### PR TITLE
Read the project version out of the public header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,31 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(cudec VERSION 0.0.1 LANGUAGES C)
+# The version has ONE source: the CUDEC_VERSION_* macros in include/cudec.h.
+# CMake reads them instead of restating the number, so a release bump touches
+# one file and package metadata cannot drift from what cudec_version()
+# reports. Reading the header (rather than configuring one) keeps it
+# self-contained for consumers who never run CMake. Fail-closed: a macro that
+# is missing, renamed, or not a plain integer is a configure error, never a
+# silent empty version - and the derivation is checked against the header a
+# second time at runtime, in tests/conformance_c.c.
+file(READ "${CMAKE_CURRENT_LIST_DIR}/include/cudec.h" _cudec_public_header)
+foreach(_component MAJOR MINOR PATCH)
+  if(NOT _cudec_public_header MATCHES
+     "\n#define CUDEC_VERSION_${_component} ([0-9]+)")
+    message(
+      FATAL_ERROR
+        "include/cudec.h defines no integer CUDEC_VERSION_${_component}; "
+        "the project version is read from those three macros.")
+  endif()
+  set(_cudec_version_${_component} "${CMAKE_MATCH_1}")
+endforeach()
+unset(_cudec_public_header)
+
+project(
+  cudec
+  VERSION
+    "${_cudec_version_MAJOR}.${_cudec_version_MINOR}.${_cudec_version_PATCH}"
+  LANGUAGES C)
 
 # The CUDA engine is opt-in and fail-closed: asking for it without a CUDA
 # toolchain is a hard configure error, never a silent host-only fallback (a

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -14,6 +14,9 @@
 extern "C" {
 #endif
 
+/* The one place the version is written. The top-level CMakeLists reads these
+ * three macros to set the project version, so a bump here is the whole bump
+ * and nothing restates the number. */
 #define CUDEC_VERSION_MAJOR 0
 #define CUDEC_VERSION_MINOR 0
 #define CUDEC_VERSION_PATCH 1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,14 @@ endfunction()
 cudec_add_test(conformance_c SOURCES conformance_c.c)
 set_target_properties(conformance_c PROPERTIES C_STANDARD 99
                                                C_STANDARD_REQUIRED ON)
+# The top-level CMakeLists reads PROJECT_VERSION out of include/cudec.h; these
+# hand the result back to the C side so that derivation is tested rather than
+# only asserted (issue #80).
+target_compile_definitions(
+  conformance_c
+  PRIVATE CUDEC_CMAKE_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
+          CUDEC_CMAKE_VERSION_MINOR=${PROJECT_VERSION_MINOR}
+          CUDEC_CMAKE_VERSION_PATCH=${PROJECT_VERSION_PATCH})
 cudec_add_test(oracle_lz4 SOURCES oracle_lz4.cpp LIBS cudec_test_fixtures)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -35,6 +35,15 @@ int main(void) {
                                    CUDEC_VERSION_MINOR * 100 +
                                    CUDEC_VERSION_PATCH);
 
+    /* The build system derives PROJECT_VERSION from the macros above and
+     * hands the three numbers back as CUDEC_CMAKE_VERSION_*. A derivation
+     * that matched the wrong line in the header would otherwise configure
+     * clean and ship package metadata disagreeing with cudec_version(). An
+     * undefined macro here is a compile error, not a zero. */
+    REQUIRE(CUDEC_CMAKE_VERSION_MAJOR == CUDEC_VERSION_MAJOR);
+    REQUIRE(CUDEC_CMAKE_VERSION_MINOR == CUDEC_VERSION_MINOR);
+    REQUIRE(CUDEC_CMAKE_VERSION_PATCH == CUDEC_VERSION_PATCH);
+
     /* Every documented reject class, one call each: null arrays, null
      * results, misaligned results, empty batch, over-limit batch. */
     REQUIRE(cudec_lz4_decompress_batch(0, sizes, dsts, caps, 1, aligned, 0) ==


### PR DESCRIPTION
# What & why

Closes #80.

The version was declared twice by hand: `project(cudec VERSION 0.0.1)` in
`CMakeLists.txt` and `CUDEC_VERSION_MAJOR/MINOR/PATCH` in `include/cudec.h`.
Nothing compared them, so a release bump that touched one side would ship
package metadata disagreeing with `cudec_version()` and nothing would red.

Of the two shapes #80 offers, this is (a): CMake reads the header macros at
configure time and feeds `project(VERSION)` from them. It is chosen over the
FATAL_ERROR comparison because it removes the second declaration instead of
policing it - there is no longer a side to bump alone. The header stays
self-contained for consumers that never run CMake, which a configured header
would not be.

Two guards, because reading a file with a regex can match the wrong line:

- Configure-time, fail-closed: a `CUDEC_VERSION_*` macro that is missing,
  renamed, or not a plain integer is a `FATAL_ERROR`, never a silent empty
  version.
- Runtime: `tests/conformance_c.c` now compares the numbers the build system
  hands back (`CUDEC_CMAKE_VERSION_*`) against the macros it compiled
  against. That closes the gap the configure-time guard cannot see - a regex
  that matched a plausible wrong line would configure clean.

## Type of change

- [x] Build / CI / supply chain
- [x] Refactor / code quality

## Engineering checklist

- [x] Fail-closed preserved. No parse path, no kernel, no decode logic
      changed. The new configure-time branch is itself fail-closed and is
      proven below.
- [x] Determinism preserved: no code on any decode path changed.
- [x] No exceptions cross the C ABI; the header's public surface is
      unchanged except for a comment.
- [ ] An adversarial review was NOT run for this change. `CMakeLists.txt`,
      `tests/CMakeLists.txt` and `include/cudec.h` are on the sensitive
      surface and the repository's own rule asks for one. See Notes; this is
      a gap, not a waiver.

## Quality checklist

- [x] Minimal: eighteen lines in the top-level `CMakeLists.txt`, six in
      `tests/CMakeLists.txt`, six in `conformance_c.c`, three comment lines
      in the header. Nothing else.
- [x] Conformance tests pass, and the structural property this change
      establishes - the build system's version equals the header's - is
      locked in as a new conformance assertion rather than left to
      construction.

## Verification

All of it in the pinned container
(`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0f...`, cmake 3.28.3, GNU
13.2.0), at this commit. The runner has no GPU, so `-LE gpu` is the host
subset, exactly as CI runs it.

Green on the tree as it stands:

```
$ cmake -B /tmp/b1 -S /w                       -> exit 0
$ grep -m1 "CMAKE_PROJECT_VERSION:" /tmp/b1/CMakeCache.txt
CMAKE_PROJECT_VERSION:STATIC=0.0.1
$ cmake --build /tmp/b1                        -> exit 0
$ cmake -B /tmp/bc -S /w -DCUDEC_ENABLE_CUDA=ON -> exit 0
$ cmake --build /tmp/bc -j                     -> exit 0
$ ctest --test-dir /tmp/bc -LE gpu --no-tests=error --output-on-failure
100% tests passed, 0 tests failed out of 9
```

`0.0.1` there is the derived value, not the old literal: the literal is gone
from `CMakeLists.txt`.

### The guards, proven by breaking them

Each probe runs on a copy of the tree; the tree in this branch is unmodified
by them.

**A. A missing version macro reds the configure.** `#define
CUDEC_VERSION_MINOR` deleted from the header:

```
CMake Error at CMakeLists.txt:15 (message):
  include/cudec.h defines no integer CUDEC_VERSION_MINOR; the project version
  is read from those three macros.
-- Configuring incomplete, errors occurred!
```

**B. The project version follows the header.** Header changed to
`CUDEC_VERSION_MINOR 7`, nothing else touched:

```
$ grep -m1 "CMAKE_PROJECT_VERSION:" /tmp/pb/CMakeCache.txt
CMAKE_PROJECT_VERSION:STATIC=0.7.1
```

That is the drift the issue names, and it is now impossible in the direction
that mattered: there is no second literal to leave behind.

**C. A wrong number from the build system reds the test net.**
`CUDEC_CMAKE_VERSION_MINOR=${PROJECT_VERSION_MINOR}` replaced by a literal
`9` in `tests/CMakeLists.txt`, then built and run:

```
1/1 Test #1: conformance_c ....................***Failed    0.00 sec
FAIL /tmp/pc/tests/conformance_c.c:44: CUDEC_CMAKE_VERSION_MINOR == CUDEC_VERSION_MINOR

0% tests passed, 1 tests failed out of 1
```

**D. An absent definition is a compile error, not a zero.** `conformance_c.c`
compiled without the definitions the build system supplies:

```
$ cc -std=c99 -Iinclude -c tests/conformance_c.c
tests/conformance_c.c:43:13: error: 'CUDEC_CMAKE_VERSION_MAJOR' undeclared (first use in this function); did you mean 'CUDEC_VERSION_MAJOR'?
   43 |     REQUIRE(CUDEC_CMAKE_VERSION_MAJOR == CUDEC_VERSION_MAJOR);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
```

So the new assertion cannot be silently disarmed by dropping the
`target_compile_definitions` line.

```
$ git diff --name-only origin/main...HEAD
CMakeLists.txt
include/cudec.h
tests/CMakeLists.txt
tests/conformance_c.c
```

## Notes

**What is not proven.** The on-device tests were not run: this container had
no GPU attached, and the `-L gpu` set is deferred as usual. Nothing in this
diff reaches device code, but that is an argument, not a measurement, and it
is recorded as an argument.

**The residual the regex leaves.** `MATCHES` takes the first match in the
file, so a line that merely looks like the define - inside a comment, say -
could win. Probe C is the answer to that class rather than the regex being
made cleverer: any wrong pick disagrees with the macro the preprocessor
actually used, and `conformance_c` reds. Stated here because "one
authoritative source" is a stronger-sounding claim than what is enforced,
which is "one authoritative source, and a disagreement is caught".

**No second reader.** No adversarial review was run and no second person read
this change; the checklist above is ticked to that effect and is not
softened. This body carries the probes in place of a reviewer, which is not
the same thing: the probes show the guards fire, and show nothing about
whether reading a header with a regex was the right shape to choose. The
alternative shape is written down in #80 and can be swapped in later without
touching any consumer.
