### PR TITLE
Add the three issue forms and the chooser config

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,132 @@
+# A decode bug is only actionable with the device, the toolchain and the input.
+# Every field below that is marked required is one whose absence has to be
+# asked back for before anything can be reproduced.
+name: Bug report
+description: Something cudec does is wrong, and it is not a decode divergence against a reference implementation.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If the bug is a crafted bitstream causing memory corruption, a hang, or
+        any other memory-safety failure, close this form and use
+        [private vulnerability reporting](https://github.com/iderex/cudec/security/advisories/new)
+        instead. A public issue for that is a disclosure you cannot take back.
+
+        If cudec and a reference implementation disagree about a stream, the
+        decode divergence form fits better than this one.
+
+  - type: input
+    id: version
+    attributes:
+      label: cudec version or commit
+      description: The output of `cudec_version()`, or the commit SHA you built.
+      placeholder: "0.0.1, or ab133e0"
+    validations:
+      required: true
+
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU model
+      description: As `nvidia-smi --query-gpu=name --format=csv,noheader` prints it.
+      placeholder: NVIDIA GeForce RTX 3080
+    validations:
+      required: true
+
+  - type: input
+    id: driver
+    attributes:
+      label: Driver version
+      description: As `nvidia-smi --query-gpu=driver_version --format=csv,noheader` prints it.
+      placeholder: "581.15"
+    validations:
+      required: true
+
+  - type: input
+    id: cuda
+    attributes:
+      label: CUDA toolkit version
+      description: The last line of `nvcc --version`.
+      placeholder: "12.6.77"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Where it was built and run
+      description:
+        A container and a native toolchain can differ in driver, runtime and
+        architecture flags, so the answer changes what to reproduce on.
+      options:
+        - Container (Docker, Podman, Apptainer)
+        - Native Linux
+        - Native Windows
+        - WSL2
+        - Other, described below
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened, and what you expected instead
+      description: Include the `cudec_status` value returned, and the per-chunk
+        `status` and `bytes_written` where a batch call is involved.
+      placeholder: |
+        Called cudec_lz4_decompress_batch with 4 chunks. Chunk 2 came back
+        CUDEC_ERR_CORRUPT_INPUT (2) with bytes_written 0. liblz4 decodes the
+        same chunk to 65536 bytes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: How to reproduce it
+      description:
+        The smallest thing that shows the failure. A complete program is
+        better than a description of one, and the exact compile and run
+        commands are part of it.
+      render: shell
+    validations:
+      required: true
+
+  - type: dropdown
+    id: input-availability
+    attributes:
+      label: The input that triggers it
+      description:
+        The bytes matter more than anything else in this form. If they cannot
+        be shared, say so here rather than leaving it open.
+      options:
+        - Attached to this issue
+        - Reproducible by the generator or command shown above
+        - I have it and can share it privately on request
+        - I cannot share it, and cannot produce a substitute
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: fixture-consent
+    attributes:
+      label: Test fixture
+      description:
+        A reproducer only stops a bug coming back if it can live in the test
+        suite. This is the permission to put it there, and leaving it unticked
+        is a fine answer.
+      options:
+        - label: This input is not confidential and may be checked into the
+            repository as a test fixture under Apache-2.0.
+          required: false
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else
+      description:
+        Compute Sanitizer output, `dmesg`, a stack trace, or the surrounding
+        code if the call is not standalone.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2-decode-divergence.yml
+++ b/.github/ISSUE_TEMPLATE/2-decode-divergence.yml
@@ -1,0 +1,118 @@
+# The oracles decide. A report that cudec and a reference implementation
+# disagree about one stream is the highest-value thing an outside reader can
+# send, because it is the exact shape of failure the whole test net is built to
+# catch, and one that escaped it. It gets its own form so the two verdicts and
+# the stream are never the fields that went missing.
+name: Decode divergence
+description: cudec and a reference implementation disagree about the same stream, in either direction.
+labels: ["bug", "area:formats"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Both directions count and neither is the boring one.
+
+        cudec accepting a stream the reference rejects is a fail-open, which is
+        the severe direction: the oracle-parity rule is that whenever the
+        reference rejects, cudec rejects too. cudec rejecting one the reference
+        accepts is a false reject. Bytes differing on a stream both accept is a
+        correctness bug in the decode itself.
+
+        cudec carries one deliberate divergence, documented in
+        `src/lz4_block.h` and pinned by `tests/parser_twin.cpp`: a match offset
+        of 0 is refused, where liblz4 tolerates it. If that is what you found,
+        it is known and intended.
+
+  - type: dropdown
+    id: direction
+    attributes:
+      label: Which way the disagreement goes
+      options:
+        - cudec accepts, the reference rejects
+        - cudec rejects, the reference accepts
+        - Both accept, and the output bytes differ
+    validations:
+      required: true
+
+  - type: dropdown
+    id: format
+    attributes:
+      label: Format
+      options:
+        - LZ4 block
+        - LZ4 frame
+    validations:
+      required: true
+
+  - type: input
+    id: reference
+    attributes:
+      label: Reference implementation and version
+      description:
+        The exact version, not "latest". The suite holds liblz4 1.10.0 as the
+        authority on validity, so a different version is itself worth knowing.
+      placeholder: liblz4 1.10.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: reference-verdict
+    attributes:
+      label: What the reference did
+      description:
+        Its return value or exit status, the decoded size, and the command or
+        call that produced it.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: cudec-verdict
+    attributes:
+      label: What cudec did
+      description:
+        The `cudec_status` value, and for a batch call the per-chunk `status`
+        and `bytes_written`. Include the call as you made it.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: stream
+    attributes:
+      label: The stream
+      description: Attach the file, or paste it base64-encoded if it is small. A
+        divergence report without the bytes cannot be turned into a test.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: cudec version or commit
+      placeholder: "0.0.1, or ab133e0"
+    validations:
+      required: true
+
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU model, driver and CUDA version
+      description:
+        Skip this only if you reproduced the divergence on the host-side parser
+        twin, in which case say that instead.
+      placeholder: RTX 3080, driver 581.15, CUDA 12.6.77
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: fixture-consent
+    attributes:
+      label: Test fixture
+      description:
+        A divergence that becomes a fixture is a divergence that cannot come
+        back. Leaving this unticked is a fine answer.
+      options:
+        - label: This stream is not confidential and may be checked into the
+            repository as a test fixture under Apache-2.0.
+          required: false

--- a/.github/ISSUE_TEMPLATE/3-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature-request.yml
@@ -1,0 +1,63 @@
+# The format ladder and the milestones are already decided in
+# docs/MASTERPLAN.md, so the useful part of a feature request is rarely the
+# format name. It is the use case, which is what says whether the ask is the
+# ladder arriving sooner or a shape the ladder does not have.
+name: Feature request
+description: A format, an API shape, or a build surface cudec does not have.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The planned formats and their milestones are in
+        [docs/MASTERPLAN.md](https://github.com/iderex/cudec/blob/main/docs/MASTERPLAN.md)
+        and the current state is the milestone table in the README. If the ask
+        is one of those arriving sooner, say so plainly and describe what is
+        waiting on it; that is useful and does not need to be dressed up as
+        something new.
+
+        cudec decodes and does not compress. That is a design decision rather
+        than a gap, so a compression ask will be closed as out of scope.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of ask
+      options:
+        - A compressed format cudec does not decode
+        - An API shape on the existing formats
+        - Build, packaging or platform support
+        - Something else, described below
+    validations:
+      required: true
+
+  - type: textarea
+    id: ask
+    attributes:
+      label: What you want cudec to do
+      description:
+        Concretely. If it is an API ask, the signature you would want to call
+        is worth more than a description of it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: The use case
+      description:
+        What you are building, what is decompressing today, and what it costs
+        you. This is the field that decides the priority, and a request without
+        it is hard to place against the milestones.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you are doing instead today
+      description:
+        A CPU library, another GPU decoder, or a workaround. Say if the
+        workaround is fine and this is only a convenience.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,20 @@
+# The New Issue chooser.
+#
+# Blank issues stay on. The maintainer files most of this tracker by hand and
+# the forms below are shaped for reports from outside; forcing every internal
+# issue through a bug-report schema would cost more than the structure buys.
+#
+# The contact link is the load-bearing part. SECURITY.md requires that a
+# crafted-bitstream report goes through private vulnerability reporting, and a
+# chooser that offers no such route invites the reporter to open a public issue
+# instead, which is a disclosure failure the reporter cannot undo. There is
+# deliberately no vulnerability *form*: any form here creates a public issue.
+blank_issues_enabled: true
+
+contact_links:
+  - name: Report a vulnerability privately
+    url: https://github.com/iderex/cudec/security/advisories/new
+    about:
+      A crafted bitstream that causes memory corruption, a hang, or any other
+      memory-safety failure goes here, not into a public issue. This opens a
+      private security advisory. See SECURITY.md.


### PR DESCRIPTION
# What & why

Closes #83.

The repository carried a pull-request template and no issue templates, so a
report arrived in whatever shape its author chose. Two costs, both concrete for
a decoder: a decode-mismatch report without the GPU, the driver, the CUDA
version and the offending bytes cannot be reproduced, and the New Issue chooser
offered no private route at all, so a crafted-bitstream finding had one obvious
path and it was a public one.

Three forms plus the chooser config, and nothing else changes.

**Bug report** requires cudec version or commit, GPU model, driver, CUDA
version, container against native, what happened including the `cudec_status`
value and the per-chunk `status` / `bytes_written`, a reproducer, and an answer
to what can be done with the input. That last one is a dropdown rather than a
free field so "I cannot share it, and cannot produce a substitute" is a recorded
answer instead of a silence somebody has to ask back about.

**Decode divergence** gets its own form because it is the highest-value report
an outside reader can send and the one whose fields most reliably go missing.
It asks which way the disagreement runs, since cudec accepting what the
reference rejects is the fail-open the oracle-parity rule exists against, and
cudec rejecting what the reference accepts is a different bug. The intro names
the one deliberate divergence already in the tree, the zero match offset refused
in `src/lz4_block.h` and pinned by `tests/parser_twin.cpp`, so a reporter who
found that is told before filing rather than after.

**Feature request** asks for the use case, which is the field that places an ask
against the milestone table, and states up front that cudec does not compress so
that ask is closed as out of scope rather than left hanging.

Both fixture-consent checkboxes are optional. A required consent turns a report
into a negotiation, and the point is to receive the report.

`config.yml` keeps blank issues on and carries one contact link to private
vulnerability reporting, which is what SECURITY.md already mandates. There is
deliberately no vulnerability form: every form in this directory opens a public
issue, which is the failure mode the link exists to avoid.

## Type of change

- [x] Docs
- [x] Build / CI / supply chain

Neither kernel, format, ABI nor performance is touched, so the engineering,
performance and oracle checklists have nothing to answer here and are not ticked
rather than ticked vacuously.

## Verification

Prettier, run in the worktree at this commit:

```
npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

Schema, checked with a throwaway script rather than by eye: every body element
carries a type GitHub accepts, every non-`markdown` element carries a unique id
and a label, `markdown` elements carry neither id nor validations, dropdowns
carry a non-empty list of string options, and checkbox options carry a `label`
key with `required` on the option rather than on the element.

```
OK   1-bug-report.yml (11 elements, labels: bug)
OK   2-decode-divergence.yml (10 elements, labels: bug,area:formats)
OK   3-feature-request.yml (5 elements, labels: enhancement)
OK  config.yml blank_issues_enabled=true contact_links=1
exit=0
```

That script is not vacuous. Deleting the `id:` line from one field of the bug
report reds it and names the element:

```
FAIL 1-bug-report.yml
    body[2] no id
exit=1
```

Required fields, as the schema actually marks them rather than as the issue
describes them:

```
1-bug-report.yml
  required: version, gpu, driver, cuda, environment, what-happened, reproducer, input-availability
  optional: fixture-consent, anything-else
2-decode-divergence.yml
  required: direction, format, reference, reference-verdict, cudec-verdict, stream, version, gpu
  optional: fixture-consent
3-feature-request.yml
  required: kind, ask, use-case
  optional: alternatives
```

The three labels these forms apply already exist on the tracker (`bug`,
`area:formats`, `enhancement`), so no form lands a label GitHub would have to
create.

Private vulnerability reporting is on, so the contact link resolves to a real
route rather than a 404:

```
gh api repos/iderex/cudec/private-vulnerability-reporting
{"enabled":true}
```

## What is not verified here, and how it will be

The script above is my reading of GitHub's form schema, not GitHub's. Nothing in
CI parses these files, and no check in this repository has issue forms as its
subject, so a form that satisfies the script and not GitHub would merge green.
The authority is GitHub's own parse of the default branch, which can only be
read after the merge:

```
gh api graphql -f query='{ repository(owner:"iderex", name:"cudec") { issueTemplates { name about } } }'
```

I will run that on `main` after merge and post the result into #83. Until then
the acceptance criterion "the three forms render on the New Issue chooser" is
claimed, not measured.

No second reader on this change. The evidence above stands in place of one.
