### PR TITLE
Exempt a range-for on its shape, not on a colon

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -450,6 +450,51 @@ endforeach()
 # carrying a real loop AND the idiom in the same element is forgiven whole,
 # since the element is judged by what it contains rather than by structure the
 # scan does not parse.
+# Does this `for` header carry a RANGE-FOR's colon, or merely a colon?
+#
+# The opaque-`for` rule exempts a range-for because its bound is the
+# container's size: loop-invariant and visible on the spot, exactly like the
+# counted form's. A colon that is something else carries none of that, so
+# testing for "a colon" granted the exemption on a coincidence (issue #250).
+# A range-for's colon sits at the header's TOP parenthesis level, which is a
+# property of a range-for rather than of the character, so that is what is
+# tested. A ternary inside a macro argument - `for (EACH(x, w ? a : b))` -
+# puts its colon a level down and is caught. `::` goes first: a qualified
+# name is not a range-for either (issue #123).
+#
+# The residual, and it is inherited rather than introduced: this scan strips
+# no string literals anywhere, so a colon inside one at the top level -
+# `for (EACH(x) "a:b")` - still exempts. Stripping literals is a pass over
+# every rule in this function, not a change to this one, and the function's
+# "Limits" paragraph already names unstripped literals as a known blind spot.
+function(cudec_for_colon_at_top_level text out_result)
+  set(${out_result} FALSE PARENT_SCOPE)
+  string(REPLACE "::" "" _text "${text}")
+  # From the header's own '(' onward; what precedes it cannot hold the colon.
+  string(REGEX MATCH "for[ \t]*\\(.*" _text "${_text}")
+  string(LENGTH "${_text}" _length)
+  if(_length EQUAL 0)
+    return()
+  endif()
+  set(_depth 0)
+  math(EXPR _last "${_length} - 1")
+  foreach(_index RANGE ${_last})
+    string(SUBSTRING "${_text}" ${_index} 1 _char)
+    if(_char STREQUAL "(")
+      math(EXPR _depth "${_depth} + 1")
+    elseif(_char STREQUAL ")")
+      math(EXPR _depth "${_depth} - 1")
+      if(_depth LESS_EQUAL 0)
+        # The header's parenthesis closed; the rest of the line is the body.
+        return()
+      endif()
+    elseif(_char STREQUAL ":" AND _depth EQUAL 1)
+      set(${out_result} TRUE PARENT_SCOPE)
+      return()
+    endif()
+  endforeach()
+endfunction()
+
 function(cudec_scan_source path check_loops out_violations)
   set(_violations "")
   set(_in_comment FALSE)
@@ -591,10 +636,8 @@ function(cudec_scan_source path check_loops out_violations)
         set(_form_line ${_for_start})
         if(_for_open LESS_EQUAL 0)
           set(_for_open 0)
-          # '::' out first, for the reason spelled out at the single-line
-          # branch below: a qualified name is not a range-for.
-          string(REPLACE "::" "" _range_text "${_for_text}")
-          if(_for_semis LESS 2 AND NOT _range_text MATCHES ":")
+          cudec_for_colon_at_top_level("${_for_text}" _is_range_for)
+          if(_for_semis LESS 2 AND NOT _is_range_for)
             set(_form "a 'for' header without a visible condition and increment")
           endif()
         elseif(_for_lines GREATER 8)
@@ -632,23 +675,20 @@ function(cudec_scan_source path check_loops out_violations)
         # Covers both `for (;;)` and `for (init;; incr)`.
         set(_form "a 'for' loop with an empty condition")
       elseif(_element_code MATCHES "[^A-Za-z_0-9]for[ \t]*\\(")
-        # The range-for test runs on the header with '::' removed: the colons
-        # of a qualified name (`cudec_detail::Foo`) carry none of the meaning
-        # the exemption rests on, and left in they would exempt any opaque
-        # header that happens to mention one.
-        string(REPLACE "::" "" _range_text "${_element_code}")
+        cudec_for_colon_at_top_level("${_element_code}" _is_range_for)
         if(_balance GREATER 0)
           set(_for_open ${_balance})
           set(_for_semis ${_line_semis})
           set(_for_start ${_element_start})
           set(_for_lines 1)
           set(_for_text "${_element_code}")
-        elseif(_line_semis LESS 2 AND NOT _range_text MATCHES ":")
+        elseif(_line_semis LESS 2 AND NOT _is_range_for)
           # A balanced header with fewer than two semicolons has no visible
           # induction variable - a macro-hidden loop, say. A range-for
-          # (`for (T& x : container)`) is exempt by the ':': its bound is the
-          # container's size, loop-invariant and visible on the spot, exactly
-          # like the counted form.
+          # (`for (T& x : container)`) is exempt: its bound is the container's
+          # size, loop-invariant and visible on the spot, exactly like the
+          # counted form. What counts as one is decided above, by
+          # cudec_for_colon_at_top_level.
           set(_form "a 'for' header without a visible condition and increment")
         endif()
       endif()
@@ -922,6 +962,25 @@ file(WRITE ${_probe_dir}/scan_for_opaque_qualified_wrapped.cu
      "    unsigned count = 0;\n" "    for (EACH_CHUNK(chunk,\n"
      "                    cudec_detail::chunks_of(src))) {\n"
      "        count += chunk;\n" "    }\n" "    return count;\n" "}\n")
+# The other two colons a macro-hidden header can plausibly carry, neither of
+# them a range-for's: one inside a nested call's string literal, one a
+# ternary. Both must still be reported (issue #250). The wrapped ternary
+# covers the multi-line branch, which decides the exemption separately.
+file(WRITE ${_probe_dir}/scan_for_colon_literal.cu
+     "unsigned probe(const unsigned char* src) {\n"
+     "    unsigned count = 0;\n"
+     "    for (EACH_FIELD(field, src, \"key:value\")) {\n"
+     "        count += field;\n" "    }\n" "    return count;\n" "}\n")
+file(WRITE ${_probe_dir}/scan_for_colon_ternary.cu
+     "unsigned probe(const unsigned char* src, int wide) {\n"
+     "    unsigned count = 0;\n"
+     "    for (EACH_CHUNK(chunk, wide ? src[0] : src[1])) {\n"
+     "        count += chunk;\n" "    }\n" "    return count;\n" "}\n")
+file(WRITE ${_probe_dir}/scan_for_colon_ternary_wrapped.cu
+     "unsigned probe(const unsigned char* src, int wide) {\n"
+     "    unsigned count = 0;\n" "    for (EACH_CHUNK(chunk,\n"
+     "                    wide ? src[0] : src[1])) {\n"
+     "        count += chunk;\n" "    }\n" "    return count;\n" "}\n")
 # A `for` header the scan cannot balance must be rejected, not skipped: while
 # the tracker is open the whole loop rule is off, so a silent skip would
 # disable the termination check for the rest of the file. String literals are
@@ -1040,6 +1099,9 @@ set(_scanner_probes
     "scan_for_opaque_wrapped|scan_for_opaque_wrapped.cu:3: a 'for' header without a visible"
     "scan_for_opaque_qualified|scan_for_opaque_qualified.cu:3: a 'for' header without a visible"
     "scan_for_opaque_qualified_wrapped|scan_for_opaque_qualified_wrapped.cu:3: a 'for' header without a visible"
+    "scan_for_colon_literal|scan_for_colon_literal.cu:3: a 'for' header without a visible"
+    "scan_for_colon_ternary|scan_for_colon_ternary.cu:3: a 'for' header without a visible"
+    "scan_for_colon_ternary_wrapped|scan_for_colon_ternary_wrapped.cu:3: a 'for' header without a visible"
     "scan_for_unbalanced|closing parenthesis was not found within 8 lines"
     "scan_for_unbalanced_eof|left unbalanced at end of file"
     "scan_wrapped_after_mask|is wrapped across lines"


### PR DESCRIPTION
# What & why

Closes #250.

The opaque-`for` rule's exemption tested `NOT _range_text MATCHES ":"` - "the
header contains a colon". The exemption's justification is narrow: a
range-for's bound is the container's size, loop-invariant and visible on the
spot, exactly like a counted loop's. No other colon carries that. So the one
hole in a fail-closed rule was being granted on a coincidence. #123 removed
the coincidence that had a name (`::` in a qualified type); a colon from a
nested string literal or from a ternary was still a way in.

The test is now for a colon at the header's **top parenthesis level**. That
is a property of a range-for rather than of the character: a range-for's
colon sits there, and a ternary inside a macro argument -
`for (EACH(x, w ? a : b))` - sits a level down. `::` is still stripped first,
for #123's reason.

Both branches of the rule use it: the single-line one and the multi-line one
that joins a wrapped header before judging it.

## What is deliberately NOT narrowed

A colon inside a string literal at the top parenthesis level still exempts.
This scan strips no string literals anywhere - the function's own "Limits"
paragraph already names that as a known blind spot, and the unbalanced-header
bail-out exists because of it. Stripping literals is a pass over every rule
in the function, not a change to this one. The residual is written beside the
rule with its reason, which is the second of #250's two acceptable outcomes,
applied to the part that is left after narrowing the rest.

## Type of change

- [x] Build / CI / supply chain
- [x] Refactor / code quality

## Engineering checklist

- [x] Fail-closed preserved, and strengthened in the direction that matters:
      the change only ever moves headers from "exempt" to "reported", never
      the reverse. No decode code, no kernel, no ABI.
- [x] Conformance/structural tests: three new probes lock the newly-caught
      forms, matched against the text the rule emits, like every other probe.

## Quality checklist

- [x] Minimal: one helper function replacing two copies of a two-line string
      test, plus three probe fixtures and three probe entries.
- [x] Self-documenting: the helper's name states the property; its comment
      says why top level is the right test and what the remaining residual
      is.

## Verification

Pinned container, `nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0f...`,
cmake 3.28.3. The scanner and all its probes run at configure time.

```
$ cmake -B /tmp/b -S . -DCUDEC_ENABLE_CUDA=ON   -> exit 0
$ cmake --build /tmp/b -j                       -> exit 0
$ ctest --test-dir /tmp/b -LE gpu --no-tests=error --output-on-failure
100% tests passed, 0 tests failed out of 10
```

A green configure is the whole probe suite passing: 31 entries now, 28
before. It also means `scan_clean.cu` still comes back silent, and that file
carries all four genuine range-for shapes the issue asks about - plain,
wrapped, qualified, qualified-and-wrapped:

```
    for (const Block& block : blocks) {
    for (const Block& wrapped :
         blocks) {
    for (const cudec_detail::Block& scoped : blocks) {
    for (const cudec_detail::Block& scoped_wrapped :
         blocks) {
```

So the rule is narrower, not merely stricter.

### The narrowing is load-bearing, proven by undoing it

One word in the depth test, on a copy of the tree - `EQUAL 1` widened back to
`GREATER 0`, which is the old "a colon anywhere in the header" behaviour:

```
$ sed -i 's/_depth EQUAL 1/_depth GREATER 0/' tests/CMakeLists.txt
$ cmake -B /tmp/bs -S . -DCUDEC_ENABLE_CUDA=ON
CMake Error at tests/CMakeLists.txt:1133 (message):
  the structural scanner is dead for one rule: probe 'scan_for_colon_literal'
  did not report "scan_for_colon_literal.cu:3: a 'for' header without a
  visible" (issue #72).  It reported:
```

The run stops at the first dead probe, so that message names one of the
three; all three fixtures carry their colon below the top level and none of
them is reported under the widened test.

```
$ git diff --name-only origin/main...HEAD
tests/CMakeLists.txt
```

## Notes

**Cost.** The helper walks the header a character at a time, which CMake does
slowly. It runs once per `for` header in `src/` plus once per probe, and the
configure above took 9.8s wall including the FetchContent step, so it is not
a measured regression - but it was not measured against a before-and-after
either, and is not claimed as free.

**No second reader.** No adversarial review was run and no second person read
this change. The commands above show the rule catches the two forms #250
names and still exempts the four genuine ones, and show nothing about whether
top-parenthesis-level is the best available test. The alternative the issue
floats - a literal-stripping pass - is left open above with the reason it was
not taken here.
