### PR TITLE
State the portability claim as single-source, not as an empty field

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ properties a closed binary cannot offer:
   check in cudec is readable, tested, and fuzz-diffed against the reference
   implementation - liblz4 today, with zlib and libzstd joining as the DEFLATE
   and Zstd formats land.
-- **Portability.** CUDA first; a HIP port is a planned milestone. A
-  vendor-locked binary can never follow.
+- **Portability.** CUDA first; a HIP port is a planned milestone. What that
+  milestone claims is one kernel family, single-source across both vendors
+  behind the same C ABI, auditable and fail-closed on either - not a first on
+  AMD, for the reason the field table linked above gives.
 - **Hackability.** Format quirks, tuning trade-offs, and kernel design are
   documented in the tree, not behind a support contract.
 

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -48,8 +48,9 @@ the open GPU decoders above are shaders belonging to a graphics runtime, and
 hipCOMP-core is a HIP preview downstream of a four-year-old fork point. The
 value proposition is not price (nvCOMP is free to use) but
 **auditability** (decompressors are classic attack surface; every bounds
-check here is readable, tested, and fuzzed), **portability** (a HIP port is
-a planned milestone - a vendor binary can never follow), and **hackability**.
+check here is readable, tested, and fuzzed), **portability** (a HIP port is a
+planned milestone; what that claim is and is not is section 3 item 5, and it
+is not an empty AMD field), and **hackability**.
 
 ## 2. Scope
 


### PR DESCRIPTION
# What & why

Two sentences in the reader's first paths said a vendor binary can never
follow. Whatever they meant about a closed binary, they read as "nobody else
decodes on AMD", which a reader can refute by naming hipCOMP-core - the same
project the field table two paragraphs above already names.

Closes #149.

## Type of change

- [x] Docs

## What changed

`README.md`, the Portability bullet, and `docs/MASTERPLAN.md` section 1's
closing positioning sentence. Both now state the claim positively: one kernel
family, single-source across both vendors behind the same C ABI, auditable and
fail-closed on either, and not a first on AMD.

Neither restates the hipCOMP facts. The README points at the field table it
already links, and the masterplan points at section 3 item 5, which was already
corrected and says what the M6 claim is and is not. A list of facts in three
places drifts; a pointer does not.

Nothing refutable is left in the tracked prose:

```
$ grep -rn "can never follow\|first on AMD\|vendor-locked" README.md docs/*.md SECURITY.md CONTRIBUTING.md
(no output)
```

## The facts, re-checked rather than carried over

The masterplan's hipCOMP row and URL are older than this change, so the claims
this wording now leans on were checked against the repository itself:

```
$ gh api repos/ROCm/hipCOMP-core --jq '.default_branch, .license.spdx_id, .pushed_at, .description'
release/rocmds-25.10
MIT
2026-07-10T14:07:03Z
hipCOMP is a library for fast lossless compression/decompression on the GPU. This repository contains the algorithms.

$ gh api repos/ROCm/hipCOMP-core/contents/src/lowlevel --jq '.[].name' | grep -iE "lz4|snappy|deflate"
LZ4Batch.cpp
LZ4CompressionKernels.cu
LZ4CompressionKernels.h
SnappyBatch.cpp
SnappyBatchKernels.cu
SnappyBatchKernels.h
gdeflateBatch.cpp
gdeflateKernels.cu
gdeflateKernels.h
```

So the tree's statement that hipCOMP-core carries LZ4 and Snappy on HIP holds,
and it is actively pushed. Its own README still says "This release is an
_early-access_ software technology preview. Running production workloads is
_not_ recommended", which is what the field table row states.

Two details worth recording rather than quietly fixing, both outside this
change's surface:

- GitHub reports the licence as MIT and also detects a BSD-3-Clause file in the
  repository. The masterplan row says "MIT fork", which is what the API's
  `license.spdx_id` says; if the head-to-head in #248 turns on the licence, that
  is where the two-file detail needs settling, not here.
- The README paragraph the fetch summarised lists "algorithms like DEFLATE,
  GDEFLATE, ANS, and zSTD" without naming LZ4 or Snappy. It says "like", and the
  directory listing above is the stronger evidence, which is why this change
  relies on the listing.

## Verification

- [x] Prettier - `All matched files use Prettier code style!`
- [x] Docs synced - this change is the doc sync; the masterplan's section 3
      item 5 and its field table already agreed and are untouched.
- [ ] No build or test change: the diff is two prose sentences in two Markdown
      files, so the container gate has nothing new to say about it. CI's build,
      sanitize and format jobs run on the PR regardless.

## Engineering checklist

- [ ] Fail-closed / oracle / determinism / CUDA-ABI - not applicable, no code
      changes.
- [ ] An adversarial review was NOT run. There is no second reader on this
      board tonight, so this body carries the evidence in place of one: the
      grep showing nothing refutable is left, and the two API calls behind the
      facts. That is weaker than a review and is not being presented as one.
- [ ] Review record - none, for the reason above.

## Notes

The positive claim is checkable against the tree as it stands only in part
today: single-source across vendors is what M6 will make true, and the README
says it is a planned milestone in the same sentence. That is the same shape the
Auditability bullet uses for zlib and libzstd, which have not landed either.
