### PR TITLE
Give the bench one percentile and one GB/s definition

### DIFF
--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -3,6 +3,7 @@
  * plugs in as a second timed path in this same harness. A report cannot
  * be produced without its methodology block; that is the point
  * (docs/MASTERPLAN.md section 5, honest numbers). */
+#include "bench_stats.h"
 #include "cudec.h"
 #include "fixtures.h"
 #include "gpu_bench.h"
@@ -458,13 +459,9 @@ bool ParseCount(const char* text, size_t min, size_t max, size_t* out) {
     return true;
 }
 
-/* Nearest-rank with ceiling: never flatters - at 30 runs, p99 is the
- * slowest run, not the second-slowest a floor index would pick. */
-double Percentile(const std::vector<double>& sorted, int pct) {
-    const size_t rank =
-        (sorted.size() * static_cast<size_t>(pct) + 99) / 100;
-    return sorted[(rank == 0 ? 1 : rank) - 1];
-}
+/* The nearest-rank definition this report shares with the GPU rows, from
+ * bench/bench_stats.h. */
+using cudec_bench::Percentile;
 
 void PrintReport(const Corpus& corpus, const std::vector<double>& sorted,
                  size_t warmup, size_t runs) {

--- a/bench/bench_stats.h
+++ b/bench/bench_stats.h
@@ -1,0 +1,45 @@
+/* The two pieces of arithmetic every reported number in this harness goes
+ * through, defined once (issue #65).
+ *
+ * The percentile method was copied three times across two translation units,
+ * and the report already promises that the CPU and GPU rows of one report share
+ * one definition (the comment at gpu_bench.cu's timing loop). A promise kept by
+ * three hand-matched copies is a promise about the copies, so here it is one
+ * function that both paths call.
+ *
+ * Bench-only. Nothing here is compiled into the library. */
+#ifndef CUDEC_BENCH_STATS_H
+#define CUDEC_BENCH_STATS_H
+
+#include <cstddef>
+#include <vector>
+
+namespace cudec_bench {
+
+/* Nearest-rank with ceiling: never flatters - at 30 runs, p99 is the slowest
+ * run, not the second-slowest a floor index would pick. The rank == 0 clamp is
+ * what makes pct == 0 and a one-element sample land on a real index.
+ *
+ * Templated because the device path times with cudaEventElapsedTime into
+ * float and the host path uses double; the index arithmetic is identical and
+ * the sample's own type is returned unconverted.
+ *
+ * REQUIRES: `sorted` is non-empty and ascending. Callers sort immediately
+ * before the call - the harness aborts on an empty sample long before here,
+ * and a bench that indexed an empty vector would be reporting nothing at all. */
+template <class T>
+T Percentile(const std::vector<T>& sorted, int pct) {
+    const size_t rank = (sorted.size() * static_cast<size_t>(pct) + 99) / 100;
+    return sorted[(rank == 0 ? 1 : rank) - 1];
+}
+
+/* Throughput from a duration in milliseconds, with the sub-microsecond case
+ * guarded: a tiny corpus can event-time to 0.0 ms, and a degenerate run must
+ * report 0 rather than inf. */
+inline double GbpsFromMs(double gb, double ms) {
+    return ms > 0.0 ? gb / (ms / 1e3) : 0.0;
+}
+
+}  // namespace cudec_bench
+
+#endif /* CUDEC_BENCH_STATS_H */

--- a/bench/gpu_bench.cu
+++ b/bench/gpu_bench.cu
@@ -4,6 +4,7 @@
  * H2D/D2H is excluded and the number is pure kernel decode throughput. */
 #include "gpu_bench.h"
 
+#include "bench_stats.h"
 #include "cudec.h"
 #include "lz4_decode.cuh"
 
@@ -71,10 +72,9 @@ bool TimeKernel(cudec_status (*launch)(const void* const*, const size_t*,
     BG_CUDA(cudaEventDestroy(start));
     BG_CUDA(cudaEventDestroy(stop));
     std::sort(times.begin(), times.end());
-    /* Nearest-rank p50, matching the CPU path's percentile method so the
-     * two rows of the same report use one definition. */
-    const size_t rank = (times.size() * 50 + 99) / 100;
-    *p50_ms = times[(rank == 0 ? 1 : rank) - 1];
+    /* The same nearest-rank definition the CPU rows use, so the two rows of
+     * one report mean the same thing (bench/bench_stats.h). */
+    *p50_ms = cudec_bench::Percentile(times, 50);
     return true;
 }
 
@@ -86,8 +86,7 @@ cudec_status LaunchFull(const void* const* s, const size_t* ss,
 
 double Median(std::vector<double>* t) {
     std::sort(t->begin(), t->end());
-    const size_t rank = (t->size() * 50 + 99) / 100;
-    return (*t)[(rank == 0 ? 1 : rank) - 1];
+    return cudec_bench::Percentile(*t, 50);
 }
 
 /* Steady-state wall time: one reusable context, warmed (so its staging is
@@ -238,10 +237,9 @@ bool cudec_bench_gpu(const unsigned char* const* comp,
     out->output_bytes = total_out;
     out->full_ms_p50 = full_ms;
     out->parse_only_ms_p50 = parse_ms;
-    /* Guard the sub-microsecond case (a tiny corpus can event-time to
-     * 0.0 ms) so a degenerate run reports 0, never inf. */
-    out->full_gbps_p50 = full_ms > 0.0 ? gb / (full_ms / 1e3) : 0.0;
-    out->parse_only_gbps_p50 = parse_ms > 0.0 ? gb / (parse_ms / 1e3) : 0.0;
+    /* GbpsFromMs carries the sub-microsecond guard (bench/bench_stats.h). */
+    out->full_gbps_p50 = cudec_bench::GbpsFromMs(gb, full_ms);
+    out->parse_only_gbps_p50 = cudec_bench::GbpsFromMs(gb, parse_ms);
     /* Buffers are reclaimed at process exit; the bench is a short-lived
      * one-shot, like the test harness. */
     return true;
@@ -337,10 +335,10 @@ bool cudec_bench_gpu_stream_ctx(const unsigned char* const* comp,
     out->host_steady_ms = host_steady;
     out->device_cold_ms = dev_cold;
     out->host_cold_ms = host_cold;
-    out->device_steady_gbps = dev_steady > 0.0 ? gb / (dev_steady / 1e3) : 0.0;
-    out->host_steady_gbps = host_steady > 0.0 ? gb / (host_steady / 1e3) : 0.0;
-    out->device_cold_gbps = dev_cold > 0.0 ? gb / (dev_cold / 1e3) : 0.0;
-    out->host_cold_gbps = host_cold > 0.0 ? gb / (host_cold / 1e3) : 0.0;
+    out->device_steady_gbps = cudec_bench::GbpsFromMs(gb, dev_steady);
+    out->host_steady_gbps = cudec_bench::GbpsFromMs(gb, host_steady);
+    out->device_cold_gbps = cudec_bench::GbpsFromMs(gb, dev_cold);
+    out->host_cold_gbps = cudec_bench::GbpsFromMs(gb, host_cold);
     /* The output arenas (d_out) are reclaimed at process exit; the bench is a
      * short-lived one-shot called once, like cudec_bench_gpu above. */
     return true;


### PR DESCRIPTION
# What & why

The nearest-rank percentile was written three times across two translation
units, and the GB/s guard six times in one file. The report already promises
that its CPU and GPU rows use one percentile definition; this makes that one
function instead of three hand-matched copies.

Closes #65.

## Type of change

- [x] Refactor / code quality

## What changed

`bench/bench_stats.h`, bench-only:

- `Percentile(sorted, pct)` - the same nearest-rank-with-ceiling arithmetic,
  templated because the device path times with `cudaEventElapsedTime` into
  `float` and the host path uses `double`. Its requirement (non-empty, sorted)
  is stated at the declaration.
- `GbpsFromMs(gb, ms)` - carries the sub-microsecond guard that keeps a tiny
  corpus reporting 0 rather than inf.

Call sites collapsed: the file-local `Percentile` in `bench_lz4.cpp` becomes a
`using`, the inlined p50 in the event-timing loop and `Median` both call the
helper, and the six GB/s expressions become six calls. Net 21 lines removed
against 16 added, plus the header.

## That it is behaviour-preserving

The arithmetic moved verbatim, and it was checked against what it replaced
rather than eyeballed. A throwaway program (not committed) compares the helper
to the replaced expressions over every sample size from 1 to 64, the
percentiles the report asks for, both element types, and the GB/s guard
including the 0 ms case the comment names:

```
$ g++ -std=c++17 -Wall -Wextra -Werror -O2 -I/w/bench /probe/pct_probe.cpp -o /tmp/pct && /tmp/pct
PASS: 773 comparisons, helper identical to the replaced arithmetic
PROBE_EXIT=0
```

Then the harness itself, on the GPU box:

```
$ ./build-cuda/bench/bench_lz4 --selfcheck --gpu
## bench_lz4 report
- decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
- host CPU: AMD Ryzen 9 5950X 16-Core Processor
- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
- corpus: builtin, 12 chunks, 0.21 MB original, 0.10 MB compressed (ratio 0.511)
- chunk sizes: min 1 / median 257 / max 65536 bytes
- method: 1 warmup + 3 measured runs, ... percentiles are nearest-rank
- wall per run: p50 0.045 ms / p90 0.045 ms / p99 0.045 ms
- decode throughput: p50 4.579 GB/s / p90 4.567 GB/s / p99 4.567 GB/s
- GPU decode (device-resident, CUDA-event timed, 1 warmup + 3 runs): p50 6.492 ms, 0.0 GB/s
- GPU parse-only ceiling (copies elided): p50 3.099 ms, 0.1 GB/s
PASS: selfcheck complete
```

Both row families still print, with the same methodology line. The numbers
themselves are timings on a 0.21 MB built-in corpus and move run to run, so they
are not offered as a before/after comparison - the 773-comparison probe is what
carries that claim. No recorded baseline in `docs/BENCHMARKS.md` is touched.

## Verification

Container gate, `nvidia/cuda:12.6.2-devel-ubuntu24.04`, cmake 3.28.3, nvcc
12.6.77, RTX 3080:

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON   CFG=0
cmake --build build-cuda -j                  BUILD=0   (no warnings; bench carries -Wall -Wextra -Werror)
ctest --test-dir build-cuda --output-on-failure
  CTEST=0
  100% tests passed, 0 tests failed out of 19
```

`bench_selfcheck` is in that run and is the pin the issue names.

- [x] `cmake --build build-cuda` - builds clean.
- [x] `ctest --test-dir build-cuda` - green, 19/19.
- [x] Prettier - no `.md`/`.yml`/`.yaml` file is touched.
- [x] Docs synced - no recorded number or methodology statement changes.

## Performance checklist

- [x] No claim is made. This changes no timed region: the helpers run once per
      reported row, after timing, and the timed regions are untouched.
- [x] No regression against the recorded baseline, because no recorded baseline
      is re-measured here. `docs/BENCHMARKS.md` is unchanged.

## Engineering checklist

- [x] Minimal: 21 lines out, 16 in, plus the header; one definition where there
      were four.
- [ ] Fail-closed / oracle / determinism / CUDA-ABI - not applicable; bench-only
      code, nothing reaches the library or the ABI.
- [ ] An adversarial review was NOT run. There is no second reader on this board
      tonight, so this body carries the evidence in place of one: the
      773-comparison equality probe and the harness output above. That is weaker
      than a review and is not being presented as one.
- [ ] Review record - none, for the reason above.

## Notes

One thing seen and deliberately not changed: the CPU report divides by a
percentile in seconds (`to_gbps / Percentile(sorted, 50)`) with no guard, so a
0.0 s percentile would print inf there, where the GPU rows print 0. It is a
different expression from the six this issue names, it fails loudly rather than
silently, and folding it in would mean changing what a CPU row prints. Worth its
own line if anyone wants the two paths to degenerate the same way.
