### PR TITLE
Make the installed CUDA-flavor package consumable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,52 @@ jobs:
           test -x build-cuda/tests/termination_gpu &&
           test -x build-cuda/tests/determinism_gpu
 
+      # The other half of the install proof (issue #137). The host-only prefix
+      # is the easy flavour: nothing reaches the exported interface. The CUDA
+      # one carries $<LINK_ONLY:CUDA::cudart>, so the consumer needs the
+      # package config to hand it find_dependency(CUDAToolkit) before the
+      # targets file is read - and the failure without it lands at the generate
+      # step, AFTER find_package(cudec) has already reported success.
+      #
+      # The runner has no GPU and does not need one: cudec_version() links and
+      # runs without touching a device, which is exactly what proves the
+      # imported target resolved.
+      #
+      # The consumer knows nothing about CUDA. That is the point of the step -
+      # a consumer that called find_package(CUDAToolkit) itself would paper
+      # over the missing dependency and prove nothing about the package.
+      # The assertion is on the substituted FLAG, not on the presence of the
+      # find_dependency line: both flavours ship the same conditional block and
+      # only the flag differs, so grepping for the call itself would pass
+      # against a host-only prefix too and prove nothing.
+      - name: Install and consume out of tree (CUDA engine)
+        run: >-
+          cmake --install build-cuda --prefix "$PWD/prefix-cuda" &&
+          grep -q "set(_cudec_built_with_cuda ON)"
+          "$(find "$PWD/prefix-cuda" -name cudec-config.cmake -print -quit)" &&
+          cmake -S tests/consumer -B build-consumer-cuda
+          -DCMAKE_PREFIX_PATH="$PWD/prefix-cuda"
+          -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1 &&
+          cmake --build build-consumer-cuda &&
+          ./build-consumer-cuda/consumer
+
+      # The guard is conditional, and this is the half that says so. A
+      # host-only prefix must not ask its consumer for a CUDA toolkit that
+      # consumer may not have. Proven twice: the installed config carries the
+      # flag OFF, and the consumer configures against it with CUDAToolkit
+      # forced undiscoverable, which is the closest this container gets to a
+      # machine that never had a toolkit at all.
+      - name: The host-only package stays CUDA-free
+        run: >-
+          grep -q "set(_cudec_built_with_cuda OFF)"
+          "$(find "$PWD/prefix-host" -name cudec-config.cmake -print -quit)" &&
+          cmake -S tests/consumer -B build-consumer-nocuda
+          -DCMAKE_PREFIX_PATH="$PWD/prefix-host"
+          -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1
+          -DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=ON &&
+          cmake --build build-consumer-nocuda &&
+          ./build-consumer-nocuda/consumer
+
       # The host-side subset; gpu-labeled tests run in this same container
       # on the maintainer's machine and their output is pasted into the PR.
       # Fail-closed plumbing: --no-tests=error reds a vacuous zero-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,35 +145,51 @@ jobs:
       # The consumer knows nothing about CUDA. That is the point of the step -
       # a consumer that called find_package(CUDAToolkit) itself would paper
       # over the missing dependency and prove nothing about the package.
-      # The assertion is on the substituted FLAG, not on the presence of the
+      # The assertion is on the substituted guard, not on the presence of the
       # find_dependency line: both flavours ship the same conditional block and
-      # only the flag differs, so grepping for the call itself would pass
-      # against a host-only prefix too and prove nothing.
+      # only the guard differs, so grepping for the call itself would pass
+      # against a host-only prefix too and prove nothing. The guard is
+      # normalised to 1/0 in CMakeLists.txt so this is not an assertion about
+      # which spelling of a boolean the configure happened to use.
+      #
+      # The consumer calls a decode entry point here, not only cudec_version().
+      # A CUDA-flavoured archive carries the C++ host orchestration alongside
+      # the one C translation unit, and a link that pulls only the latter proves
+      # the target name resolved and nothing about the rest of the link surface.
       - name: Install and consume out of tree (CUDA engine)
         run: >-
           cmake --install build-cuda --prefix "$PWD/prefix-cuda" &&
-          grep -q "set(_cudec_built_with_cuda ON)"
+          grep -q "^if(1)$"
           "$(find "$PWD/prefix-cuda" -name cudec-config.cmake -print -quit)" &&
           cmake -S tests/consumer -B build-consumer-cuda
           -DCMAKE_PREFIX_PATH="$PWD/prefix-cuda"
-          -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1 &&
+          -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1
+          -DCUDEC_CONSUMER_CALLS_DECODE=ON &&
           cmake --build build-consumer-cuda &&
           ./build-consumer-cuda/consumer
 
       # The guard is conditional, and this is the half that says so. A
       # host-only prefix must not ask its consumer for a CUDA toolkit that
-      # consumer may not have. Proven twice: the installed config carries the
-      # flag OFF, and the consumer configures against it with CUDAToolkit
-      # forced undiscoverable, which is the closest this container gets to a
-      # machine that never had a toolkit at all.
+      # consumer may not have.
+      #
+      # Two legs. The installed config carries the guard as 0, and the consumer
+      # configures against it in an environment stripped of every route to the
+      # toolkit: PATH without the CUDA bin directory, CUDAToolkit_ROOT pointed
+      # at nothing, and the CUDA prefix ignored. That is a real absent-toolkit
+      # simulation rather than CMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit, which
+      # does not make anything undiscoverable - against the REQUIRED call that
+      # find_dependency emits, CMake refuses the disable request itself and the
+      # step would red on the wrong rule.
       - name: The host-only package stays CUDA-free
         run: >-
-          grep -q "set(_cudec_built_with_cuda OFF)"
+          grep -q "^if(0)$"
           "$(find "$PWD/prefix-host" -name cudec-config.cmake -print -quit)" &&
+          env -i PATH=/usr/bin:/bin HOME="$HOME"
           cmake -S tests/consumer -B build-consumer-nocuda
           -DCMAKE_PREFIX_PATH="$PWD/prefix-host"
           -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1
-          -DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=ON &&
+          -DCUDAToolkit_ROOT=/nonexistent
+          -DCMAKE_IGNORE_PREFIX_PATH=/usr/local/cuda &&
           cmake --build build-consumer-nocuda &&
           ./build-consumer-nocuda/consumer
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@ build-san/
 # produced by the install proof in ci.yml and reproducible the same way.
 build-consumer/
 build-consumer-badver/
+build-consumer-cuda/
+build-consumer-nocuda/
 prefix-host/
+prefix-cuda/
 badver.log
 
 # Downloaded benchmark corpora - hash-pinned by bench/get-corpora.sh,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,11 +51,14 @@ today.
   public header, the archive, and a package config, so an outside project links
   cudec through `find_package(cudec)` and the exported `cudec::cudec` target
   instead of vendoring the tree. The compatibility rule is `SameMinorVersion`,
-  which at 0.x means a consumer asking for 0.0 is not handed 0.1. Both build
-  flavours install and are consumed out of tree in CI: the consumer writes
-  nothing about CUDA, because a prefix from a CUDA build carries its own
+  which at 0.x means a consumer asking for 0.0 is not handed 0.1, and CI drives
+  a consumer in both directions of that rule. Both build flavours install and
+  are consumed out of tree in CI: the consumer writes nothing about CUDA,
+  because a prefix from a CUDA build carries its own
   `find_dependency(CUDAToolkit)` and a host-only prefix carries none, so it
-  stays consumable where no CUDA toolkit exists.
+  stays consumable where no CUDA toolkit exists. Consuming a CUDA-flavoured
+  prefix does require the toolkit on the consuming machine and a project that
+  enables C++, both stated in [README.md](README.md).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,11 +51,11 @@ today.
   public header, the archive, and a package config, so an outside project links
   cudec through `find_package(cudec)` and the exported `cudec::cudec` target
   instead of vendoring the tree. The compatibility rule is `SameMinorVersion`,
-  which at 0.x means a consumer asking for 0.0 is not handed 0.1. CI installs
-  the host-only build and builds and runs an out-of-tree consumer against the
-  result, in both directions of that version rule. The CUDA-flavoured prefix
-  installs but is not consumable yet, because its package config does not yet
-  carry `find_dependency(CUDAToolkit)`.
+  which at 0.x means a consumer asking for 0.0 is not handed 0.1. Both build
+  flavours install and are consumed out of tree in CI: the consumer writes
+  nothing about CUDA, because a prefix from a CUDA build carries its own
+  `find_dependency(CUDAToolkit)` and a host-only prefix carries none, so it
+  stays consumable where no CUDA toolkit exists.
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,19 @@ if(PROJECT_IS_TOP_LEVEL)
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMinorVersion)
 
+  # Normalised to 1 or 0 before it is substituted into the config template
+  # (issue #137). CUDEC_ENABLE_CUDA is a plain cache entry, so its text can be
+  # ON, TRUE, 1, yes or anything else CMake reads as true, and the installed
+  # config would then carry whichever spelling this configure happened to use.
+  # The gate that checks the installed config reads this line, so an assertion
+  # on the raw option would red a correct package built with a different
+  # spelling.
+  if(CUDEC_ENABLE_CUDA)
+    set(CUDEC_PACKAGE_NEEDS_CUDA 1)
+  else()
+    set(CUDEC_PACKAGE_NEEDS_CUDA 0)
+  endif()
+
   configure_package_config_file(
     "${CMAKE_CURRENT_LIST_DIR}/cmake/cudec-config.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/cudec-config.cmake"

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ docker run --rm --gpus all -v "$PWD:/w" -w /w \
          ctest --test-dir build-cuda --no-tests=error --output-on-failure"
 ```
 
-The host-only build installs into a prefix that an outside project consumes
-through `find_package`:
+Either build installs into a prefix that an outside project consumes through
+`find_package`:
 
 ```sh
 cmake --install build --prefix /some/prefix
@@ -116,14 +116,10 @@ target_link_libraries(your_target PRIVATE cudec::cudec)
 ```
 
 Point the consumer's configure at the prefix with
-`-DCMAKE_PREFIX_PATH=/some/prefix`.
-
-The CUDA build installs too, and its prefix is **not** consumable yet: the
-library links the CUDA runtime privately, which still reaches the consumer's
-targets file, and the package config does not yet hand the consumer
-`find_dependency(CUDAToolkit)`. Configuring against such a prefix fails with
-`The link interface of target "cudec::cudec" contains: CUDA::cudart but the
-target was not found`. That gap is issue #137.
+`-DCMAKE_PREFIX_PATH=/some/prefix`. The consumer writes nothing about CUDA: a
+prefix from a CUDA build carries its own `find_dependency(CUDAToolkit)`, and a
+host-only prefix carries none, so it stays consumable on a machine that has no
+CUDA toolkit at all. Both flavours are installed and consumed in CI.
 
 cudec builds as a static library only, and a top-level configure with
 `BUILD_SHARED_LIBS=ON` is refused rather than producing an untested shared

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ docker run --rm --gpus all -v "$PWD:/w" -w /w \
 ```
 
 Either build installs into a prefix that an outside project consumes through
-`find_package`:
+`find_package` (`build-cuda` in place of `build` for the CUDA flavour):
 
 ```sh
 cmake --install build --prefix /some/prefix
@@ -120,6 +120,16 @@ Point the consumer's configure at the prefix with
 prefix from a CUDA build carries its own `find_dependency(CUDAToolkit)`, and a
 host-only prefix carries none, so it stays consumable on a machine that has no
 CUDA toolkit at all. Both flavours are installed and consumed in CI.
+
+Two limits on the CUDA flavour, both consumer-side. It needs the CUDA toolkit
+present on the consuming machine, not merely the runtime library: the
+dependency resolves through CMake's `FindCUDAToolkit`, which looks for `nvcc`.
+And the consuming project must enable C++ (`project(... LANGUAGES C CXX)`),
+because cudec's host orchestration is C++ and CMake picks the link driver from
+the languages the consuming project enabled, not from the archive. A C-only
+consumer links `cudec_version()` and fails on the first decode call with
+undefined C++ runtime symbols. The host-only prefix has neither limit; it is
+pure C and needs no toolkit.
 
 cudec builds as a static library only, and a top-level configure with
 `BUILD_SHARED_LIBS=ON` is refused rather than producing an untested shared

--- a/cmake/cudec-config.cmake.in
+++ b/cmake/cudec-config.cmake.in
@@ -1,18 +1,33 @@
 # The package config find_package(cudec) loads (issue #79).
 #
-# It stays this short on purpose. cudec's public surface is one header and one
-# static library with no dependency outside the CUDA runtime, so the config has
-# nothing to search for and nothing to reconcile; anything more here would be
-# machinery describing a complexity the library does not have.
+# It stays short on purpose. cudec's public surface is one header and one static
+# library with no dependency outside the CUDA runtime, so the config has almost
+# nothing to search for and nothing to reconcile.
 #
-# The CUDA-flavoured install needs one more thing than this: a static library
-# links CUDA::cudart privately, which still reaches the consumer's targets file
-# as $<LINK_ONLY:CUDA::cudart>, so a consumer of a CUDA-enabled prefix has to
-# be handed find_dependency(CUDAToolkit) before the targets file is included.
-# That is issue #137 and it is deliberately not stubbed here: a guard written
-# before the consumer that proves it exists is a guard nobody has watched bite.
+# The one thing it does have to carry is the CUDA runtime (issue #137). cudec
+# links CUDA::cudart PRIVATE, but for a static library a private link still
+# reaches the consumer through the exported interface as
+# $<LINK_ONLY:CUDA::cudart>, so the targets file names an imported target the
+# consumer has never defined. Without the find_dependency below, a consumer of a
+# CUDA-enabled prefix dies at the generate step with "target CUDA::cudart not
+# found" - after find_package(cudec) has already reported success, which is the
+# worse half of that failure.
+#
+# Guarded, not unconditional. A host-only install must stay consumable on a
+# machine with no CUDA toolkit at all, and an unconditional find_dependency
+# would refuse exactly that consumer over a dependency their prefix does not
+# have. The flag is substituted from the build that produced the prefix, so each
+# installed config carries the answer for its own flavour rather than for the
+# flavour the reader happens to be building today.
 
 @PACKAGE_INIT@
+
+set(_cudec_built_with_cuda @CUDEC_ENABLE_CUDA@)
+if(_cudec_built_with_cuda)
+  include(CMakeFindDependencyMacro)
+  find_dependency(CUDAToolkit)
+endif()
+unset(_cudec_built_with_cuda)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cudec-targets.cmake")
 

--- a/cmake/cudec-config.cmake.in
+++ b/cmake/cudec-config.cmake.in
@@ -22,12 +22,15 @@
 
 @PACKAGE_INIT@
 
-set(_cudec_built_with_cuda @CUDEC_ENABLE_CUDA@)
-if(_cudec_built_with_cuda)
+# The flag is substituted inline rather than through a variable. find_dependency
+# is a macro that return()s out of this file when the dependency is missing, so
+# a variable set above it would survive that return and leak into the consumer's
+# scope on exactly the path that reports not-found. There is nothing to clean up
+# if nothing is set.
+if(@CUDEC_PACKAGE_NEEDS_CUDA@)
   include(CMakeFindDependencyMacro)
   find_dependency(CUDAToolkit)
 endif()
-unset(_cudec_built_with_cuda)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cudec-targets.cmake")
 

--- a/tests/consumer/CMakeLists.txt
+++ b/tests/consumer/CMakeLists.txt
@@ -27,6 +27,24 @@ find_package(cudec ${CUDEC_CONSUMER_REQUEST_VERSION} REQUIRED)
 
 add_executable(consumer main.c)
 
+# Off by default, because a host-only prefix has no decode entry point to call.
+# On, the consumer calls one, which is what makes the link exercise more of the
+# archive than the single C translation unit cudec_version() lives in. See the
+# comment at the call site.
+option(CUDEC_CONSUMER_CALLS_DECODE
+       "Call a decode entry point, not only cudec_version()" OFF)
+if(CUDEC_CONSUMER_CALLS_DECODE)
+  target_compile_definitions(consumer PRIVATE CUDEC_CONSUMER_CALLS_DECODE)
+  # cudec's host orchestration is C++, so a CUDA-flavoured archive carries
+  # objects that need the C++ runtime. CMake picks the link driver from the
+  # languages the CONSUMING project enabled, so a C-only consumer links with
+  # cc and never gets that runtime - it only gets away with it while nothing
+  # pulls those objects in. Enabling C++ here is the consumer-side half of the
+  # limit the README states.
+  enable_language(CXX)
+  set_target_properties(consumer PROPERTIES LINKER_LANGUAGE CXX)
+endif()
+
 # The namespaced name only, which is what an outside consumer would write. The
 # bare `cudec` would resolve against a stray system library of that name; the
 # namespaced one is an error if the package did not define it.

--- a/tests/consumer/main.c
+++ b/tests/consumer/main.c
@@ -32,6 +32,33 @@ int main(void) {
         return 1;
     }
 
+#ifdef CUDEC_CONSUMER_CALLS_DECODE
+    /* cudec_version() alone links one object out of the archive, so a green
+     * build proves the target resolved and nothing about the rest of the link
+     * surface. A CUDA-flavoured archive also carries the host orchestration
+     * translation units, which are C++ and drag the C++ runtime in with them;
+     * without this call nothing pulls them and the missing runtime cannot
+     * surface until a real consumer hits it.
+     *
+     * The reject path is the right call to make here. It is host-side argument
+     * validation that returns before any CUDA call, so the GPU-less runner can
+     * execute it, and it is defined: a NULL destination is an invalid argument.
+     * Anything that reached the device would make this a GPU test. */
+    {
+        size_t written = 0;
+        const cudec_status st = cudec_lz4f_decompress(NULL, 0, NULL, 0,
+                                                      &written);
+        if (st != CUDEC_ERR_INVALID_ARGUMENT || written != 0) {
+            (void)fprintf(stderr,
+                          "installed library returned %d (wrote %zu) for a "
+                          "NULL-argument frame decode; expected %d and 0\n",
+                          (int)st, written, (int)CUDEC_ERR_INVALID_ARGUMENT);
+            return 1;
+        }
+        (void)printf("argument reject reached: %d\n", (int)st);
+    }
+#endif
+
     (void)printf("cudec %d.%d.%d, consumed via find_package(cudec)\n",
                  CUDEC_VERSION_MAJOR, CUDEC_VERSION_MINOR,
                  CUDEC_VERSION_PATCH);


### PR DESCRIPTION
# What & why

Closes #137. Sits on #79, which landed the install surface and disclosed this gap rather than papering over it.

A CUDA-enabled install produced a prefix that reported itself found and then failed. cudec links `CUDA::cudart` PRIVATE, but for a static library a private link still reaches the consumer through the exported interface as a LINK_ONLY entry, so the targets file named an imported target the consumer had never defined. `find_package(cudec)` returned success and the generate step then died:

```
CMake Error at .../cudec-targets.cmake:61 (set_target_properties):
  The link interface of target "cudec::cudec" contains:
    CUDA::cudart
  but the target was not found.
```

The report of success arriving before the failure is the worse half of that.

The package config now carries `find_dependency(CUDAToolkit)`, guarded on a flag substituted from the build that produced the prefix. Unconditional would be wrong in the other direction: a host-only install has to stay consumable on a machine with no CUDA toolkit, and an unconditional dependency would refuse that consumer over something their prefix does not have.

## Type of change

- [x] Build / CI / supply chain
- [x] Docs

No kernel, format or ABI surface is touched; `include/cudec.h` is unchanged.

## What the CUDA prefix costs its consumer, stated rather than left to be discovered

A CUDA-flavoured archive carries the C++ host orchestration (`frame.cpp`, `stream.cpp`) alongside the one C translation unit. CMake picks the link driver from the languages the **consuming** project enabled, not from the archive, so a `project(... LANGUAGES C)` consumer links `cudec_version()` happily and then fails on undefined C++ runtime symbols the moment it calls the real API. And the dependency resolves through `FindCUDAToolkit`, which looks for `nvcc`, so consuming a CUDA prefix needs the toolkit present and not merely `libcudart`.

Both limits are now in the README beside the recipe, and the CHANGELOG points at them. The host-only prefix has neither.

## The two things the obvious version of this got wrong

**Asserting the wrong string.** Both flavours ship the same conditional block and only the substituted guard differs, so a CI leg grepping for `find_dependency(CUDAToolkit)` passes against a host-only prefix too. The legs assert the guard, and the guard is normalised to `1`/`0` in `CMakeLists.txt` before substitution so the assertion is not a claim about which spelling of a boolean the configure used.

**Proving the link with one object.** `cudec_version()` lives in the only C translation unit, so a consumer that calls nothing else pulls exactly that object out of the static archive. A green step then means the target name resolved and nothing more. The fixture takes `CUDEC_CONSUMER_CALLS_DECODE`; the CUDA leg sets it, the consumer calls the frame decoder's argument-reject path, and the binary comes back linked against the C++ runtime and the CUDA runtime rather than libc alone.

## Verification

All of it in the digest-pinned image CI uses, source mounted read-only, build trees inside the container.

The substituted guard, both flavours:

```
host-only: 54:if(0)
cuda:      54:if(1)
```

Both new steps, extracted from the rendered YAML and run verbatim:

```
-- Found CUDAToolkit: /usr/local/cuda/targets/x86_64-linux/include (found version "12.6.77")
[100%] Linking CXX executable consumer
argument reject reached: 1
cudec 0.0.1, consumed via find_package(cudec)        <- CUDA prefix
...
CMake Warning:
  Manually-specified variables were not used by the project:
    CUDAToolkit_ROOT
[100%] Linking C executable consumer
cudec 0.0.1, consumed via find_package(cudec)        <- host-only prefix, environment stripped
both steps exit=0
```

That warning is the point of the second leg rather than noise: nothing in the host-only configure ever looked for a CUDA toolkit.

The CUDA consumer now links what it is supposed to be proving:

```
ldd build-consumer-cuda/consumer
  libcudart.so.12 => /usr/local/cuda-12.6/targets/x86_64-linux/lib/libcudart.so.12
  libstdc++.so.6  => /lib/x86_64-linux-gnu/libstdc++.so.6
```

**Every guard bites.** The issue asks for the `find_dependency` removal to be checked by hand once and reported; it was, along with the other three directions.

`find_dependency` deleted from the template:

```
consumer configure exit=1
CMake Error at .../prefix-cuda/lib/cmake/cudec/cudec-targets.cmake:61 (set_target_properties):
  The link interface of target "cudec::cudec" contains:
    CUDA::cudart
```

Guard forced to `0` in a CUDA prefix: the CUDA step's guard leg exits 1. Guard forced to `1` in a host-only prefix: the CUDA-free step exits non-zero (on its guard leg, before the consumer runs).

The README limit is not a theory. The same fixture with the consumer's C++ language line removed, against the CUDA prefix, calling decode:

```
configure exit=0
build exit=2
undefined reference to `__cxa_begin_catch'
undefined reference to `__gxx_personality_v0'
undefined reference to `operator delete(void*, unsigned long)'
```

No variable leaks into the consumer on the not-found path:

```
-- FOUND=0
-- LEAK=[]
```

## Quality checklist

- [x] Minimal: nothing added beyond the guard, the two CI legs, and the fixture's optional decode call.
- [x] Self-documenting: each comment states why, including what the disable-variable approach could not prove.
- [x] The structural property this establishes (the installed config's guard matches the flavour) is locked by the two CI legs, which are the only mechanism available - a ctest entry cannot install and consume without nesting a build inside the run. That limit is recorded rather than papered over.

## Verification checklist

- [x] `cmake --build` clean, both flavours, in the pinned container.
- [ ] `ctest` - not re-run; this change adds no test and touches no library source. The suite's own gate runs in CI.
- [x] Prettier over the markdown and YAML: clean.
- [x] Docs synced: README carries the recipe and both limits; CHANGELOG's install entry names them.

## Constraints from the issue

- The `tests/consumer/` fixture is reused rather than forked. It gained one option and one guarded block; there is still exactly one consumer project in the tree.
- The library is compiled without `CUDA_SEPARABLE_COMPILATION`, so each `.cu` translation unit is self-contained and the consumer needs no device link step. That assumption holds and is now actually exercised: the CUDA leg's consumer links the archive with the C++ objects pulled in and no device link step, and runs. The earlier claim rested on a run that never pulled a device object, which is the kind of evidence the issue asked not to be given.

## Review record

An adversarial review ran over the first cut of this diff: five refute-by-default lenses (correctness, robustness, integration, requirements-and-docs, and one that executes rather than reads), each given the diff, the full touched files and the acceptance criteria, and none of them the case for the defence.

**CONFIRMED 9 / PLAUSIBLE 2** as raised. Dispositions:

| Finding | Disposition |
| --- | --- |
| The CUDA prefix is not linkable from a C-only consumer beyond `cudec_version()`; the README documented exactly that recipe (reproduced by three lenses independently) | FIX. The limit is stated in README and CHANGELOG, and the fixture now links the C++ objects so the gate can see the class of breakage at all. |
| The gate linked one of the archive's four objects, so it proved the target name resolved and nothing else (reproduced) | FIX. `CUDEC_CONSUMER_CALLS_DECODE`, set on the CUDA leg. |
| Consuming a CUDA prefix needs nvcc, not merely libcudart, and nothing said so (reproduced on a toolkit-free image) | FIX. Stated in the README. |
| `_cudec_built_with_cuda` leaked into the consumer's scope on the not-found path, because `find_dependency` returns out of the file before the unset (reproduced) | FIX. The flag is substituted inline; nothing is set, so nothing leaks. |
| The CI assertion was a string match on one spelling of a user-settable boolean | FIX. Normalised to `1`/`0` before substitution. |
| The comment claimed `CMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit` approximates an absent toolkit; it refuses the call instead, so the leg red on a different rule | FIX. The leg strips the environment, which is the real simulation, and the comment says what the old approach could not prove. |
| The CHANGELOG rewrite dropped the disclosure that the version rule is tested in both directions, which this change did not touch | FIX. Restored. |
| The PR body claimed the no-device-link assumption "held in practice" on a run that never linked a device object | FIX. The claim is now backed by the leg that does link one, and the earlier evidence is named as insufficient. |
| README generalised to "either build" while showing only the host-only build directory | FIX. |
| `find_dependency(CUDAToolkit)` pins no version, so the contract is "some toolkit" rather than a compatible one | DECLINE. The repo's own `find_package(CUDAToolkit REQUIRED)` is equally unversioned, so pinning here would state a compatibility promise the build itself does not make. Worth its own issue rather than a side effect of this one. |
| Acceptance criterion 2's by-hand check is recorded only in PR prose, so nothing in the tree keeps it honest | DECLINE. That is what the criterion asks for. The nearest mechanism is the guard leg, which is now in CI and does red when the guard is wrong. |

The post-fix state was re-verified by the container run quoted above rather than by asking any lens whether its own finding was addressed.

No second reader on this change. The gate and the runs quoted stand in place of one.
