### PR TITLE
Name the LZ4 token constants at the decode sites

### DIFF
--- a/src/lz4_block.h
+++ b/src/lz4_block.h
@@ -40,6 +40,11 @@ constexpr uint64_t kLz4MinTrailingSlackDst = 12;  /* MFLIMIT */
 constexpr uint64_t kLz4MinTrailingSlackSrc = 8;   /* 2 + 1 + LASTLITERALS */
 constexpr uint64_t kLz4LastLiterals = 5;          /* LASTLITERALS */
 constexpr uint64_t kLz4RunMask = 15;              /* RUN_MASK */
+constexpr uint64_t kLz4MinMatch = 4;              /* MINMATCH */
+/* The token's two nibbles: the high one is the literal length, the low one is
+ * match_len - MINMATCH. Either nibble reading RUN_MASK means the length
+ * continues in the extension bytes that follow. */
+constexpr unsigned kLz4TokenLiteralShift = 4;
 /* liblz4 caps a length extension's byte reads at a margin before the input
  * end (read_variable_length's ilimit): iend - RUN_MASK for literals,
  * iend - (LASTLITERALS - 1) for matches. A decoder reading extension bytes
@@ -131,8 +136,8 @@ struct Lz4Parser {
         }
         const unsigned char token = src[src_pos++];
 
-        uint64_t literals_len = token >> 4;
-        if (literals_len == 15) {
+        uint64_t literals_len = token >> kLz4TokenLiteralShift;
+        if (literals_len == kLz4RunMask) {
             const cudec_status status = AccumulateLength(
                 &literals_len, kLz4LiteralReadMargin, /*initial_check=*/true);
             if (status != CUDEC_OK) {
@@ -200,9 +205,9 @@ struct Lz4Parser {
             return CUDEC_ERR_CORRUPT_INPUT; /* match source underflow */
         }
 
-        uint64_t match_len = (token & 0xF) + uint64_t{4};
-        if ((token & 0xF) == 15) {
-            /* The +4 minmatch is already in match_len; the extension
+        uint64_t match_len = (token & kLz4RunMask) + kLz4MinMatch;
+        if ((token & kLz4RunMask) == kLz4RunMask) {
+            /* MINMATCH is already in match_len; the extension
              * accumulates on top with the same in-loop bound. */
             const cudec_status status = AccumulateLength(
                 &match_len, kLz4MatchReadMargin, /*initial_check=*/false);


### PR DESCRIPTION
# What & why

The LZ4 token decode read the format's fields as bare literals, in the one file
that already had a name for one of them. `kLz4RunMask` existed and was used only
for the read-margin constant, so the token sites compared against `15` and masked
with `0xF` instead.

Closes #59.

## Type of change

- [x] Refactor / code quality

## What changed

- `kLz4MinMatch = 4` and `kLz4TokenLiteralShift = 4` added beside the existing
  constants, with one line above them saying what the token's two nibbles hold:
  the high one is the literal length, the low one is `match_len - MINMATCH`, and
  either reading `RUN_MASK` means the length continues in the extension bytes.
- `literals_len == 15` and `(token & 0xF) == 15` both read `kLz4RunMask`, so the
  two extension gates are visibly the same test against the same definition.
- `(token & 0xF) + uint64_t{4}` reads `(token & kLz4RunMask) + kLz4MinMatch`.

No value moves: `0xF`, `15` and `RUN_MASK` are the same number, and the addend is
the same 4.

## That it is behaviour-preserving

Not asserted from the diff. Both versions of the header were built in the same
tree and the parser twin was run over each. Its oracle-parity summary is
identical down to every count:

```
=== named constants ===
PASS: 12 fixtures + 310 mutants in oracle parity (248 oracle-rejected, 1 stricter-than-liblz4 on spec-invalid input); 6 crafted negatives; last-5 sweep 27 accept / 9 reject; empty block, offset==0 divergence, SIZE_MAX and beyond-convention capacity pinned; ext-read sweep 123 accept / 45 reject
termination: parser liveness and frame-walk termination hold over the truncation ladder, the mutant corpus, the crafted streams, and the frame cases

=== bare literals (origin/main) ===
PASS: 12 fixtures + 310 mutants in oracle parity (248 oracle-rejected, 1 stricter-than-liblz4 on spec-invalid input); 6 crafted negatives; last-5 sweep 27 accept / 9 reject; empty block, offset==0 divergence, SIZE_MAX and beyond-convention capacity pinned; ext-read sweep 123 accept / 45 reject
termination: parser liveness and frame-walk termination hold over the truncation ladder, the mutant corpus, the crafted streams, and the frame cases
```

Same accept set, same reject set, same stricter-than-liblz4 case, over the whole
fixture and mutant corpus and both extension sweeps.

## Verification

Container gate, `nvidia/cuda:12.6.2-devel-ubuntu24.04`, cmake 3.28.3, nvcc
12.6.77, RTX 3080:

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON   CFG=0
cmake --build build-cuda -j                  BUILD=0
ctest --test-dir build-cuda --output-on-failure
  CTEST=0
  100% tests passed, 0 tests failed out of 18
```

The GPU twins are in that run, so the device path that includes this header is
covered too.

- [x] `cmake --build build-cuda` - builds clean.
- [x] `ctest --test-dir build-cuda` - green, 18/18.
- [x] Prettier - no `.md`/`.yml`/`.yaml` file is touched.
- [x] Docs synced - the explanation is the comment above the constants.

## Engineering checklist

- [x] Fail-closed preserved. Same comparisons, same values; the twin's reject
      set is unchanged, which is the statement that matters here.
- [x] Oracle coverage - the parser twin's liblz4 parity run is the evidence
      above.
- [x] Determinism preserved - no behaviour changes.
- [ ] CUDA API errors / C ABI - not applicable.
- [ ] An adversarial review was NOT run, and this touches the block parser.
      There is no second reader on this board tonight, so this body carries the
      evidence in place of one: the identical parity summaries from both
      versions built in the same tree. That is weaker than a review and is not
      being presented as one.
- [ ] Review record - none, for the reason above.

## Notes

`kLz4MatchReadMargin` is `kLz4LastLiterals - 1`, which is also 4, and is
deliberately left deriving from LASTLITERALS rather than from `kLz4MinMatch`:
the two are equal by coincidence and mean different things.
