### PR TITLE
Record the empty AMD state in the baseline record

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -11,6 +11,12 @@ Regressions against the recorded baselines block merges unless explicitly
 justified ([MASTERPLAN](MASTERPLAN.md) section 5). Corpora are fetched
 hash-pinned via `bench/get-corpora.sh` and never committed.
 
+Every entry below is an NVIDIA measurement. The mirror of the rule above is
+that a missing number is stated rather than omitted, so the AMD side has its
+own section near the end of this file
+([Community AMD results](#community-amd-results)) whose current content is that
+there are none.
+
 ## M1: first GPU decode (Silesia)
 
 The first GPU decode numbers, recorded 2026-07-17 inside the digest-pinned
@@ -460,6 +466,64 @@ longer uses, so it was removed rather than left as an orphaned lock.
 The device-resident M1 row (~18 GB/s, H2D/D2H excluded) remains the kernel
 throughput; the streaming numbers are a different, honest metric (copy +
 per-wave submission included) and are not a regression of it.
+
+## Community AMD results
+
+**No community results yet.** Nothing in this section is a measurement; it
+exists so that the absence of AMD numbers everywhere above is a recorded fact
+rather than a silence.
+
+**What has and has not happened on AMD, as of this entry.** Every number in
+this file was taken on one NVIDIA device (RTX 3080, sm_86, CUDA 12.6). The
+maintainer hardware is NVIDIA-only, so no AMD GPU has ever executed this
+decoder for the project, and no AMD measurement exists to record. There is also
+no AMD build: the HIP port is a planned M6 milestone, `CUDEC_ENABLE_HIP` does
+not exist in `CMakeLists.txt` today, and no CI job compiles for a `gfx` target.
+So the honest state is neither measured nor compiled, which is one rung below
+where this section will sit once the HIP compile gate lands (issues #209 and
+#111) and the "compiled" half becomes a thing a workflow run can be pointed at.
+
+**What a community result is, and what it is not.** A third-party measurement
+on hardware the maintainer does not have and cannot re-run. It is recorded as
+exactly that. It is **not** promoted to a project baseline and it does **not**
+gate merges: the rule that regressions against a recorded baseline block a
+merge (MASTERPLAN section 5) applies to the CUDA baselines above, which the
+maintainer can reproduce on demand, and extending it to a number nobody here can
+reproduce would make an unreproducible figure into a merge veto. A community
+result informs; it does not gate.
+
+**The recording format, fixed before the first result rather than by it.** When
+one arrives it is appended below as its own subsection, headed exactly like
+this so the index values cannot be left out of the heading and filled in
+somewhere less visible:
+
+```
+### <GPU name> / <gfx target> / ROCm <version> / wave <32|64> (#<issue>)
+```
+
+- The reporter's `bench_lz4` report block, pasted **whole and unedited**, in a
+  fenced code block. Not summarised, not re-typed, and not trimmed to the lines
+  that seemed interesting. The block is the evidence; a paraphrase of it is not.
+- The four index values repeated in the heading above are what the entry is
+  keyed by, because they are what makes two AMD results comparable or not. The
+  wave width is load-bearing here in a way it is not on the CUDA rows: a 32-wide
+  and a 64-wide build of the same kernel family are different executions of the
+  same source, and a table that loses that distinction is a table that averages
+  across it.
+- The submitting issue linked, and the reporter credited by the name or handle
+  they used to submit. If they asked not to be credited, that is written here
+  too, in place of the name.
+- Anything the reporter's environment did that the report block does not carry
+  goes underneath in prose, marked as the reporter's statement rather than as a
+  measured field.
+
+The `bench_lz4` report block emits a `CUDA device:` line and carries no ROCm
+version and no wave width today (`bench/bench_lz4.cpp`). Until the HIP build
+lands and the harness emits them, those two index values come from the reporter
+by hand and are recorded as reported, not as read out of the device.
+
+No sentence in this section can be refuted by pointing out that no AMD GPU was
+ever run, because that is what it says.
 
 ## Baseline: CPU oracle (M0, pre-kernel)
 


### PR DESCRIPTION
# What & why

Closes #247.

Every entry in `docs/BENCHMARKS.md` is an RTX 3080 measurement, and nothing in
the file said the AMD column had never been run. The file's own rule is that a
number cannot be produced without its methodology; the mirror of that rule is
that a missing number is stated rather than omitted, and that half was missing.
This adds a "Community AMD results" section whose correct content today is that
there are none, plus one sentence in the file header pointing at it so a reader
who stops after the M1 block still meets the fact.

## One deviation from the issue, and it is deliberate

The issue's Done-when reads "a reader of `docs/BENCHMARKS.md` alone can tell
that AMD has been **compiled**, not measured." That phrasing was written against
a tree in which the HIP port had landed. It has not:

```
grep -rn "CUDEC_ENABLE_HIP" . --exclude-dir=.git --exclude-dir=docs | wc -l
0

grep -rniE "gfx|rocm|hipcc" .github/workflows | wc -l
0
```

So there is no AMD build to report, and writing "compiled, not measured" today
would turn a negative disclosure into a positive one. The section instead says
neither measured nor compiled, and names #209 and #111 as the two landings after
which the compiled half becomes a thing a workflow run can be pointed at. The
intent of the issue, that the absence is recorded rather than silent, is met; its
literal wording is not, and this is the deviation rather than an oversight.

## What the section fixes

The recording format, written before the first result so the first result does
not get to invent it. The reporter's `bench_lz4` report block pasted whole and
unedited, keyed by GPU name, `gfx` target, ROCm version and wave width, with the
submitting issue linked and the reporter credited.

Wave width is in the key because it is load-bearing in a way it is not on the
CUDA rows: a 32-wide and a 64-wide build of the same kernel family are different
executions of one source, and a record that loses the distinction averages
across it.

The status of such a result is stated rather than left to be argued later. It is
a third-party measurement on hardware I do not have and cannot
re-run, so it is not promoted to a project baseline and does not gate merges.
MASTERPLAN section 5 makes a regression against a recorded baseline block a
merge; extending that to a number nobody here can reproduce would make an
unreproducible figure into a merge veto.

The section also records that the harness does not emit two of its own index
values today: `bench/bench_lz4.cpp` prints a `CUDA device:` line and no ROCm
version and no wave width, so those two come from the reporter by hand and are
marked as reported rather than as read from the device.

## Constraints checked

- #244 (README wording, still open) is not contradicted: this section makes no
  build claim at all, so it cannot disagree with one.
- #149 (hipCOMP exists; the M6 claim is single-source, not "first on AMD") is not
  touched. No comparative claim appears here.
- No number is added, changed, or removed. The diff is 64 added lines and
  nothing else:

```
git diff --stat origin/main...HEAD
 docs/BENCHMARKS.md | 64 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 64 insertions(+)
```

- Every existing measurement block in the file is NVIDIA, which is the claim the
  section opens with:

```
grep -o '^- CUDA device: .*' docs/BENCHMARKS.md | sort -u
- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
```

## Type of change

- [x] Docs

No kernel, format, ABI or performance surface is touched, so the engineering,
oracle and performance checklists have nothing to answer and are left unticked
rather than ticked vacuously.

## Verification

```
npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

The in-document link `[Community AMD results](#community-amd-results)` matches
the heading `## Community AMD results` under GitHub's slug rule. That is a
reading of the rule, not a rendered check.

No second reader on this change. The evidence above stands in place of one.
