### PR TITLE
Land the Snappy validation ladder as a single-source parser core [#171]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,8 @@ jobs:
           test -x build-cuda/tests/frame_twin &&
           test -x build-cuda/tests/stream_twin &&
           test -x build-cuda/tests/termination_gpu &&
-          test -x build-cuda/tests/determinism_gpu
+          test -x build-cuda/tests/determinism_gpu &&
+          test -x build-cuda/tests/snappy_block_device
 
       # The other half of the install proof (issue #137). The host-only prefix
       # is the easy flavour: nothing reaches the exported interface. The CUDA
@@ -208,6 +209,7 @@ jobs:
           grep -E ': conformance_c$' host-selected.txt &&
           grep -E ': oracle_lz4$' host-selected.txt &&
           grep -E ': parser_twin$' host-selected.txt &&
+          grep -E ': snappy_parser_twin$' host-selected.txt &&
           grep -E ': termination$' host-selected.txt &&
           grep -E ': launch_fail$' host-selected.txt &&
           grep -E ': bench_selfcheck$' host-selected.txt &&
@@ -219,7 +221,8 @@ jobs:
           grep -E ': frame_twin$' gpu-deferred.txt &&
           grep -E ': stream_twin$' gpu-deferred.txt &&
           grep -E ': termination_gpu$' gpu-deferred.txt &&
-          grep -E ': determinism_gpu$' gpu-deferred.txt
+          grep -E ': determinism_gpu$' gpu-deferred.txt &&
+          grep -E ': snappy_block_device$' gpu-deferred.txt
 
   sanitize:
     # The host-side ASan/UBSan gate over the untrusted-input decode path (issue
@@ -262,8 +265,8 @@ jobs:
 
       # Host-only subset with the sanitizers on. The GPU tests and bench are
       # skipped by the CMake gate (they are nvcc-linked), so the build is pure
-      # host. The test -x lines are fail-closed: the four sanitized binaries
-      # must exist, so a build that silently stopped producing them reds here.
+      # host. The test -x lines are fail-closed: every sanitized binary must
+      # exist, so a build that silently stopped producing one reds here.
       - name: Build the host attack surface with ASan+UBSan
         run: >-
           cmake -B build-san -DCUDEC_ENABLE_CUDA=ON
@@ -272,6 +275,7 @@ jobs:
           test -x build-san/tests/conformance_c &&
           test -x build-san/tests/oracle_lz4 &&
           test -x build-san/tests/parser_twin &&
+          test -x build-san/tests/snappy_parser_twin &&
           test -x build-san/tests/frame_host_negative &&
           test -x build-san/tests/termination
 
@@ -290,16 +294,17 @@ jobs:
       # per-name identity greps mirror the build job: --no-tests=error only
       # reds on a ZERO selection, so a single sanitized test silently losing
       # its registration (say, by gaining a gpu-matching label) would shrink
-      # the set unnoticed - the greps pin all four by name so that reds too.
+      # the set unnoticed - the greps pin every one by name so that reds too.
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|frame_host_negative|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|frame_host_negative|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
           grep -E ': oracle_lz4$' san-selected.txt &&
           grep -E ': parser_twin$' san-selected.txt &&
+          grep -E ': snappy_parser_twin$' san-selected.txt &&
           grep -E ': frame_host_negative$' san-selected.txt &&
           grep -E ': termination$' san-selected.txt
 

--- a/src/lz4_block.h
+++ b/src/lz4_block.h
@@ -22,10 +22,17 @@
 
 #include <stdint.h>
 
+/* Guarded: src/snappy_block.h defines the same macro for the same reason,
+ * and a device translation unit that decodes both formats includes both
+ * headers. The definitions are identical, so an unguarded second one is
+ * legal rather than an error - which is exactly why it would go unnoticed
+ * if they ever stopped being identical. */
+#ifndef CUDEC_HOST_DEVICE
 #if defined(__CUDACC__)
 #define CUDEC_HOST_DEVICE __host__ __device__
 #else
 #define CUDEC_HOST_DEVICE
+#endif
 #endif
 
 namespace cudec_detail {

--- a/src/snappy_block.h
+++ b/src/snappy_block.h
@@ -1,0 +1,371 @@
+/* The Snappy block sequence parser and its validation ladder - the
+ * fail-closed core of the Snappy decoder, single-sourced for host and
+ * device, the sibling of src/lz4_block.h. The parser owns every check;
+ * callers own the copies: the CPU twin test executes them sequentially, the
+ * M3 kernel fans them out across a warp. Internal header, not part of the
+ * ABI.
+ *
+ * Ladder contract: every value decoded from the stream is validated before
+ * first use as an address, length, or offset. The declared uncompressed
+ * length is attacker-controlled and the destination capacity is the
+ * caller's truth, so the declared length is checked against the capacity
+ * before the first element is parsed and nothing is ever sized from the
+ * stream. Success is reported ONLY at exact source consumption AND exact
+ * production of the declared length, which is what snappy's own
+ * `decompressor->eof() && writer->CheckLength()` enforces on both ends.
+ *
+ * Two differences from LZ4 shape the code. An element is a literal OR a
+ * copy rather than a literal run followed by a match, so SnappyElement
+ * carries one range and a kind. And a length never continues across an
+ * unbounded chain of extension bytes: an element's header is the tag plus
+ * at most four trailing bytes, which is snappy's kMaximumTagLength, so the
+ * per-element termination argument needs no fuel counter.
+ *
+ * Widths, for the kernel that will consume this: the declared length is a
+ * varint32, so every output position, every copy offset and every element
+ * length provably fits in 32 bits. The fields below are 64-bit anyway,
+ * because the caller's capacity is a size_t and mixing the two widths in
+ * the bound comparisons is where an overflow would hide. Whether the
+ * DEVICE side should carry 32-bit copies of them is a kernel-shape question
+ * and is not settled here.
+ *
+ * Edge semantics are settled empirically by oracle parity - whenever
+ * snappy rejects, this parser must reject (tests/snappy_parser_twin.cpp).
+ * There is one deliberate exception, at the literal length arithmetic
+ * below, and it is documented and pinned there. */
+#ifndef CUDEC_SNAPPY_BLOCK_H
+#define CUDEC_SNAPPY_BLOCK_H
+
+#include "cudec.h"
+
+#include <stdint.h>
+
+/* Guarded: src/lz4_block.h defines the same macro for the same reason, and
+ * a device translation unit that decodes both formats includes both
+ * headers. The definitions are identical, so an unguarded second one is
+ * legal rather than an error - which is exactly why it would go unnoticed
+ * if they ever stopped being identical. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+/* The preamble is a varint32, read the way snappy's own preamble readers
+ * read it - Varint::Parse32WithLimit is the one GetUncompressedLength goes
+ * through: five unrolled groups of seven bits, stopping at the first byte
+ * whose continuation bit is clear. The fifth group contributes only four
+ * bits before a 32-bit accumulator would overflow, which is why that
+ * reference refuses a fifth byte of 16 or more - and why a non-minimal
+ * encoding, which nothing there rejects, must stay accepted here. */
+constexpr uint64_t kSnappyVarintGroups = 5;
+constexpr unsigned kSnappyVarintBits = 7;
+constexpr unsigned char kSnappyVarintContinue = 0x80;
+constexpr unsigned char kSnappyVarintPayload = 0x7f;
+constexpr unsigned char kSnappyVarintFinalMax = 16;
+
+/* The tag byte: the low two bits select the element kind, the upper six
+ * carry a length (literals and the two wide copy forms) or a length and
+ * the offset's high bits (the narrow copy form). */
+constexpr unsigned char kSnappyTagKindMask = 0x3;
+constexpr unsigned kSnappyTagKindLiteral = 0;
+constexpr unsigned kSnappyTagKindCopy1 = 1;
+constexpr unsigned kSnappyTagKindCopy2 = 2;
+constexpr unsigned kSnappyTagKindCopy4 = 3;
+constexpr unsigned kSnappyTagLengthShift = 2;
+constexpr unsigned kSnappyBitsPerByte = 8;
+
+/* Every element header begins with the tag byte itself. */
+constexpr uint64_t kSnappyTagBytes = 1;
+
+/* Literals: the six tag bits hold length-1 up to and including this value.
+ * Above it they select how many little-endian bytes carry length-1
+ * instead, which is at most four - so an element header never exceeds the
+ * five bytes snappy calls kMaximumTagLength. */
+constexpr uint64_t kSnappyLiteralInlineMax = 59;
+
+/* The narrow copy form: three bits of length biased by four, and three tag
+ * bits supplying the offset's high byte. It cannot express lengths 1 to 3
+ * at all; the wide forms can, and snappy accepts them (tests/snappy_probes.cpp
+ * probe 5), so no length floor may be imposed here. */
+constexpr unsigned char kSnappyCopy1LengthMask = 0x7;
+constexpr unsigned kSnappyCopy1OffsetShift = 5;
+constexpr uint64_t kSnappyCopy1MinLength = 4;
+
+/* Offset widths, one per copy form. */
+constexpr uint64_t kSnappyCopy1OffsetBytes = 1;
+constexpr uint64_t kSnappyCopy2OffsetBytes = 2;
+constexpr uint64_t kSnappyCopy4OffsetBytes = 4;
+
+/* One parsed element, in absolute offsets.
+ *
+ * A LITERAL (is_copy false) copies `length` bytes from src[from ..
+ * from+length) to dst[to .. to+length). `from` indexes the source stream
+ * and `to` the destination; they count in different buffers and no
+ * inequality relates them.
+ *
+ * A COPY (is_copy true) replicates `length` bytes inside dst, reading from
+ * dst[from ..]. The read may run into bytes this element is itself writing,
+ * which is the pattern-repeating semantics an overlapping Snappy copy has,
+ * so a caller executing it sequentially must copy byte by byte in
+ * increasing order (offset = to - from, and a warp gather reduces by that
+ * offset). `from < to` always holds: an offset of zero is refused.
+ *
+ * The TERMINAL element, the one handed back with *done set, is a literal of
+ * length 0 with `from` 0 and `to` equal to the declared length. Executing
+ * it copies nothing. It is spelled out rather than left undefined because
+ * a caller that executes unconditionally before testing *done reads all
+ * four fields.
+ *
+ * What the parser has already proved when it hands one back: for a literal,
+ * from + length <= the source size; for a copy, from < to and
+ * to + length <= the declared output length; and in both cases
+ * to + length <= the declared length <= the caller's capacity. */
+struct SnappyElement {
+    uint64_t from;
+    uint64_t to;
+    uint64_t length;
+    bool is_copy;
+};
+
+/* The preamble alone, for a caller that must BOUND its destination before
+ * any element exists - the batch entry point checks the declared length
+ * against the chunk's capacity, and the CPU twin allocates from it after
+ * that check. Nothing here licenses sizing an allocation from `*declared`
+ * without comparing it against a capacity the caller already owns: the
+ * value is attacker-controlled and reaches 2^32-1.
+ *
+ * SnappyParser::Begin reads the preamble through this same function, so
+ * there is one varint reader and not two. On success `*declared` is the
+ * declared uncompressed length and `*preamble_size` the bytes it
+ * occupied. */
+CUDEC_HOST_DEVICE inline cudec_status SnappyDeclaredLength(
+    const unsigned char* src, uint64_t src_size, uint64_t* declared,
+    uint64_t* preamble_size) {
+    uint64_t result = 0;
+    for (uint64_t group = 0; group < kSnappyVarintGroups; group++) {
+        if (group >= src_size) {
+            return CUDEC_ERR_CORRUPT_INPUT; /* preamble byte missing */
+        }
+        const unsigned char byte = src[group];
+        /* The final group is refused above 15 rather than truncated: a
+         * decoder that masked the excess away would accept a declared
+         * length the reference rejects outright. */
+        if (group + 1 == kSnappyVarintGroups &&
+            byte >= kSnappyVarintFinalMax) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        result |= static_cast<uint64_t>(byte & kSnappyVarintPayload)
+                  << (kSnappyVarintBits * group);
+        if ((byte & kSnappyVarintContinue) == 0) {
+            *declared = result;
+            *preamble_size = group + 1;
+            return CUDEC_OK;
+        }
+    }
+    /* Unreachable: a fifth byte below 16 has its continuation bit clear and
+     * returned above, and one at or above 16 was refused. The exit exists
+     * because the compiler requires one, and it is the reason this branch
+     * carries no crafted negative. */
+    return CUDEC_ERR_CORRUPT_INPUT;
+}
+
+struct SnappyParser {
+    const unsigned char* src;
+    uint64_t src_size;
+    uint64_t dst_capacity;
+    uint64_t src_pos = 0;
+    uint64_t dst_pos = 0;
+    /* Valid once Begin has succeeded. */
+    uint64_t declared = 0;
+    bool begun = false;
+    bool finished = false;
+
+    /* Reads the preamble and checks the declaration against the caller's
+     * capacity. Idempotent, and Next calls it, so a caller that needs the
+     * declared length up front pays for the varint once rather than twice. */
+    CUDEC_HOST_DEVICE cudec_status Begin() {
+        if (begun) {
+            return CUDEC_OK;
+        }
+        uint64_t preamble_size = 0;
+        const cudec_status status =
+            SnappyDeclaredLength(src, src_size, &declared, &preamble_size);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+        /* Against the caller's capacity, never the other way round: this is
+         * the one place a hostile 4 GiB declaration is stopped from sizing
+         * anything. */
+        if (declared > dst_capacity) {
+            return CUDEC_ERR_OUTPUT_TOO_SMALL;
+        }
+        src_pos = preamble_size;
+        begun = true;
+        return CUDEC_OK;
+    }
+
+    /* Parses the next element and advances both cursors past it. Exactly
+     * one of three outcomes: CUDEC_OK with *element filled (execute it,
+     * then call again); CUDEC_OK with *done set (the ONLY success exit,
+     * reached when the source is consumed exactly and the declared length
+     * was produced exactly); or a reject status.
+     *
+     * Liveness, stated as the caller needs it rather than as a slogan.
+     * Every call that hands back a non-terminal element consumes at least
+     * the tag byte, and the first call consumes the preamble as well. The
+     * TERMINAL call consumes nothing - there is nothing left to consume -
+     * so it is the parser and not the caller that must stop the loop: a
+     * further call after it is refused. A driver that ignores *done
+     * therefore terminates on a reject instead of spinning, which is what
+     * a warp lane needs, because a lane that never leaves its element loop
+     * holds the whole launch. src/lz4_block.h gets the same property from
+     * its terminal run consuming the rest of the source; this format's
+     * terminal element consumes nothing, so the flag does it instead.
+     *
+     * Nothing here loops on a stream-derived count. Three loops read the
+     * stream - the varint groups, a literal's length bytes and a copy's
+     * offset bytes - and each is a counted for whose trip count is bounded
+     * by a compile-time maximum of five, four and four; the tag selects a
+     * value inside that bound and cannot raise it. */
+    CUDEC_HOST_DEVICE cudec_status Next(SnappyElement* element, bool* done) {
+        *done = false;
+        if (finished) {
+            return CUDEC_ERR_CORRUPT_INPUT; /* called past the terminal element */
+        }
+        const cudec_status started = Begin();
+        if (started != CUDEC_OK) {
+            return started;
+        }
+
+        if (src_pos >= src_size) {
+            /* Under-production rejects here; over-production cannot reach
+             * this point, because every element's length was bounded by the
+             * declared output remaining. Trailing bytes do not reach it
+             * either: with the declared length already produced, the next
+             * element finds zero output remaining and every element
+             * produces at least one byte. */
+            if (dst_pos != declared) {
+                return CUDEC_ERR_CORRUPT_INPUT;
+            }
+            element->from = 0;
+            element->to = dst_pos;
+            element->length = 0;
+            element->is_copy = false;
+            finished = true;
+            *done = true;
+            return CUDEC_OK;
+        }
+
+        /* src_pos < src_size here, so every `src_size - src_pos` below is at
+         * least 1 and no header check underflows. dst_pos <= declared holds
+         * on entry as the loop invariant the two output bounds maintain, so
+         * `declared - dst_pos` does not underflow either. */
+        const unsigned char tag = src[src_pos];
+        const unsigned kind = tag & kSnappyTagKindMask;
+
+        if (kind == kSnappyTagKindLiteral) {
+            uint64_t length = tag >> kSnappyTagLengthShift;
+            uint64_t header = kSnappyTagBytes;
+            if (length > kSnappyLiteralInlineMax) {
+                const uint64_t extra = length - kSnappyLiteralInlineMax;
+                header += extra;
+                if (header > src_size - src_pos) {
+                    return CUDEC_ERR_CORRUPT_INPUT; /* header past the end */
+                }
+                length = 0;
+                for (uint64_t i = 0; i < extra; i++) {
+                    length |= static_cast<uint64_t>(
+                                  src[src_pos + kSnappyTagBytes + i])
+                              << (kSnappyBitsPerByte * i);
+                }
+            }
+            /* The encoded value is length-1, and this accumulator is 64-bit,
+             * so the addition below cannot wrap. THE REFERENCE'S DOES: it
+             * adds in 32 bits, so the four-byte class spelling 0xFFFFFFFF
+             * becomes a zero-length literal there and the stream is
+             * accepted. cudec refuses it - a length that only exists
+             * because an accumulator wrapped is not a length, and
+             * fail-closed on spec-nonsense outranks bug-for-bug parity
+             * (prime directive 1), exactly as it does for LZ4's tolerated
+             * offset == 0. This is the ONE point where cudec's accept set
+             * is a strict subset of snappy's; the twin pins it as a
+             * divergence rather than letting it hide inside a parity
+             * count. Never widen the accumulator's wrap back in to regain
+             * parity. */
+            length += 1;
+            src_pos += header;
+            if (length > src_size - src_pos) {
+                return CUDEC_ERR_CORRUPT_INPUT; /* literal bytes missing */
+            }
+            if (length > declared - dst_pos) {
+                return CUDEC_ERR_CORRUPT_INPUT; /* over-production */
+            }
+            element->from = src_pos;
+            element->to = dst_pos;
+            element->length = length;
+            element->is_copy = false;
+            src_pos += length;
+            dst_pos += length;
+            return CUDEC_OK;
+        }
+
+        uint64_t offset_bytes = kSnappyCopy1OffsetBytes;
+        if (kind == kSnappyTagKindCopy2) {
+            offset_bytes = kSnappyCopy2OffsetBytes;
+        } else if (kind == kSnappyTagKindCopy4) {
+            offset_bytes = kSnappyCopy4OffsetBytes;
+        }
+        const uint64_t header = kSnappyTagBytes + offset_bytes;
+        if (header > src_size - src_pos) {
+            return CUDEC_ERR_CORRUPT_INPUT; /* header past the end */
+        }
+        uint64_t offset = 0;
+        for (uint64_t i = 0; i < offset_bytes; i++) {
+            offset |= static_cast<uint64_t>(src[src_pos + kSnappyTagBytes + i])
+                      << (kSnappyBitsPerByte * i);
+        }
+        uint64_t length = 0;
+        if (kind == kSnappyTagKindCopy1) {
+            /* The narrow form splits its offset: three tag bits carry the
+             * high byte, the trailing byte the low one. */
+            offset |= static_cast<uint64_t>(tag >> kSnappyCopy1OffsetShift)
+                      << kSnappyBitsPerByte;
+            length = kSnappyCopy1MinLength +
+                     ((tag >> kSnappyTagLengthShift) & kSnappyCopy1LengthMask);
+        } else {
+            length = (tag >> kSnappyTagLengthShift) + 1;
+        }
+        src_pos += header;
+        /* offset == 0 has no meaning: there is no byte to replicate. snappy
+         * refuses it in all three copy forms, with and without output
+         * behind it, which is pinned by crafted negatives in the twin
+         * rather than read off the reference's source. It is also
+         * load-bearing for the kernel exactly as it is for LZ4 - a
+         * closed-form gather reduces by offset, so a zero reaching the
+         * device copy engine would be a modulo by zero. */
+        if (offset == 0) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        if (offset > dst_pos) {
+            return CUDEC_ERR_CORRUPT_INPUT; /* reads before the output start */
+        }
+        if (length > declared - dst_pos) {
+            return CUDEC_ERR_CORRUPT_INPUT; /* over-production */
+        }
+        element->from = dst_pos - offset;
+        element->to = dst_pos;
+        element->length = length;
+        element->is_copy = true;
+        dst_pos += length;
+        return CUDEC_OK;
+    }
+};
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_SNAPPY_BLOCK_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -217,6 +217,25 @@ cudec_add_test(snappy_probes SOURCES snappy_probes.cpp LIBS
 # it runs on the GPU-less runner.
 cudec_add_test(snappy_corpus SOURCES snappy_corpus.cpp LIBS
                cudec_test_fixtures)
+# The Snappy counterpart of parser_twin (issue #171): the single-source
+# ladder from src/snappy_block.h executed on the host and held to snappy's
+# verdicts. Host-side, so the GPU-less runner and the sanitizer gate both
+# reach it - which is what makes the exactly-sized stream copy inside it
+# worth having.
+cudec_add_test(snappy_parser_twin SOURCES snappy_parser_twin.cpp LIBS
+               cudec_test_fixtures)
+target_include_directories(snappy_parser_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The other half of "single-source host AND device" (issue #171): the twin
+# above compiles src/snappy_block.h with the host compiler and this one hands
+# the same header to nvcc, then requires the two to produce an identical
+# element trace. Without it the device half of the header is a comment. Not
+# the device gate set (#154) - one thread, no warp cooperation, no kernel.
+cudec_add_test(snappy_block_device SOURCES snappy_block_device.cu GPU)
+if(TARGET snappy_block_device)
+  target_include_directories(snappy_block_device
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+endif()
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/snappy_block_device.cu
+++ b/tests/snappy_block_device.cu
@@ -1,0 +1,286 @@
+/* The "single-source host and device" half of src/snappy_block.h, executed
+ * rather than asserted (issue #171). The header is written __host__
+ * __device__ and the CPU twin exercises only the host half, so without this
+ * nothing in the tree ever hands it to nvcc: the property would be a comment.
+ *
+ * What runs: one thread parses each stream on the device and records a
+ * trace - the final status, the produced length, the element count and a
+ * digest over every element field in order. The host runs the same parser
+ * over the same bytes and the two traces must be identical. That is the
+ * single-source claim stated as a comparison, and it is also the
+ * determinism claim at the granularity this header owns: the same input
+ * produces the same element sequence on both.
+ *
+ * Not the device gate set (#154), which is a kernel's business. There is no
+ * kernel yet; this is the header on a device, one thread, no warp
+ * cooperation. */
+#include "cudec.h"
+#include "require.h"
+#include "snappy_block.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* The whole observable behaviour of one parse, in a form two sides can
+ * compare byte for byte. */
+struct Trace {
+    int status;
+    int out_of_fuel;
+    unsigned long long produced;
+    unsigned long long elements;
+    unsigned long long digest;
+};
+
+/* One warp per launch block. Named rather than written twice, so the two
+ * places that need it cannot drift. */
+constexpr unsigned kThreadsPerBlock = 32;
+
+/* FNV-1a over the element fields, in order. Not crypto: a difference
+ * detector that does not need the element sequence copied off the device. */
+CUDEC_HOST_DEVICE inline unsigned long long Mix(unsigned long long hash,
+                                                unsigned long long value) {
+    for (unsigned i = 0; i < sizeof(value); i++) {
+        hash ^= (value >> (8 * i)) & 0xFF;
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+CUDEC_HOST_DEVICE inline void RunParser(const unsigned char* src,
+                                        unsigned long long src_size,
+                                        unsigned long long capacity,
+                                        Trace* trace) {
+    cudec_detail::SnappyParser parser{src, src_size, capacity};
+    cudec_detail::SnappyElement element;
+    bool done = false;
+    unsigned long long digest = 14695981039346656037ull;
+    unsigned long long elements = 0;
+    cudec_status status = CUDEC_OK;
+    int out_of_fuel = 0;
+    /* Fuel: every non-terminal call consumes at least one source byte, so
+     * this budget is unreachable for a live parser - and a regression that
+     * stopped consuming reds this test instead of holding the device. */
+    unsigned long long fuel = src_size + 2;
+    while (true) {
+        if (fuel-- == 0) {
+            out_of_fuel = 1;
+            break;
+        }
+        status = parser.Next(&element, &done);
+        if (status != CUDEC_OK) {
+            break;
+        }
+        digest = Mix(digest, element.from);
+        digest = Mix(digest, element.to);
+        digest = Mix(digest, element.length);
+        digest = Mix(digest, element.is_copy ? 1u : 0u);
+        elements++;
+        if (done) {
+            break;
+        }
+    }
+    trace->status = static_cast<int>(status);
+    trace->out_of_fuel = out_of_fuel;
+    trace->produced = parser.dst_pos;
+    trace->elements = elements;
+    trace->digest = digest;
+}
+
+__global__ void ParseOnDevice(const unsigned char* streams,
+                              const unsigned long long* offsets,
+                              const unsigned long long* sizes,
+                              unsigned long long capacity, unsigned count,
+                              Trace* traces) {
+    const unsigned index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= count) {
+        return;
+    }
+    RunParser(streams + offsets[index], sizes[index], capacity,
+              &traces[index]);
+}
+
+Bytes Preamble(unsigned length) {
+    Bytes out;
+    unsigned v = length;
+    while (v >= 0x80) {
+        out.push_back(static_cast<unsigned char>((v & 0x7f) | 0x80));
+        v >>= 7;
+    }
+    out.push_back(static_cast<unsigned char>(v));
+    return out;
+}
+
+void Append(Bytes* out, const Bytes& more) {
+    out->insert(out->end(), more.begin(), more.end());
+}
+
+Bytes Literal(const char* text, size_t size) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>((size - 1) << 2));
+    for (size_t i = 0; i < size; i++) {
+        out.push_back(static_cast<unsigned char>(text[i]));
+    }
+    return out;
+}
+
+Bytes Copy2(unsigned length, unsigned offset) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>(((length - 1) << 2) | 2));
+    out.push_back(static_cast<unsigned char>(offset & 0xff));
+    out.push_back(static_cast<unsigned char>((offset >> 8) & 0xff));
+    return out;
+}
+
+/* Valid streams, rejects from several rungs of the ladder, and the shapes
+ * whose arithmetic differs between the two compilers if anything does: the
+ * wide length classes and the wide offset form. */
+std::vector<Bytes> MakeStreams() {
+    std::vector<Bytes> out;
+    out.push_back(Bytes{});                     /* no preamble */
+    out.push_back(Preamble(0));                 /* a valid empty stream */
+    {
+        Bytes s = Preamble(4);
+        Append(&s, Literal("abcd", 4));
+        out.push_back(s);                       /* one literal */
+    }
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal("abcd", 4));
+        Append(&s, Copy2(4, 4));
+        out.push_back(s);                       /* literal then copy */
+    }
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal("ab", 2));
+        Append(&s, Copy2(6, 1));
+        out.push_back(s);                       /* an overlapping copy */
+    }
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal("abcd", 4));
+        Append(&s, Copy2(4, 0));
+        out.push_back(s);                       /* offset zero, refused */
+    }
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal("abcd", 4));
+        Append(&s, Copy2(4, 9));
+        out.push_back(s);                       /* offset past the output */
+    }
+    out.push_back(Bytes{0x80, 0x80, 0x80, 0x80, 0x10}); /* varint overflow */
+    out.push_back(Bytes{0x00, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF}); /* the wrap */
+    {
+        Bytes s = Preamble(300);
+        s.push_back(0xF0); /* long-form literal, its length byte missing */
+        out.push_back(s);
+    }
+    {
+        Bytes s = Preamble(64);
+        s.push_back(0xF4); /* two length bytes for a 64-byte literal */
+        s.push_back(63);
+        s.push_back(0);
+        for (int i = 0; i < 64; i++) {
+            s.push_back(static_cast<unsigned char>('a' + i % 26));
+        }
+        out.push_back(s);
+    }
+    return out;
+}
+
+}  // namespace
+
+int main() {
+    const std::vector<Bytes> streams = MakeStreams();
+    const unsigned count = static_cast<unsigned>(streams.size());
+    REQUIRE(count > 0);
+    const unsigned long long capacity = 1u << 20;
+
+    Bytes flat;
+    std::vector<unsigned long long> offsets;
+    std::vector<unsigned long long> sizes;
+    for (const auto& s : streams) {
+        offsets.push_back(flat.size());
+        sizes.push_back(s.size());
+        flat.insert(flat.end(), s.begin(), s.end());
+    }
+    /* One byte of slack, so a zero-length stream still has a valid base
+     * pointer to hand the parser and the allocation is never zero-sized. */
+    flat.push_back(0);
+
+    unsigned char* d_streams = nullptr;
+    unsigned long long* d_offsets = nullptr;
+    unsigned long long* d_sizes = nullptr;
+    Trace* d_traces = nullptr;
+    REQUIRE_CUDA(cudaMalloc(&d_streams, flat.size()));
+    REQUIRE_CUDA(cudaMalloc(&d_offsets, offsets.size() * sizeof(*d_offsets)));
+    REQUIRE_CUDA(cudaMalloc(&d_sizes, sizes.size() * sizeof(*d_sizes)));
+    REQUIRE_CUDA(cudaMalloc(&d_traces, count * sizeof(*d_traces)));
+    REQUIRE_CUDA(cudaMemcpy(d_streams, flat.data(), flat.size(),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_offsets, offsets.data(),
+                            offsets.size() * sizeof(*d_offsets),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_sizes, sizes.data(),
+                            sizes.size() * sizeof(*d_sizes),
+                            cudaMemcpyHostToDevice));
+    /* Poisoned, so a trace the kernel never wrote cannot pass as a match. */
+    REQUIRE_CUDA(cudaMemset(d_traces, 0xFF, count * sizeof(*d_traces)));
+
+    ParseOnDevice<<<(count + kThreadsPerBlock - 1) / kThreadsPerBlock,
+                    kThreadsPerBlock>>>(d_streams, d_offsets, d_sizes,
+                                        capacity, count, d_traces);
+    REQUIRE_CUDA(cudaGetLastError());
+    REQUIRE_CUDA(cudaDeviceSynchronize());
+
+    std::vector<Trace> device_traces(count);
+    REQUIRE_CUDA(cudaMemcpy(device_traces.data(), d_traces,
+                            count * sizeof(Trace), cudaMemcpyDeviceToHost));
+
+    size_t accepted = 0;
+    for (unsigned i = 0; i < count; i++) {
+        Trace host_trace;
+        RunParser(flat.data() + offsets[i], sizes[i], capacity, &host_trace);
+        const Trace& device_trace = device_traces[i];
+        REQUIRE_CTX(host_trace.status == device_trace.status,
+                    "stream %u: host status %d, device status %d", i,
+                    host_trace.status, device_trace.status);
+        REQUIRE_CTX(host_trace.produced == device_trace.produced,
+                    "stream %u: produced %llu vs %llu", i, host_trace.produced,
+                    device_trace.produced);
+        REQUIRE_CTX(host_trace.elements == device_trace.elements,
+                    "stream %u: %llu elements vs %llu", i, host_trace.elements,
+                    device_trace.elements);
+        REQUIRE_CTX(host_trace.digest == device_trace.digest,
+                    "stream %u: element digest %llx vs %llx", i,
+                    host_trace.digest, device_trace.digest);
+        /* The fuel budget must never be what ended a parse, on either side. */
+        REQUIRE_CTX(host_trace.out_of_fuel == 0,
+                    "stream %u did not terminate on the host", i);
+        REQUIRE_CTX(device_trace.out_of_fuel == 0,
+                    "stream %u did not terminate on the device", i);
+        if (host_trace.status == CUDEC_OK) {
+            accepted++;
+        }
+    }
+    /* Both directions, so the comparison is not vacuous on a corpus that
+     * only rejects or only accepts. */
+    REQUIRE(accepted > 0);
+    REQUIRE(accepted < count);
+
+    REQUIRE_CUDA(cudaFree(d_streams));
+    REQUIRE_CUDA(cudaFree(d_offsets));
+    REQUIRE_CUDA(cudaFree(d_sizes));
+    REQUIRE_CUDA(cudaFree(d_traces));
+
+    std::printf("PASS: %u streams parsed identically by the host compiler and "
+                "nvcc from one header (%zu accepted, %zu rejected)\n",
+                count, accepted, count - accepted);
+    return 0;
+}

--- a/tests/snappy_parser_twin.cpp
+++ b/tests/snappy_parser_twin.cpp
@@ -1,0 +1,789 @@
+/* The CPU twin of the Snappy decoder core, the sibling of
+ * tests/parser_twin.cpp: the single-source parser and validation ladder
+ * from src/snappy_block.h, executed sequentially on the host and held to
+ * oracle parity on the GPU-less CI runner - the fail-closed heart of M3
+ * lands under CI before any kernel exists. Parity is the authority:
+ * wherever snappy rejects, the twin must reject; where both accept, the
+ * bytes and the size must match the reference's own output.
+ *
+ * The stream carries its own uncompressed length, so a verdict needs no
+ * size argument and the twin sizes its destination the way
+ * SnappyOracleDecodes does - from the declared length, refused above the
+ * harness bound in fixtures.h. That keeps the two sides comparable on the
+ * mutants that declare an absurd length. The capacity axis the format
+ * cannot express, a destination smaller than the declaration, is driven
+ * against the parser directly further down. */
+#include "cudec.h"
+#include "fixtures.h"
+#include "require.h"
+#include "snappy_block.h"
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* Counts elements the parser handed back that the caller could not have
+ * executed without leaving its buffers, and cursors left outside their own
+ * bounds. main() requires it to be zero; the status Drive returns is left
+ * alone, so a violation cannot be swallowed by a parity comparison that
+ * only reads verdicts.
+ *
+ * It exists because a verdict alone cannot prove a bounds guard. Removing
+ * the check that a long-form literal's length bytes are present, or that a
+ * copy's offset bytes are, still rejects every crafted stream: the cursor
+ * runs past the source end, the next subtraction wraps, and a later branch
+ * catches it after the read has already happened. What the guard actually
+ * prevents is that read, so that is what is counted. Measured - three of
+ * those removals left a verdict-only suite green. */
+size_t g_bounds_violations = 0;
+
+/* Sequential reference execution of the parsed elements. A copy is the
+ * chasing byte copy - reads may land on just-written bytes, which is the
+ * pattern-repeating semantics an overlapping Snappy copy has. */
+cudec_status Drive(const unsigned char* src, uint64_t src_size,
+                   uint64_t capacity, Bytes* out) {
+    out->assign(static_cast<size_t>(capacity), 0);
+    cudec_detail::SnappyParser parser{src, src_size, capacity};
+    cudec_detail::SnappyElement element;
+    bool done = false;
+    /* Fuel, for the same reason every driver loop in this tree carries one:
+     * a parser that stops making progress must red the run rather than hang
+     * it. Every non-terminal call consumes at least one source byte, so one
+     * call per byte plus the terminal one is more than a live parser needs. */
+    uint64_t fuel = src_size + 2;
+    while (true) {
+        if (fuel-- == 0) {
+            std::fprintf(stderr, "the parser did not terminate on a %llu-byte "
+                                 "stream\n",
+                         static_cast<unsigned long long>(src_size));
+            g_bounds_violations++;
+            out->clear();
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        const cudec_status status = parser.Next(&element, &done);
+        if (status != CUDEC_OK) {
+            /* A rejected stream produces nothing, the same contract
+             * SnappyOracleDecodes holds its caller to. */
+            out->clear();
+            return status;
+        }
+        /* Both cursors stay inside their buffers, the produced length stays
+         * inside the declaration, and the element lies inside what the
+         * parser says it produced. A literal's source range is inside the
+         * stream; a copy reaches strictly backwards, which is what makes the
+         * chasing read below defined. */
+        const bool bounded =
+            parser.src_pos <= parser.src_size &&
+            parser.dst_pos <= parser.declared &&
+            parser.declared <= capacity &&
+            element.to + element.length <= parser.dst_pos &&
+            (element.is_copy ? element.from < element.to
+                             : element.from + element.length <=
+                                   parser.src_pos);
+        if (!bounded) {
+            std::fprintf(stderr,
+                         "the parser left its bounds: src_pos=%llu/%llu "
+                         "dst_pos=%llu/%llu element from=%llu to=%llu len=%llu "
+                         "copy=%d\n",
+                         static_cast<unsigned long long>(parser.src_pos),
+                         static_cast<unsigned long long>(parser.src_size),
+                         static_cast<unsigned long long>(parser.dst_pos),
+                         static_cast<unsigned long long>(parser.declared),
+                         static_cast<unsigned long long>(element.from),
+                         static_cast<unsigned long long>(element.to),
+                         static_cast<unsigned long long>(element.length),
+                         element.is_copy ? 1 : 0);
+            g_bounds_violations++;
+            out->clear();
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        if (element.is_copy) {
+            for (uint64_t i = 0; i < element.length; i++) {
+                (*out)[static_cast<size_t>(element.to + i)] =
+                    (*out)[static_cast<size_t>(element.from + i)];
+            }
+        } else {
+            for (uint64_t i = 0; i < element.length; i++) {
+                (*out)[static_cast<size_t>(element.to + i)] =
+                    src[element.from + i];
+            }
+        }
+        if (done) {
+            break;
+        }
+    }
+    out->resize(static_cast<size_t>(parser.dst_pos));
+    return CUDEC_OK;
+}
+
+/* Parse from an EXACTLY-sized copy of the stream, as TwinDecode in
+ * tests/parser_twin.cpp does: the mutation corpus truncates by
+ * resize()-DOWN, which leaves the vector's rounded-up capacity readable, so
+ * an over-read past src_size would land in that slack and leave ASan green.
+ * A tight allocation puts a redzone right after the last stream byte. */
+cudec_status TwinDecode(const Bytes& stream, Bytes* out) {
+    out->clear();
+    const size_t stream_size = stream.size();
+    auto tight = std::make_unique<unsigned char[]>(stream_size);
+    if (stream_size != 0) {
+        std::memcpy(tight.get(), stream.data(), stream_size);
+    }
+    /* The declaration is read through the parser's own Begin, so the varint
+     * is parsed once and the destination is sized from a value that has
+     * already been compared against a capacity. The capacity here is the
+     * harness bound rather than the declaration itself: that is the same
+     * refusal SnappyOracleDecodes applies, so a mutant declaring 4 GiB is
+     * refused on both sides for the same reason instead of reading as a
+     * parity failure. */
+    cudec_detail::SnappyParser probe{tight.get(), stream_size,
+                                     kSnappyOracleMaxOutput};
+    const cudec_status header = probe.Begin();
+    if (header != CUDEC_OK) {
+        return header;
+    }
+    return Drive(tight.get(), stream_size, probe.declared, out);
+}
+
+/* Drives the parser for its liveness contract alone, producing nothing.
+ * Returns false, with a reason, when a non-terminal call consumed no source
+ * byte, when a call after the terminal one succeeded, or when the parser did
+ * not terminate inside a bound every live parse fits in. A lane that never
+ * leaves its element loop holds a whole launch, so this is a fail-closed
+ * property and not a nicety. */
+bool LivenessHolds(const Bytes& stream, const char** why) {
+    const size_t stream_size = stream.size();
+    auto tight = std::make_unique<unsigned char[]>(stream_size);
+    if (stream_size != 0) {
+        std::memcpy(tight.get(), stream.data(), stream_size);
+    }
+    cudec_detail::SnappyParser parser{tight.get(), stream_size,
+                                      kSnappyOracleMaxOutput};
+    cudec_detail::SnappyElement element;
+    bool done = false;
+    uint64_t fuel = static_cast<uint64_t>(stream_size) + 2;
+    while (true) {
+        if (fuel-- == 0) {
+            *why = "the parser did not terminate";
+            return false;
+        }
+        const uint64_t before = parser.src_pos;
+        const cudec_status status = parser.Next(&element, &done);
+        if (status != CUDEC_OK) {
+            return true; /* a reject ends any driver loop */
+        }
+        if (done) {
+            /* The terminal call consumes nothing, so the parser itself has
+             * to stop a driver that ignores *done. */
+            bool again = false;
+            if (parser.Next(&element, &again) == CUDEC_OK) {
+                *why = "a call after the terminal element succeeded";
+                return false;
+            }
+            return true;
+        }
+        if (parser.src_pos <= before) {
+            *why = "a non-terminal call consumed no source byte";
+            return false;
+        }
+    }
+}
+
+/* Stream builders. tests/snappy_probes.cpp carries its own copies of five
+ * of these, where they exist to ask the reference what it accepts and their
+ * comments cite the reference lines each encoding was read from. These are
+ * duplicates of that arithmetic, kept local because the citations belong
+ * with the probes; a shared builder header is the right home and is not
+ * this change. */
+
+void Append(Bytes* out, const Bytes& more) {
+    out->insert(out->end(), more.begin(), more.end());
+}
+
+Bytes Preamble(uint32_t length) {
+    Bytes out;
+    uint32_t v = length;
+    while (v >= 0x80) {
+        out.push_back(static_cast<unsigned char>((v & 0x7f) | 0x80));
+        v >>= 7;
+    }
+    out.push_back(static_cast<unsigned char>(v));
+    return out;
+}
+
+/* A short-form literal: the tag's upper six bits hold length-1, which
+ * reaches 60 bytes before the length needs bytes of its own. */
+Bytes Literal(const Bytes& data) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>((data.size() - 1) << 2));
+    Append(&out, data);
+    return out;
+}
+
+/* A long-form literal: `extra` little-endian bytes carry length-1, and the
+ * tag's six bits select how many. */
+Bytes LongLiteral(const Bytes& data, unsigned extra) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>(((59 + extra) << 2)));
+    const uint64_t encoded = data.size() - 1;
+    for (unsigned i = 0; i < extra; i++) {
+        out.push_back(static_cast<unsigned char>((encoded >> (8 * i)) & 0xff));
+    }
+    Append(&out, data);
+    return out;
+}
+
+Bytes Copy1(unsigned length, unsigned offset) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>(((offset >> 8) << 5) |
+                                             ((length - 4) << 2) | 1));
+    out.push_back(static_cast<unsigned char>(offset & 0xff));
+    return out;
+}
+
+Bytes Copy2(unsigned length, unsigned offset) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>(((length - 1) << 2) | 2));
+    out.push_back(static_cast<unsigned char>(offset & 0xff));
+    out.push_back(static_cast<unsigned char>((offset >> 8) & 0xff));
+    return out;
+}
+
+Bytes Copy4(unsigned length, uint32_t offset) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>(((length - 1) << 2) | 3));
+    for (int i = 0; i < 4; i++) {
+        out.push_back(static_cast<unsigned char>((offset >> (8 * i)) & 0xff));
+    }
+    return out;
+}
+
+Bytes Ascii(const std::string& text) {
+    return Bytes(text.begin(), text.end());
+}
+
+struct CraftedNegative {
+    const char* name;
+    Bytes stream;
+    cudec_status expected;
+};
+
+/* One crafted stream per validation-ladder branch. Each pins the twin's
+ * specific status AND asserts snappy rejects the same bytes, so the branch
+ * is demonstrably in parity rather than merely present. Byte layouts
+ * verified by trace against src/snappy_block.h. */
+std::vector<CraftedNegative> MakeCraftedNegatives() {
+    const Bytes abcd = Ascii("abcd");
+    std::vector<CraftedNegative> out;
+
+    /* Preamble: no byte at all. */
+    out.push_back({"preamble-absent", {}, CUDEC_ERR_CORRUPT_INPUT});
+    /* Preamble: a continuation bit with nothing behind it. */
+    out.push_back({"preamble-truncated", {0x80}, CUDEC_ERR_CORRUPT_INPUT});
+    /* Preamble: a sixth group. The fifth byte still carries the
+     * continuation bit, which the reference refuses outright. */
+    out.push_back({"preamble-six-groups",
+                   {0x80, 0x80, 0x80, 0x80, 0x80, 0x00},
+                   CUDEC_ERR_CORRUPT_INPUT});
+    /* Preamble: five groups whose value needs a 33rd bit. */
+    out.push_back({"preamble-overflows-32-bit",
+                   {0x80, 0x80, 0x80, 0x80, 0x10},
+                   CUDEC_ERR_CORRUPT_INPUT});
+
+    /* Elements: a declaration with no elements behind it. */
+    {
+        Bytes s = Preamble(4);
+        out.push_back({"under-production-empty", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* Elements: production stops short of the declaration. */
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        out.push_back({"under-production-short", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* A long-form literal whose length bytes run past the source end. The
+     * declaration is deliberately larger than any length those missing
+     * bytes could have spelled - 256 for the one-byte class, 65536 for the
+     * two-byte one - so that removing the guard does not merely trade one
+     * reject for another: whatever lies past the buffer, the element is
+     * accepted and the cursor leaves the stream, which is what the guard
+     * exists to prevent and what Drive's bounds check then reports. */
+    {
+        Bytes s = Preamble(300);
+        s.push_back(0xF0); /* class 60: one length byte follows, and none does */
+        out.push_back({"literal-header-truncated", s,
+                       CUDEC_ERR_CORRUPT_INPUT});
+    }
+    {
+        Bytes s = Preamble(70000);
+        s.push_back(0xF4); /* class 61: two length bytes follow, and none do */
+        out.push_back({"literal-header-truncated-wide", s,
+                       CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* A literal whose payload runs past the source end. */
+    {
+        Bytes s = Preamble(4);
+        Append(&s, Literal(abcd));
+        s.resize(s.size() - 2);
+        out.push_back({"literal-payload-truncated", s,
+                       CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* A literal longer than the declaration leaves room for. */
+    {
+        Bytes s = Preamble(2);
+        Append(&s, Literal(abcd));
+        out.push_back({"literal-over-production", s,
+                       CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* A copy whose offset bytes run past the source end. */
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        s.push_back(0x0E); /* a two-byte-offset copy tag, with no offset */
+        out.push_back({"copy-header-truncated", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* The same for the narrow form, whose header is one byte shorter and
+     * whose guard is therefore a separate branch. */
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        s.push_back(0x01); /* a one-byte-offset copy tag, with no offset */
+        out.push_back({"copy1-header-truncated", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* And for the four-byte-offset form, which is missing three of them. */
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        Append(&s, Copy4(4, 4));
+        s.resize(s.size() - 3);
+        out.push_back({"copy4-header-truncated", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* A copy with no byte to replicate, in each of the three forms, both
+     * with output behind it and with none. */
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        Append(&s, Copy2(4, 0));
+        out.push_back({"copy-offset-zero-tag-10", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        Append(&s, Copy4(4, 0));
+        out.push_back({"copy-offset-zero-tag-11", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        Append(&s, Copy1(4, 0));
+        out.push_back({"copy-offset-zero-tag-01", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    {
+        Bytes s = Preamble(4);
+        Append(&s, Copy2(4, 0));
+        out.push_back({"copy-offset-zero-at-start", s,
+                       CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* A copy reaching before the start of the produced output. */
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        Append(&s, Copy2(4, 5));
+        out.push_back({"copy-offset-before-start", s,
+                       CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* The same, through the four-byte-offset form, where the offset is
+     * wide enough to be a pointer-sized mistake rather than a small one. */
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        Append(&s, Copy4(4, 0xFFFFFFFFu));
+        out.push_back({"copy-offset-huge", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* A copy longer than the declaration leaves room for. */
+    {
+        Bytes s = Preamble(6);
+        Append(&s, Literal(abcd));
+        Append(&s, Copy2(4, 1));
+        out.push_back({"copy-over-production", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* A complete stream with one more element behind it: the declared
+     * length is already produced, so the trailing element over-produces. */
+    {
+        Bytes s = Preamble(4);
+        Append(&s, Literal(abcd));
+        Append(&s, Literal(Ascii("x")));
+        out.push_back({"trailing-element", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    /* A complete stream with one dangling tag byte: the source is not
+     * consumed exactly, and the tag's own payload is missing too. */
+    {
+        Bytes s = Preamble(4);
+        Append(&s, Literal(abcd));
+        s.push_back(0x00);
+        out.push_back({"trailing-tag", s, CUDEC_ERR_CORRUPT_INPUT});
+    }
+    return out;
+}
+
+/* Streams the reference accepts, which the ladder must not over-reject.
+ * Over-strictness is a parity failure and not extra safety: every entry
+ * here is a shape snappy's own compressor never emits, so nothing in the
+ * fixture corpus covers them. */
+struct AcceptCase {
+    std::string name;
+    Bytes stream;
+    std::string expected;
+};
+
+std::vector<AcceptCase> MakeAcceptCases() {
+    const Bytes abcd = Ascii("abcd");
+    std::vector<AcceptCase> out;
+
+    /* A declaration of nothing, which is a whole valid stream. */
+    out.push_back({"empty-output", Preamble(0), ""});
+
+    /* A non-minimal preamble. Nothing in Varint::Parse32WithLimit rejects
+     * an encoding that could have been shorter (snappy_probes.cpp probe 1). */
+    {
+        Bytes s = {0x84, 0x00};
+        Append(&s, Literal(abcd));
+        out.push_back({"preamble-non-minimal", s, "abcd"});
+    }
+    /* The longest legal preamble for a small number: five groups. */
+    {
+        Bytes s = {0x84, 0x80, 0x80, 0x80, 0x00};
+        Append(&s, Literal(abcd));
+        out.push_back({"preamble-five-groups", s, "abcd"});
+    }
+    /* The four-byte-offset copy form, which no compressor emits at all
+     * (snappy_probes.cpp probe 4). */
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(abcd));
+        Append(&s, Copy4(4, 4));
+        out.push_back({"copy-tag-11", s, "abcdabcd"});
+    }
+    /* Copy lengths 1 to 3, which the narrow form cannot express and the
+     * compressor never emits (snappy_probes.cpp probe 5). Both wide forms,
+     * since they decode through different arithmetic. */
+    for (unsigned length = 1; length <= 3; length++) {
+        const std::string expected = "abcd" + std::string(length, 'd');
+        Bytes wide2 = Preamble(static_cast<uint32_t>(4 + length));
+        Append(&wide2, Literal(abcd));
+        Append(&wide2, Copy2(length, 1));
+        out.push_back({"copy-length-" + std::to_string(length) + "-tag-10",
+                       wide2, expected});
+        Bytes wide4 = Preamble(static_cast<uint32_t>(4 + length));
+        Append(&wide4, Literal(abcd));
+        Append(&wide4, Copy4(length, 1));
+        out.push_back({"copy-length-" + std::to_string(length) + "-tag-11",
+                       wide4, expected});
+    }
+    /* The narrow form itself, whose offset arrives in two pieces. */
+    {
+        Bytes s = Preamble(9);
+        Append(&s, Literal(Ascii("abcde")));
+        Append(&s, Copy1(4, 5));
+        out.push_back({"copy-tag-01", s, "abcdeabcd"});
+    }
+    /* A one-byte overlapping copy repeating its pattern, the semantics an
+     * offset smaller than the length has. */
+    {
+        Bytes s = Preamble(8);
+        Append(&s, Literal(Ascii("ab")));
+        Append(&s, Copy2(6, 1));
+        out.push_back({"copy-overlapping", s, "abbbbbbb"});
+    }
+    /* A long-form literal in each of its four width classes. */
+    for (unsigned extra = 1; extra <= 4; extra++) {
+        const Bytes payload = Ascii(std::string(64, 'z'));
+        Bytes s = Preamble(64);
+        Append(&s, LongLiteral(payload, extra));
+        out.push_back({"literal-long-form-" + std::to_string(extra) + "-bytes",
+                       s, std::string(64, 'z')});
+    }
+    return out;
+}
+
+/* An offset at or above 65536 needs that much produced output behind it, so
+ * it gets its own builder rather than a line in the table above. snappy's
+ * compressor asserts `offset < 65536` before emitting any copy, so this
+ * shape exists only in hand-built streams and in nothing the corpus holds. */
+Bytes WideOffsetStream(uint32_t offset, unsigned length) {
+    const uint32_t produced = offset + length;
+    Bytes payload;
+    payload.reserve(offset);
+    for (uint32_t i = 0; i < offset; i++) {
+        payload.push_back(static_cast<unsigned char>('A' + (i % 26)));
+    }
+    Bytes s = Preamble(produced);
+    Append(&s, LongLiteral(payload, 4));
+    Append(&s, Copy4(length, offset));
+    return s;
+}
+
+}  // namespace
+
+int main() {
+    const auto fixtures = MakeSnappyFixtures();
+    REQUIRE(!fixtures.empty());
+
+    /* Every fixture decodes to its original through the twin. */
+    for (const auto& f : fixtures) {
+        Bytes out;
+        REQUIRE_CTX(TwinDecode(f.compressed, &out) == CUDEC_OK, "fixture %s",
+                    f.name.c_str());
+        REQUIRE_CTX(out.size() == f.original.size(), "fixture %s",
+                    f.name.c_str());
+        REQUIRE_CTX(equal_bytes(out.data(), f.original.data(), out.size()),
+                    "fixture %s", f.name.c_str());
+    }
+
+    /* Full mutant parity, as the two security-critical directions of a
+     * fail-closed decoder:
+     *   1. where the twin ACCEPTS, snappy must accept and the bytes and
+     *      size must match - the twin never invents an acceptance;
+     *   2. where snappy REJECTS, the twin must reject - never more lenient.
+     * Together these make the twin's accept set a subset of the
+     * reference's, with bit-exact output on it. Over this corpus the count
+     * of streams the twin refuses while snappy accepts is pinned at zero
+     * rather than merely reported. The one class where it is not zero is
+     * unreachable by mutation - it needs a length field the generator never
+     * writes - and is pinned by name further down. */
+    size_t mutant_total = 0;
+    size_t rejected_total = 0;
+    size_t stricter_than_oracle = 0;
+    for (const auto& f : fixtures) {
+        for (const auto& m : MutateSnappyStream(f.compressed, f.seed)) {
+            Bytes oracle_out;
+            const bool oracle_accepts =
+                SnappyOracleDecodes(m.stream, &oracle_out);
+            Bytes twin_out;
+            const cudec_status twin_status = TwinDecode(m.stream, &twin_out);
+            mutant_total++;
+            if (twin_status == CUDEC_OK) {
+                REQUIRE_CTX(oracle_accepts,
+                            "twin accepts what snappy rejects: %s/%s",
+                            f.name.c_str(), m.description.c_str());
+                REQUIRE_CTX(twin_out.size() == oracle_out.size(),
+                            "size parity: %s/%s", f.name.c_str(),
+                            m.description.c_str());
+                REQUIRE_CTX(equal_bytes(twin_out.data(), oracle_out.data(),
+                                        twin_out.size()),
+                            "byte parity: %s/%s", f.name.c_str(),
+                            m.description.c_str());
+            } else {
+                REQUIRE_CTX(twin_status == CUDEC_ERR_CORRUPT_INPUT ||
+                                twin_status == CUDEC_ERR_OUTPUT_TOO_SMALL,
+                            "undefined reject status %d: %s/%s",
+                            static_cast<int>(twin_status), f.name.c_str(),
+                            m.description.c_str());
+                if (oracle_accepts) {
+                    stricter_than_oracle++;
+                    std::fprintf(stderr,
+                                 "stricter than snappy: %s/%s (status %d)\n",
+                                 f.name.c_str(), m.description.c_str(),
+                                 static_cast<int>(twin_status));
+                } else {
+                    rejected_total++;
+                }
+            }
+        }
+    }
+    REQUIRE(mutant_total > 0);
+    REQUIRE(rejected_total > 0);
+    REQUIRE(stricter_than_oracle == 0);
+
+    /* One crafted negative per ladder branch: pins the twin's specific
+     * status AND that the stream is malformed by the reference's reckoning. */
+    const auto crafted = MakeCraftedNegatives();
+    for (const auto& c : crafted) {
+        Bytes twin_out;
+        REQUIRE_CTX(TwinDecode(c.stream, &twin_out) == c.expected,
+                    "crafted %s", c.name);
+        REQUIRE_CTX(twin_out.empty(),
+                    "crafted %s: a rejected stream produced output", c.name);
+        Bytes oracle_out;
+        REQUIRE_CTX(!SnappyOracleDecodes(c.stream, &oracle_out),
+                    "crafted %s: snappy unexpectedly accepts", c.name);
+        REQUIRE_CTX(!SnappyOracleAccepts(c.stream),
+                    "crafted %s: snappy's validator unexpectedly accepts",
+                    c.name);
+    }
+
+    /* The deliberate divergence, pinned explicitly. The four-byte literal
+     * length class spelling 0xFFFFFFFF means length-1, and the reference
+     * adds the 1 in 32 bits, so the value wraps to zero and snappy accepts
+     * the stream as carrying a zero-length literal. cudec refuses it: a
+     * length that exists only because an accumulator wrapped is not a
+     * length. The oracle's acceptance is asserted rather than assumed -
+     * that it accepts is the whole reason this case is written down - and
+     * the twin's refusal must be a DEFINED status. This is the Snappy
+     * analogue of LZ4's offset == 0 divergence. */
+    {
+        const Bytes wrapped = {0x00, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF};
+        Bytes oracle_out;
+        REQUIRE(SnappyOracleDecodes(wrapped, &oracle_out));
+        REQUIRE(oracle_out.empty());
+        Bytes twin_out;
+        REQUIRE(TwinDecode(wrapped, &twin_out) == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(twin_out.empty());
+        /* The neighbouring value needs no wrap: it asks for a literal of
+         * 0xFFFFFFFF bytes, which no source here carries, so both sides
+         * refuse it on the bytes that are missing. That is what makes the
+         * refusal above the wrap and not the four-byte class itself. */
+        Bytes near = {0x00, 0xFC, 0xFE, 0xFF, 0xFF, 0xFF};
+        Bytes near_out;
+        REQUIRE(!SnappyOracleDecodes(near, &near_out));
+        REQUIRE(TwinDecode(near, &near_out) == CUDEC_ERR_CORRUPT_INPUT);
+    }
+
+    /* The accept set, held open in both directions: snappy accepts these
+     * and so must the twin, byte for byte. */
+    const auto accepted = MakeAcceptCases();
+    for (const auto& a : accepted) {
+        Bytes oracle_out;
+        REQUIRE_CTX(SnappyOracleDecodes(a.stream, &oracle_out),
+                    "accept case %s: snappy rejects it", a.name.c_str());
+        Bytes twin_out;
+        REQUIRE_CTX(TwinDecode(a.stream, &twin_out) == CUDEC_OK,
+                    "accept case %s: the twin over-rejects", a.name.c_str());
+        REQUIRE_CTX(twin_out.size() == a.expected.size(), "accept case %s",
+                    a.name.c_str());
+        REQUIRE_CTX(equal_bytes(twin_out.data(), a.expected.data(),
+                                twin_out.size()),
+                    "accept case %s", a.name.c_str());
+        REQUIRE_CTX(twin_out.size() == oracle_out.size() &&
+                        equal_bytes(twin_out.data(), oracle_out.data(),
+                                    twin_out.size()),
+                    "accept case %s: oracle bytes", a.name.c_str());
+    }
+
+    /* Offsets at and above the 65536 the compressor cannot emit, swept
+     * across the boundary in both directions. */
+    for (uint32_t offset : {65535u, 65536u, 65537u, 131072u}) {
+        const Bytes s = WideOffsetStream(offset, 4);
+        Bytes oracle_out;
+        REQUIRE_CTX(SnappyOracleDecodes(s, &oracle_out), "wide offset %u",
+                    offset);
+        Bytes twin_out;
+        REQUIRE_CTX(TwinDecode(s, &twin_out) == CUDEC_OK, "wide offset %u",
+                    offset);
+        REQUIRE_CTX(twin_out.size() == oracle_out.size(), "wide offset %u",
+                    offset);
+        REQUIRE_CTX(
+            equal_bytes(twin_out.data(), oracle_out.data(), twin_out.size()),
+            "wide offset %u", offset);
+        /* And one byte past what the stream produced, which must reject. */
+        const Bytes past = WideOffsetStream(offset, 4);
+        Bytes over = past;
+        over[over.size() - 4] = static_cast<unsigned char>((offset + 1) & 0xff);
+        over[over.size() - 3] =
+            static_cast<unsigned char>(((offset + 1) >> 8) & 0xff);
+        over[over.size() - 2] =
+            static_cast<unsigned char>(((offset + 1) >> 16) & 0xff);
+        over[over.size() - 1] =
+            static_cast<unsigned char>(((offset + 1) >> 24) & 0xff);
+        Bytes over_out;
+        REQUIRE_CTX(TwinDecode(over, &over_out) == CUDEC_ERR_CORRUPT_INPUT,
+                    "wide offset %u, one past the produced output", offset);
+        Bytes over_oracle;
+        REQUIRE_CTX(!SnappyOracleDecodes(over, &over_oracle),
+                    "wide offset %u: snappy accepts a copy past its output",
+                    offset);
+    }
+
+    /* The capacity axis, which the format cannot express and the oracle
+     * therefore cannot be asked about: the declared length is checked
+     * against the caller's capacity before any element is parsed, and the
+     * refusal is CUDEC_ERR_OUTPUT_TOO_SMALL rather than a corrupt-input
+     * verdict on a stream that is not corrupt. */
+    {
+        const auto& f = fixtures.front();
+        const size_t size = f.compressed.size();
+        auto tight = std::make_unique<unsigned char[]>(size);
+        std::memcpy(tight.get(), f.compressed.data(), size);
+        uint64_t declared = 0;
+        uint64_t preamble_size = 0;
+        REQUIRE(cudec_detail::SnappyDeclaredLength(tight.get(), size,
+                                                   &declared,
+                                                   &preamble_size) ==
+                CUDEC_OK);
+        REQUIRE(declared == f.original.size());
+        REQUIRE(preamble_size >= 1);
+
+        Bytes out;
+        REQUIRE(Drive(tight.get(), size, declared - 1, &out) ==
+                CUDEC_ERR_OUTPUT_TOO_SMALL);
+        REQUIRE(out.empty());
+        /* Exactly enough still decodes, so the bound is not off by one. */
+        REQUIRE(Drive(tight.get(), size, declared, &out) == CUDEC_OK);
+        REQUIRE(out.size() == f.original.size());
+        REQUIRE(equal_bytes(out.data(), f.original.data(), out.size()));
+        /* And a capacity beyond the declaration produces the declared
+         * length, never the capacity - the anti-pattern a decoder that
+         * sizes its output from the caller would have. */
+        REQUIRE(Drive(tight.get(), size, declared + 4096, &out) == CUDEC_OK);
+        REQUIRE(out.size() == f.original.size());
+        REQUIRE(equal_bytes(out.data(), f.original.data(), out.size()));
+    }
+
+    /* Liveness, over every stream this test has: valid, mutated and
+     * crafted. Every non-terminal call consumes at least one source byte,
+     * the terminal call is reached, and a further call after it is refused
+     * - so a driver that ignores *done terminates on a reject instead of
+     * spinning a warp lane against the launch. */
+    size_t liveness_streams = 0;
+    {
+        std::vector<Bytes> streams;
+        for (const auto& f : fixtures) {
+            streams.push_back(f.compressed);
+            for (const auto& m : MutateSnappyStream(f.compressed, f.seed)) {
+                streams.push_back(m.stream);
+            }
+        }
+        for (const auto& c : crafted) {
+            streams.push_back(c.stream);
+        }
+        for (const auto& a : accepted) {
+            streams.push_back(a.stream);
+        }
+        /* Plus every stream of up to two bytes, exhaustively: that is where
+         * a parser mishandling its own terminal state shows first. */
+        streams.push_back(Bytes{});
+        for (unsigned first = 0; first < 256; first++) {
+            streams.push_back(Bytes{static_cast<unsigned char>(first)});
+            for (unsigned second = 0; second < 256; second++) {
+                streams.push_back(Bytes{static_cast<unsigned char>(first),
+                                        static_cast<unsigned char>(second)});
+            }
+        }
+        for (const auto& stream : streams) {
+            const char* why = "";
+            REQUIRE_CTX(LivenessHolds(stream, &why),
+                        "liveness on a %zu-byte stream: %s", stream.size(),
+                        why);
+            liveness_streams++;
+        }
+    }
+
+    /* No element the parser handed back was outside the buffers the caller
+     * could execute it in, on any stream above. */
+    REQUIRE(g_bounds_violations == 0);
+
+    std::printf("PASS: %zu snappy fixtures + %zu mutants in oracle parity "
+                "(%zu oracle-rejected, %zu stricter-than-snappy); %zu crafted "
+                "negatives; %zu accept cases held open; wide-offset sweep and "
+                "the capacity axis pinned; the 32-bit literal-length wrap "
+                "pinned as the one divergence; liveness on %zu streams\n",
+                fixtures.size(), mutant_total, rejected_total,
+                stricter_than_oracle, crafted.size(), accepted.size(),
+                liveness_streams);
+    return 0;
+}

--- a/tests/snappy_parser_twin.cpp
+++ b/tests/snappy_parser_twin.cpp
@@ -642,6 +642,51 @@ int main() {
         Bytes near_out;
         REQUIRE(!SnappyOracleDecodes(near, &near_out));
         REQUIRE(TwinDecode(near, &near_out) == CUDEC_ERR_CORRUPT_INPUT);
+        /* The wrap is not confined to an otherwise empty stream: with the
+         * zero-length literal followed by a real one, snappy decodes four
+         * bytes and cudec still refuses. Both spellings are pinned so a
+         * future change cannot silence one and leave the other. */
+        const Bytes wrapped_then_literal = {0x04, 0xFC, 0xFF, 0xFF, 0xFF,
+                                            0xFF, 0x0C, 'a',  'b',  'c',
+                                            'd'};
+        Bytes tail_out;
+        REQUIRE(SnappyOracleDecodes(wrapped_then_literal, &tail_out));
+        REQUIRE(tail_out.size() == 4);
+        Bytes tail_twin;
+        REQUIRE(TwinDecode(wrapped_then_literal, &tail_twin) ==
+                CUDEC_ERR_CORRUPT_INPUT);
+    }
+
+    /* The band above the harness bound, disclosed rather than left silent.
+     * TwinDecode and SnappyOracleDecodes both refuse a declaration above
+     * kSnappyOracleMaxOutput, so every mutant declaring more than that is
+     * in parity for the HARNESS's reason and tests nothing about either
+     * decoder - the corpus's own preamble-declares-max mutant included.
+     * What is testable without allocating gigabytes is that the parser
+     * refuses it on the capacity rung and says so, rather than letting a
+     * 4 GiB declaration reach an element. */
+    {
+        const Bytes huge = {0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x0C,
+                            'a',  'b',  'c',  'd'};
+        uint64_t declared = 0;
+        uint64_t preamble_size = 0;
+        REQUIRE(cudec_detail::SnappyDeclaredLength(huge.data(), huge.size(),
+                                                   &declared,
+                                                   &preamble_size) ==
+                CUDEC_OK);
+        REQUIRE(declared == 0xFFFFFFFFu);
+        REQUIRE(preamble_size == 5);
+        /* Driven through Begin rather than Drive: the refusal has to happen
+         * before anything is sized, and a driver that allocated the
+         * capacity first would be testing the allocator. */
+        cudec_detail::SnappyParser parser{huge.data(), huge.size(),
+                                          declared - 1};
+        REQUIRE(parser.Begin() == CUDEC_ERR_OUTPUT_TOO_SMALL);
+        REQUIRE(parser.dst_pos == 0);
+        Bytes twin_out;
+        REQUIRE(TwinDecode(huge, &twin_out) == CUDEC_ERR_OUTPUT_TOO_SMALL);
+        Bytes oracle_out;
+        REQUIRE(!SnappyOracleDecodes(huge, &oracle_out));
     }
 
     /* The accept set, held open in both directions: snappy accepts these


### PR DESCRIPTION
# What & why

Closes #171.

`src/snappy_block.h` carries the Snappy block-format sequence parser and its
validation ladder once, for host and device, the way `src/lz4_block.h` carries
LZ4's. `tests/snappy_parser_twin.cpp` executes it on the host against
google/snappy 1.2.2; `tests/snappy_block_device.cu` hands the same header to
nvcc and requires the device to produce an identical element trace. No kernel
change, no ABI change. `src/lz4_block.h` changes by five lines: both headers
define `CUDEC_HOST_DEVICE`, so each definition is now guarded.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved. Twelve ladder guards, at least one crafted
      negative per reject branch, every negative's oracle verdict asserted.
- [x] Oracle coverage. 21 fixtures and 1069 mutants in two-directional parity
      with snappy 1.2.2, plus 16 accept cases, a wide-offset sweep and the
      capacity axis.
- [x] Determinism preserved, and now measured across compilers: host and
      device produce the same element sequence for the same bytes.
- [x] No CUDA call is added outside the new device test, where every one is
      checked. No exceptions cross anything.
- [x] The adversarial review was run over this diff.
- [x] Review record below.

### Guards proven by removal

Each guard was deleted one at a time from `src/snappy_block.h` and the
sanitized suite re-run. All twelve red:

```
== baseline (sanitized) ==
GREEN
== guard removals ==
151 preamble byte present: RED - AddressSanitizer: heap-buffer-overflow
159 preamble fifth-group overflow: RED - FAIL ...:608 crafted preamble-overflows-32-bit
204 declared length vs capacity: RED - FAIL ...:722 Drive(..., declared - 1, ...)
237 refusal after the terminal element: RED - FAIL ...:769 LivenessHolds(stream, &why)
252 exact production: RED - FAIL ...:571 twin accepts what snappy rejects
277 literal length bytes present: RED - AddressSanitizer: heap-buffer-overflow
302 literal payload present: RED - FAIL ...:778 g_bounds_violations == 0
305 literal over-production: RED - FAIL ...:778 g_bounds_violations == 0
324 copy header present: RED - AddressSanitizer: heap-buffer-overflow
351 copy offset non-zero: RED - FAIL ...:778 g_bounds_violations == 0
354 copy offset within produced output: RED - FAIL ...:778 g_bounds_violations == 0
357 copy over-production: RED - FAIL ...:778 g_bounds_violations == 0
```

Three of them red only under AddressSanitizer, and that is the finding
inside the finding. A verdict alone cannot prove a bounds guard: with the
check gone the cursor runs past the source end, the next subtraction wraps,
and a later branch rejects the stream after the read has already happened.
An earlier cut of this test passed all three. The twin now counts the
parser's own bounds after every element instead of reading verdicts alone.

### The stricter-than-reference count, and the one divergence

Over the fixture and mutation corpora the count is **0**. There is one class
where it is not, and mutation cannot reach it:

- The four-byte literal length class spelling `0xFFFFFFFF` means length-1,
  and the reference adds the one in 32 bits, so the value wraps to zero and
  snappy accepts the stream as carrying a zero-length literal. cudec refuses
  it. A length that exists only because an accumulator wrapped is not a
  length, and fail-closed on spec-nonsense outranks bug-for-bug parity, the
  same call as LZ4's tolerated offset of zero.
- Both spellings are pinned: the wrap alone (`00 fc ff ff ff ff`), and the
  wrap followed by a real literal (`04 fc ff ff ff ff 0c 61 62 63 64`, which
  snappy decodes to four bytes). The test asserts that snappy accepts each,
  rather than assuming so.
- The neighbouring value below the wrap, which needs no wrap, is asserted to
  reject on both sides. That is what makes the refusal the wrap and not the
  width class.

### What is not compared against the reference

`SnappyOracleDecodes` refuses a declaration above 256 MiB, and so does the
twin, so every stream declaring more than that is in parity for the harness's
bound rather than for anything either decoder did. The corpus's own
`preamble-declares-max` mutant is inside that band. What the test does pin
there is that the parser refuses a 4 GiB declaration on the capacity rung,
before anything is sized, and reports `CUDEC_ERR_OUTPUT_TOO_SMALL` for it.
Raising the bound means allocating gigabytes in the harness and is not this
change.

## Quality checklist

- [x] Minimal, with one duplication disclosed under Notes.
- [x] Comments explain why. Every load-bearing claim about the reference was
      checked by running the reference.
- [ ] No new structural conformance test. The single-source and
      branch-count locks for this header are #173 and are deliberately not
      here.

## Verification

Every command below ran in the pinned container
(`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0f...`) at this branch's
head, on an RTX 3080, driver 560.94, CUDA 12.6.2.

- [x] Host-only configure and build: clean.
- [x] CUDA configure and build: clean.
- [x] `ctest --test-dir build-cuda -LE gpu`: **14/14 passed**, which is what
      the GPU-less runner sees.
- [x] `ctest --test-dir build-cuda` with the device attached: **21/21
      passed**, 7 of them gpu-labelled.
- [x] Sanitized subset (`-DCUDEC_SANITIZE=address,undefined`): **6/6 passed**.
- [x] Prettier over `**/*.{md,yml,yaml}`: clean.
- [ ] Docs: nothing in MASTERPLAN, README or BENCHMARKS changes here. One
      doc follow-up is named under Notes.

```
100% tests passed, 0 tests failed out of 21

Label Time Summary:
gpu    =   5.26 sec*proc (7 tests)

Total Test time (real) =   7.68 sec
```

The two new tests, printing what they covered:

```
PASS: 21 snappy fixtures + 1069 mutants in oracle parity (941 oracle-rejected,
0 stricter-than-snappy); 22 crafted negatives; 16 accept cases held open;
wide-offset sweep and the capacity axis pinned; the 32-bit literal-length wrap
pinned as the one divergence; liveness on 66921 streams

PASS: 11 streams parsed identically by the host compiler and nvcc from one
header (5 accepted, 6 rejected)
```

The same twin binary built with ASan and UBSan prints the identical line.

## Notes

**No second person has read this change.** The evidence above stands in place
of one: the guard-removal table, the two-directional oracle parity, the
sanitized run and the device trace comparison are all executed results, and
every claim in this body carries the command that produced it.

An adversarial review ran over the diff before this body was written and
raised sixteen findings, five of them CONFIRMED with reproductions. It also
ran differential harnesses of its own against the pinned oracle, over 22.6
million streams including every stream of three bytes or fewer
exhaustively, and reported zero cases where the parser accepts what snappy
rejects and zero byte differences on accepted streams. Dispositions:

| Finding | Disposition |
| --- | --- |
| The `0xFFFFFFFF` literal length is refused where snappy accepts it (CONFIRMED) | FIX - pinned as a documented divergence, both spellings, with the oracle's acceptance asserted |
| The liveness contract is false at the terminal call; a driver ignoring `done` spins (CONFIRMED) | FIX - the parser refuses a call after its terminal element, and the twin sweeps the property over 66921 streams |
| Nothing in the tree compiles the header under nvcc (CONFIRMED) | FIX - `tests/snappy_block_device.cu` |
| `CUDEC_HOST_DEVICE` defined unguarded in two headers (CONFIRMED) | FIX - guarded in both |
| Streams declaring more than the harness bound are in parity for the harness's reason and test nothing (CONFIRMED) | FIX - disclosed above, with the capacity rung pinned directly |
| The element contract states a bound that is false for literals | FIX - rewritten per kind, with the terminal element spelled out |
| The terminal element's fields were undocumented and the caller reads them | FIX - documented |
| The preamble helper's comment invited sizing from the varint | FIX - reworded to bounding, with the reason |
| The preamble was parsed twice by every real caller | FIX - `Begin()` is public and idempotent |
| A literal-named constant was used as the generic tag width; offset widths unnamed | FIX - renamed and named |
| The termination comment miscounted the loops | FIX |
| The offset-zero comment cited a reference guard by inference | FIX - it now cites the crafted negatives that measured it |
| Duplicate accept-case names made a failure unidentifiable | FIX - names carry their parameter |
| A reserved ABI status was borrowed as a test sentinel | FIX - replaced by a counter |
| Two CI comments stated counts the lists had outgrown | FIX |
| Five stream builders duplicate `tests/snappy_probes.cpp` | DECLINE - the probe copies carry the reference line citations they were read from, which belong with the probes; the comment no longer claims a distinction that does not exist, and it names where the shared home would be |
| The all-64-bit element contract forces a 64-bit gather where 32 bits provably suffice | DEFER - the header now records that every position, offset and length fits in 32 bits; whether the device side carries 32-bit copies is the kernel's shape and belongs with #150 |
| `docs/MASTERPLAN.md` names `tests/termination.cpp` as where the parser's per-call liveness contract is asserted, which is now incomplete | DECLINE here - that file is being changed by other open work and a second hand in it is the collision worth avoiding; the sentence needs `tests/snappy_parser_twin.cpp` added to its list |

Out of scope and owned elsewhere: the kernel instantiation (#150), the
structural locks for this header (#173), the device gate set (#154), the
baddata fixtures (#156), the fuzz target (#90).
