### PR TITLE
Enforce the Action SHA-pin rule in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,49 @@ jobs:
 
       - name: Prettier check
         run: npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
+
+      # Every Action pinned to a full commit SHA, enforced rather than swept
+      # (issue #131). A tag or branch pin resolves to whatever the upstream
+      # owner points it at later, which is the supply-chain hole the pinning
+      # rule exists to close; the audit was clean and only the mechanism that
+      # keeps it clean was missing.
+      #
+      # Shell rather than a pin-audit Action, per the masterplan's preference
+      # for near-zero third-party surface in the security net itself: an Action
+      # that checks the pinning of Actions is one more pinned dependency to
+      # keep current, and this rule is one regex.
+      #
+      # Fail-closed like the rest of this file: no workflow files, or workflow
+      # files with no `uses:` at all, means the check is reading the wrong
+      # place - it reds rather than passes silently.
+      - name: Every Action pinned to a full commit SHA
+        run: |
+          set -eu
+          find .github/workflows -type f -name '*.yml' > workflow-files.txt
+          find .github/workflows -type f -name '*.yaml' >> workflow-files.txt
+          sort -o workflow-files.txt workflow-files.txt
+          if [ ! -s workflow-files.txt ]; then
+            echo "FAIL: no workflow files under .github/workflows"
+            exit 1
+          fi
+          # shellcheck disable=SC2046
+          grep -nE '^[[:space:]]*(-[[:space:]]+)?uses:' $(cat workflow-files.txt) > action-refs.txt || true
+          if [ ! -s action-refs.txt ]; then
+            echo "FAIL: no 'uses:' line in any workflow - this check is reading the wrong files"
+            exit 1
+          fi
+          # The version comment goes first, so the 40-hex anchor sits at the end
+          # of the line. Local actions (./...) and docker:// references have no
+          # commit to pin; a reusable workflow
+          # (owner/repo/.github/workflows/x.yml@SHA) must still be pinned and
+          # matches the same pattern.
+          sed 's/#.*$//; s/[[:space:]]*$//' action-refs.txt > refs-bare.txt
+          grep -vE "uses:[[:space:]]*\./" refs-bare.txt > refs-remote.txt || true
+          grep -vE "uses:[[:space:]]*docker://" refs-remote.txt > refs-actions.txt || true
+          grep -vE "uses:[[:space:]]*[^[:space:]@]+@[0-9a-f]{40}$" refs-actions.txt > unpinned.txt || true
+          if [ -s unpinned.txt ]; then
+            echo "FAIL: Action reference not pinned to a full 40-character commit SHA:"
+            cat unpinned.txt
+            exit 1
+          fi
+          echo "PASS: $(wc -l < action-refs.txt) Action reference(s) across $(wc -l < workflow-files.txt) workflow file(s), all SHA-pinned"


### PR DESCRIPTION
# What & why

Every `uses:` in this tree is pinned to a full commit SHA. The rule that keeps
it that way was enforced only by an on-demand sweep and by review, so a
tag-pinned Action could be introduced and merged unnoticed - and a tag resolves
to whatever the upstream owner points it at later.

Closes #131.

## Type of change

- [x] Build / CI / supply chain

## The shape, and why this one

A shell step in the existing `format` job rather than a pin-audit Action. An
Action that checks the pinning of Actions is one more pinned dependency to keep
current, and the masterplan prefers near-zero third-party surface in the
security net itself. The rule is one regex; the step adds no dependency and no
token scope (`format` already runs with `contents: read`).

Local actions (`./...`) and `docker://` references are excluded - neither has a
commit to pin. A reusable workflow (`owner/repo/.github/workflows/x.yml@SHA`) is
held to the same 40-hex anchor as an action, and the proofs below include one.

Fail-closed in the sense this file already uses: a check that matches nothing
reds rather than passes.

## Every branch run

The step's script was extracted verbatim from the workflow and run under
`ubuntu:24.04`, the runner image family, on a copy of the tree.

The tree as it stands:

```
$ sh pincheck.sh
PASS: 8 Action reference(s) across 3 workflow file(s), all SHA-pinned
A_EXIT=0
```

A tag-pinned action, which is the case the issue is about:

```
$ perl -0pi -e 's/actions\/checkout\@3d3c42e5... # v7.0.1/actions\/checkout\@v7/' .github/workflows/ci.yml
$ sh pincheck.sh
FAIL: Action reference not pinned to a full 40-character commit SHA:
.github/workflows/ci.yml:62:        uses: actions/checkout@v7
B_EXIT=1
```

A branch-pinned reusable workflow, which the issue requires be caught too:

```
$ printf '\n      - name: probe\n        uses: owner/repo/.github/workflows/x.yml@main\n' >> .github/workflows/ci.yml
$ sh pincheck.sh
FAIL: Action reference not pinned to a full 40-character commit SHA:
.github/workflows/ci.yml:256:        uses: owner/repo/.github/workflows/x.yml@main
C_EXIT=1
```

The two legitimate non-SHA forms, which must not red:

```
$ printf '\n      - name: local\n        uses: ./.github/actions/thing\n      - name: docker\n        uses: docker://alpine:3\n' >> .github/workflows/ci.yml
$ sh pincheck.sh
PASS: 10 Action reference(s) across 3 workflow file(s), all SHA-pinned
D_EXIT=0
```

Both vacuous-run modes, which is the fail-closed half:

```
$ # workflows present, no `uses:` anywhere
$ sh pincheck.sh
FAIL: no 'uses:' line in any workflow - this check is reading the wrong files
E_EXIT=1

$ # no workflow files at all
$ sh pincheck.sh
FAIL: no workflow files under .github/workflows
F_EXIT=1
```

Note what D shows beyond "no false red": the count went from 8 to 10, so the
excluded forms are still counted as references seen. A silent skip would have
left the count at 8 and looked identical to not reading them.

## Verification

- [x] Prettier - `All matched files use Prettier code style!`
- [x] The step itself runs green on this branch in CI, which is where it now
      lives; the transcripts above are the branch coverage CI cannot show
      without breaking the tree on purpose.
- [x] Docs synced - the reasoning and the fail-closed intent are in the step's
      own header comment, beside the check.
- [ ] No build or test change: the diff is one workflow file, so the container
      gate has nothing new to say about it.

## Engineering checklist

- [x] Fail-closed preserved, and extended: two new refusals, both demonstrated.
- [x] Any Action the check introduces is SHA-pinned - it introduces none.
- [x] Least-privilege permissions - the step adds no scope; the job keeps
      `contents: read`.
- [ ] Oracle / determinism / CUDA-ABI - not applicable, no code changes.
- [ ] An adversarial review was NOT run, and this touches a workflow. There is
      no second reader on this board tonight, so this body carries the evidence
      in place of one: six runs covering every branch of the check. That is
      weaker than a review and is not being presented as one.
- [ ] Review record - none, for the reason above.

## Notes

What this does not do, stated because the issue's parent asks for more: it does
not check `permissions:` blocks, workflow triggers, or expression injection -
only the pin. The OpenSSF Scorecard half of #71 is #129 and is untouched here.

The check reads the workflow files as text. A `uses:` constructed at runtime, or
one hidden in a composite action outside `.github/workflows/`, is not seen -
the same honest limit the structural scanner in `tests/` states about itself.
