### PR TITLE
Correct three refutable competitive-landscape claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ memory-bandwidth speed - auditable, fail-closed, and fuzz-tested.**
 GPU decompression matters wherever decode throughput is the bottleneck:
 asset streaming, analytics scans, ML data loading, checkpoint restore. The
 only production-grade library in this space, NVIDIA's nvCOMP, has been
-proprietary since v2.3 - there is no maintained open-source library that
+proprietary since v2.3 - there is no maintained open-source CUDA library that
 decodes the standard formats on the GPU. Meta's dietgpu is open but uses its
-own rANS format; the GDeflate reference implementation is CPU-only; the
-academic prototypes are unmaintained.
+own rANS format; the open GPU GDeflate and Zstd decoders that do exist are
+shaders owned by a graphics runtime (DirectStorage, vkd3d-proton) rather than
+libraries you can call; AMD's hipCOMP-core is an early-access HIP preview
+downstream of a frozen nvCOMP fork; the academic prototypes are unmaintained.
+[docs/MASTERPLAN.md](docs/MASTERPLAN.md) section 1 has the field table and
+the sources.
 
 cudec fills that gap. Not on price - nvCOMP is free to use - but on the
 properties a closed binary cannot offer:
@@ -52,7 +56,7 @@ milestones:
 | M1 - LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed      | done        |
 | M2 - LZ4 batch   | Frame format, batch API, streaming path, benchmarks | in progress |
 | M3 - Snappy      | Snappy decode on the same kernel family             | planned     |
-| M4 - GDeflate    | The first open GPU GDeflate decoder                 | planned     |
+| M4 - GDeflate    | GDeflate decode as an auditable CUDA library        | planned     |
 | M5 - Zstd        | Zstd decode (FSE/Huffman sequences)                 | planned     |
 | M6 - Portability | HIP port                                            | planned     |
 

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -13,15 +13,40 @@ on the GPU.
 
 The field today:
 
-| Existing work              | Why it does not fill the gap                              |
-| -------------------------- | --------------------------------------------------------- |
-| nvCOMP / nvCOMPDx (NVIDIA) | Proprietary since v2.3; NVIDIA-only; not auditable        |
-| dietgpu (Meta)             | Open, but its own rANS format - not format-compatible     |
-| GDeflate reference (MS/NV) | Open spec + CPU codec; the GPU decoder is Windows-runtime |
-| Academic prototypes        | Unmaintained research code                                |
+| Existing work                   | Why it does not fill the gap                                                    |
+| ------------------------------- | ------------------------------------------------------------------------------- |
+| nvCOMP / nvCOMPDx (NVIDIA)      | Proprietary since v2.3; NVIDIA-only; not auditable                              |
+| dietgpu (Meta)                  | Open, but its own rANS format - not format-compatible                           |
+| GDeflate reference (MS/NV)      | Open spec + CPU codec; its GPU decoder is the HLSL shader in the row below      |
+| DirectStorage `GDeflate.hlsl`   | Open (Apache-2.0) GPU GDeflate decoder, but a shader inside a D3D12 runtime     |
+| DirectStorage `zstd/` (dev)     | Open HLSL zstd decompression shaders, marked by Microsoft as not for production |
+| vkd3d-proton `cs_gdeflate.comp` | Open (LGPL-2.1) GLSL GDeflate decoder, bound to the vkd3d-proton runtime        |
+| hipCOMP-core (AMD/ROCm)         | MIT fork of nvCOMP branch-2.2 on HIP; early-access preview, not for production  |
+| Academic prototypes             | Unmaintained research code                                                      |
 
-There is no maintained open-source library that decodes the standard formats
-on the GPU. The value proposition is not price (nvCOMP is free to use) but
+Where those rows come from, so the next pass does not re-derive them from
+memory: `GDeflate/shaders/GDeflate.hlsl` and the `zstd/` tree on the
+`development` branch of
+[microsoft/DirectStorage](https://github.com/microsoft/DirectStorage);
+`libs/vkd3d/shaders/cs_gdeflate.comp` in
+[vkd3d-proton](https://github.com/HansKristian-Work/vkd3d-proton);
+[ROCm/hipCOMP-core](https://github.com/ROCm/hipCOMP-core). Read at those
+paths on 2026-08-05.
+
+No milestone here claims a "first", and that is deliberate. A code search
+for GDeflate in CUDA sources on the same day returned a partial decoder in
+an application tree (`crush-gpu/src/shader/gdeflate_decompress.cu` in
+john-agentic-ai-tools/crush: fixed-Huffman blocks only, no declared licence),
+so a bare "the first open CUDA GDeflate decoder" is refutable and is not
+made. hipCOMP-core's `src/lowlevel/gdeflateKernels.cu` is not a
+counterexample in the other direction - it is a status-conversion shim
+around an external `gdeflate::` component, not a decoder.
+
+There is no maintained open-source CUDA library that decodes the standard
+formats on the GPU. "Maintained", "CUDA" and "library" are all load-bearing:
+the open GPU decoders above are shaders belonging to a graphics runtime, and
+hipCOMP-core is a HIP preview downstream of a four-year-old fork point. The
+value proposition is not price (nvCOMP is free to use) but
 **auditability** (decompressors are classic attack surface; every bounds
 check here is readable, tested, and fuzzed), **portability** (a HIP port is
 a planned milestone - a vendor binary can never follow), and **hackability**.
@@ -50,17 +75,22 @@ a planned milestone - a vendor binary can never follow), and **hackability**.
    family generalizes.
 3. **GDeflate** (M4) - the strategic differentiator. The format is designed
    for GPU decode (the DEFLATE bitstream is split into 32 interleaved
-   sub-streams so a full warp reads Huffman codes in parallel), the spec is
-   open, and the reference implementation is CPU-only: the only shipping GPU
-   decoder lives inside the Windows DirectStorage runtime. An open CUDA
-   GDeflate decoder - usable on Linux, in HPC, anywhere - does not exist
-   until cudec ships it.
+   sub-streams so a full warp reads Huffman codes in parallel) and the spec
+   is open. Open GPU decoders already exist, but each one is a shader owned
+   by a graphics runtime - DirectStorage's HLSL decoder and vkd3d-proton's
+   GLSL one (section 1). What does not exist is an open CUDA GDeflate
+   decoder callable as a library, on Linux, in HPC, anywhere, and that is
+   what cudec ships.
 4. **Zstd decode** (M5) - the flagship and by far the hardest: FSE/Huffman
    entropy stages feeding an LZ77 sequence executor with long-range matches.
    Attempted only once the kernel family, the oracle net, and the benchmark
    discipline are proven on 1–3.
 5. **HIP port** (M6) - portability as a moat. The kernels stay on warp-level
-   primitives available on both vendors to keep this tractable.
+   primitives available on both vendors to keep this tractable. AMD is not
+   an empty field: hipCOMP-core carries HIP LZ4 and Snappy decode (section
+   1). The claim M6 can make is one audited fail-closed kernel family,
+   single-source across vendors behind a stable C ABI - never "first on
+   AMD".
 
 ## 4. Architecture pillars
 
@@ -187,7 +217,7 @@ a planned milestone - a vendor binary can never follow), and **hackability**.
 | M1 - LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed against liblz4, first honest numbers                                          |
 | M2 - LZ4 batch   | Frame format, batch API, pinned-host streaming path, published benchmark + methodology write-up                              |
 | M3 - Snappy      | Snappy decode on the shared kernel family                                                                                    |
-| M4 - GDeflate    | The first open GPU GDeflate decoder (32-substream warp decode)                                                               |
+| M4 - GDeflate    | GDeflate decode as an auditable CUDA library (32-substream warp decode)                                                      |
 | M5 - Zstd        | Zstd decode: FSE/Huffman stages + sequence execution                                                                         |
 | M6 - Portability | HIP port of the kernel family                                                                                                |
 


### PR DESCRIPTION
# What & why

Closes #84. Also closes #148, which is item 1 of this issue and nothing else;
the wording it asks for is here, in the stronger form explained below.

Three public claims were refutable or dated. Each was checked against the
primary source today rather than carried over from the July research pass,
and one of them came back differently from what #84 recorded.

**1. "The first open GPU GDeflate decoder"** (README milestone table,
MASTERPLAN sections 3 and 6). Refuted: two open GPU GDeflate decoders exist.

```
$ gh api repos/microsoft/DirectStorage/contents/GDeflate/shaders/GDeflate.hlsl --jq '"path=\(.path) size=\(.size)"'
path=GDeflate/shaders/GDeflate.hlsl size=28102
$ gh api repos/microsoft/DirectStorage/contents/GDeflate/shaders/GDeflate.hlsl --jq .content | base64 -d | sed -n '2,4p'
 * SPDX-FileCopyrightText: Copyright (c) 2020, 2021, 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 * SPDX-FileCopyrightText: Copyright (c) Microsoft Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0
$ gh api "search/code?q=repo:HansKristian-Work/vkd3d-proton+filename:cs_gdeflate.comp" --jq '.items[].path'
libs/vkd3d/shaders/cs_gdeflate.comp
$ gh api repos/HansKristian-Work/vkd3d-proton --jq '"\(.license.spdx_id) pushed=\(.pushed_at)"'
LGPL-2.1 pushed=2026-08-04T08:16:14Z
```

**2. The M6 story implied an AMD vacuum.** hipCOMP-core exists.

```
$ gh api repos/ROCm/hipCOMP-core --jq '"\(.license.spdx_id) pushed=\(.pushed_at) archived=\(.archived)"'
MIT pushed=2026-07-10T14:07:03Z archived=false
```

**3. The field table predated DirectStorage's Zstd work.** The development
branch carries GPU zstd shaders, Microsoft's own words on their status:

```
$ gh api "repos/microsoft/DirectStorage/contents?ref=development" --jq '.[].name' | tail -1
zstd
$ gh api "repos/microsoft/DirectStorage/contents/zstd/README.md?ref=development" --jq .content | base64 -d | sed -n '7,11p'
# ZSTD decompression shaders
This sample includes reference implementations of shaders that are designed to perform zstd decompression using a GPU.  These shaders are all authored in HLSL and support a wide variety of GPUs.

<span style="color:red;font-size:20px; font-weight:bold;">
This code is currently in development and should NOT be used in production environments or for released products.</span>
```

## Where this departs from what #84 asked for

#84 prescribes the narrowed wording "the first open-source CUDA GDeflate
decoder", on the basis that a GitHub sweep found no other CUDA
implementation. That sweep is from 2026-07-25. Re-run today it returns one:

```
$ gh api "search/code?q=gdeflate+language:cuda" --jq '.items[] | "\(.repository.full_name)  \(.path)"' | grep -v nvcomp
john-agentic-ai-tools/crush  crush-gpu/src/shader/gdeflate_decompress.cu
...
$ gh api repos/john-agentic-ai-tools/crush --jq '"license=\(.license.spdx_id // "none") pushed=\(.pushed_at) stars=\(.stargazers_count)"'
license=NOASSERTION pushed=2026-08-04T03:45:10Z stars=1
```

Its header says "Fixed Huffman only (BTYPE=01)", so it is a partial decoder
inside an application, unlicensed and one-starred. It is not a competitor and
it is not a library. It is, however, enough to make a bare "first" cost an
argument the moment someone runs that search, which is the exact failure mode
#84 exists to remove.

So the milestone rows drop the superlative entirely and say what cudec
delivers - "GDeflate decode as an auditable CUDA library". The positioning
moves to the gap sentence, which is a negative claim and survives: no
maintained open-source **CUDA library** decodes the standard formats on the
GPU. Section 1 records the search and its result so the next pass does not
re-litigate it.

One near-miss in the other direction, also recorded: hipCOMP-core carries
`src/lowlevel/gdeflateKernels.cu`, which reads like an open CUDA GDeflate
decoder and is not one.

```
$ gh api repos/ROCm/hipCOMP-core/contents/src/lowlevel/gdeflateKernels.cu --jq '"size=\(.size)"'
size=4167
```

4 KB, and its whole body is `convertGdeflateOutputStatusesKernel`, a status
converter around an external `gdeflate::` component behind `#ifdef
ENABLE_GDEFLATE`.

## Type of change

- [x] Docs

## Engineering checklist

Not applicable: no code, no parse path, no kernel, no ABI. `README.md` and
`docs/MASTERPLAN.md` only.

## Quality checklist

- [x] Minimal: the field table gains four rows, three prose passages change,
      two milestone rows change. No section is rewritten.
- [x] Self-documenting: each new claim carries its source path in the
      document, not only in this body.

## Verification

```
$ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

The acceptance grep, on the tree at this commit - every remaining
`first`/`only` line touching the landscape:

```
$ grep -inE "first|only" README.md docs/MASTERPLAN.md | grep -iE "gdeflate|zstd|open|GPU decoder|AMD"
docs/MASTERPLAN.md:40:so a bare "the first open CUDA GDeflate decoder" is refutable and is not
docs/MASTERPLAN.md:360:projects >= ~10x the CPU p50 baseline (>= ~35 GB/s); reopen two-phase only
```

The first is the sentence that refuses the claim; the second is about a
benchmark threshold. No GDeflate or Zstd superlative remains.

```
$ git diff --name-only origin/main...HEAD
README.md
docs/MASTERPLAN.md
```

## Notes

**What is not verified.** The claim that vkd3d-proton's decoder has shipped
in Proton since 2023 and runs on RADV is carried from #84 and is not
re-checked here; it is not written into the tree, only the file, its path and
its licence are. The DirectStorage zstd shaders are described in the table
using Microsoft's own status wording, quoted above, rather than an assessment
of them.

**No second reader.** No adversarial review was run and no second person read
this change. This body carries the commands in place of one, which is not the
same thing: every command above shows that a source says what the document
now says, and none of them shows that the document says everything worth
saying about the field. The departure from #84's prescribed wording is the
part a reviewer would most reasonably push back on, and it is stated in full
above rather than folded into the diff.
