### PR TITLE
Analyse the host decode surface with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,93 @@
+# CodeQL - static analysis over the C/C++/CUDA surface, into Code Scanning.
+#
+# What it analyses and why the build is manual. CodeQL's C/C++ extractor only
+# sees translation units a real compiler compiles, so the build mode decides
+# the scope. `autobuild` here would find the top-level CMakeLists and produce
+# the host-only configuration, whose whole library is src/version.c - an
+# analysis of nothing. So the build is written out, in the same digest-pinned
+# container ci.yml uses, with CUDEC_ENABLE_CUDA=ON: that compiles the frame
+# parse, the streaming path, the C-ABI boundary and the CPU twin of the block
+# parser, which is the hostile-input surface worth analysing. The runner has
+# no GPU and needs none - nothing here runs a kernel.
+#
+# What it does NOT do. It never fails a pull request. Findings land in the
+# Code Scanning tab, where the security-review sweeps read them; making a
+# CodeQL alert a merge blocker is a separate decision with its own
+# false-positive budget, and is not taken here. Nor does this replace the
+# host sanitizer gate in ci.yml or the compute-sanitizer runs: those execute
+# the code on real inputs, and this one does not execute it at all.
+
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, Tuesday 04:17 UTC. Off Monday, when the Dependabot tick already
+    # runs (.github/dependabot.yml), and off the hour, where scheduled runs
+    # queue behind everyone else's cron.
+    - cron: "17 4 * * 2"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Fail closed: no ambient token scope at the top level.
+permissions: {}
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read # to check out the source
+      security-events: write # to upload the SARIF results to Code Scanning
+    # The exact toolchain the build gate uses - same image, same digest.
+    container:
+      image: nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # Same git-before-checkout lesson as ci.yml: git in the container keeps
+      # actions/checkout off the flakier REST-tarball fallback, and the CUDA
+      # apt repo is dropped before the update because it is a historic
+      # false-red vector.
+      - name: Install git and CMake
+        run: >-
+          rm -f /etc/apt/sources.list.d/cuda*.list &&
+          apt-get update -q -o Acquire::Retries=3 &&
+          apt-get install -yq -o Acquire::Retries=3 --no-install-recommends
+          git cmake
+
+      - name: Check out the source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
+        with:
+          languages: c-cpp
+          build-mode: manual
+
+      # Fail-closed plumbing, borrowed from ci.yml's build job: the device
+      # binaries exist only if the CUDA configuration actually compiled, so a
+      # renamed option cannot quietly turn this into an analysis of the
+      # host-only stub. -D on an unknown CMake option is a warning, not an
+      # error.
+      - name: Build the analysed configuration
+        run: >-
+          cmake -B build-codeql -DCUDEC_ENABLE_CUDA=ON &&
+          cmake --build build-codeql -j &&
+          test -x build-codeql/tests/parser_twin &&
+          test -x build-codeql/tests/frame_host_negative &&
+          test -x build-codeql/tests/determinism_gpu
+
+      - name: Analyse
+        uses: github/codeql-action/analyze@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
+        with:
+          category: /language:c-cpp

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -23,9 +23,7 @@ int cudec_codeql_probe_delete_me(int n) {
     if (n > 0) {
         value = n;
     }
-    char narrow[4];
-    std::memcpy(narrow, "0123456789", 10);
-    return value + narrow[0];
+    return value;
 }
 
 namespace {

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -14,18 +14,6 @@
 #include <cstring>
 #include <vector>
 
-/* PROBE for #70 - reverted before merge. Two deliberate defects that need no
- * taint source, so an alert on THIS file proves the analysed configuration
- * extracts it. Never called from anywhere. */
-int cudec_codeql_probe_delete_me(int n);
-int cudec_codeql_probe_delete_me(int n) {
-    int value;
-    if (n > 0) {
-        value = n;
-    }
-    return value;
-}
-
 namespace {
 
 constexpr uint32_t kLz4FrameMagic = 0x184D2204u;

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -14,6 +14,16 @@
 #include <cstring>
 #include <vector>
 
+/* PROBE for #70 - reverted in the next commit. A deliberate unbounded write,
+ * so an alert on THIS file proves the analysed configuration extracts it.
+ * Never called from anywhere. */
+void cudec_codeql_probe_delete_me(const char* name);
+void cudec_codeql_probe_delete_me(const char* name) {
+    char narrow[4];
+    std::strcpy(narrow, name);
+    (void)narrow;
+}
+
 namespace {
 
 constexpr uint32_t kLz4FrameMagic = 0x184D2204u;

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -14,14 +14,18 @@
 #include <cstring>
 #include <vector>
 
-/* PROBE for #70 - reverted in the next commit. A deliberate unbounded write,
- * so an alert on THIS file proves the analysed configuration extracts it.
- * Never called from anywhere. */
-void cudec_codeql_probe_delete_me(const char* name);
-void cudec_codeql_probe_delete_me(const char* name) {
+/* PROBE for #70 - reverted before merge. Two deliberate defects that need no
+ * taint source, so an alert on THIS file proves the analysed configuration
+ * extracts it. Never called from anywhere. */
+int cudec_codeql_probe_delete_me(int n);
+int cudec_codeql_probe_delete_me(int n) {
+    int value;
+    if (n > 0) {
+        value = n;
+    }
     char narrow[4];
-    std::strcpy(narrow, name);
-    (void)narrow;
+    std::memcpy(narrow, "0123456789", 10);
+    return value + narrow[0];
 }
 
 namespace {


### PR DESCRIPTION
# What & why

Closes #70.

The security-review sweeps consult Code Scanning and nothing was writing to
it. This adds `.github/workflows/codeql.yml`: CodeQL `c-cpp` analysis on push
to `main`, on pull requests, and weekly.

The build is written out rather than left to `autobuild`, because for a C/C++
extractor **the build mode is the scope**. `autobuild` would find the
top-level `CMakeLists.txt` at its defaults and produce the host-only
configuration, whose entire library is `src/version.c`. The job instead
builds the same configuration `ci.yml` builds - `-DCUDEC_ENABLE_CUDA=ON`, in
the same digest-pinned container - so the frame parse, the streaming path,
the C-ABI boundary and the CPU twin of the block parser are what the compiler
touches. Three `test -x` lines, copied from `ci.yml`'s build job, keep a
renamed CMake option from quietly turning it back into the host-only stub.

It never fails a pull request. Making an alert a merge blocker is a separate
decision with its own false-positive budget; the header comment says so
rather than leaving the absence to be discovered later.

## Type of change

- [x] Build / CI / supply chain

## Engineering checklist

Not applicable to decode behaviour: no code, no parse path, no kernel, no
ABI. `src/frame.cpp` was touched by the probes described below and is
byte-identical to `main` at the tip of this branch.

- [x] Both Actions pinned to full 40-char commit SHAs with version comments.
- [x] `permissions: {}` at the top level; the job re-grants `contents: read`
      and `security-events: write`, each with its reason on the line.
- [ ] An adversarial review was NOT run. See Notes.

## Verification

**The pins, resolved from the release rather than from memory:**

```
$ gh api repos/github/codeql-action/releases/latest --jq .tag_name
codeql-bundle-v2.26.2
$ gh api repos/github/codeql-action/git/ref/tags/codeql-bundle-v2.26.2 --jq '"\(.object.type) \(.object.sha)"'
commit 18420e3271f74589575af831a523c833acda327f
```

**zizmor 1.16.0, pedantic, over `.github/`:**

```
 INFO audit: zizmor: 🌈 completed .github/dependabot.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/ci.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/codeql.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/dependency-review.yml
No findings to report. Good job!
```

The first draft did carry a finding - `undocumented-permissions` on
`security-events: write` - and the fix is the per-line reasons now in the
file.

```
$ npx --yes prettier@3 --check ".github/workflows/codeql.yml"
All matched files use Prettier code style!
```

**Results reach Code Scanning.** The analysis for this pull request, read
back from the API:

```
$ gh api "repos/iderex/cudec/code-scanning/analyses?per_page=1" --jq '.[0] | {created_at, results_count, rules_count, warning, tool: .tool.version, category}'
{"category":"/language:c-cpp","created_at":"2026-08-05T04:40:05Z","results_count":0,"rules_count":58,"tool":"2.26.2","warning":""}
```

58 rules, 0 results, no warning. The `analyze` job ran 5m32s and the
extractor built a real database:

```
Finished writing database (relations: 31.49 MiB; string pool: 9.53 MiB).
TRAP import complete (20.7s).
```

and the traced build step compiled the file the analysis is for:

```
[ 10%] Building CXX object CMakeFiles/cudec.dir/src/frame.cpp.o
```

## What I could NOT prove, having tried three times

**"0 alerts" here is not evidence that this repository's own sources were
analysed.** I tried to prove it by planting a defect in `src/frame.cpp` - a
file only the CUDA configuration compiles, so an alert on it would settle
both the extraction and the build-mode choice at once. Three commits, all
reverted, none merged:

1. `a770c58` - an unbounded `strcpy` into a 4-byte buffer. No alert. Bad
   probe: `cpp/unbounded-write` wants flow from a source, and the probe had
   none, so its silence meant nothing.
2. `f135f8d` - added a `memcpy` of a 10-byte literal into a 4-byte array.
   Never reached CodeQL: `-Werror=stringop-overflow` reds the compile first
   (`build` and `sanitize` both failed on it). That is the existing gate
   working, and it makes the defect unusable as a probe.
3. `8cd873a` - a read of a possibly-uninitialized local, which gcc does not
   diagnose without optimisation. Built clean, analysed clean. No alert.

So after three attempts I still cannot say whether the third probe's silence
means "`cpp/uninitialized-local` is not in the default 58-rule suite" or
"`src/frame.cpp` is not in the database". What the evidence above does
support is narrower: the extractor ran, produced a 31 MiB database, reported
no warning, and the action did not raise its "no source code was seen" error,
which it does raise on an empty database.

`src/frame.cpp` is restored exactly - the branch diff against `main` is one
file:

```
$ git diff --name-only origin/main...HEAD
.github/workflows/codeql.yml
```

Follow-up issue for the unproven half: #274.

## Notes

**No second reader.** No adversarial review was run and no second person read
this change. The commands above stand in place of one and cover less than a
reviewer would: they show the workflow is well-formed, pinned, audited and
uploading, and they do not show that what it uploads covers the code this
repository cares about. That gap is stated here rather than left for someone
to assume away, and it is the reason the follow-up exists.
