### PR TITLE
Refuse a bare wave-width literal in the sources

### DIFF
--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -216,7 +216,11 @@ cudec_status DecodeFrame(const unsigned char* f, size_t frame_size,
     if (bmax < 4 || bmax > 7) {
         return CUDEC_ERR_CORRUPT_INPUT;
     }
-    const size_t block_max = (size_t{64} << 10) << ((bmax - 4) * 2);
+    /* The frame format's smallest block-max, 64 KiB, doubled twice per BD
+     * step. Named for the reason issue #211 gives: digits in an expression
+     * cannot be told from a lane count by anything that reads this tree. */
+    constexpr size_t kBlockMaxKiB = 64;
+    const size_t block_max = (kBlockMaxKiB << 10) << ((bmax - 4) * 2);
     if (!block_independent || dict_id) {
         return CUDEC_ERR_UNSUPPORTED; /* linked blocks / dictionaries */
     }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -38,8 +38,14 @@ namespace cudec_stream_detail {
 constexpr size_t kWaveChunks = 64; /* chunks per wave: amortizes launch cost */
 
 /* The batch entry's own launch limit; a stream batch cannot exceed it either.
- * Kept in sync with validate_batch_args in lz4_decode.cuh. */
-constexpr size_t kMaxChunks = static_cast<size_t>(INT32_MAX) * 32;
+ * Kept in sync with validate_batch_args in lz4_decode.cuh, which writes the
+ * same product as INT32_MAX * kWarpSize. This host translation unit does not
+ * see that header, so the lane count is named here rather than left as digits:
+ * a wave64 device makes this bound wrong, and a bare 32 is exactly what
+ * nothing would have flagged (issue #211). Single-sourcing the two is the
+ * width port's job (#241, #242). */
+constexpr size_t kWarpLanes = 32;
+constexpr size_t kMaxChunks = static_cast<size_t>(INT32_MAX) * kWarpLanes;
 
 /* Metadata layout inside p_meta/d_meta for a wave of up to kWaveChunks chunks:
  * [src_ptrs][src_sizes][dst_ptrs][dst_caps], each kWaveChunks wide, 8-byte

--- a/src/xxhash32.h
+++ b/src/xxhash32.h
@@ -19,7 +19,11 @@ inline uint32_t xxh_read32(const unsigned char* p) {
 }
 
 inline uint32_t xxh_rotl(uint32_t x, int r) {
-    return (x << r) | (x >> (32 - r));
+    /* The accumulator's width, named because every bare 32 in this tree has
+     * to be (issue #211): a rotation width and a wave width look identical to
+     * a text scan, and only one of them is safe to leave as digits. */
+    constexpr int kAccumulatorBits = 32;
+    return (x << r) | (x >> (kAccumulatorBits - r));
 }
 
 inline uint32_t xxh_round(uint32_t acc, uint32_t input) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -430,13 +430,30 @@ endforeach()
 #    so a wrapped call would hide its mask from every rule here;
 #  - determinism: no floating-point type and no floating-point atomic, which
 #    is what makes the gpu_to_gpu level in docs/DETERMINISM.md hold by
-#    construction rather than by measurement.
+#    construction rather than by measurement;
+#  - wave width: no bare 32 or 64 outside the one line that binds it to a
+#    name. The maintainer's hardware is NVIDIA, so a hardcoded 32 left in a
+#    lane-stride expression is invisible to every test that can be run here
+#    and wrong on every wave64 device (issue #211). A width must arrive as the
+#    `WaveSize` template parameter or as a constant named after it, and the
+#    only place the digits themselves may appear is a `constexpr` definition
+#    or a `#define` whose entire initializer they are. The rule already caught
+#    one: the host copy of the batch limit in src/stream.cpp multiplied
+#    INT32_MAX by a bare 32 while its device twin used kWarpSize.
 #
 # Limits, stated as the neighbouring checks state theirs: constructs hidden
 # inside string literals are not stripped; a mask computed into a variable on
 # an earlier line is judged by its name at the call site; a `fuel` mention on
 # the line above an unrelated loop satisfies the loop rule; and a loop or
 # intrinsic introduced under a fresh spelling is code review's job.
+#
+# The width rule cannot tell a lane width from any other 32 or 64, and it does
+# not try: every one of them must be named, whatever it counts, and the cost of
+# a wrong guess is one `constexpr` line rather than a wrong answer on hardware
+# nobody here owns. What it does NOT catch is a width written any other way -
+# `31 + 1`, `0x20`, `1 << 5`, a `sizeof` that happens to be 32, or a name that
+# lies about what it holds. It is a drift detector under the spelling somebody
+# will actually type, like every rule above it.
 #
 # Backslash continuations split the rules in two, and the split is where each
 # rule's reason points (issue #251). The collective, legacy-intrinsic and
@@ -802,6 +819,30 @@ function(cudec_scan_source path check_loops out_violations)
              "  ${path}:${_lineno}: floating-point atomic - its result "
              "depends on the order the device happens to schedule\n")
     endif()
+
+    # The wave width. The digits may appear on exactly one kind of line: the
+    # one that binds them to a name, as the whole initializer, where a reader
+    # looking for what the width is finds it. The dot in the exclusions keeps
+    # 1.32 and .64 out, and every identifier character keeps uint32_t,
+    # INT32_MAX and 0x64 out.
+    set(_width_bound FALSE)
+    if(_code MATCHES "constexpr[^=]*=[ \t]*(32|64)[uUlL]*[ \t]*;")
+      set(_width_bound TRUE)
+    elseif(_code MATCHES
+           "#[ \t]*define[ \t]+[A-Za-z_][A-Za-z_0-9]*[ \t]+(32|64)[uUlL]*[ \t]*$")
+      set(_width_bound TRUE)
+    endif()
+    if(NOT _width_bound AND _code MATCHES
+       "[^A-Za-z_0-9.](32|64)[uUlL]*[^A-Za-z_0-9.]")
+      string(REGEX MATCH "[^A-Za-z_0-9.](32|64)[uUlL]*[^A-Za-z_0-9.]" _unused
+                   "${_code}")
+      string(APPEND _violations
+             "  ${path}:${_lineno}: bare wave-width literal "
+             "'${CMAKE_MATCH_1}' - the width comes from the WaveSize "
+             "parameter or from a constant named after it, never from digits "
+             "in an expression; a hardcoded 32 is invisible on every device "
+             "this project can test on\n")
+    endif()
   endforeach()
   # A file whose last line ends in a backslash leaves an element the loop rule
   # never got to judge, so the construct inside it went unread. Reject rather
@@ -1072,6 +1113,45 @@ file(WRITE ${_probe_dir}/scan_macro_for_opaque.cu
 # the unbalanced `for` header above.
 file(WRITE ${_probe_dir}/scan_continuation_at_eof.cu
      "void probe() {\n" "    g(1);\n" "}\n" "#define PROBE_TAIL(x) \\\n")
+# The wave-width rule (issue #211). One violating spelling per literal, so the
+# report's own text is what the probe asserts and the alternation cannot go
+# half-dead, plus the two silent shapes the rule exists to permit: the width
+# arriving as the template parameter, and the one line that binds the digits to
+# a name - which is the shape src/lz4_decode.cuh has carried since M1.
+file(WRITE ${_probe_dir}/scan_width_literal_32.cu
+     "template <int WaveSize>
+"
+     "__device__ unsigned probe(unsigned tid) {
+"
+     "    return tid % 32;
+" "}
+")
+file(WRITE ${_probe_dir}/scan_width_literal_64.cu
+     "template <int WaveSize>
+"
+     "__device__ unsigned probe(unsigned tid) {
+"
+     "    return tid / 64;
+" "}
+")
+file(WRITE ${_probe_dir}/scan_width_from_parameter.cu
+     "template <int WaveSize>
+"
+     "__device__ unsigned probe(unsigned tid) {
+"
+     "    constexpr unsigned kLanes = WaveSize;
+"
+     "    return tid % kLanes;
+" "}
+")
+file(WRITE ${_probe_dir}/scan_width_named_constant.cu
+     "constexpr unsigned kWaveLanes = 32;
+"
+     "__device__ unsigned probe(unsigned tid) {
+"
+     "    return tid % kWaveLanes;
+" "}
+")
 # The byte the reader borrows for its own bookkeeping, in the file it is
 # reading. It has to come back refused, or the borrowing is a way to write a
 # separator or a backslash the split will not see as one.
@@ -1122,6 +1202,10 @@ set(_scanner_probes
     "scan_macro_for_opaque|scan_macro_for_opaque.cu:1: a 'for' header without a visible"
     "scan_continuation_at_eof|scan_continuation_at_eof.cu:4: a backslash continuation left open at end of file"
     "scan_control_byte|a control byte (0x01 or 0x02) in a source read as text"
+    "scan_width_literal_32|scan_width_literal_32.cu:3: bare wave-width literal '32'"
+    "scan_width_literal_64|scan_width_literal_64.cu:3: bare wave-width literal '64'"
+    "scan_width_from_parameter|"
+    "scan_width_named_constant|"
 )
 foreach(_entry IN LISTS _scanner_probes)
   string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")


### PR DESCRIPTION
# What & why

Nothing in the tree refused a hardcoded warp width. On NVIDIA hardware a bare
32 in a lane-stride expression is correct and invisible; on a wave64 device it
is wrong, and no test that can be run here would say so. The structural scan
now refuses one.

Closes #211.

## Type of change

- [x] Build / CI / supply chain
- [x] Bug fix

## The rule

The digits 32 and 64 may appear on exactly one kind of line: the one that binds
them to a name as its whole initializer, a `constexpr` definition or a
`#define`. Everywhere else they are a violation. So a width arrives as the
`WaveSize` parameter or as a constant named after it, and a reader looking for
what a width is finds it in one place.

Identifier and decimal characters on both sides of the match keep `uint32_t`,
`INT32_MAX`, `0x64` and `1.32` out. Configure-time and vendor-independent, so it
runs in the existing `build` job with no ROCm anywhere near it.

What it does not catch is written into the function's Limits paragraph rather
than left to be discovered: a width spelled `31 + 1`, `0x20`, `1 << 5`, or a
name that lies about what it holds. It is a drift detector under the spelling
somebody will actually type, like every rule beside it.

## The tree was not green

The issue expected the rule to be green as the tree stood. It was not, and one
of the three sites is the defect the check exists for.

`src/stream.cpp` computed the host copy of the batch limit as
`static_cast<size_t>(INT32_MAX) * 32`, while its device twin in
`src/lz4_decode.cuh:168` writes the same product as `INT32_MAX * kWarpSize`. The
comment above the host copy says it is kept in sync with that function. On a
wave64 device the device side would follow the width and the host side would
not, and the two bounds would disagree with only the host one wrong. It is named
here (`kWarpLanes`); single-sourcing the pair is the width port's job (#241,
#242) and is not attempted in this change.

The other two are not lane counts and are named anyway, because nothing that
reads this tree can tell one 32 from another: the accumulator width in
`src/xxhash32.h`'s rotation, and the LZ4 frame format's 64 KiB block-max base in
`src/frame.cpp`. Each carries its reason on the line.

`src/lz4_decode.cuh:17`'s `constexpr unsigned kWarpSize = 32;` is untouched -
it is the binding line the rule permits, which is what the fourth probe pins.

## Each guard proven by breaking it

Same container, one change at a time on a copy of the tree.

The rule catches the real site. Putting the host bound back to a bare 32:

```
48:constexpr size_t kMaxChunks = static_cast<size_t>(INT32_MAX) * 32;
A_EXIT=1
  structural rules violated (issue #72):
    /tree/tests/../src/stream.cpp:48: bare wave-width literal '32' - the width comes from
    the WaveSize parameter or from a constant named after it, never from digits in an
    expression; a hardcoded 32 is invisible on every device this project can test on
```

The probes catch a dead rule. With the violation test turned off:

```
B_EXIT=1
  the structural scanner is dead for one rule: probe 'scan_width_literal_32'
  did not report "scan_width_literal_32.cu:3: bare wave-width literal '32'"
```

And the calibration holds in the other direction. With the name-binding
allowance removed, the rule becomes merely stricter and the silent probe says
so:

```
C_EXIT=1
  the structural scanner rejects a compliant probe: 'scan_width_named_constant'
  must come back silent (issue #72). It reported:
    .../scan_width_named_constant.cu:1: bare wave-width literal '32' - ...
```

## Verification

Rebased onto `main` at 8b602b6 and re-run. Container gate,
`nvidia/cuda:12.6.2-devel-ubuntu24.04`, cmake 3.28.3, nvcc 12.6.77, RTX 3080:

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON   CFG=0
cmake --build build-cuda -j                  BUILD=0
ctest --test-dir build-cuda --output-on-failure
  CTEST=0
  100% tests passed, 0 tests failed out of 18
ctest --test-dir build-cuda -LE gpu --no-tests=error   HOSTONLY=0
```

`CFG=0` is the statement that all 33 scanner probes pass and that `src/` is
clean under the new rule; both are configure-time `FATAL_ERROR`s.

- [x] `cmake --build build-cuda` - builds clean.
- [x] `ctest --test-dir build-cuda` - green, 18/18, GPU tests included.
- [x] Prettier - no `.md`/`.yml`/`.yaml` file is touched.
- [x] Docs synced - the rule and its limits are written in the function's own
      Rules and Limits paragraphs, where the neighbouring rules keep theirs.

## Engineering checklist

- [x] Fail-closed preserved. The change is a refusal, and the three source
      edits are name bindings with identical values - `kAccumulatorBits`,
      `kBlockMaxKiB` and `kWarpLanes` each equal the literal they replace, so no
      bound moves. The full suite, including the GPU frame and stream twins,
      covers that.
- [ ] Oracle coverage - not applicable, no format path changes.
- [x] Determinism preserved - no decode behaviour changes; same values.
- [x] Every CUDA API call's error is checked - unchanged, no call sites touched.
- [ ] An adversarial review was NOT run, and this change edits three files on
      the sensitive surface. There is no second reader on this board tonight, so
      this body carries the evidence in place of one: the three deliberate
      breakages above, and the fact that the three source edits are
      value-identical name bindings, with the full GPU suite green over them.
      That is weaker than a review and is not being presented as one.
- [ ] Review record - none, for the reason above. No lens ran, so there are no
      CONFIRMED or PLAUSIBLE counts to report.

## Notes

The `stream.cpp` finding is worth reading on its own: it is a latent wave64 bug
that this rule surfaced on the day it landed, in host code, in a bound whose
comment already said it had to track the device side.
