### PR TITLE
Keep the GPU sanitizer cross-check level with the CI job's list [#125]

### DIFF
--- a/scripts/sanitize-gpu.sh
+++ b/scripts/sanitize-gpu.sh
@@ -94,7 +94,7 @@ is not a clean sweep. Configure with -DCUDEC_ENABLE_CUDA=ON."
 # otherwise shrink this sweep and still print PASS. The names are that job's,
 # so the two gates cannot drift apart unnoticed.
 for known in smoke gpu_fixture frame_twin stream_twin termination_gpu \
-    determinism_gpu; do
+    determinism_gpu snappy_block_device; do
     printf '%s\n' "$tests" | grep -qx "$known" ||
         die "gpu test '$known' is absent from the discovered set - the sweep
 would cover less than the CI job's own cross-check demands."


### PR DESCRIPTION
# What & why

Refs #125. Does not close it, for the reason under Notes.

`scripts/sanitize-gpu.sh` cross-checks its dynamic discovery against a list of
GPU test names, and the comment above that list says the names are the CI
job's, "so the two gates cannot drift apart unnoticed". They had drifted:
`snappy_block_device` became a gpu-labelled test and was added to the
workflow's deferred listing in #291 without reaching this list. One line, one
name.

This is a guard gap rather than a coverage gap. Discovery is dynamic, so the
new test was already being swept; what was missing is the guard that notices
if it stops being registered.

## Type of change

- [x] Build / CI / supply chain

## Verification

Run in the pinned container with `--gpus all`, RTX 3080, driver 560.94, CUDA
12.6.2, at this branch's head. `CUDEC_COMMIT` is set because the container
ships no git and a worktree's `.git` is a file naming a host path.

The guard, in both directions, against a build tree whose discovery no longer
lists the name:

```
--- WITH the name in the cross-check list (this change) ---
exit=1
cross-check message count: 1
sanitize-gpu: gpu test 'snappy_block_device' is absent from the discovered set - the sweep
would cover less than the CI job's own cross-check demands.

--- WITHOUT it (the list as it stood before) ---
exit=1
cross-check message count: 0
sanitize-gpu: expected exactly one executable named 'snappy_block_deviceX' under 'build-cuda', found
0 - discovery and the build tree disagree.
```

Read that second block honestly: the pre-change script also exits 1 here, but
on a different rule, because this synthetic removal renames the test rather
than deleting it. The cross-check message count is the part that matters -
0 before, 1 after. A registration dropped outright, which is the case the
cross-check exists for, leaves no renamed binary to trip the later rule.

The script's other fail-closed legs, re-run on this branch, since they are
part of what #125 owes and had no recorded output anywhere:

```
=== 1. compute-sanitizer absent ===
sanitize-gpu: compute-sanitizer is not on PATH - this must run inside the pinned
CUDA container (see the header). A sweep that ran no tool is refused.
script exit=1

=== 2. zero gpu-labeled tests discovered ===
sanitize-gpu: zero gpu-labeled tests discovered in 'build-hostonly' - a sweep over nothing
is not a clean sweep. Configure with -DCUDEC_ENABLE_CUDA=ON.
script exit=1

=== 3. build directory absent ===
sanitize-gpu: build directory 'build-nope' does not exist
script exit=1

=== 4. a cross-check target missing from discovery ===
sanitize-gpu: gpu test 'snappy_block_device' is absent from the discovered set - the sweep
would cover less than the CI job's own cross-check demands.
script exit=1
```

The discovered set on the restored tree, which is what the cross-check reads:

```
ctest --test-dir build-cuda -L gpu -N | sed -n 's/^ *Test *#[0-9][0-9]*: *\([^ ][^ ]*\) *$/\1/p'
snappy_block_device smoke gpu_fixture frame_twin stream_twin termination_gpu determinism_gpu
```

No source, header, CMake or workflow file changes, so the build, sanitize and
format checks stand on the mainline result they had before this branch. They
run on this PR regardless.

## Notes

**No second person has read this change.** The evidence above stands in place
of one.

**The full adversarial panel was not run for this diff, and that is a
departure worth naming.** The change is one identifier added to a list of
names, and its effect was demonstrated in both directions above rather than
argued. The gate the repository requires is for kernels, format parsing, the
C-ABI boundary, `CMakeLists.txt`/`tools/` and the workflows; this touches none
of those, and running six lenses over a one-word list addition would buy less
than the two runs already pasted. If that reading is wrong, this is small
enough to revert.

**This does not close #125.** That issue's Done-when needs a seeded
out-of-bounds device read to produce a memcheck FAIL and a non-zero exit,
which cannot be demonstrated on this machine: #258 measured that Compute
Sanitizer cannot attach to the device here at all, so every tool fails on
every binary whatever the code under it does, and a seeded fault produced no
device-side report. A FAIL obtained that way would be the tool failing to
start, not the gate catching a fault, and recording it as the criterion met
would be worse than leaving the box unticked. The three vacuous-run legs
above are what is genuinely demonstrable today; the seeded-fault leg is
blocked on #258, and #73 carries the same blocker for the process wiring.
