### PR TITLE
Record the enwik8 GPU baseline [#138]

### DIFF
--- a/docs/BENCHMARK-METHODOLOGY.md
+++ b/docs/BENCHMARK-METHODOLOGY.md
@@ -72,16 +72,18 @@ workload the GPU path is built for.
   extend the offset-1 run into one long match), so the harness builds the
   block directly and the oracle validates it (round-trips through
   `LZ4_decompress_safe`) before any timing. This is the throughput worst case.
-- **enwik8** - fetched and hash-pinned by the harness for completeness, but
-  **not yet recorded with a GPU row**; when an enwik8 GPU number is published
-  it will carry its own full methodology block. It is listed here so the
-  corpus set is stated honestly, not to imply a measurement that does not
-  exist.
+- **enwik8** - the first 100 MB of an English Wikipedia dump, so pure
+  marked-up text rather than a mixture. 1526 chunks, 100.00 MB original,
+  57.00 MB compressed (ratio 0.570). Chunk sizes: min 57600 / median 65536 /
+  max 65536 bytes. Recorded 2026-08-05, later than the rows above and on the
+  same platform. This is the text-heavy case, and it is kept because it does
+  not reproduce the Silesia average.
 
 ## Measured results
 
-All figures are p50 of 30 runs, recorded 2026-07-17 on the platform above.
-The full per-report methodology blocks are in
+All figures are p50 of 30 runs, recorded 2026-07-17 on the platform above,
+except the enwik8 table, which was recorded 2026-08-05 on the same platform
+and says so again where it sits. The full per-report methodology blocks are in
 [BENCHMARKS.md](BENCHMARKS.md); this is the summary.
 
 ### Silesia (average case)
@@ -126,6 +128,28 @@ an attacker who fully controls a valid input can force. The honest findings:
   per-chunk output cap fail-closes the size axis regardless.
 - **The GPU advantage holds under the worst input:** 8.1 GB/s worst-case GPU
   is still ~5.4× the CPU worst case and ~2.3× the CPU's Silesia _average_.
+
+### enwik8 (text-heavy)
+
+Recorded 2026-08-05, same platform and same container digest as the tables
+above. `bench_lz4 bench/corpora/enwik8 --gpu --warmup 3 --runs 30`.
+
+| Path                                   | Throughput | vs. its Silesia row |
+| -------------------------------------- | ---------- | ------------------- |
+| CPU oracle, liblz4 single thread       | 2.96 GB/s  | ~1.15× slower       |
+| GPU decode, device-resident (cudec)    | 11.1 GB/s  | ~1.6× slower        |
+| GPU parse-only ceiling (copies elided) | 21.8 GB/s  | ~1.6× slower        |
+
+The corpus is kept pinned because of the right-hand column: the two GPU paths
+slow by roughly 1.6× while the CPU path barely moves, so the GPU-over-CPU
+factor falls from ~5.3× on Silesia to ~3.8× here. A corpus that reproduced
+Silesia would have earned its removal instead.
+
+Why it goes that way is not established by these numbers. enwik8 compresses
+worse than Silesia (ratio 0.570 against 0.483), and the cost model recorded
+for this kernel is linear in the number of sequences rather than in output
+bytes, which predicts this direction; the harness reports no sequence count,
+so nothing here measured it.
 
 ### Streaming, end-to-end (M2 reusable context)
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -277,6 +277,57 @@ Reproduce with `bench_lz4 --worst4b --gpu`; the construction is oracle-
 validated in-harness and locked against rot by the `bench_worst4b_selfcheck`
 ctest on the GPU-less runner.
 
+### Text-heavy: the enwik8 corpus (issue #138)
+
+`bench/get-corpora.sh` has pinned enwik8 since the corpora were pinned, and
+this file carried no row for it. That is the gap #138 was opened on: a pinned
+corpus we never measure is an unkept promise in the methodology document, so
+it either gains a row or loses its pin. It gains a row.
+
+The first 100 MB of an English Wikipedia dump, so pure marked-up text rather
+than the mixture Silesia averages over. No harness work was needed:
+`bench_lz4` takes corpus files positionally and splits any file into 64 KB
+chunks, so this is the same code path the Silesia rows use, on a different
+input. Recorded 2026-08-05 inside the digest-pinned dev container
+(`nvidia/cuda:12.6.2-devel-ubuntu24.04`) on the same RTX 3080 as every row
+above, `--warmup 3 --runs 30`. Fetched and verified before the run: zip
+SHA-256 `547994d9...34bc` and extracted-file SHA-256 `2b49720e...24a8`, both
+`OK` against `bench/get-corpora.sh`'s pins.
+
+```
+## bench_lz4 report
+- decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
+- cudec: 1 (the CPU rows time the liblz4 oracle baseline; the GPU rows below, when --gpu is set, time cudec's decoder)
+- corpus: enwik8, 1526 chunks, 100.00 MB original, 57.00 MB compressed (ratio 0.570), compressed in-harness via LZ4_compress_default
+- chunk sizes: min 57600 / median 65536 / max 65536 bytes
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
+- wall per run: p50 33.835 ms / p90 33.999 ms / p99 34.142 ms
+- decode throughput: p50 2.956 GB/s / p90 2.941 GB/s / p99 2.929 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs): p50 8.999 ms, 11.1 GB/s
+- GPU parse-only ceiling (copies elided): p50 4.592 ms, 21.8 GB/s - ceilings this design AND any two-phase phase-1 (shared parse)
+```
+
+What the row is worth keeping for: enwik8 is **not** a restatement of the
+Silesia average. Its GPU decode lands at 11.1 GB/s against Silesia's 18.1,
+about 1.6× slower, and its parse-only ceiling at 21.8 against 34.6, about the
+same factor. The CPU oracle moves much less, 2.956 against 3.41. So the
+corpus separates the two paths rather than scaling both, and the GPU-over-CPU
+factor falls from ~5.3× on Silesia to ~3.8× here. Had the row simply
+reproduced Silesia, unpinning would have been the better answer.
+
+What the row does **not** establish is why. enwik8 compresses worse than
+Silesia (ratio 0.570 against 0.483), which under the cost model already
+recorded above - cost linear in the number of sequences, not in output bytes -
+would predict exactly this direction, since a less compressible input carries
+more sequences per decoded byte. That is consistent with the number and is not
+measured by it: the harness reports no sequence count, and nothing here
+counted one. Stated as the reading it is.
+
+Reproduce with `bench/get-corpora.sh` followed by
+`bench_lz4 bench/corpora/enwik8 --gpu --warmup 3 --runs 30`.
+
 ### Cost of the termination fuel cap (issue #72)
 
 The sequence loop in `src/lz4_decode.cuh` now carries an explicit decrementing


### PR DESCRIPTION
# What & why

Closes #138.

`bench/get-corpora.sh` fetches and hash-pins enwik8, and `docs/BENCHMARKS.md`
had no row for it. `docs/BENCHMARK-METHODOLOGY.md` said so in its own text.
The issue offered two ways out, record it or unpin it with the reason. This
records it, and the measurement is what decided which way to go.

No harness work was needed, as the issue said: `bench_lz4` takes corpus files
positionally and chunks any file at 64 KB, so this is the same code path the
Silesia rows use on a different input.

## The run

Inside the digest-pinned dev container
(`nvidia/cuda:12.6.2-devel-ubuntu24.04`, digest `sha256:738fba0f...`) on the
RTX 3080. Corpus verified against both of `get-corpora.sh`'s pins first:

    $ echo '547994d9980ebed1288380d652999f38a14fe291a6247c157c3d33d4932534bc  enwik8.zip' | sha256sum -c
    enwik8.zip: OK
    $ echo '2b49720ec4d78c3c9fabaee6e4179a5e997302b3a70029f30f2d582218c024a8  enwik8' | sha256sum -c
    enwik8: OK

    $ bench_lz4 bench/corpora/enwik8 --gpu --warmup 3 --runs 30
    ## bench_lz4 report
    - decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
    - host CPU: AMD Ryzen 9 5950X 16-Core Processor
    - CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
    - corpus: enwik8, 1526 chunks, 100.00 MB original, 57.00 MB compressed (ratio 0.570), compressed in-harness via LZ4_compress_default
    - chunk sizes: min 57600 / median 65536 / max 65536 bytes
    - method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
    - wall per run: p50 33.835 ms / p90 33.999 ms / p99 34.142 ms
    - decode throughput: p50 2.956 GB/s / p90 2.941 GB/s / p99 2.929 GB/s
    - GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs): p50 8.999 ms, 11.1 GB/s
    - GPU parse-only ceiling (copies elided): p50 4.592 ms, 21.8 GB/s

The block is pasted into `docs/BENCHMARKS.md` whole, as every other row is.

## Why (a) and not (b)

The issue's option (b) argued that Silesia's text component already covers the
regime enwik8 would add, so the pin bought nothing. The numbers say otherwise.
Against the recorded Silesia rows:

| Path                | enwik8    | Silesia   | ratio        |
| ------------------- | --------- | --------- | ------------ |
| CPU oracle, liblz4  | 2.96 GB/s | 3.41 GB/s | ~1.15x slower |
| GPU decode (cudec)  | 11.1 GB/s | 18.1 GB/s | ~1.6x slower  |
| GPU parse-only      | 21.8 GB/s | 34.6 GB/s | ~1.6x slower  |

The two GPU paths slow by ~1.6x while the CPU path barely moves, so the
GPU-over-CPU factor falls from ~5.3x to ~3.8x. The corpus separates the paths
rather than scaling both, which is what a corpus has to do to be worth a pin.
Had it tracked Silesia, (b) would have been the right answer and this pull
request would have deleted the pin instead.

## What is written as a reading rather than a result

enwik8 compresses worse than Silesia (ratio 0.570 against 0.483), and the cost
model already recorded in `docs/BENCHMARKS.md` is linear in the number of
sequences rather than in output bytes, which predicts this direction. That is
consistent with the number and is not measured by it: `bench_lz4` reports no
sequence count and nothing here counted one. Both documents say so at the
point where the explanation appears, rather than only here.

## Type of change

- [x] Performance (recorded measurement, no code change)
- [x] Docs

## Engineering checklist

Not applicable, all of it. No source file is touched:

    $ git diff --stat origin/main...HEAD
     docs/BENCHMARK-METHODOLOGY.md | 34 +++++++++++++---
     docs/BENCHMARKS.md            | 55 +++++++++++++++++++++++++
     2 files changed, 82 insertions(+), 7 deletions(-)

- [ ] An adversarial review (`/security-review`) was run. Not run, and the box
      stays unticked. Neither changed file is on the sensitive surface and no
      executable line moved, which is the reason rather than a dispensation.
- [ ] Review record. There is none. This change had no second reader; the
      commands in this body and the pasted harness block are the evidence in
      place of one.

## Performance checklist

- [x] The claim is measured, not reasoned. GPU model, driver, CUDA version,
      corpus, chunk-size distribution and run count are in the pasted block,
      which is the harness's own output.
- [x] No regression against the recorded baseline. Nothing existing is
      re-measured or moved; this adds a corpus that had no baseline.

## Quality checklist

- [x] Minimal: two documents, one new row and one replaced paragraph.
- [x] Docs synced with each other: the summary table in the methodology
      document is derived from the block in the baseline record, and both
      carry the later recording date rather than inheriting 2026-07-17.
- [ ] Conformance test. None. The issue's closing line calls the invariant
      mechanical, that every corpus `get-corpora.sh` pins has an entry in
      `docs/BENCHMARKS.md`, and nothing enforces it: a future pin can arrive
      without a row exactly as enwik8 did. Silesia's twelve files are recorded
      as one aggregate row, so a name-by-name check would red on the tree as
      it stands, which is why one is not bolted on here. Said out loud in the
      commit message and in `docs/BENCHMARKS.md` rather than left implied.

## Verification

- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.
- [ ] `cmake --build` / `ctest` - not run for this change. No source, test or
      CMake file is touched; the build gate runs on this pull request in CI.
      `bench_lz4` was built in the container to produce the number above.

## Notes

The means is Markdown in the two documents that already hold every other
number, and the number itself comes from the harness rather than from a new
script, so nothing new is introduced to maintain.

`docs/MASTERPLAN.md` line 126 is untouched. It names "(Silesia, enwik)" as the
oracle-diff corpora, which stays true under this option; only option (b) would
have edited it. The game-asset-like corpus half of the parent (#77) is out of
scope and MASTERPLAN section 8 is not touched.



## Merge state

All required checks are green on this head and this pull request was **not
merged**. The merge was attempted and refused by the environment the change
was prepared in, twice, once through `gh pr merge` and once through the
equivalent REST call, so the refusal is the environment rather than the
branch. Nothing was worked around. It is left open, green and rebased on the
current mainline for whoever holds the merge.