### PR TITLE
Add the OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,69 @@
+# OpenSSF Scorecard - the repository's supply-chain posture, scored, into Code
+# Scanning.
+#
+# Informational, and that is the whole of its authority. It reports posture; it
+# is NOT a required check and must not be added to the branch ruleset. It also
+# scores things this project has already decided about on purpose - the
+# FetchContent oracle pins are deliberately manual (docs/MASTERPLAN.md section
+# 5), and a low pinned-dependencies score is that decision showing up, not a
+# finding. Remediation it suggests is a separate issue, never an edit made to
+# move the number.
+#
+# The public dashboard is deliberately not fed. `publish_results` stays false
+# and no `id-token: write` is granted, because publishing would send this
+# repository's posture to a third-party service, which is a decision the
+# maintainer takes and not a side effect of adding a workflow. The results are
+# visible where the other analysis lands: Security -> Code scanning.
+#
+# The push trigger on `main` is not optional decoration. Scorecard's
+# branch-protection and maintained checks read the default branch, so a run
+# from anywhere else scores a different thing; the pull-request trigger is
+# deliberately unused.
+
+name: scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly, Wednesday 04:23 UTC. Off Monday (the Dependabot tick), off
+    # Tuesday (codeql.yml), and off the hour, where scheduled runs queue behind
+    # everyone else's cron.
+    - cron: "23 4 * * 3"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Fail closed: no ambient token scope at the top level.
+permissions: {}
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read # to check out the source and read the repo's metadata
+      security-events: write # to upload the SARIF results to Code Scanning
+    steps:
+      - name: Check out the source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run the analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # See the header: not published, so no id-token is granted either.
+          publish_results: false
+
+      # The same pin the CodeQL workflow carries, so the two uploads cannot
+      # drift onto different versions of the same action.
+      - name: Upload the results to Code Scanning
+        uses: github/codeql-action/upload-sarif@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
# What & why

An OpenSSF Scorecard workflow: weekly and on push to `main`, results into Code
Scanning beside the CodeQL findings.

Closes #129.

## Type of change

- [x] Build / CI / supply chain

## What it is, and what it is not

Informational, and the header comment says so in the file: it reports posture,
it is not a required check, and it must not be added to the branch ruleset. It
will also score decisions this project has already taken deliberately - the
FetchContent oracle pins are manual by policy (`docs/MASTERPLAN.md` section 5) -
so a low pinned-dependencies number is that policy showing up rather than a
finding to chase. Landing the workflow and getting a first result is the whole
claim here.

The push trigger on `main` is load-bearing: Scorecard's branch-protection and
maintained checks read the default branch, so a run from anywhere else scores a
different thing. The pull-request trigger is deliberately unused, which is also
why this PR's own checks say nothing about it.

## The public dashboard is not fed

`publish_results: false`, and no `id-token: write` anywhere. Publishing would
send this repository's posture to a third-party service, which is a decision for
me and not a side effect of adding a workflow. The issue's
instruction was to drop both together rather than leave a scope granted and
unused, and that is what this does. The results are visible where the other
analysis lands: Security -> Code scanning.

## Pins

Three actions, each a full 40-character commit SHA with its version comment:

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` - the
  same pin `ci.yml` and `codeql.yml` carry.
- `ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4` -
  resolved from the tag rather than copied:

```
$ gh api repos/ossf/scorecard-action/git/ref/tags/v2.4.4 --jq '.object.sha'
55891bbd73f2425e97637d96e306fc9d491d0b21          (annotated tag object)
$ gh api repos/ossf/scorecard-action/git/tags/55891bbd73f2425e97637d96e306fc9d491d0b21 --jq '.object.type, .object.sha, .tag'
commit
2d1146689b8cda280b9bc96326124645441f03bc
v2.4.4
$ gh api repos/ossf/scorecard-action/commits/2d1146689b8cda280b9bc96326124645441f03bc --jq '.sha, .commit.committer.date'
2d1146689b8cda280b9bc96326124645441f03bc
2026-07-23T21:04:42Z
```

- `github/codeql-action/upload-sarif@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2`
  - deliberately the exact pin `codeql.yml` already uses, so the two uploads
    cannot drift onto different versions of the same action.

No `actions/upload-artifact` step. The SARIF is visible in Code Scanning, and one
fewer pinned dependency is worth more than the debugging convenience.

The pin check that landed in #131 was run over the tree with this file in it:

```
$ sh pincheck.sh
PASS: 11 Action reference(s) across 4 workflow file(s), all SHA-pinned
PIN_EXIT=0
```

Eight references across three files before, eleven across four after - the three
this workflow adds, counted.

## Verification

- [x] `.github/workflows/scorecard.yml` exists; every `uses:` is a 40-char SHA;
      top-level `permissions: {}` with the job granting `contents: read` and
      `security-events: write` and nothing else.
- [x] Prettier - `All matched files use Prettier code style!`
- [ ] No build or test change: the diff is one new workflow file, so the
      container gate has nothing to say about it.
- [ ] **The run and its score are not yet observed.** This workflow triggers on
      push to `main`, so the first run is the merge of this PR - it cannot run
      from the pull request, by design. The run link and the aggregate score are
      appended to this body once that run finishes, and if it fails the fix
      lands before anything is claimed about it. Nothing above should be read as
      saying a Scorecard result exists today.

## Engineering checklist

- [x] Least-privilege permissions - `permissions: {}` at the top level, two
      scopes on the job, each with the reason on its line.
- [x] Every Action pinned to a full commit SHA, and #131's check confirms it.
- [ ] Fail-closed / oracle / determinism / CUDA-ABI - not applicable, no code
      changes and this workflow gates nothing.
- [ ] An adversarial review was NOT run, and this adds a workflow with
      `security-events: write`. There is no second reader on this board tonight,
      so this body carries the evidence in place of one: the resolved pin chain,
      the permission list, and the pin check over the result. That is weaker
      than a review and is not being presented as one.
- [ ] Review record - none, for the reason above.

## Notes

Any remediation Scorecard suggests is a separate issue, per the parent's
constraint. In particular the score will be dragged down by the manual oracle
pins, which are a recorded decision, and by the absence of a signed-releases
history, which is a thing #82 will produce rather than a thing to fix here.

---

## The first run, appended after the merge

The merge of this PR was the push to `main` that triggered it, as the body above
said it would be.

- Run: https://github.com/iderex/cudec/actions/runs/30978112006 - completed,
  conclusion `success`.
- The SARIF reached Code Scanning. Three Scorecard analyses at 05:27 UTC against
  commit `cfba9151`, and the alerts are queryable:

```
$ gh api "repos/iderex/cudec/code-scanning/analyses?per_page=5" --jq '.[] | "\(.tool.name) \(.created_at) rules=\(.results_count) \(.commit_sha[0:8])"'
Scorecard 2026-08-05T05:27:02Z rules=3 cfba9151
Scorecard 2026-08-05T05:27:01Z rules=3 cfba9151
Scorecard 2026-08-05T05:27:00Z rules=1 cfba9151
CodeQL    2026-08-05T05:26:04Z rules=0 38936ff3
CodeQL    2026-08-05T05:24:06Z rules=0 57c69d36
```

Seven alerts, one per check that scored below its maximum:

```
$ gh api "repos/iderex/cudec/code-scanning/alerts?per_page=100&tool_name=Scorecard" --jq '.[] | "\(.rule.id)|\(.rule.security_severity_level // .rule.severity)|\(.most_recent_instance.message.text | split("\n")[0])"'
CIIBestPracticesID|low|score is 0: no effort to earn an OpenSSF best practices badge detected
CodeReviewID|high|score is 0: Found 0/13 approved changesets -- score normalized to 0
MaintainedID|high|score is 0: project was created within the last 90 days. Please review its contents carefully:
FuzzingID|medium|score is 0: project is not fuzzed:
SASTID|medium|score is 8: SAST tool detected but not run on all commits:
SecurityPolicyID|medium|score is 4: security policy file detected:
BranchProtectionID|high|score is 3: branch protection is not maximal on development and all release branches:
```

**There is no aggregate score to paste, and this is the reason rather than an
omission.** The issue asked for one; the SARIF route does not produce one. With
`results_format: sarif` the action emits per-check findings only, and the
aggregate number is what the JSON output and the public dashboard carry - the
route this workflow deliberately does not take. The seven per-check scores above
are what exists. Reporting an aggregate here would mean either turning on
publishing, which the body above declines on purpose, or computing a number
Scorecard did not emit.

Two of the seven are worth naming so nobody reads them as news: `MaintainedID`
scores 0 because the repository is younger than 90 days, and `FuzzingID` scores 0
because the fuzzing work is #69 and #141, which have not landed. `SASTID` at 8
is the CodeQL workflow being younger than the history it is measured over. None
of these are acted on here, per the parent's constraint.

