### PR TITLE
Extend the mutation corpus to Snappy streams

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -212,6 +212,11 @@ cudec_add_test(oracle_snappy SOURCES oracle_snappy.cpp LIBS
 # the answers are what the M3 fail-closed matrix is allowed to lock against.
 cudec_add_test(snappy_probes SOURCES snappy_probes.cpp LIBS
                cudec_test_fixtures)
+# The Snappy corpus proving itself (issue #157), the counterpart of oracle_lz4:
+# real pairs, a deterministic generator, and mutations that bite. Host-side, so
+# it runs on the GPU-less runner.
+cudec_add_test(snappy_corpus SOURCES snappy_corpus.cpp LIBS
+               cudec_test_fixtures)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/fixtures.cpp
+++ b/tests/fixtures.cpp
@@ -191,6 +191,246 @@ bool SnappyOracleAccepts(const std::vector<unsigned char>& stream) {
         reinterpret_cast<const char*>(stream.data()), stream.size());
 }
 
+namespace {
+
+/* Where one Snappy element begins and how long it is. The walk exists to place
+ * mutations on the reference's branches; it is not a decoder and never decides
+ * whether a stream is valid. */
+struct Element {
+    size_t offset; /* of the tag byte */
+    size_t size;   /* tag plus its trailing bytes and any literal payload */
+    unsigned char tag;
+};
+
+/* The varint preamble's length in bytes, or 0 if it does not terminate inside
+ * the stream. Five groups at most, the bound Varint::Parse32WithLimit stops at
+ * (snappy-stubs-internal.h:455-475). */
+size_t SnappyPreambleSize(const std::vector<unsigned char>& stream) {
+    for (size_t i = 0; i < 5 && i < stream.size(); i++) {
+        if ((stream[i] & 0x80u) == 0) {
+            return i + 1;
+        }
+    }
+    return 0;
+}
+
+/* Element boundaries, in stream order, stopping at the first byte sequence the
+ * walk cannot account for. Tag encoding: snappy.cc:1613-1631 for literals,
+ * snappy.cc:1650-1663 for the three copy forms. */
+std::vector<Element> SnappyElements(const std::vector<unsigned char>& stream) {
+    std::vector<Element> out;
+    size_t at = SnappyPreambleSize(stream);
+    if (at == 0) {
+        return out;
+    }
+    while (at < stream.size()) {
+        const unsigned char tag = stream[at];
+        size_t size = 0;
+        if ((tag & 3u) == 0u) {
+            const unsigned length_class = tag >> 2;
+            if (length_class < 60u) {
+                size = 1 + (length_class + 1u);
+            } else {
+                const size_t extra = length_class - 59u;
+                if (at + 1 + extra > stream.size()) {
+                    break;
+                }
+                size_t length = 0;
+                for (size_t k = 0; k < extra; k++) {
+                    length |= static_cast<size_t>(stream[at + 1 + k]) << (8 * k);
+                }
+                size = 1 + extra + (length + 1);
+            }
+        } else if ((tag & 3u) == 1u) {
+            size = 2;
+        } else if ((tag & 3u) == 2u) {
+            size = 3;
+        } else {
+            size = 5;
+        }
+        if (size == 0 || at + size > stream.size()) {
+            break;
+        }
+        out.push_back(Element{at, size, tag});
+        at += size;
+    }
+    return out;
+}
+
+/* The declared uncompressed length as a 5-byte varint, which is the longest
+ * form the parser accepts and therefore the one a length mutation should use:
+ * it changes the number without changing where the elements start. */
+std::vector<unsigned char> SnappyWithDeclaredLength(
+    const std::vector<unsigned char>& stream, uint32_t declared) {
+    const size_t preamble = SnappyPreambleSize(stream);
+    std::vector<unsigned char> out;
+    uint32_t v = declared;
+    for (int i = 0; i < 4; i++) {
+        out.push_back(static_cast<unsigned char>((v & 0x7fu) | 0x80u));
+        v >>= 7;
+    }
+    out.push_back(static_cast<unsigned char>(v & 0x0fu));
+    out.insert(out.end(), stream.begin() + static_cast<long>(preamble),
+               stream.end());
+    return out;
+}
+
+}  // namespace
+
+std::vector<Fixture> MakeSnappyFixtures() {
+    std::vector<Fixture> out;
+    const auto add = [&out](std::string name, uint64_t seed,
+                            std::vector<unsigned char> original) {
+        Fixture f;
+        f.name = std::move(name);
+        f.seed = seed;
+        f.original = std::move(original);
+        f.compressed = SnappyCompressBlock(f.original);
+        out.push_back(std::move(f));
+    };
+    /* One long run: every copy element the compressor emits sits at the
+     * 64-byte cap, which is the shape the length field's upper end takes. */
+    add("zeros-65536", 0x41, std::vector<unsigned char>(65536, 0));
+    /* Incompressible, so the stream is literals only, including the long
+     * length classes that carry their own length bytes. */
+    add("random-65536", 0x51, RandomBytes(65536, 0x51));
+    /* Two blocks: the compressor splits at 65536 and starts a fresh element
+     * stream, so a stream carrying that seam is in the corpus. */
+    add("random-70000", 0x52, RandomBytes(70000, 0x52));
+    add("zeros-70000", 0x42, std::vector<unsigned char>(70000, 0));
+    /* Sizes across the literal-length class break at 60 and the small-size
+     * edges, where the preamble is one byte and an element may be the whole
+     * stream. */
+    static const size_t kEdgeSizes[] = {1,   2,   59,   60,   61,  62,
+                                        63,  64,  65,   127,  128, 255,
+                                        256, 257, 4095, 4096, 65535};
+    for (const size_t n : kEdgeSizes) {
+        add("text-" + std::to_string(n), 0x62 + n, TextLike(n, 0x62 + n));
+    }
+    return out;
+}
+
+std::vector<Mutant> MutateSnappyStream(const std::vector<unsigned char>& stream,
+                                       uint64_t seed) {
+    /* The format-agnostic ladder first: truncations at fixed fractions, 1..8
+     * bytes off either end, and seeded bit flips. */
+    std::vector<Mutant> out = MutateStream(stream, seed);
+    const size_t n = stream.size();
+    if (n == 0) {
+        return out;
+    }
+    const auto add = [&out](std::string description,
+                            std::vector<unsigned char> s) {
+        out.push_back(Mutant{std::move(description), std::move(s)});
+    };
+    const size_t preamble = SnappyPreambleSize(stream);
+
+    /* The preamble, which is its own branch: a length that terminates, one
+     * that does not, and one the parser must refuse for being too long. */
+    if (preamble > 0) {
+        std::vector<unsigned char> continued = stream;
+        continued[preamble - 1] |= 0x80u;
+        add("preamble-continuation-bit-set", std::move(continued));
+
+        size_t declared = 0;
+        for (size_t k = 0; k < preamble; k++) {
+            declared |= static_cast<size_t>(stream[k] & 0x7fu) << (7 * k);
+        }
+        add("preamble-declares-0", SnappyWithDeclaredLength(stream, 0));
+        add("preamble-declares-1", SnappyWithDeclaredLength(stream, 1));
+        add("preamble-declares-one-less",
+            SnappyWithDeclaredLength(
+                stream, static_cast<uint32_t>(declared > 0 ? declared - 1 : 0)));
+        add("preamble-declares-one-more",
+            SnappyWithDeclaredLength(stream,
+                                     static_cast<uint32_t>(declared + 1)));
+        /* The upper end of what a 32-bit length can say. This one is refused
+         * by the decode wrapper's own bound before snappy sees it, so what it
+         * exercises is that bound; SnappyOracleAccepts still routes it to the
+         * reference, which has no such limit. */
+        add("preamble-declares-max", SnappyWithDeclaredLength(stream,
+                                                              0xffffffffu));
+    }
+
+    /* One mutation per element branch, on the first elements and the last: the
+     * first are where a wrong bound shows immediately, the last is where a
+     * length that overruns the declared output has nothing after it to
+     * absorb the error. */
+    const std::vector<Element> elements = SnappyElements(stream);
+    std::vector<size_t> targets;
+    for (size_t i = 0; i < elements.size() && i < 3; i++) {
+        targets.push_back(i);
+    }
+    if (elements.size() > 3) {
+        targets.push_back(elements.size() - 1);
+    }
+    for (const size_t index : targets) {
+        const Element& e = elements[index];
+        const std::string at = "element-" + std::to_string(index);
+        /* Each of the four tag classes in turn, the length bits left alone:
+         * a literal read as a copy takes its offset from bytes that were
+         * payload, and a copy read as a literal consumes payload that was a
+         * neighbouring element. */
+        for (unsigned kind = 0; kind < 4; kind++) {
+            if ((e.tag & 3u) == kind) {
+                continue;
+            }
+            std::vector<unsigned char> retagged = stream;
+            retagged[e.offset] =
+                static_cast<unsigned char>((e.tag & ~3u) | kind);
+            add(at + "-tag-class-" + std::to_string(kind),
+                std::move(retagged));
+        }
+        /* The length field, one step in each direction: for a copy this is
+         * the length AppendFromSelf bounds against the output; for a short
+         * literal it is the payload the element claims. */
+        for (const int delta : {-1, 1}) {
+            const unsigned high = e.tag >> 2;
+            if (delta < 0 && high == 0u) {
+                continue;
+            }
+            if (delta > 0 && high == 63u) {
+                continue;
+            }
+            const unsigned moved = delta < 0 ? high - 1u : high + 1u;
+            std::vector<unsigned char> relength = stream;
+            relength[e.offset] =
+                static_cast<unsigned char>((moved << 2) | (e.tag & 3u));
+            add(at + "-length-bits-" + (delta < 0 ? "minus-1" : "plus-1"),
+                std::move(relength));
+        }
+        /* The offset a copy element carries, which snappy refuses at 0 and
+         * beyond what it has already produced (snappy.cc:2200-2212). Both
+         * bounds, written into whichever width this tag has. */
+        const unsigned kind = e.tag & 3u;
+        if (kind != 0u) {
+            const size_t offset_bytes = kind == 1u ? 1 : (kind == 2u ? 2 : 4);
+            for (const unsigned long long value : {0ull, 0xffffffffull}) {
+                std::vector<unsigned char> reoffset = stream;
+                for (size_t k = 0; k < offset_bytes; k++) {
+                    reoffset[e.offset + 1 + k] =
+                        static_cast<unsigned char>((value >> (8 * k)) & 0xffu);
+                }
+                if (kind == 1u) {
+                    /* The 1-byte form keeps three offset bits in the tag; a
+                     * zero offset needs those cleared too. */
+                    reoffset[e.offset] = static_cast<unsigned char>(
+                        (e.tag & 0x1fu) |
+                        (value == 0ull ? 0u : 0xe0u));
+                }
+                add(at + "-copy-offset-" + (value == 0ull ? "0" : "max"),
+                    std::move(reoffset));
+            }
+        }
+    }
+    /* A trailing byte, the mutation the reference refuses on its eof() half
+     * rather than on any output count (snappy.cc:1789). */
+    std::vector<unsigned char> trailing = stream;
+    trailing.push_back(0x00);
+    add("trailing-byte", std::move(trailing));
+    return out;
+}
+
 std::vector<unsigned char> SnappyCompressBlock(
     const std::vector<unsigned char>& original) {
     std::vector<unsigned char> compressed(

--- a/tests/fixtures.h
+++ b/tests/fixtures.h
@@ -15,7 +15,10 @@ struct Fixture {
     std::string name;
     uint64_t seed;
     std::vector<unsigned char> original;
-    std::vector<unsigned char> compressed; /* LZ4 block format */
+    /* The compressed form, in whichever format the generator that produced
+     * this fixture names: LZ4 block for MakeLz4BlockFixtures, Snappy block
+     * for MakeSnappyFixtures. */
+    std::vector<unsigned char> compressed;
 };
 
 /* Corpus chosen against the future kernel geometry: max-compressible,
@@ -68,5 +71,31 @@ bool SnappyOracleAccepts(const std::vector<unsigned char>& stream);
  * Lz4CompressBlock does. */
 std::vector<unsigned char> SnappyCompressBlock(
     const std::vector<unsigned char>& original);
+
+/* The Snappy corpus, compressed by the pinned oracle so every pair is real by
+ * construction. Sizes are chosen against the format's own boundaries - the
+ * literal-length class break at 60, the 64-byte copy cap, and the 65536-byte
+ * block the compressor splits its input into - rather than against any
+ * geometry of the decoder that will read them. Fixture::compressed carries
+ * Snappy block streams here, the format the generator names. */
+std::vector<Fixture> MakeSnappyFixtures();
+
+/* Mutations placed on the branch set read out of snappy 1.2.2's decoder: the
+ * varint preamble, the literal-length classes, all three copy tags, and the
+ * offset and length bounds that AppendFromSelf refuses on. The generic
+ * truncation and bit-flip ladder from MutateStream is included, so this is a
+ * superset of the format-agnostic mutations.
+ *
+ * The placement walks the stream's elements the way snappy does, and that walk
+ * is the harness's, not the decoder's: it decides only WHERE a mutation lands.
+ * The verdict on every mutant still comes from the oracle, so a wrong step in
+ * the walk can only make a mutation less targeted - never turn a rejected
+ * stream into an accepted one or the other way round.
+ *
+ * As with MutateStream, a mutant is NOT necessarily invalid: a non-minimal
+ * preamble is a mutation the reference accepts by design. Consumers ask the
+ * oracle. */
+std::vector<Mutant> MutateSnappyStream(const std::vector<unsigned char>& stream,
+                                       uint64_t seed);
 
 #endif /* CUDEC_TESTS_FIXTURES_H */

--- a/tests/snappy_corpus.cpp
+++ b/tests/snappy_corpus.cpp
@@ -1,0 +1,145 @@
+/* The Snappy corpus proving itself before any Snappy decoder exists, the
+ * counterpart of oracle_lz4.cpp: the fixture pairs are real (the oracle
+ * round-trips every one), the mutation machinery is deterministic (two
+ * generation passes agree on the mutants and on their verdicts), and the
+ * mutations bite (at least one rejected mutant per fixture - "all rejected"
+ * would be false, since a non-minimal preamble is a mutation the reference
+ * accepts by design).
+ *
+ * The oracle is the sole authority on validity here: docs/MASTERPLAN.md, "the
+ * oracles decide". */
+#include "fixtures.h"
+#include "require.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+/* Corpus drift tripwire, the same instrument oracle_lz4.cpp carries and for
+ * the same reason: a snappy bump that moves RawCompress's output moves every
+ * mutant and every verdict with it, and the bump PR should have to update this
+ * number on purpose instead of watching a changed corpus pass. FNV-1a, not
+ * crypto: a tripwire against drift, not a defense. */
+constexpr uint64_t kExpectedSnappyCorpusDigest = 0x79af9459a11bfd4cull;
+
+uint64_t Fnv1a64(uint64_t hash, const void* data, size_t size) {
+    const unsigned char* bytes = static_cast<const unsigned char*>(data);
+    for (size_t i = 0; i < size; i++) {
+        hash ^= bytes[i];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+}  // namespace
+
+int main() {
+    const auto fixtures = MakeSnappyFixtures();
+    REQUIRE(!fixtures.empty());
+
+    uint64_t digest = 14695981039346656037ull;
+    for (const auto& f : fixtures) {
+        digest = Fnv1a64(digest, f.name.data(), f.name.size());
+        digest = Fnv1a64(digest, f.compressed.data(), f.compressed.size());
+    }
+    REQUIRE_CTX(digest == kExpectedSnappyCorpusDigest,
+                "corpus digest is 0x%016llx - an oracle or generator change "
+                "moved the fixtures; verify deliberately, then update the pin",
+                static_cast<unsigned long long>(digest));
+
+    size_t mutant_total = 0;
+    size_t rejected_total = 0;
+    for (const auto& f : fixtures) {
+        std::vector<unsigned char> decoded;
+        REQUIRE_CTX(SnappyOracleDecodes(f.compressed, &decoded), "fixture %s",
+                    f.name.c_str());
+        REQUIRE_CTX(decoded.size() == f.original.size(), "fixture %s",
+                    f.name.c_str());
+        REQUIRE_CTX(
+            equal_bytes(decoded.data(), f.original.data(), decoded.size()),
+            "fixture %s", f.name.c_str());
+        /* The two verdict routes must agree on a stream the compressor made:
+         * a validator that quietly disagreed with the decoder would make every
+         * reject-parity claim built on it ambiguous. */
+        REQUIRE_CTX(SnappyOracleAccepts(f.compressed), "fixture %s",
+                    f.name.c_str());
+
+        const auto mutants = MutateSnappyStream(f.compressed, f.seed);
+        const auto mutants_again = MutateSnappyStream(f.compressed, f.seed);
+        REQUIRE_CTX(!mutants.empty(), "fixture %s", f.name.c_str());
+        /* The branch-derived half has to be there, per fixture. Without this
+         * the suite would pass on the generic truncation ladder alone if the
+         * element walk ever stopped finding elements - the corpus would still
+         * look large, deterministic and biting while having stopped targeting
+         * the reference's branches at all. */
+        size_t preamble_mutants = 0;
+        size_t element_mutants = 0;
+        for (const auto& m : mutants) {
+            if (m.description.compare(0, 9, "preamble-") == 0) {
+                preamble_mutants++;
+            }
+            if (m.description.compare(0, 8, "element-") == 0) {
+                element_mutants++;
+            }
+        }
+        REQUIRE_CTX(preamble_mutants >= 6,
+                    "fixture %s carries %zu preamble mutants", f.name.c_str(),
+                    preamble_mutants);
+        /* Four is what one element yields at the floor: the three tag classes
+         * it is not, plus one reachable step of its length field. The
+         * one-byte fixture is exactly that case. */
+        REQUIRE_CTX(element_mutants >= 4,
+                    "fixture %s carries %zu element mutants - the element walk "
+                    "found nothing to target",
+                    f.name.c_str(), element_mutants);
+        REQUIRE_CTX(mutants.size() == mutants_again.size(), "fixture %s",
+                    f.name.c_str());
+        size_t rejected = 0;
+        for (size_t i = 0; i < mutants.size(); i++) {
+            REQUIRE_CTX(mutants[i].stream == mutants_again[i].stream,
+                        "generation determinism: fixture %s mutant %zu (%s)",
+                        f.name.c_str(), i, mutants[i].description.c_str());
+            REQUIRE_CTX(mutants[i].description == mutants_again[i].description,
+                        "generation determinism: fixture %s mutant %zu",
+                        f.name.c_str(), i);
+            std::vector<unsigned char> first_out;
+            std::vector<unsigned char> second_out;
+            const bool first =
+                SnappyOracleDecodes(mutants[i].stream, &first_out);
+            const bool second =
+                SnappyOracleDecodes(mutants[i].stream, &second_out);
+            REQUIRE_CTX(first == second,
+                        "verdict determinism: fixture %s mutant %zu (%s)",
+                        f.name.c_str(), i, mutants[i].description.c_str());
+            if (first) {
+                REQUIRE_CTX(first_out == second_out,
+                            "output determinism: fixture %s mutant %zu (%s)",
+                            f.name.c_str(), i,
+                            mutants[i].description.c_str());
+            } else {
+                REQUIRE_CTX(first_out.empty(),
+                            "a rejected mutant produced output: fixture %s "
+                            "mutant %zu (%s)",
+                            f.name.c_str(), i,
+                            mutants[i].description.c_str());
+                rejected++;
+            }
+        }
+        REQUIRE_CTX(rejected > 0,
+                    "no mutant rejected for fixture %s - mutations do not bite",
+                    f.name.c_str());
+        mutant_total += mutants.size();
+        rejected_total += rejected;
+    }
+    /* Both directions across the whole corpus, so the suite cannot pass with a
+     * generator that only ever produces streams the reference refuses - which
+     * would make every accept-side claim built on this corpus vacuous. */
+    REQUIRE(rejected_total > 0);
+    REQUIRE(rejected_total < mutant_total);
+
+    std::printf("PASS: %zu snappy fixtures round-trip; %zu mutants, %zu "
+                "rejected, machinery deterministic and biting\n",
+                fixtures.size(), mutant_total, rejected_total);
+    return 0;
+}


### PR DESCRIPTION
# What & why

The Snappy half of the corpus machinery: fixtures made by the pinned
compressor, and a mutation set derived from the reference's decode branches
rather than from any decoder of ours.

Closes #157.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)

## The corpus

21 fixtures, sized against the format's own boundaries rather than against a
kernel geometry: the literal-length class break at 60 (59 through 65), the
small-size edges where an element is the whole stream, and 65536, where the
compressor starts a new block - two fixtures carry that seam at 70000 bytes.
One all-zero fixture so every copy element sits at the 64-byte cap, one
incompressible so the stream is literals only, including the classes that carry
their own length bytes.

## The mutations, and where they come from

Per stream: the varint preamble as its own class (continuation bit set,
declared length 0, 1, one less, one more, and the 32-bit maximum), then per
targeted element the three tag classes it is not, its length field stepped in
both directions, and for copies the offset bounds `AppendFromSelf` refuses at
(`snappy.cc:2200-2212`). Targets are the first three elements and the last. The
generic ladder from `MutateStream` - truncations at fixed fractions, 1..8 bytes
off either end, seeded bit flips - is included, so this is a superset of the
format-agnostic mutations, and a trailing byte is added because the reference
refuses that on its `eof()` half rather than on any output count
(`snappy.cc:1789`).

Placing a mutation on a tag means knowing where tags are, so the generator
walks the elements the way snappy does. That walk is the harness's and decides
only WHERE a mutation lands - every verdict still comes from the oracle, so a
wrong step in it can make a mutation less targeted and cannot turn a rejected
stream into an accepted one. This is stated in `fixtures.h` beside the
declaration, not only here.

## What the self-proof asserts

```
$ ./build-cuda/tests/snappy_corpus
PASS: 21 snappy fixtures round-trip; 1069 mutants, 941 rejected, machinery deterministic and biting
```

941 of 1069 rejected, and the test requires both of those numbers to be
non-zero: a generator that only produced streams the reference refuses would
make every accept-side claim built on this corpus vacuous, and one that
produced only acceptable streams would prove nothing about rejection. Per
fixture: every pair round-trips byte-exact, both verdict routes agree on the
compressor-made stream, two generation passes agree on the mutants and on their
verdicts, a rejected mutant produces no output, and at least one mutant is
rejected.

It also asserts that the branch-derived mutations are present per fixture, at
least six preamble ones and at least four element ones. Without that, the
generic truncation ladder alone would keep the corpus large, deterministic and
biting after an element walk that had quietly stopped finding elements. That
assertion is not decoration - it fired during development on the one-byte
fixture, whose single literal element yields exactly four, which is what set the
floor.

## The digest pin bites

The pinned FNV-1a digest was wrong on the first run on purpose, and the failure
is what produced the number now in the tree:

```
FAIL /w/tests/snappy_corpus.cpp:46: digest == kExpectedSnappyCorpusDigest | corpus digest is 0x79af9459a11bfd4c - an oracle or generator change moved the fixtures; verify deliberately, then update the pin
RUN=1
```

Two consecutive runs of the pinned binary agree, which is the determinism claim
executed rather than argued:

```
RUN1=0
RUN2=0
```

## Verification

Container gate on this branch, `nvidia/cuda:12.6.2-devel-ubuntu24.04`, cmake
3.28.3, nvcc 12.6.77, RTX 3080:

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON   CFG=0
cmake --build build-cuda -j                  BUILD=0
ctest --test-dir build-cuda --output-on-failure
  CTEST=0
  5/18 Test  #5: snappy_corpus .......   Passed    0.87 sec
  100% tests passed, 0 tests failed out of 18
ctest --test-dir build-cuda -LE gpu --no-tests=error
  HOSTONLY=0, 12 tests passed
```

- [x] `cmake --build build-cuda` - builds clean.
- [x] `ctest --test-dir build-cuda` - green, 18/18; 12/12 with `-LE gpu`.
- [x] Prettier - `All matched files use Prettier code style!`
- [x] Docs synced - no behaviour of this project changes.

## Engineering checklist

- [x] Fail-closed preserved - nothing of cudec's decodes here. What the change
      records is which streams the reference refuses, and it refuses to treat
      output from a rejected mutant as real.
- [x] Oracle coverage - every fixture and every mutant verdict comes from the
      pinned oracle.
- [x] Determinism preserved - seeded generator, pinned digest, two passes
      compared inside the test, two binary runs compared above.
- [ ] CUDA API errors / C ABI - not applicable.
- [ ] An adversarial review was NOT run. There is no second reader on this
      board tonight, so this body carries the evidence in place of one. That is
      weaker than a review and is not being presented as one.
- [ ] Review record - none, for the reason above.

## Notes

`Fixture::compressed` now says the format is whichever the generator names,
instead of saying LZ4 block. Same field, two generators.

The `preamble-declares-max` mutant is refused by the decode wrapper's own
256 MiB bound before snappy sees it, so on that one route it exercises the
bound rather than the reference; `SnappyOracleAccepts` still puts it to
snappy, which has no such limit. The bound and that consequence were written
into `fixtures.h` when it landed in #153.

Out of scope, each with its own issue: the crafted negatives and the device
gate set (#154, #172), the vendored `baddata` fixtures (#156), and the parser
core the corpus will be run against (#171).
