### PR TITLE
Add the CMake install and export surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,55 @@ jobs:
       - name: Configure and build (host-only)
         run: cmake -B build && cmake --build build
 
+      # The install surface is proven by consuming it, never by inspecting it
+      # (issue #79). Install the host-only build into a prefix, then configure,
+      # build AND RUN a project outside this tree that knows nothing but
+      # find_package(cudec) - so a broken export set, a header installed where
+      # the exported include interface does not point, or a package config that
+      # never reaches the targets file reds this gate.
+      #
+      # It runs rather than only links because an archive can carry a symbol
+      # the consumer never actually reaches; cudec_version() touches no device,
+      # so the GPU-less runner can execute it. Fail-closed on the two files the
+      # consumer would otherwise fail on with a worse message, and the config
+      # is located rather than assumed at lib/ - GNUInstallDirs is free to put
+      # it under lib64 on another distribution.
+      #
+      # The consumer is driven TWICE, and both runs pass a version, because
+      # config mode reads cudec-config-version.cmake only when the caller
+      # requests one: a no-version consumer configures happily against a prefix
+      # whose version file was never installed. 0.0.1 must be accepted, 0.1
+      # must be refused, and the refusal leg reds if that configure SUCCEEDS.
+      #
+      # What that pair does NOT prove, stated so the gate is not read as
+      # stronger than it is: at 0.0.1 no request separates SameMinorVersion
+      # from SameMajorVersion or AnyNewerVersion, because every one of them
+      # refuses a request above the installed version. Measured by swapping the
+      # mode to AnyNewerVersion and watching this step stay green. What the
+      # legs do prove is that the version file is installed and consulted -
+      # dropping it from the install reds the step - and the modes become
+      # distinguishable the first time the minor moves.
+      - name: Install and consume out of tree (host-only)
+        run: >-
+          cmake --install build --prefix "$PWD/prefix-host" &&
+          test -f "$PWD/prefix-host/include/cudec.h" &&
+          test -n "$(find "$PWD/prefix-host" -name cudec-config.cmake
+          -print -quit)" &&
+          test -n "$(find "$PWD/prefix-host" -name cudec-config-version.cmake
+          -print -quit)" &&
+          cmake -S tests/consumer -B build-consumer
+          -DCMAKE_PREFIX_PATH="$PWD/prefix-host"
+          -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1 &&
+          cmake --build build-consumer &&
+          ./build-consumer/consumer &&
+          if cmake -S tests/consumer -B build-consumer-badver
+          -DCMAKE_PREFIX_PATH="$PWD/prefix-host"
+          -DCUDEC_CONSUMER_REQUEST_VERSION=0.1 > badver.log 2>&1; then
+          echo "FAIL: find_package(cudec 0.1) was accepted against a 0.0.1
+          prefix - the version policy is not being applied"; exit 1; else
+          echo "PASS: find_package(cudec 0.1) refused against a 0.0.1 prefix";
+          fi
+
       # Unconditional AND self-verifying: the GPU-test binaries exist only
       # if the CUDA configuration actually built the device TUs, so a
       # renamed CMake option cannot quietly turn this step into a green

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 build/
 build-cuda/
 build-san/
+# The out-of-tree consumer's own build trees and the prefix they consume, all
+# produced by the install proof in ci.yml and reproducible the same way.
+build-consumer/
+build-consumer-badver/
+prefix-host/
+badver.log
 
 # Downloaded benchmark corpora - hash-pinned by bench/get-corpora.sh,
 # never committed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ today.
 - **`cudec_version()`** and the `CUDEC_VERSION_*` macros, single-sourced: the
   build system reads the version out of the public header, and a conformance
   test refuses a mismatch between the two.
+- **An install surface.** `cmake --install` produces a prefix carrying the
+  public header, the archive, and a package config, so an outside project links
+  cudec through `find_package(cudec)` and the exported `cudec::cudec` target
+  instead of vendoring the tree. The compatibility rule is `SameMinorVersion`,
+  which at 0.x means a consumer asking for 0.0 is not handed 0.1. CI installs
+  the host-only build and builds and runs an out-of-tree consumer against the
+  result, in both directions of that version rule. The CUDA-flavoured prefix
+  installs but is not consumable yet, because its package config does not yet
+  carry `find_dependency(CUDAToolkit)`.
+
+### Changed
+
+- **`BUILD_SHARED_LIBS=ON` is refused in a top-level cudec build** rather than
+  producing a shared library with no SOVERSION and no symbol-visibility policy.
+  A project that vendors cudec as a subdirectory is unaffected: it gets a static
+  cudec and keeps its own setting.
 
 ### Supported subset, stated as limits rather than implied
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ project(
     "${_cudec_version_MAJOR}.${_cudec_version_MINOR}.${_cudec_version_PATCH}"
   LANGUAGES C)
 
+# CMAKE_INSTALL_INCLUDEDIR / _LIBDIR are read below by the install interface of
+# the library target, so this has to come before the target is defined rather
+# than beside the install() rules at the end.
+include(GNUInstallDirs)
+
 # The CUDA engine is opt-in and fail-closed: asking for it without a CUDA
 # toolchain is a hard configure error, never a silent host-only fallback (a
 # CI job that passed without compiling the kernels would be a fail-open
@@ -61,8 +66,40 @@ if(CUDEC_SANITIZE)
   set(CUDEC_SANITIZE_LINK_FLAGS -fsanitize=${CUDEC_SANITIZE})
 endif()
 
-add_library(cudec src/version.c)
-target_include_directories(cudec PUBLIC include)
+# Static only, and pinned rather than left to a global switch (issue #79). A
+# shared cudec needs SOVERSION discipline and symbol-visibility work - decide
+# what is exported, hide the rest, hold the soname to the ABI - and none of that
+# exists yet. Building one anyway would produce a library whose ABI story is
+# unmanaged while looking exactly like one whose story is managed, which is the
+# worse of the two failures. Revisit when a packager asks for it or at 1.0,
+# whichever comes first; the work is the visibility audit, not this line.
+#
+# The explicit STATIC is what enforces it, so BUILD_SHARED_LIBS=ON cannot
+# produce a shared cudec by accident. The refusal below is scoped to a top-level
+# build on purpose: a superbuild that sets BUILD_SHARED_LIBS globally and
+# vendors cudec is asking for shared *everything else*, and killing its
+# configure over a library it gets statically either way would be this project
+# reaching outside its own build.
+add_library(cudec STATIC src/version.c)
+if(BUILD_SHARED_LIBS AND PROJECT_IS_TOP_LEVEL)
+  message(
+    FATAL_ERROR
+      "cudec builds as a static library only. BUILD_SHARED_LIBS=ON would need "
+      "an SOVERSION and a symbol-visibility policy this project has not "
+      "settled (issue #79).")
+endif()
+
+# The in-tree spelling of the exported name, so a consumer inside this build
+# and a consumer of the installed package link the same string.
+add_library(cudec::cudec ALIAS cudec)
+# One include directory, two spellings, because the path differs between the
+# tree it is built in and the prefix it is installed to. The install-tree half
+# is stated here and NOT a second time via install(TARGETS ... INCLUDES
+# DESTINATION): both write the same entry, and using both ships the exported
+# INTERFACE_INCLUDE_DIRECTORIES with the directory listed twice.
+target_include_directories(
+  cudec PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+               $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 if(NOT MSVC)
   target_compile_options(cudec
@@ -203,4 +240,68 @@ if(CUDEC_ENABLE_CUDA)
   # Last, so it sees every directory both subdirectories added: no ctest entry
   # anywhere in the tree may have escaped the timeout check (issue #72).
   cudec_sweep_test_timeouts(${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+# ---- The install surface (issue #79). A release nobody can install is not a
+# release, and until this existed every consumer had to vendor the tree.
+#
+# Placed after both configurations so the exported target is whatever this
+# configure actually built, and after tests/ so nothing here can slip a
+# property past the conformance snapshot inside it: install() rules read the
+# target, they do not modify it.
+#
+# Top-level only. A project that vendors cudec by add_subdirectory or
+# FetchContent gets the target, not the packaging: without this guard its own
+# `cmake --install` would ship cudec's header, archive and package config into
+# the parent's prefix, where find_package(cudec) would then find a config the
+# parent never meant to publish and shadow a real install.
+if(PROJECT_IS_TOP_LEVEL)
+  include(CMakePackageConfigHelpers)
+
+  # No INCLUDES DESTINATION here: the install-tree include path is already in
+  # the target's interface as $<INSTALL_INTERFACE:...>, and stating it both
+  # ways writes the same directory into the exported
+  # INTERFACE_INCLUDE_DIRECTORIES twice.
+  install(
+    TARGETS cudec
+    EXPORT cudec-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+  # The whole public surface is one header, by design: include/cudec.h needs no
+  # CUDA headers and pulls in nothing but stddef.h and stdint.h. src/ is
+  # internal and is not installed.
+  install(FILES include/cudec.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+  install(
+    EXPORT cudec-targets
+    FILE cudec-targets.cmake
+    NAMESPACE cudec::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cudec)
+
+  # SameMinorVersion, and the reason is the 0.x in the version rather than a
+  # preference. SemVer itself promises nothing at 0.y.z - "anything MAY change
+  # at any time" - so this is a convention this project adopts and states,
+  # not a rule read out of the specification. The convention is the common one:
+  # at 0.x the minor bump is the breaking one, so 0.0.1 and 0.1.0 are not
+  # interchangeable and a consumer asking for 0.0 must not be handed 0.1.
+  # ExactVersion was the alternative and is too strict in the other direction:
+  # it would refuse 0.0.2 to a consumer who wrote 0.0.1 and meant the patch
+  # series, which is the axis this project intends to keep compatible.
+  #
+  # The revisit is at 1.0, where the same convention gives SameMajorVersion.
+  # That is a deliberate change of policy at a deliberate moment, not a default
+  # to drift into.
+  write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/cudec-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMinorVersion)
+
+  configure_package_config_file(
+    "${CMAKE_CURRENT_LIST_DIR}/cmake/cudec-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cudec-config.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cudec)
+
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cudec-config.cmake"
+                "${CMAKE_CURRENT_BINARY_DIR}/cudec-config-version.cmake"
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cudec)
 endif()

--- a/README.md
+++ b/README.md
@@ -103,6 +103,34 @@ docker run --rm --gpus all -v "$PWD:/w" -w /w \
          ctest --test-dir build-cuda --no-tests=error --output-on-failure"
 ```
 
+The host-only build installs into a prefix that an outside project consumes
+through `find_package`:
+
+```sh
+cmake --install build --prefix /some/prefix
+```
+
+```cmake
+find_package(cudec 0.0.1 REQUIRED)
+target_link_libraries(your_target PRIVATE cudec::cudec)
+```
+
+Point the consumer's configure at the prefix with
+`-DCMAKE_PREFIX_PATH=/some/prefix`.
+
+The CUDA build installs too, and its prefix is **not** consumable yet: the
+library links the CUDA runtime privately, which still reaches the consumer's
+targets file, and the package config does not yet hand the consumer
+`find_dependency(CUDAToolkit)`. Configuring against such a prefix fails with
+`The link interface of target "cudec::cudec" contains: CUDA::cudart but the
+target was not found`. That gap is issue #137.
+
+cudec builds as a static library only, and a top-level configure with
+`BUILD_SHARED_LIBS=ON` is refused rather than producing an untested shared
+build. The version compatibility rule is `SameMinorVersion`: while the version
+is 0.x, this project treats a minor bump as the breaking one, so a consumer
+asking for 0.0 is not handed 0.1.
+
 ## Contributing
 
 Issue-driven: every change starts as an issue and lands as a gated PR - see

--- a/cmake/cudec-config.cmake.in
+++ b/cmake/cudec-config.cmake.in
@@ -1,0 +1,19 @@
+# The package config find_package(cudec) loads (issue #79).
+#
+# It stays this short on purpose. cudec's public surface is one header and one
+# static library with no dependency outside the CUDA runtime, so the config has
+# nothing to search for and nothing to reconcile; anything more here would be
+# machinery describing a complexity the library does not have.
+#
+# The CUDA-flavoured install needs one more thing than this: a static library
+# links CUDA::cudart privately, which still reaches the consumer's targets file
+# as $<LINK_ONLY:CUDA::cudart>, so a consumer of a CUDA-enabled prefix has to
+# be handed find_dependency(CUDAToolkit) before the targets file is included.
+# That is issue #137 and it is deliberately not stubbed here: a guard written
+# before the consumer that proves it exists is a guard nobody has watched bite.
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/cudec-targets.cmake")
+
+check_required_components(cudec)

--- a/tests/consumer/CMakeLists.txt
+++ b/tests/consumer/CMakeLists.txt
@@ -1,0 +1,33 @@
+# The out-of-tree consumer that proves the install surface (issue #79).
+#
+# Deliberately NOT added by the parent build: it is configured on its own,
+# against an installed prefix, by the CI step that installs one. A consumer
+# that could see the source tree would prove nothing about the package, since
+# every path it needs would already be in scope.
+cmake_minimum_required(VERSION 3.24)
+
+project(cudec_consumer LANGUAGES C)
+
+# The version this consumer asks for. Parameterised because the version file is
+# otherwise dead weight in the proof: config mode only reads
+# cudec-config-version.cmake when the caller requests a version, so a consumer
+# that requests none would configure happily against a prefix whose version
+# file was missing, or generated with the wrong compatibility mode. The CI step
+# drives this twice - once with a version the policy must accept and once with
+# one it must refuse - so the SameMinorVersion decision is exercised in both
+# directions rather than merely installed.
+set(CUDEC_CONSUMER_REQUEST_VERSION ""
+    CACHE STRING "Version to pass to find_package(cudec) (empty = none)")
+
+# REQUIRED, so a prefix that is missing the config reds the configure rather
+# than falling through to a link error with a worse message. With a version
+# requested it also reds on an incompatible one; with none, it does not, which
+# is why the CI step always passes one.
+find_package(cudec ${CUDEC_CONSUMER_REQUEST_VERSION} REQUIRED)
+
+add_executable(consumer main.c)
+
+# The namespaced name only, which is what an outside consumer would write. The
+# bare `cudec` would resolve against a stray system library of that name; the
+# namespaced one is an error if the package did not define it.
+target_link_libraries(consumer PRIVATE cudec::cudec)

--- a/tests/consumer/main.c
+++ b/tests/consumer/main.c
@@ -1,0 +1,39 @@
+/* The whole point of the consumer: an outside translation unit that knows
+ * only <cudec.h> and the exported cudec::cudec target compiles, links, and
+ * calls into the installed library.
+ *
+ * It runs as well as builds, on a machine with no GPU, because cudec_version()
+ * touches no device. A compile-and-link-only check would pass against an
+ * archive whose symbol was never actually reachable at run time.
+ *
+ * The header is included by its installed spelling. If the install put it
+ * anywhere the exported include interface does not point at, this line fails
+ * before anything else can. */
+#include <cudec.h>
+
+#include <stdio.h>
+
+int main(void) {
+    const int expected = CUDEC_VERSION_MAJOR * 10000 +
+                         CUDEC_VERSION_MINOR * 100 + CUDEC_VERSION_PATCH;
+    const int reported = cudec_version();
+
+    /* The installed header and the installed archive are two separate files
+     * in the prefix, and nothing in the package config can tell that they came
+     * from one build: a config-version file compares the version the CONSUMER
+     * asked for against the version the prefix declares, and has no view
+     * inside the prefix at all. So this comparison is the only place that skew
+     * is visible from outside, and it is cheap. */
+    if (reported != expected) {
+        (void)fprintf(stderr,
+                      "installed cudec_version() reports %d, the installed "
+                      "header says %d\n",
+                      reported, expected);
+        return 1;
+    }
+
+    (void)printf("cudec %d.%d.%d, consumed via find_package(cudec)\n",
+                 CUDEC_VERSION_MAJOR, CUDEC_VERSION_MINOR,
+                 CUDEC_VERSION_PATCH);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #79.

cudec built but could not be consumed. No `install()` rules, no export set, no package config, so `find_package(cudec)` failed and every consumer had to vendor the tree.

The library now installs its one public header, its archive and a package config, exporting `cudec::cudec`. The same name is aliased in-tree so a consumer inside this build and a consumer of an installed prefix write the same string.

The install rules are top-level only. Without that guard a project vendoring cudec by `add_subdirectory` or FetchContent would ship cudec's header, archive and package config into its own prefix, where `find_package(cudec)` would later find a config that project never meant to publish.

## Type of change

- [x] Build / CI / supply chain
- [x] Docs

No kernel, format or ABI surface is touched. `include/cudec.h` is byte-identical; it is only installed. The engineering, oracle and performance checklists therefore have nothing to answer here and are left unticked rather than ticked vacuously.

## The two decisions the issue asks to be recorded

**Static only.** Pinned as `add_library(cudec STATIC src/version.c)`, so no global switch produces a shared cudec without the SOVERSION and symbol-visibility work that does not exist. The accompanying `BUILD_SHARED_LIBS` refusal is scoped to a top-level configure: a superbuild that sets the switch globally and vendors cudec is asking for shared everything else, and taking its configure down over a library it links statically anyway would be this project reaching outside its own build. Revisit when a packager asks or at 1.0.

**`SameMinorVersion`.** Stated as a convention this project adopts, not as a rule read out of the specification: SemVer promises nothing at 0.y.z. The common reading is that at 0.x the minor bump is the breaking one, so 0.0 and 0.1 are not interchangeable. `ExactVersion` was the alternative and is too strict in the other direction. The revisit is at 1.0, where the same convention gives `SameMajorVersion`.

## What is NOT delivered, stated rather than omitted

**A CUDA-flavoured prefix installs and is not consumable.** `target_link_libraries(cudec PRIVATE CUDA::cudart)` on a static library still reaches the exported interface as a LINK_ONLY entry, and the package config carries no `find_dependency(CUDAToolkit)`, so a consumer's configure fails at the generate step:

```
CMake Error at /tmp/px-cuda/lib/cmake/cudec/cudec-targets.cmake:61 (set_target_properties):
  The link interface of target "cudec::cudec" contains:
    CUDA::cudart
  but the target was not found.
```

The README says this in the Building section and the config template says it beside the include line. The issue makes the host-only proof the acceptance criterion and the container-flavour proof the additional one, which is #137, so this lands with the gap open and disclosed rather than papered over.

**The version policy is only partly provable at 0.0.1.** See the verification section.

## Verification

Everything below ran in the digest-pinned image CI uses, source mounted read-only, all build trees in the container.

The CI step's own script, extracted from the rendered YAML and run verbatim:

```
cmake --install build --prefix "$PWD/prefix-host" && test -f ... &&
cmake -S tests/consumer -B build-consumer -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1 &&
cmake --build build-consumer && ./build-consumer/consumer &&
if cmake ... -DCUDEC_CONSUMER_REQUEST_VERSION=0.1 ...

cudec 0.0.1, consumed via find_package(cudec)
PASS: find_package(cudec 0.1) refused against a 0.0.1 prefix
CI step exit=0
```

The exported include directory is listed once, not twice:

```
grep -n INTERFACE_INCLUDE_DIRECTORIES prefix-host/lib/cmake/cudec/cudec-targets.cmake
62:  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
```

The version leg bites. Dropping `cudec-config-version.cmake` from the install reds the step:

```
-- Installing: /tmp/src3/prefix-host/lib/cmake/cudec/cudec-config.cmake
CI step exit=1
```

**What that leg does not prove, measured rather than assumed.** At 0.0.1 no request separates `SameMinorVersion` from `SameMajorVersion` or `AnyNewerVersion`, because all three refuse a request above the installed version. Swapping the mode to `AnyNewerVersion` leaves the step green:

```
297:    COMPATIBILITY AnyNewerVersion)
PASS: find_package(cudec 0.1) refused against a 0.0.1 prefix
CI step exit=0
```

So what the legs establish is that the version file is installed and consulted. The modes become distinguishable the first time the minor moves. That limit is written into the comment beside the step rather than left for a reader to discover.

A parent that vendors cudec keeps its own prefix clean, and its configure survives a global `BUILD_SHARED_LIBS=ON`:

```
parent configure exit=0
-- Install configuration: ""
files under the parent prefix:
(none listed = nothing of cudec's leaked)
and the vendored library is still static:
/tmp/pb/cudec/libcudec.a
```

A top-level build still refuses it:

```
top-level configure exit=1
CMake Error at CMakeLists.txt:85 (message):
  cudec builds as a static library only.  BUILD_SHARED_LIBS=ON would need an
  SOVERSION and a symbol-visibility policy this project has not settled
  (issue #79).
```

The CUDA configuration still generates, so `install(EXPORT)` does not break the existing gate:

```
cuda configure/generate exit=0
-- Generating done (0.1s)
```

Prettier is clean over the markdown and YAML.

## Review record

An adversarial review was run over this diff before this body was written: five refute-by-default lenses (correctness, robustness, integration, requirements-and-docs, and one that executes rather than reads), each given the diff, the full touched files and the acceptance criteria, and none of them the case for the defence.

**CONFIRMED 7 / PLAUSIBLE 4** as raised. Dispositions:

| Finding | Disposition |
| --- | --- |
| README claimed the CUDA-flavoured prefix is consumable; it is not (reproduced) | FIX. The README now states the failure and names #137. |
| The version file was never exercised: the consumer requested no version, and the prefix stayed green with the file deleted (reproduced) | FIX. The consumer takes a requested version and CI drives it twice; the file is also asserted present. The residual limit is in the verification section above. |
| Install rules fired unconditionally, so a vendoring parent's prefix got cudec's package config (reproduced) | FIX. `PROJECT_IS_TOP_LEVEL` guard. |
| The `BUILD_SHARED_LIBS` refusal killed a vendoring parent's configure (reproduced) | FIX. `STATIC` pinned on the target; the refusal scoped to a top-level build. |
| `INCLUDES DESTINATION` and the install-interface generator expression both wrote the include path, shipping it twice (reproduced) | FIX. The `INCLUDES DESTINATION` dropped; the comment corrected, since it had justified the surviving line against a hazard neither spelling risked. |
| No CHANGELOG entry, though the file defines a build-observable change as notable | FIX. Entry added under Unreleased, including the `BUILD_SHARED_LIBS` change. |
| The SemVer rationale asserted a promise SemVer does not make at 0.y.z | FIX. Reworded as this project's convention, in both the comment and the README. |
| `main.c` attributed its header-against-archive check to the version file, which has no view inside a prefix | FIX. Comment corrected. |
| The decisions are not in `docs/MASTERPLAN.md`, which CLAUDE.md names as the design record | DECLINE. The criterion says recorded, and the README is where a consumer reads. Moving the record is a masterplan edit with its own scope. |
| `check_required_components(cudec)` is component machinery in a package with no components | DECLINE. It is live rather than boilerplate: `find_package(cudec REQUIRED COMPONENTS bogus)` exits 1 against the installed prefix. |
| No conformance test locks the install surface; the CI step is its only driver | DECLINE. The acceptance criterion is a CI proof, and a ctest entry cannot install and consume without nesting a build inside the run. The gap is real and is the reason the CI legs above were strengthened rather than left as a single happy path. |

The post-fix state was re-verified by the container run quoted in the verification section rather than by asking the lens that raised the finding.

No second reader on this change. The review above and the runs quoted stand in place of one.
