### PR TITLE
Bootstrap CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,106 @@
+# Changelog
+
+All notable changes to this project are recorded here, in the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, and the
+version numbers follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+What "notable" means here: a change a consumer of the C ABI, the build, or the
+recorded numbers can observe. Internal refactors, test-net work and process
+changes stay in the git history and in their issues, where they are already
+readable.
+
+No version has been released yet. `include/cudec.h` reports 0.0.1 and no tag
+exists, so the entry below sits under Unreleased rather than under a number and
+a date this project has not chosen: the released heading is the release's to
+write, together with the version bump (#82). Everything in it is in the tree
+today.
+
+## [Unreleased]
+
+### Added
+
+- **LZ4 block batch decode on the GPU.** `cudec_lz4_decompress_batch` decodes
+  N independent LZ4 block-format chunks in one launch on a caller-provided
+  stream, one warp per chunk, with a per-chunk `cudec_chunk_result`. The call is
+  asynchronous: its return value covers argument validation and launch
+  submission, and the per-chunk statuses are valid once the stream reaches the
+  end of the launch.
+- **`.lz4` frame decode.** `cudec_lz4f_decompress` decodes the frame format's
+  block-independent subset, host memory to host memory, driving the batch
+  decoder internally. The header, block and content checksums and the optional
+  declared content size are verified fail-closed when present. A valid frame
+  outside that subset - block-linked mode, which is liblz4's own frame-compressor
+  default, or a dictionary id - is refused with `CUDEC_ERR_UNSUPPORTED` rather
+  than decoded partially.
+- **Streaming decode over pinned host memory.** `cudec_stream_ctx_create` /
+  `cudec_lz4_decompress_stream_ctx` / `cudec_stream_ctx_destroy` decode from and
+  to host memory through a reusable context that owns its CUDA stream and its
+  pinned staging, plus `cudec_lz4_decompress_stream` as the one-shot wrapper for
+  a caller that does not want to hold a context. A context that hits a CUDA
+  fault is poisoned: it decodes nothing further and only its destructor is valid
+  on it.
+- **A defined status for every outcome.** `cudec_status` covers argument
+  rejects, corrupt input, an output buffer too small, and CUDA faults, with
+  `CUDEC_ERR_UNSUPPORTED` for a stream cudec understands and will not decode and
+  `CUDEC_ERR_NOT_IMPLEMENTED` reserved for entry points that do not exist yet.
+  No exception crosses the ABI and every CUDA call's error is checked.
+- **`cudec_version()`** and the `CUDEC_VERSION_*` macros, single-sourced: the
+  build system reads the version out of the public header, and a conformance
+  test refuses a mismatch between the two.
+
+### Supported subset, stated as limits rather than implied
+
+- LZ4 only. Snappy, GDeflate, Zstd and the HIP port are planned milestones with
+  no code in this release; the milestone table in
+  [README.md](README.md) is the current state.
+- Frames must be block-independent and carry no dictionary id.
+- Decode only. Nothing here compresses.
+- NVIDIA GPUs. The default architecture list is `80` plus `86-real`, and the
+  recorded numbers are all from an `sm_86` device. The CUDA
+  engine is opt-in at configure time (`-DCUDEC_ENABLE_CUDA=ON`) and fails the
+  configure without a toolchain rather than quietly building a host-only
+  library.
+- One deliberate divergence from liblz4, documented and tested: cudec refuses a
+  match offset of 0, which liblz4 tolerates. cudec's accept set is a strict
+  subset of the reference's on that one point.
+
+### Guarantees, as tested
+
+- **Fail-closed decode.** A malformed, truncated or hostile chunk produces a
+  defined error with `bytes_written == 0`, never an out-of-bounds access and
+  never partial output presented as success. Held to liblz4 1.10.0 as the
+  authority on validity over the fixture corpus, its mutants and hand-crafted
+  negatives; the parser twin runs that comparison on the GPU-less CI runner and
+  the device twins repeat it on hardware.
+- **Determinism.** Same input, bit-identical output. The levels this holds at,
+  and what each one is measured against, are in
+  [docs/DETERMINISM.md](docs/DETERMINISM.md); `determinism_gpu` covers the
+  launch-geometry axis a same-batch-twice comparison cannot see.
+- **Termination.** Every parser call consumes at least one byte, asserted per
+  call over the truncation ladder, the mutant corpus and the crafted streams, so
+  a decode loop cannot hang the device on any input.
+- **Structural invariants locked as tests rather than as prose.** The C ABI
+  carries no dependency beyond the CUDA runtime, the decode path is
+  integer-only, warp collectives may not take their participation metadata from
+  parsed input, no bare wave-width literal is allowed outside the line that
+  names it, and every ctest entry carries a timeout. These are configure-time
+  refusals with their own liveness probes.
+
+### Measured
+
+Baselines are recorded, never quoted bare: every entry in
+[docs/BENCHMARKS.md](docs/BENCHMARKS.md) carries the methodology block its
+harness emitted - GPU, driver, CUDA version, corpus, chunk-size distribution and
+run count - and
+[docs/BENCHMARK-METHODOLOGY.md](docs/BENCHMARK-METHODOLOGY.md) is the write-up
+that reads them. That file also records the perf passes whose optimizations were
+measured and **rejected**, which is the part a changelog usually loses.
+
+### Known gaps
+
+- Compute Sanitizer cannot attach to the device on the maintainer's machine, so
+  the four-tool sweep has never produced a clean run there. The runner script is
+  in the tree and the blocker is tracked; nothing in this release is claimed to
+  have passed it.
+- The GPU tests run on the maintainer's hardware, not in CI, which has no GPU.
+  CI builds both configurations and runs the host-side subset.


### PR DESCRIPTION
# What & why

The repository had no `CHANGELOG.md`. This adds the first entry, distilled from
what is in the tree and what the merged history shipped.

Part of #143 - see the one deviation below, which is why this does not close it.

## Type of change

- [x] Docs

## What the entry says

The observable surface, one bullet each: the batch entry point and its
asynchronous contract, the frame subset with what it verifies and what it
refuses, the streaming context including its poisoned state, the status set, and
the version single-sourcing.

Then three sections a changelog usually leaves out, which are the ones a consumer
of a decompressor actually needs:

- **the supported subset as limits** - LZ4 only, block-independent frames only,
  decode only, opt-in CUDA engine, and the deliberate divergence from liblz4 on
  a zero match offset;
- **the guarantees as tested**, each naming the test that holds it up rather than
  the intention behind it;
- **known gaps** - Compute Sanitizer cannot attach on my machine,
  so the four-tool sweep has never produced a clean run, and the GPU tests run
  there rather than in CI. A first changelog that drops those two is the wrong
  kind of shorter.

Numbers are referenced, never quoted: the baselines carry their own methodology
blocks in `docs/BENCHMARKS.md` and the write-up that reads them is linked.

## Every line traced

Each claim was checked against the tree rather than written from memory. The
non-obvious ones:

- the asynchronous batch contract and the per-chunk result: `include/cudec.h`
  above `cudec_lz4_decompress_batch`;
- the frame subset, the four things verified when present, and
  `CUDEC_ERR_UNSUPPORTED` for block-linked mode being liblz4's own default:
  `include/cudec.h:109-126`;
- the poisoned streaming context and that only the destructor is valid on it
  afterwards: `include/cudec.h` above `cudec_lz4_decompress_stream_ctx`, and
  `ctx.poisoned` in `src/stream.cpp`;
- `CUDEC_ERR_NOT_IMPLEMENTED` reserved and returned by no current entry point:
  `include/cudec.h:34-38`;
- the version cross-check: the `CUDEC_CMAKE_VERSION_*` assertions in
  `tests/conformance_c.c`;
- the architecture list `80` plus `86-real`: `CMakeLists.txt:97` - written as the
  default list rather than as "baseline sm_80", which is the masterplan's phrasing
  and not what the build says;
- the zero-offset divergence: the comment and reject in `src/lz4_block.h`, pinned
  by `tests/parser_twin.cpp`;
- the structural invariants: the configure-time refusals in
  `tests/CMakeLists.txt`, each with its own liveness probe.

Nothing in the entry claims a capability the suite does not exercise. Snappy is
in the tree as an oracle and a corpus only, so it appears in the entry as a
planned milestone and nowhere else.

## The deviation, and why this does not close the issue

The issue asks for `[0.1.0] - <date>` as the first released section. The entry
sits under `[Unreleased]` instead, and the file says why in its own header:
`include/cudec.h` reports **0.0.1**, and no tag exists.

```
$ grep -n "CUDEC_VERSION" include/cudec.h | head -3
17:#define CUDEC_VERSION_MAJOR 0
18:#define CUDEC_VERSION_MINOR 0
19:#define CUDEC_VERSION_PATCH 1

$ git tag
(no output)
```

So a `[0.1.0]` heading here would name a version the tree does not carry and a
date the project has not chosen, in the one file whose job is to be accurate
about exactly that. The issue also says this change must not bump the version -
which is the same constraint from the other side. Both the number and the date
belong to the release that bumps it (#82), and moving the content under a heading
is one edit there.

That is one bullet of the Done-when unmet by choice, so the issue stays open with
this reasoning in it rather than being closed on a technicality. The other two
bullets - the file exists and is Prettier-clean, every line traces to the tree or
a merged PR, and no claimed capability is untested - are met.

## Verification

- [x] Prettier - `All matched files use Prettier code style!`
- [x] Docs synced - the entry references the README milestone table, BENCHMARKS,
      BENCHMARK-METHODOLOGY and DETERMINISM rather than restating them, so there
      is nothing here to drift against.
- [ ] No build or test change: the diff is one new Markdown file.

## Engineering checklist

- [ ] Fail-closed / oracle / determinism / CUDA-ABI - not applicable, no code
      changes. What the entry says about each of those was checked against the
      test that holds it.
- [ ] An adversarial review was NOT run. There is no second reader on this board
      tonight, so this body carries the evidence in place of one: the per-claim
      trace above and the version/tag commands behind the deviation. That is
      weaker than a review and is not being presented as one.
- [ ] Review record - none, for the reason above.

## Notes

The header paragraph also states what "notable" means for this file, so the next
entry does not have to re-decide whether an internal refactor belongs in it.
