### PR TITLE
Pin snappy 1.2.2 and build the decode-only oracle

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -169,8 +169,10 @@ a planned milestone - a vendor binary can never follow), and **hackability**.
   invariant working, not as noise. FetchContent pins are invisible to
   Dependabot - oracle bumps are deliberate manual PRs owned by the
   supply-chain sweep. Third-party oracle code compiles with SYSTEM includes
-  and without the project's strict flags; one translation unit per oracle,
-  never its build system.
+  and without the project's strict flags; only the translation units the
+  oracle's decode path needs, never its build system. For liblz4 that is one
+  file; the Snappy oracle needs two, because the source abstraction its
+  exact-consume decode reads through lives in a second one.
 - Fuzzing: mutation-based corpus fuzzing of the host-side parsers, plus
   GPU-vs-oracle diff loops on mutated streams for the kernels.
 - Benchmarks live in `bench/` with recorded methodology; every published

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,12 +42,96 @@ target_include_directories(lz4_frame_oracle SYSTEM PUBLIC
 # optimization-independent; honest numbers are not.
 target_compile_options(lz4_oracle PRIVATE -O2)
 
-# PRIVATE on purpose: the archive still links through, but the lz4 include
-# path stays out of every consumer's command line - so an accidental
-# #include <lz4.h> in a .cu test is a compile error, and the "nvcc never
-# sees lz4.h" rule is enforced, not just observed.
+# google/snappy, the M3 oracle, pinned by the SHA-256 of the tag archive.
+# snappy publishes no maintainer-uploaded release asset, so this is the
+# fallback the pinning policy names (docs/MASTERPLAN.md section 5): the
+# auto-generated archive, pinned, with a future hash mismatch read as the
+# invariant working rather than as noise. Cross-checked at pin time against a
+# second packaging ecosystem each - the SHA-256 against the Homebrew formula,
+# the SHA-512
+# 0c1e1019e1bec9281f9877996d896e59e1533456130143224acb9cbfc35c1b0dd9de0a76e4a36494844d9ec58c295eed8c50bdf6dbabe47cf679652eb24b1281
+# against vcpkg (conan-center only reaches 1.2.1). 1108618 bytes.
+set(CUDEC_SNAPPY_VERSION 1.2.2)
+FetchContent_Declare(
+  snappy
+  URL https://github.com/google/snappy/archive/refs/tags/${CUDEC_SNAPPY_VERSION}.tar.gz
+  URL_HASH
+    SHA256=90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc
+  # snappy, unlike lz4, DOES ship a top-level CMakeLists.txt, and pointing
+  # MakeAvailable at a directory that holds none is what keeps that build out
+  # of this tree: one oracle target over the sources the decode path needs,
+  # never the project's own build system, which would bring its tests, its
+  # install rules and its generated config.h with it.
+  SOURCE_SUBDIR cudec-uses-no-snappy-cmake
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+FetchContent_MakeAvailable(snappy)
+# And the same statement as a check rather than as a comment: snappy's build
+# system defines this target, so its presence means the line above stopped
+# working - a newer snappy layout, or a MakeAvailable that stopped honouring
+# SOURCE_SUBDIR.
+if(TARGET snappy)
+  message(
+    FATAL_ERROR
+      "snappy's own build system was added to this tree - the oracle rule is "
+      "one target over the translation units the decode path needs "
+      "(docs/MASTERPLAN.md section 5)")
+endif()
+
+# snappy.h includes snappy-stubs-public.h, which snappy generates from a .in
+# at configure time; generated here instead, with the four substitutions it
+# has and nothing else. config.h stays undefined: every reference to it in
+# these translation units sits behind `#if HAVE_CONFIG_H`, so the platform
+# detection falls back to the compiler's own macros rather than to a header
+# this project would have to keep true.
+#
+# A function, not inline code: the .in names ${PROJECT_VERSION_MAJOR} and its
+# siblings, which are CMake's own variables for the enclosing project, and
+# setting them for the rest of this directory to satisfy a third-party
+# template is a trap for whoever reads one later.
+function(cudec_generate_snappy_stubs version out_dir)
+  string(REPLACE "." ";" _parts "${version}")
+  list(LENGTH _parts _count)
+  if(NOT _count EQUAL 3)
+    message(FATAL_ERROR "the snappy pin '${version}' is not major.minor.patch "
+                        "- the version macros cannot be derived from it")
+  endif()
+  list(GET _parts 0 PROJECT_VERSION_MAJOR)
+  list(GET _parts 1 PROJECT_VERSION_MINOR)
+  list(GET _parts 2 PROJECT_VERSION_PATCH)
+  # 1 for the Linux container this builds in, which is where iovec lives. On a
+  # host without sys/uio.h the header defines its own, so the 0 case is real
+  # code and not a fallback that has to be added later.
+  set(HAVE_SYS_UIO_H_01 1)
+  # No @ONLY: the template's placeholders are ${...}, which is exactly what
+  # the default substitution reads.
+  configure_file(${snappy_SOURCE_DIR}/snappy-stubs-public.h.in
+                 ${out_dir}/snappy-stubs-public.h)
+endfunction()
+set(_snappy_generated_dir ${CMAKE_CURRENT_BINARY_DIR}/snappy-generated)
+cudec_generate_snappy_stubs(${CUDEC_SNAPPY_VERSION} ${_snappy_generated_dir})
+
+# Two translation units, which is the whole decode path: snappy.cc, and
+# snappy-sinksource.cc for the ByteArraySource the Source-taking calls read
+# through. snappy-stubs-internal.cc carries none of it. SYSTEM include and
+# none of the project's strict flags, the rule lz4_oracle follows for the
+# same reason - third-party code is audited by hash, not reformatted.
+add_library(snappy_oracle STATIC ${snappy_SOURCE_DIR}/snappy.cc
+                                 ${snappy_SOURCE_DIR}/snappy-sinksource.cc)
+target_include_directories(snappy_oracle SYSTEM PUBLIC ${snappy_SOURCE_DIR}
+                                                       ${_snappy_generated_dir})
+set_target_properties(snappy_oracle PROPERTIES CXX_STANDARD 11
+                                               CXX_STANDARD_REQUIRED ON)
+# -O2 for the same reason lz4_oracle carries it: the documented container
+# command sets no CMAKE_BUILD_TYPE, and the reference decoder runs over whole
+# corpora during fixture generation.
+target_compile_options(snappy_oracle PRIVATE -O2)
+
+# PRIVATE on purpose: the archive still links through, but the lz4 and snappy
+# include paths stay out of every consumer's command line - so an accidental
+# #include <lz4.h> or <snappy.h> in a .cu test is a compile error, and the
+# "nvcc never sees the oracle headers" rule is enforced, not just observed.
 add_library(cudec_test_fixtures STATIC fixtures.cpp)
-target_link_libraries(cudec_test_fixtures PRIVATE lz4_oracle)
+target_link_libraries(cudec_test_fixtures PRIVATE lz4_oracle snappy_oracle)
 target_include_directories(cudec_test_fixtures PUBLIC .)
 set_target_properties(cudec_test_fixtures PROPERTIES CXX_STANDARD 17
                                                      CXX_STANDARD_REQUIRED ON)
@@ -111,6 +195,10 @@ cudec_add_test(conformance_c SOURCES conformance_c.c)
 set_target_properties(conformance_c PROPERTIES C_STANDARD 99
                                                C_STANDARD_REQUIRED ON)
 cudec_add_test(oracle_lz4 SOURCES oracle_lz4.cpp LIBS cudec_test_fixtures)
+# The M3 oracle is only useful if it is present and callable; this is that,
+# and nothing about cudec's own Snappy path, which does not exist yet.
+cudec_add_test(oracle_snappy SOURCES oracle_snappy.cpp LIBS
+               cudec_test_fixtures)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/fixtures.cpp
+++ b/tests/fixtures.cpp
@@ -1,6 +1,7 @@
 #include "fixtures.h"
 
 #include <lz4.h>
+#include <snappy.h>
 
 #include <cstdlib>
 #include <cstring>
@@ -155,4 +156,56 @@ bool OracleDecodes(const std::vector<unsigned char>& stream,
     }
     decoded->resize(static_cast<size_t>(written));
     return true;
+}
+
+bool SnappyOracleDecodes(const std::vector<unsigned char>& stream,
+                         std::vector<unsigned char>* decoded) {
+    decoded->clear();
+    if (stream.empty()) {
+        return false; /* never hand snappy a null source pointer */
+    }
+    const char* src = reinterpret_cast<const char*>(stream.data());
+    size_t declared = 0;
+    if (!snappy::GetUncompressedLength(src, stream.size(), &declared)) {
+        return false;
+    }
+    if (declared > kSnappyOracleMaxOutput) {
+        return false; /* the wrapper's bound, documented in fixtures.h */
+    }
+    decoded->assign(declared, 0);
+    if (!snappy::RawUncompress(src, stream.size(),
+                               reinterpret_cast<char*>(decoded->data()))) {
+        /* A rejected stream produces no output: a caller that reads the
+         * buffer after a false verdict must find nothing to mistake for one. */
+        decoded->clear();
+        return false;
+    }
+    return true;
+}
+
+bool SnappyOracleAccepts(const std::vector<unsigned char>& stream) {
+    if (stream.empty()) {
+        return false;
+    }
+    return snappy::IsValidCompressedBuffer(
+        reinterpret_cast<const char*>(stream.data()), stream.size());
+}
+
+std::vector<unsigned char> SnappyCompressBlock(
+    const std::vector<unsigned char>& original) {
+    std::vector<unsigned char> compressed(
+        snappy::MaxCompressedLength(original.size()));
+    size_t written = 0;
+    snappy::RawCompress(reinterpret_cast<const char*>(original.data()),
+                        original.size(),
+                        reinterpret_cast<char*>(compressed.data()), &written);
+    /* Corpus generation is infrastructure, not a test, exactly as in
+     * Lz4CompressBlock: a compressor that wrote more than the bound it
+     * promised has already overrun this buffer, so there is nothing left to
+     * report from. */
+    if (written == 0 || written > compressed.size()) {
+        std::abort();
+    }
+    compressed.resize(written);
+    return compressed;
 }

--- a/tests/fixtures.h
+++ b/tests/fixtures.h
@@ -43,4 +43,30 @@ bool OracleDecodes(const std::vector<unsigned char>& stream,
 std::vector<unsigned char> Lz4CompressBlock(
     const std::vector<unsigned char>& original);
 
+/* The Snappy oracle (google/snappy, pinned in tests/CMakeLists.txt), same
+ * authority over stream validity that liblz4 holds for LZ4.
+ *
+ * The parity call: snappy's exact-consume, exact-produce decode. The declared
+ * uncompressed length comes out of the stream itself, so a verdict needs no
+ * size argument - unlike the LZ4 block format, which has none.
+ *
+ * kSnappyOracleMaxOutput is this wrapper's bound and not snappy's: a stream
+ * may declare up to 4 GiB - 1 of output, and a mutated one will, so the
+ * harness refuses to allocate on a declared length no corpus here produces.
+ * A generator that ever needs more must raise the bound consciously, because
+ * above it this wrapper rejects a stream snappy itself might accept. */
+const size_t kSnappyOracleMaxOutput = 256u * 1024u * 1024u;
+bool SnappyOracleDecodes(const std::vector<unsigned char>& stream,
+                         std::vector<unsigned char>* decoded);
+
+/* The no-write validation analog: snappy's own verdict on a stream, reached
+ * without producing output. */
+bool SnappyOracleAccepts(const std::vector<unsigned char>& stream);
+
+/* CPU-reference Snappy compression, the single provenance for every Snappy
+ * stream in the project; aborts on compressor failure for the same reason
+ * Lz4CompressBlock does. */
+std::vector<unsigned char> SnappyCompressBlock(
+    const std::vector<unsigned char>& original);
+
 #endif /* CUDEC_TESTS_FIXTURES_H */

--- a/tests/oracle_snappy.cpp
+++ b/tests/oracle_snappy.cpp
@@ -1,0 +1,55 @@
+/* The Snappy oracle proving itself before any Snappy decoder exists: the
+ * pinned build links, its two harness-facing verdicts agree with each other
+ * on a real stream, and both refuse a stream the format cannot describe. No
+ * cudec code is under test here - this is the reference the M3 parity tests
+ * will be held to, checked for being present and callable at all. */
+#include "fixtures.h"
+#include "require.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+int main() {
+    /* Compressible, so the stream carries a copy element rather than one
+     * literal run: a link that resolved the wrong symbols would not survive
+     * a round trip through both element kinds. */
+    std::vector<unsigned char> original;
+    const std::string token = "cudec snappy oracle ";
+    while (original.size() < 4096) {
+        original.insert(original.end(), token.begin(), token.end());
+    }
+
+    const auto compressed = SnappyCompressBlock(original);
+    REQUIRE(!compressed.empty());
+    REQUIRE(compressed.size() < original.size());
+    REQUIRE(SnappyOracleAccepts(compressed));
+
+    std::vector<unsigned char> decoded;
+    REQUIRE(SnappyOracleDecodes(compressed, &decoded));
+    REQUIRE_CTX(decoded.size() == original.size(), "decoded %zu of %zu bytes",
+                decoded.size(), original.size());
+    REQUIRE(equal_bytes(decoded.data(), original.data(), decoded.size()));
+
+    /* Truncation is the one negative this test owes: it proves the verdicts
+     * are being read from snappy rather than assumed. The reject ladder and
+     * the mutation corpus are their own issues. */
+    std::vector<unsigned char> truncated(compressed.begin(),
+                                         compressed.end() - 1);
+    REQUIRE(!SnappyOracleAccepts(truncated));
+    std::vector<unsigned char> truncated_out;
+    REQUIRE(!SnappyOracleDecodes(truncated, &truncated_out));
+    REQUIRE(truncated_out.empty());
+
+    /* An empty buffer never reaches snappy: the wrapper refuses it so no
+     * caller can hand the reference a null pointer. */
+    std::vector<unsigned char> empty;
+    std::vector<unsigned char> empty_out;
+    REQUIRE(!SnappyOracleAccepts(empty));
+    REQUIRE(!SnappyOracleDecodes(empty, &empty_out));
+
+    std::printf("PASS: snappy oracle round-trips %zu bytes to %zu and refuses "
+                "a truncated stream\n",
+                original.size(), compressed.size());
+    return 0;
+}


### PR DESCRIPTION
# What & why

M3 needs a reference that decides what a valid Snappy stream is. This pins
google/snappy 1.2.2 and builds it as a decode-only static oracle beside the
existing liblz4 pin, with three harness symbols and a liveness test.

Closes #153.

## Type of change

- [x] Build / CI / supply chain

## The pin

```
$ curl -sSL -o snappy-1.2.2.tar.gz https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz
$ wc -c snappy-1.2.2.tar.gz
1108618 snappy-1.2.2.tar.gz
$ sha256sum snappy-1.2.2.tar.gz
90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc  snappy-1.2.2.tar.gz
$ sha512sum snappy-1.2.2.tar.gz
0c1e1019e1bec9281f9877996d896e59e1533456130143224acb9cbfc35c1b0dd9de0a76e4a36494844d9ec58c295eed8c50bdf6dbabe47cf679652eb24b1281  snappy-1.2.2.tar.gz
```

snappy publishes no upstream-uploaded release asset, so the auto-generated
tag archive is the documented fallback rather than a departure. The SHA-256 is
cross-checked against the Homebrew formula and the SHA-512 against vcpkg;
conan-center only reaches 1.2.1, which is why it is not cited.

The pin bites. One digit changed in the recorded SHA-256, same container:

```
$ sed -i 's/SHA256=90f74bc1/SHA256=90f74bc2/' tests/CMakeLists.txt
$ cmake -B b-badhash -DCUDEC_ENABLE_CUDA=ON
-- SHA256 hash of .../1.2.2.tar.gz
-- Hash mismatch, removing...
A_EXIT=1
```

## Keeping snappy's build system out

This is the difference from liblz4, whose uploaded tarball has no top-level
`CMakeLists.txt` to begin with. snappy has one, and left to itself
`FetchContent_MakeAvailable` would add it, bringing snappy's tests, its install
rules and a generated `config.h` this project would then have to keep true.
`SOURCE_SUBDIR` points at a directory that holds no `CMakeLists.txt`, and the
statement is also made as a check, because a comment cannot notice a newer
layout or a `MakeAvailable` that stops honouring `SOURCE_SUBDIR`.

Deleting the `SOURCE_SUBDIR` line reds the configure on that check:

```
$ sed -i '/SOURCE_SUBDIR cudec-uses-no-snappy-cmake/d' tests/CMakeLists.txt
$ cmake -B b-nosubdir -DCUDEC_ENABLE_CUDA=ON
CMake Error at tests/CMakeLists.txt:72 (message):
  snappy's own build system was added to this tree - the oracle rule is one
  target over the translation units the decode path needs (docs/MASTERPLAN.md
  section 5)
B_EXIT=1
```

## The oracle

Two translation units, which is the whole decode path: `snappy.cc`, and
`snappy-sinksource.cc` for the `ByteArraySource` the `Source`-taking calls read
through. `snappy-stubs-internal.cc` carries none of it. Both objects, from the
finished build:

```
build-cuda/tests/CMakeFiles/snappy_oracle.dir/__/_deps/snappy-src/snappy.cc.o
build-cuda/tests/CMakeFiles/snappy_oracle.dir/__/_deps/snappy-src/snappy-sinksource.cc.o
```

`snappy-stubs-public.h` is generated from its template, in a function so that
the template's `PROJECT_VERSION_*` names, which are CMake's own for the
enclosing project, cannot leak into the rest of the directory. `config.h` stays
undefined; every reference to it in these two units sits behind
`#if HAVE_CONFIG_H`. The generated header:

```
40:#if 1  // HAVE_SYS_UIO_H
41:#include <sys/uio.h>
44:#define SNAPPY_MAJOR 1
45:#define SNAPPY_MINOR 2
46:#define SNAPPY_PATCHLEVEL 2
52:#if !1  // !HAVE_SYS_UIO_H
```

The three version macros come from the pin string itself, so they cannot drift
away from the version that was pinned.

## The harness surface

- `SnappyOracleDecodes` - the parity call, snappy's exact-consume,
  exact-produce decode. The declared length comes out of the stream, so a
  verdict needs no size argument, unlike the LZ4 block format.
- `SnappyOracleAccepts` - `IsValidCompressedBuffer`, the verdict without
  output.
- `SnappyCompressBlock` - one provenance for every Snappy stream in the
  project, aborting on compressor failure like `Lz4CompressBlock`.

One thing in there is a deliberate divergence and is written into the header
rather than left to be discovered: a stream may declare up to 4 GiB - 1 of
output and a mutated one will, so the decode wrapper refuses a declared length
above 256 MiB instead of allocating on a number the stream chose. Above that
bound this wrapper rejects a stream snappy itself might accept, which the
mutation generator in #157 has to stay under or raise consciously.

## Verification

The documented container gate on this branch,
`nvidia/cuda:12.6.2-devel-ubuntu24.04`, cmake 3.28.3, nvcc 12.6.77, RTX 3080:

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON   CFG_EXIT=0   (downloads and hash-checks the archive)
cmake --build build-cuda -j                  BUILD_EXIT=0 (no warnings)
ctest --test-dir build-cuda --output-on-failure
  CTEST_EXIT=0
  3/16 Test  #3: oracle_snappy .......   Passed    0.01 sec
  100% tests passed, 0 tests failed out of 16
$ ./build-cuda/tests/oracle_snappy
PASS: snappy oracle round-trips 4100 bytes to 215 and refuses a truncated stream
```

15 tests before this change, 16 after.

- [x] `cmake --build build-cuda` - builds clean.
- [x] `ctest --test-dir build-cuda` - green, 16/16.
- [x] Prettier - `All matched files use Prettier code style!`
- [x] Docs synced. The masterplan's oracle-pinning clause said one translation
      unit per oracle, which this change makes untrue; it now names the decode
      path, and says why Snappy needs two.

## Engineering checklist

- [x] Fail-closed preserved. Nothing decodes here yet; what this change adds
      is refusals - the hash mismatch, the build-system check, the declared
      length bound, and the empty buffer that never reaches snappy.
- [x] Oracle coverage - this change IS the oracle. No cudec Snappy path exists
      to diff against yet; `oracle_snappy` proves the reference is present,
      callable, and answering rather than assumed.
- [x] Determinism preserved - no decode path or corpus changes; the LZ4 corpus
      digest tripwire in `oracle_lz4` still passes, which is what says so.
- [ ] CUDA API errors / C ABI - not applicable, no device or ABI code changes.
- [ ] An adversarial review was NOT run on this change. There is no second
      reader on this board tonight, so this body carries the evidence in place
      of one: the two deliberate breakages above, each reproduced with the
      command that produced it. That is weaker than a review and is not being
      presented as one.
- [ ] Review record - none, for the reason above. No lens ran, so there are no
      CONFIRMED or PLAUSIBLE counts to report.

## Notes

Out of scope, and each has its own issue: the empirical probes for snappy's
documented decode behaviours (#155), the vendored `baddata` fixtures (#156),
the mutation corpus (#157), and the device gate set (#154). The oracle is
built here so those have something to be held to.

`snappy_oracle` is deliberately left uninstrumented under the sanitizer gate,
the same treatment `lz4_oracle` gets and for the same reason: third-party code
audited by hash must not red a gate about this project's own code.
