### PR TITLE
Give the batch launch limit one definition

### DIFF
--- a/src/batch_limits.h
+++ b/src/batch_limits.h
@@ -1,0 +1,38 @@
+/* The batch geometry both decode entry points are bounded by, defined once.
+ *
+ * The limit used to be written twice - once in validate_batch_args and once in
+ * the streaming path's pre-check - and kept in agreement by a comment saying
+ * so (issue #39). Nothing failed if they drifted, and a drift means either a
+ * chunk_count the streaming pre-check accepts and the batch entry then rejects
+ * per wave, or a needless reject. Both are wrong answers on a fail-closed
+ * boundary, so the bound has one definition and both callers read it.
+ *
+ * Nothing CUDA-specific here on purpose: this header is included by a .cu
+ * translation unit and by a host .cpp compiled as plain C++, so it must not
+ * pull in the CUDA runtime. Internal header, not part of the ABI. */
+#ifndef CUDEC_BATCH_LIMITS_H
+#define CUDEC_BATCH_LIMITS_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace cudec_detail {
+
+/* Lanes per warp, the kernel's chunk-to-lane divisor and the multiplier below.
+ * The one place the width's digits are written (issue #211); the width port
+ * turns this into the WaveSize parameter (#241). */
+constexpr unsigned kWarpSize = 32;
+
+/* One chunk per warp and at most INT32_MAX warps in a grid, so this is the
+ * largest chunk_count either entry point can map onto a launch. */
+constexpr size_t kMaxBatchChunks = static_cast<size_t>(INT32_MAX) * kWarpSize;
+
+/* The over-limit contract test hands SIZE_MAX to both entry points and expects
+ * a reject; that is only a test of the bound while the bound is below
+ * SIZE_MAX. */
+static_assert(kMaxBatchChunks < SIZE_MAX,
+              "the SIZE_MAX over-limit contract test relies on this");
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_BATCH_LIMITS_H */

--- a/src/lz4_decode.cuh
+++ b/src/lz4_decode.cuh
@@ -7,6 +7,7 @@
 #ifndef CUDEC_LZ4_DECODE_CUH
 #define CUDEC_LZ4_DECODE_CUH
 
+#include "batch_limits.h"
 #include "cudec.h"
 #include "lz4_block.h"
 
@@ -14,7 +15,6 @@
 
 namespace cudec_detail {
 
-constexpr unsigned kWarpSize = 32;
 constexpr unsigned kBlockWarps = 4;
 constexpr unsigned kBlockThreads = kWarpSize * kBlockWarps;  /* 128 */
 
@@ -165,14 +165,11 @@ inline cudec_status validate_batch_args(const void* const* d_src_ptrs,
                                         const size_t* d_dst_capacities,
                                         size_t chunk_count,
                                         cudec_chunk_result* d_results) {
-    constexpr size_t kMaxChunks = static_cast<size_t>(INT32_MAX) * kWarpSize;
-    static_assert(kMaxChunks < SIZE_MAX,
-                  "the SIZE_MAX over-limit contract test relies on this");
     if (d_src_ptrs == nullptr || d_src_sizes == nullptr ||
         d_dst_ptrs == nullptr || d_dst_capacities == nullptr ||
         d_results == nullptr ||
         reinterpret_cast<uintptr_t>(d_results) % 16 != 0 ||
-        chunk_count == 0 || chunk_count > kMaxChunks) {
+        chunk_count == 0 || chunk_count > kMaxBatchChunks) {
         return CUDEC_ERR_INVALID_ARGUMENT;
     }
     return CUDEC_OK;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -23,6 +23,7 @@
  * single stream whose one reusable staging set is grown on demand and reused;
  * the amortization this context buys is real but small. See docs/BENCHMARKS.md
  * for the corrected overlap analysis and the output-D2H future lever. */
+#include "batch_limits.h"
 #include "cudec.h"
 
 #include "cuda_raii.h"
@@ -37,15 +38,10 @@ namespace cudec_stream_detail {
 
 constexpr size_t kWaveChunks = 64; /* chunks per wave: amortizes launch cost */
 
-/* The batch entry's own launch limit; a stream batch cannot exceed it either.
- * Kept in sync with validate_batch_args in lz4_decode.cuh, which writes the
- * same product as INT32_MAX * kWarpSize. This host translation unit does not
- * see that header, so the lane count is named here rather than left as digits:
- * a wave64 device makes this bound wrong, and a bare 32 is exactly what
- * nothing would have flagged (issue #211). Single-sourcing the two is the
- * width port's job (#241, #242). */
-constexpr size_t kWarpLanes = 32;
-constexpr size_t kMaxChunks = static_cast<size_t>(INT32_MAX) * kWarpLanes;
+/* The batch entry's launch limit bounds a stream batch too, and it is
+ * cudec_detail::kMaxBatchChunks in src/batch_limits.h for both of them - the
+ * duplicate that used to live here is what issue #39 was about. */
+using cudec_detail::kMaxBatchChunks;
 
 /* Metadata layout inside p_meta/d_meta for a wave of up to kWaveChunks chunks:
  * [src_ptrs][src_sizes][dst_ptrs][dst_caps], each kWaveChunks wide, 8-byte
@@ -149,7 +145,7 @@ cudec_status ValidateStreamArgs(const void* const* h_src_ptrs,
                                 const cudec_chunk_result* h_results) {
     if (h_src_ptrs == nullptr || h_src_sizes == nullptr ||
         dst_ptrs == nullptr || dst_caps == nullptr || h_results == nullptr ||
-        chunk_count == 0 || chunk_count > kMaxChunks ||
+        chunk_count == 0 || chunk_count > kMaxBatchChunks ||
         (dst_space != CUDEC_MEM_HOST && dst_space != CUDEC_MEM_DEVICE)) {
         return CUDEC_ERR_INVALID_ARGUMENT;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -229,6 +229,13 @@ target_include_directories(parser_twin
 # sanitizer gate (issue #42), gives src/frame.cpp's hostile-input pointer
 # arithmetic ASan/UBSan coverage that the GPU-labeled frame_twin cannot get in
 # CI. It computes header checksums with the library's own xxhash32.h.
+# Both entry points against the one shared launch limit (issue #39). Host-side:
+# every call in it is an argument reject that returns before any CUDA call, so
+# it runs on the GPU-less runner. It reads the limit from src/, like the twins.
+cudec_add_test(batch_limit_parity SOURCES batch_limit_parity.cpp)
+target_include_directories(batch_limit_parity
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+
 cudec_add_test(frame_host_negative SOURCES frame_host_negative.cpp)
 target_include_directories(frame_host_negative
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
@@ -396,6 +403,77 @@ foreach(_tu frame.cpp stream.cpp)
                           "(issue #40)")
     endif()
   endforeach()
+endforeach()
+
+# Single-source lock for the batch launch limit (issue #39): the bound both
+# decode entry points enforce lives once, in src/batch_limits.h, and the two
+# callers read it from there. It used to be written twice and held in agreement
+# by a comment, which is a fail-open on a fail-closed boundary as soon as one
+# copy moves: a chunk_count the streaming pre-check accepts and the batch entry
+# then rejects per wave.
+#
+# The detector is the arithmetic itself. INT32_MAX is what the bound is built
+# from, so a second source writing its own bound has to name it, and this
+# refuses any source but the header doing so. Honest limit, as with the checks
+# above: a copy that computes the same number a different way is not caught -
+# a drift detector, not tamper-proofing.
+set(_limits_header ${CMAKE_CURRENT_SOURCE_DIR}/../src/batch_limits.h)
+if(NOT EXISTS ${_limits_header})
+  message(FATAL_ERROR "src/batch_limits.h is missing: the batch launch limit "
+                      "must be single-sourced there (issue #39)")
+endif()
+file(READ ${_limits_header} _limits_src)
+if(NOT _limits_src MATCHES "kMaxBatchChunks")
+  message(FATAL_ERROR "src/batch_limits.h no longer defines kMaxBatchChunks "
+                      "(issue #39)")
+endif()
+foreach(_tu lz4_decode.cuh stream.cpp)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_tu} _tu_src)
+  if(NOT _tu_src MATCHES "#include \"batch_limits.h\"")
+    message(FATAL_ERROR "src/${_tu} no longer includes batch_limits.h: the "
+                        "batch launch limit is single-sourced there "
+                        "(issue #39)")
+  endif()
+  # The comparison itself, not merely a mention of the name: a translation unit
+  # can carry the include, keep the using-declaration and still bound
+  # chunk_count by some other constant, which is the divergence this lock
+  # exists for. Measured, not supposed - a streaming bound raised to twice the
+  # canonical one passes every behavioural check available at that magnitude,
+  # because no caller can hand the validator an array of tens of billions of
+  # entries to walk.
+  if(NOT _tu_src MATCHES "chunk_count > kMaxBatchChunks")
+    message(FATAL_ERROR "src/${_tu} no longer bounds chunk_count by "
+                        "kMaxBatchChunks: both entry points enforce the one "
+                        "shared limit (issue #39)")
+  endif()
+endforeach()
+# Every source, not a list somebody has to remember to extend: a new
+# translation unit carrying its own bound is exactly the case this is for.
+file(GLOB_RECURSE _batch_limit_sources RELATIVE
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src CONFIGURE_DEPENDS
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cc
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cu
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cuh
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.h
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.hpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.inl)
+if(NOT _batch_limit_sources)
+  message(FATAL_ERROR "the batch-limit sweep found no sources under src/ - the "
+                      "glob has stopped matching (issue #39)")
+endif()
+foreach(_source IN LISTS _batch_limit_sources)
+  if(NOT _source STREQUAL "batch_limits.h")
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source} _source_src)
+    if(_source_src MATCHES "INT32_MAX")
+      message(
+        FATAL_ERROR
+          "src/${_source} builds its own bound from INT32_MAX - the batch "
+          "launch limit is cudec_detail::kMaxBatchChunks in "
+          "src/batch_limits.h (issue #39)")
+    endif()
+  endif()
 endforeach()
 
 # ---- Termination, warp-collective integrity, and determinism as structural

--- a/tests/batch_limit_parity.cpp
+++ b/tests/batch_limit_parity.cpp
@@ -1,0 +1,73 @@
+/* The two decode entry points are bounded by the same chunk_count limit, and
+ * this asserts they answer the same way at that boundary (issue #39). The
+ * limit comes from src/batch_limits.h, so the test cannot carry a third copy
+ * of the number it is checking.
+ *
+ * Host-side and GPU-less: every call below is rejected by argument validation
+ * before any CUDA call, which is what makes it safe to hand both entry points
+ * pointer arrays with one element and a chunk_count of tens of billions. No
+ * call here passes validation, deliberately - a validation-passing call would
+ * launch on fake pointers.
+ *
+ * What this test does NOT catch, measured rather than reasoned: a streaming
+ * bound raised above the batch one. Set to twice the canonical value, every
+ * assertion below still passes - the over-limit count then clears the
+ * streaming count check and the per-chunk walk reads past these one-element
+ * arrays, which is undefined and happened to reject. No caller can hand that
+ * validator an array of tens of billions of entries, so no behavioural test
+ * can separate "rejected for the count" from "rejected for something else" at
+ * this magnitude. The lock against a divergent bound is therefore the
+ * configure-time one in tests/CMakeLists.txt, which reads the comparison out
+ * of both sources; what this test carries is that the two entry points still
+ * answer identically at the boundary and on both of its ends. */
+#include "batch_limits.h"
+#include "cudec.h"
+#include "require.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+int main() {
+    alignas(16) static cudec_chunk_result results[1];
+    static const void* srcs[1] = {nullptr};
+    static size_t sizes[1] = {0};
+    static void* dsts[1] = {nullptr};
+    static size_t caps[1] = {0};
+
+    const size_t over = cudec_detail::kMaxBatchChunks + 1;
+    /* The bound is the thing under test, so its shape is asserted rather than
+     * assumed: an over-limit count that had silently become 0 through some
+     * arithmetic change would make every check below pass vacuously, since 0
+     * is a reject class of its own. */
+    REQUIRE(over > cudec_detail::kMaxBatchChunks);
+    REQUIRE(cudec_detail::kMaxBatchChunks > 0);
+
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, over, results,
+                                       nullptr) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_stream(srcs, sizes, dsts, caps, over,
+                                        CUDEC_MEM_DEVICE, results) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, SIZE_MAX,
+                                       results, nullptr) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_stream(srcs, sizes, dsts, caps, SIZE_MAX,
+                                        CUDEC_MEM_DEVICE, results) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+
+    /* Zero is the other end of the same field, and both entry points name it
+     * as a reject class of its own. Cheap to include and it keeps the pair
+     * being compared over the whole boundary rather than one side of it. */
+    REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, 0, results,
+                                       nullptr) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_lz4_decompress_stream(srcs, sizes, dsts, caps, 0,
+                                        CUDEC_MEM_DEVICE, results) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+
+    std::printf("PASS: both entry points refuse chunk_count 0, %zu and "
+                "SIZE_MAX against the shared limit %zu\n",
+                over, cudec_detail::kMaxBatchChunks);
+    return 0;
+}


### PR DESCRIPTION
# What & why

The maximum `chunk_count` was defined twice and kept in agreement by a comment.
It now has one definition in `src/batch_limits.h`, both entry points read it,
and two locks refuse the drift.

Closes #39.

## Type of change

- [x] Refactor / code quality
- [x] Bug fix

## What changed

`src/batch_limits.h` holds the bound and the lane count it is built from. It
includes no CUDA runtime, which is what lets `src/lz4_decode.cuh` (a `.cu`
include) and `src/stream.cpp` (host C++) share it. `validate_batch_args` and
`ValidateStreamArgs` both compare against `cudec_detail::kMaxBatchChunks`, and
`stream.cpp`'s own copy - the one the issue is about - is gone.

Two locks, because they catch different things.

Configure-time, in `tests/CMakeLists.txt`: each of the two sources must include
the header and must bound `chunk_count` by the shared constant, and no other
source under `src/` may build a bound out of `INT32_MAX`. The sweep globs `src/`
rather than naming files, so a new translation unit carrying its own bound is
covered without anyone remembering to extend a list. It checks the comparison
and not just a mention of the name, because a translation unit can keep the
include and the using-declaration and still compare against something else -
which is exactly what happened while this was being tested.

Behavioural, `tests/batch_limit_parity.cpp`: both entry points refuse
`chunk_count` 0, the limit plus one, and `SIZE_MAX`. The number is read from the
header, so the test carries no third copy of what it is checking. Host-side and
GPU-less - every call in it is rejected before any CUDA call, which is also why
it is safe to hand one-element arrays with a count of tens of billions. No call
in it passes validation, deliberately.

## What the behavioural test cannot do, measured

With the streaming bound raised to twice the canonical one, every assertion in
`batch_limit_parity` still passes:

```
constexpr size_t kStreamOnlyHigherBound = kMaxBatchChunks * 2;   (stream.cpp bounds by this)
$ ./bc/tests/batch_limit_parity
PASS: both entry points refuse chunk_count 0, 68719476705 and SIZE_MAX against the shared limit 68719476704
C_RUN=0
```

The over-limit count clears the raised count check and the per-chunk walk then
reads past the caller's one-element arrays, which is undefined and in that run
happened to reject. No caller can hand that validator an array of tens of
billions of entries, so nothing at this magnitude separates a reject for the
count from a reject for anything else. That is written into the test file rather
than left here, and it is why the configure-time lock exists and was tightened.

## Each lock proven by breaking it

Container, one change at a time on a copy of the tree.

A local bound re-introduced in `stream.cpp`:

```
A_EXIT=1
  src/stream.cpp builds its own bound from INT32_MAX - the batch launch limit
  is cudec_detail::kMaxBatchChunks in src/batch_limits.h (issue #39)
```

The include dropped:

```
B_EXIT=1
  src/stream.cpp no longer includes batch_limits.h: the batch launch limit is
  single-sourced there (issue #39)
```

The comparison pointed at a different constant, which is the divergence the
behavioural test cannot see:

```
C_EXIT=1
  src/stream.cpp no longer bounds chunk_count by kMaxBatchChunks: both entry
  points enforce the one shared limit (issue #39)
```

## Verification

Container gate, `nvidia/cuda:12.6.2-devel-ubuntu24.04`, cmake 3.28.3, nvcc
12.6.77, RTX 3080:

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON   CFG=0
cmake --build build-cuda -j                  BUILD=0
ctest --test-dir build-cuda --output-on-failure
  CTEST=0
  7/19 Test  #7: batch_limit_parity ...   Passed    0.01 sec
  100% tests passed, 0 tests failed out of 19
$ ./build-cuda/tests/batch_limit_parity
PASS: both entry points refuse chunk_count 0, 68719476705 and SIZE_MAX against the shared limit 68719476704
```

18 tests before this change, 19 after. The GPU twins (`frame_twin`,
`stream_twin`, `determinism_gpu`, `termination_gpu`) are in that run and are
what say the moved constants did not move a bound.

- [x] `cmake --build build-cuda` - builds clean.
- [x] `ctest --test-dir build-cuda` - green, 19/19.
- [x] Prettier - no `.md`/`.yml`/`.yaml` file is touched.
- [x] Docs synced - the reasoning lives in the new header's own comment.

## Engineering checklist

- [x] Fail-closed preserved. Both validators reject the same counts as before;
      the value is identical, `INT32_MAX * 32`, now written once. The new test
      is itself a negative test on that boundary.
- [ ] Oracle coverage - not applicable, no format path changes.
- [x] Determinism preserved - no decode behaviour changes.
- [x] Every CUDA API call's error is checked - no call sites touched.
- [ ] An adversarial review was NOT run, and this change touches the kernel
      header and the streaming host path. There is no second reader on this
      board tonight, so this body carries the evidence in place of one: the
      three deliberate breakages, the measured limit of the behavioural test,
      and the full GPU suite green. That is weaker than a review and is not
      being presented as one.
- [ ] Review record - none, for the reason above.

## Notes

`kWarpSize` moved into the new header with the bound, because the bound is built
from it and the two belong together. Its digits are still written exactly once,
which is what #211's width rule requires.

The deeper version of this - the width arriving as a template parameter rather
than a constant - is #241 and #242 and is not attempted here.
