### PR TITLE
Refresh the zstd field-table row against what DirectStorage now says

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -13,16 +13,16 @@ on the GPU.
 
 The field today:
 
-| Existing work                   | Why it does not fill the gap                                                    |
-| ------------------------------- | ------------------------------------------------------------------------------- |
-| nvCOMP / nvCOMPDx (NVIDIA)      | Proprietary since v2.3; NVIDIA-only; not auditable                              |
-| dietgpu (Meta)                  | Open, but its own rANS format - not format-compatible                           |
-| GDeflate reference (MS/NV)      | Open spec + CPU codec; its GPU decoder is the HLSL shader in the row below      |
-| DirectStorage `GDeflate.hlsl`   | Open (Apache-2.0) GPU GDeflate decoder, but a shader inside a D3D12 runtime     |
-| DirectStorage `zstd/` (dev)     | Open HLSL zstd decompression shaders, marked by Microsoft as not for production |
-| vkd3d-proton `cs_gdeflate.comp` | Open (LGPL-2.1) GLSL GDeflate decoder, bound to the vkd3d-proton runtime        |
-| hipCOMP-core (AMD/ROCm)         | MIT fork of nvCOMP branch-2.2 on HIP; early-access preview, not for production  |
-| Academic prototypes             | Unmaintained research code                                                      |
+| Existing work                   | Why it does not fill the gap                                                                                                         |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| nvCOMP / nvCOMPDx (NVIDIA)      | Proprietary since v2.3; NVIDIA-only; not auditable                                                                                   |
+| dietgpu (Meta)                  | Open, but its own rANS format - not format-compatible                                                                                |
+| GDeflate reference (MS/NV)      | Open spec + CPU codec; its GPU decoder is the HLSL shader in the row below                                                           |
+| DirectStorage `GDeflate.hlsl`   | Open (Apache-2.0) GPU GDeflate decoder, but a shader inside a D3D12 runtime                                                          |
+| DirectStorage `zstd/` (dev)     | Open HLSL zstd decode shaders; the sample says not for production, and the runtime compiles versions of them in as a driver fallback |
+| vkd3d-proton `cs_gdeflate.comp` | Open (LGPL-2.1) GLSL GDeflate decoder, bound to the vkd3d-proton runtime                                                             |
+| hipCOMP-core (AMD/ROCm)         | MIT fork of nvCOMP branch-2.2 on HIP; early-access preview, not for production                                                       |
+| Academic prototypes             | Unmaintained research code                                                                                                           |
 
 Where those rows come from, so the next pass does not re-derive them from
 memory: `GDeflate/shaders/GDeflate.hlsl` and the `zstd/` tree on the
@@ -32,6 +32,18 @@ memory: `GDeflate/shaders/GDeflate.hlsl` and the `zstd/` tree on the
 [vkd3d-proton](https://github.com/HansKristian-Work/vkd3d-proton);
 [ROCm/hipCOMP-core](https://github.com/ROCm/hipCOMP-core). Read at those
 paths on 2026-08-05.
+
+The zstd row is worth a paragraph of its own, because the open/production
+line runs through the middle of it rather than around it. `zstd/README.md` on
+that branch calls the shaders "reference implementations ... authored in HLSL"
+and says in red that the code "is currently in development and should NOT be
+used in production environments or for released products" - and, four lines
+later, that "versions of these same shaders are also included/compiled inside
+the DirectStorage runtime to be used as a fallback for GPUs that do not have
+optimized zstd GPU decompression driver support", most game-ready drivers
+carrying their own faster implementation. So an open GPU zstd decoder exists,
+some of it ships, and the fast paths on both sides of it are closed. The
+shaders live under `zstd/zstdgpu/Shaders`.
 
 No milestone here claims a "first", and that is deliberate. A code search
 for GDeflate in CUDA sources on the same day returned a partial decoder in
@@ -85,7 +97,11 @@ is not an empty AMD field), and **hackability**.
 4. **Zstd decode** (M5) - the flagship and by far the hardest: FSE/Huffman
    entropy stages feeding an LZ77 sequence executor with long-range matches.
    Attempted only once the kernel family, the oracle net, and the benchmark
-   discipline are proven on 1–3.
+   discipline are proven on 1–3. An open GPU zstd decoder already exists, in
+   HLSL, in a graphics runtime, and partly shipped (section 1); the drivers'
+   own zstd paths are closed and so is nvCOMP. What does not exist is an open
+   CUDA zstd decoder callable as a library, which is the claim space here and
+   is not a first.
 5. **HIP port** (M6) - portability as a moat. The kernels stay on warp-level
    primitives available on both vendors to keep this tractable. AMD is not
    an empty field: hipCOMP-core carries HIP LZ4 and Snappy decode (section


### PR DESCRIPTION
# What & why

The zstd row in the field table said the DirectStorage HLSL shaders are marked
not for production and stopped there. Read at the source, that is half of what
the project says, and the other half changes what the row means.

Closes #151.

## Type of change

- [x] Docs

## What the source says

```
$ gh api repos/microsoft/DirectStorage/contents/zstd?ref=development --jq '.[].name'
NuGet.Config
README.md
ThirdParty
platform
scripts
zstd.png
zstd.sln
zstdgpu
zstdgpu_ci_tests
zstdgpu_demo
zstdgpu_tests

$ gh api repos/microsoft/DirectStorage/contents/zstd/zstdgpu?ref=development --jq '.[].name'
Shaders
packages.config
zstdgpu.cpp
zstdgpu.h
...
```

`zstd/README.md` on that branch, in its own words:

> This sample includes reference implementations of shaders that are designed
> to perform zstd decompression using a GPU. These shaders are all authored in
> HLSL and support a wide variety of GPUs.

> This code is currently in development and should NOT be used in production
> environments or for released products.

and four lines later:

> Versions of these same shaders are also included/compiled inside the
> DirectStorage runtime to be used as a fallback for GPUs that do not have
> optimized zstd GPU decompression driver support. Most game ready GPU drivers
> will come with their own optimized decompression support which is faster and
> more efficient than this implementation.

So an open GPU zstd decoder exists, some of it ships inside a production
runtime, and the faster paths on both sides of it - the drivers' and nvCOMP's -
are closed.

## What changed

- The field-table row now says both halves: open HLSL zstd decode shaders, the
  sample not for production, and the runtime compiling versions of them in as a
  driver fallback.
- The provenance paragraph carries the two quotes and the shader path
  (`zstd/zstdgpu/Shaders`), so the next pass reads the record rather than
  re-running the search.
- Section 3's Zstd item takes the shape its GDeflate neighbour already has:
  what exists, what does not, and the claim space stated without a "first" - an
  open CUDA zstd decoder callable as a library is what does not exist.

No new "first" claim enters the tree; section 1's statement that no milestone
claims one still holds, and this change is what keeps the Zstd item from being
readable as one.

## Verification

- [x] Prettier - `All matched files use Prettier code style!` (the table was
      reflowed by Prettier after the row grew).
- [x] Docs synced - the row, the provenance paragraph and section 3 item 4 now
      say the same thing; the README's "Why" paragraph already said open GPU
      Zstd decoders exist and needed no change.
- [ ] No build or test change: the diff is one Markdown file. CI's build,
      sanitize, format and analyze jobs run on the PR regardless.

Rebased onto `main` at f309624 so it sits on top of #149's wording change to the
same file.

## Engineering checklist

- [ ] Fail-closed / oracle / determinism / CUDA-ABI - not applicable, no code
      changes.
- [ ] An adversarial review was NOT run. There is no second reader on this
      board tonight, so this body carries the evidence in place of one: the two
      API listings and the README quotes above, each with the command or the
      path it came from. That is weaker than a review and is not being
      presented as one.
- [ ] Review record - none, for the reason above.

## Notes

The issue proposed stating that nvCOMP is the only production GPU zstd decoder.
That is not in this change: the driver-side implementations the DirectStorage
README describes are production zstd GPU decompression too, so the sentence
would have been refutable by the same file that motivated the rest of it. What
the row says instead is what each thing is.
