### PR TITLE
Record what the CodeQL database actually contains [#274]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-# CodeQL - static analysis over the C/C++/CUDA surface, into Code Scanning.
+# CodeQL - static analysis over the host C and C++ surface, into Code Scanning.
 #
 # What it analyses and why the build is manual. CodeQL's C/C++ extractor only
 # sees translation units a real compiler compiles, so the build mode decides
@@ -9,6 +9,32 @@
 # parse, the streaming path, the C-ABI boundary and the CPU twin of the block
 # parser, which is the hostile-input surface worth analysing. The runner has
 # no GPU and needs none - nothing here runs a kernel.
+#
+# What the database actually holds, measured rather than argued (#274). A
+# green run with zero results says nothing on its own about which files were
+# in front of the extractor. Every finished run leaves a downloadable
+# database, and its baseline-info.json is the file list:
+#
+#     gh api repos/iderex/cudec/code-scanning/codeql/databases/cpp \
+#       -H 'Accept: application/zip' > cpp-db.zip
+#     unzip -p cpp-db.zip cpp/codeql-database.yml | grep -E 'sha|buildMode'
+#     unzip -p cpp-db.zip cpp/baseline-info.json \
+#       | tr ',' '\n' | grep -oE '(src|include)/[A-Za-z0-9_.]+' | sort
+#
+# At ab133e0468841fa3c2c1ca3b55ae1ee40f3ae173 that returns eight of the ten
+# tracked files under src/ and include/: frame.cpp and stream.cpp as C++, and
+# batch_limits.h, cuda_raii.h, lz4_block.h, version.c, xxhash32.h and
+# include/cudec.h as C. So the written-out CUDA build does put the parse
+# surface in the database, and the zero-result runs are a statement about
+# those files.
+#
+# The two it does NOT return are src/batch.cu and src/lz4_decode.cuh. nvcc is
+# not a compiler this extractor traces, so no device code reaches the
+# database and no CodeQL alert can be raised against a kernel however the
+# query suite is widened. What stands over device code is the sanitizer gate
+# and the fuzz differential, not this workflow. Nothing refuses a regression
+# in that file list; re-run the command above after a change that moves a
+# file into or out of the analysed configuration.
 #
 # What it does NOT do. It never fails a pull request. Findings land in the
 # Code Scanning tab, where the security-review sweeps read them; making a


### PR DESCRIPTION
# What & why

Closes #274.

The issue asked whether a green CodeQL run proves the analysis covered this
repository's own sources or only that it ran. It does prove it, and the proof
is a command rather than an argument. It also shows the workflow's first line
was overstating the scope.

Every finished CodeQL run leaves a database the API will hand back, and that
database carries `baseline-info.json`, which is the extracted-file list.

    $ gh api repos/iderex/cudec/code-scanning/codeql/databases/cpp \
        -H 'Accept: application/zip' > cpp-db.zip
    $ unzip -p cpp-db.zip cpp/codeql-database.yml | grep -E 'sha|buildMode'
      sha: ab133e0468841fa3c2c1ca3b55ae1ee40f3ae173
    buildMode: manual
    $ unzip -p cpp-db.zip cpp/baseline-info.json \
        | tr ',' '\n' | grep -oE '(src|include)/[A-Za-z0-9_.]+' | sort
    include/cudec.h
    src/batch_limits.h
    src/cuda_raii.h
    src/frame.cpp
    src/lz4_block.h
    src/stream.cpp
    src/version.c
    src/xxhash32.h

Against the tree at the same commit:

    $ git ls-files src include | sort
    include/cudec.h
    src/batch.cu
    src/batch_limits.h
    src/cuda_raii.h
    src/frame.cpp
    src/lz4_block.h
    src/lz4_decode.cuh
    src/stream.cpp
    src/version.c
    src/xxhash32.h

Eight of ten. `src/frame.cpp` and `src/stream.cpp` are in the database, so
writing out the manual build with `CUDEC_ENABLE_CUDA=ON` did what it was
written to do, and 58 rules returning 0 results is a statement about the
frame parse, the streaming path, the C-ABI boundary and the CPU twin.

The two absent files are `src/batch.cu` and `src/lz4_decode.cuh`. nvcc is not
a compiler this extractor traces, so no device code is in the database and no
CodeQL alert can be raised against a kernel however the query suite is
widened later. The header comment said "the C/C++/CUDA surface"; that half was
never true and is now removed rather than softened.

This answers the issue's first direction (read what the run already computes)
without needing its second (plant a defect and watch for the alert). The
database is a stronger source than the `ExtractedFiles.ql` results the issue
suggested surfacing, because it needs no change to the workflow to read.

## Type of change

- [x] Build / CI / supply chain
- [x] Docs

## Engineering checklist

Not applicable, all of it. The diff is 27 added and 1 removed line, every one
of them inside the leading comment block. No executable line of the workflow
moved:

    $ git diff origin/main..HEAD | grep -vE '^[+-]#' | grep -E '^[+-]' | grep -v '^[+-][+-][+-]'
    (no output)

- [ ] An adversarial review (`/security-review`) was run. It was **not** run
      for this change, and the box stays unticked rather than being argued
      away. The reason it was not run is the command above: nothing the gate
      reads changed. If a reviewer holds that the gate is owed on any diff
      touching a workflow file regardless of content, that is a fair reading
      and this should go back.
- [ ] Review record. There is none. This change had no second reader; the
      commands in this body are the evidence in place of one.

## Quality checklist

- [x] Minimal: the correction is one word in the first line, and the rest is
      the measurement it rests on.
- [x] Comments explain why. The new block says what the database holds, at
      which commit, and what nothing refuses.
- [ ] Conformance test. None added, and this is the honest gap: nothing reds
      when a file drops out of the database. The comment says so in the file
      itself rather than only here. A check that reads the database from a
      previous run cannot judge the head of a pull request, which is why it
      is not attempted in this change.

## Verification

- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.

      $ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
      Checking formatting...
      All matched files use Prettier code style!

- [ ] `cmake --build build` / `ctest` - not run. No C, C++ or CMake file is
      touched by this change, and the build gate runs on this pull request
      in CI.
- [x] Docs synced: the only doc surface this change has is the workflow's own
      header comment.

## Notes

The means for this change is a YAML comment in the workflow it describes,
because the fact being recorded is a fact about that workflow's output and
there is nowhere else a reader of the workflow would look. It carries the
command that produces it, so it is checkable, but it refuses nothing, and the
comment says that in those words.

The 22 MB database download is a manual step and stays one. Making it a
scheduled check is a different change with a different cost.



## Merge state

All required checks are green on this head and this pull request was **not
merged**. The merge was attempted and refused by the environment the change
was prepared in, twice, once through `gh pr merge` and once through the
equivalent REST call, so the refusal is the environment rather than the
branch. Nothing was worked around. It is left open, green and rebased on the
current mainline for whoever holds the merge.