### PR TITLE
Lock the Snappy parser core: one source, one rung per negative [#173]

### DIFF
--- a/src/snappy_block.h
+++ b/src/snappy_block.h
@@ -101,6 +101,50 @@ constexpr uint64_t kSnappyCopy1OffsetBytes = 1;
 constexpr uint64_t kSnappyCopy2OffsetBytes = 2;
 constexpr uint64_t kSnappyCopy4OffsetBytes = 4;
 
+/* The reject ladder, enumerated once (issue #173).
+ *
+ * Every refusal in this header names its branch here and returns through
+ * SnappyRefuse, so the branch set is DERIVED from the code rather than
+ * restated beside it. Two gates read that: tests/CMakeLists.txt refuses a
+ * refusal that does not go through the choke point, an enumerator with no
+ * site, and a site with no enumerator; tests/snappy_parser_twin.cpp refuses
+ * a branch no negative reaches. Adding a branch without a negative therefore
+ * reds the suite, and deleting a negative reds it too.
+ *
+ * kSnappyRejectPreambleUnreachable is the compiler-required exit of the
+ * varint loop, argued unreachable where it sits. It is declared unreachable
+ * in the twin instead of carrying a negative, and that declaration is
+ * fail-closed in both directions: the twin reds if it is ever reached. */
+enum SnappyReject {
+    kSnappyRejectNone = 0,
+    kSnappyRejectPreambleByteMissing,
+    kSnappyRejectPreambleFinalGroup,
+    kSnappyRejectPreambleUnreachable,
+    kSnappyRejectDeclaredOverCapacity,
+    kSnappyRejectPastTerminal,
+    kSnappyRejectUnderProduction,
+    kSnappyRejectLiteralHeaderTruncated,
+    kSnappyRejectLiteralPayloadTruncated,
+    kSnappyRejectLiteralOverProduction,
+    kSnappyRejectCopyHeaderTruncated,
+    kSnappyRejectCopyOffsetZero,
+    kSnappyRejectCopyOffsetBeforeStart,
+    kSnappyRejectCopyOverProduction,
+    kSnappyRejectCount
+};
+
+/* The one choke point. It records which branch refused and returns that
+ * branch's status; `out` is null only where a caller has no interest in the
+ * reason, and the ladder itself always supplies one. */
+CUDEC_HOST_DEVICE inline cudec_status SnappyRefuse(SnappyReject branch,
+                                                   cudec_status status,
+                                                   SnappyReject* out) {
+    if (out != 0) {
+        *out = branch;
+    }
+    return status;
+}
+
 /* One parsed element, in absolute offsets.
  *
  * A LITERAL (is_copy false) copies `length` bytes from src[from ..
@@ -145,11 +189,12 @@ struct SnappyElement {
  * occupied. */
 CUDEC_HOST_DEVICE inline cudec_status SnappyDeclaredLength(
     const unsigned char* src, uint64_t src_size, uint64_t* declared,
-    uint64_t* preamble_size) {
+    uint64_t* preamble_size, SnappyReject* reject = 0) {
     uint64_t result = 0;
     for (uint64_t group = 0; group < kSnappyVarintGroups; group++) {
         if (group >= src_size) {
-            return CUDEC_ERR_CORRUPT_INPUT; /* preamble byte missing */
+            return SnappyRefuse(kSnappyRejectPreambleByteMissing,
+                                CUDEC_ERR_CORRUPT_INPUT, reject);
         }
         const unsigned char byte = src[group];
         /* The final group is refused above 15 rather than truncated: a
@@ -157,7 +202,8 @@ CUDEC_HOST_DEVICE inline cudec_status SnappyDeclaredLength(
          * length the reference rejects outright. */
         if (group + 1 == kSnappyVarintGroups &&
             byte >= kSnappyVarintFinalMax) {
-            return CUDEC_ERR_CORRUPT_INPUT;
+            return SnappyRefuse(kSnappyRejectPreambleFinalGroup,
+                                CUDEC_ERR_CORRUPT_INPUT, reject);
         }
         result |= static_cast<uint64_t>(byte & kSnappyVarintPayload)
                   << (kSnappyVarintBits * group);
@@ -170,8 +216,10 @@ CUDEC_HOST_DEVICE inline cudec_status SnappyDeclaredLength(
     /* Unreachable: a fifth byte below 16 has its continuation bit clear and
      * returned above, and one at or above 16 was refused. The exit exists
      * because the compiler requires one, and it is the reason this branch
-     * carries no crafted negative. */
-    return CUDEC_ERR_CORRUPT_INPUT;
+     * carries no crafted negative - it is declared unreachable in the twin
+     * instead, which reds if it is ever reached. */
+    return SnappyRefuse(kSnappyRejectPreambleUnreachable,
+                        CUDEC_ERR_CORRUPT_INPUT, reject);
 }
 
 struct SnappyParser {
@@ -184,6 +232,10 @@ struct SnappyParser {
     uint64_t declared = 0;
     bool begun = false;
     bool finished = false;
+    /* Which ladder branch refused, valid after any call that returned a
+     * reject status. Diagnostic only: no decode decision reads it, and the
+     * verdict a caller acts on stays the returned cudec_status. */
+    SnappyReject reject = kSnappyRejectNone;
 
     /* Reads the preamble and checks the declaration against the caller's
      * capacity. Idempotent, and Next calls it, so a caller that needs the
@@ -193,8 +245,8 @@ struct SnappyParser {
             return CUDEC_OK;
         }
         uint64_t preamble_size = 0;
-        const cudec_status status =
-            SnappyDeclaredLength(src, src_size, &declared, &preamble_size);
+        const cudec_status status = SnappyDeclaredLength(
+            src, src_size, &declared, &preamble_size, &reject);
         if (status != CUDEC_OK) {
             return status;
         }
@@ -202,7 +254,8 @@ struct SnappyParser {
          * the one place a hostile 4 GiB declaration is stopped from sizing
          * anything. */
         if (declared > dst_capacity) {
-            return CUDEC_ERR_OUTPUT_TOO_SMALL;
+            return SnappyRefuse(kSnappyRejectDeclaredOverCapacity,
+                                CUDEC_ERR_OUTPUT_TOO_SMALL, &reject);
         }
         src_pos = preamble_size;
         begun = true;
@@ -235,7 +288,9 @@ struct SnappyParser {
     CUDEC_HOST_DEVICE cudec_status Next(SnappyElement* element, bool* done) {
         *done = false;
         if (finished) {
-            return CUDEC_ERR_CORRUPT_INPUT; /* called past the terminal element */
+            /* Called past the terminal element. */
+            return SnappyRefuse(kSnappyRejectPastTerminal,
+                                CUDEC_ERR_CORRUPT_INPUT, &reject);
         }
         const cudec_status started = Begin();
         if (started != CUDEC_OK) {
@@ -250,7 +305,8 @@ struct SnappyParser {
              * element finds zero output remaining and every element
              * produces at least one byte. */
             if (dst_pos != declared) {
-                return CUDEC_ERR_CORRUPT_INPUT;
+                return SnappyRefuse(kSnappyRejectUnderProduction,
+                                    CUDEC_ERR_CORRUPT_INPUT, &reject);
             }
             element->from = 0;
             element->to = dst_pos;
@@ -275,7 +331,9 @@ struct SnappyParser {
                 const uint64_t extra = length - kSnappyLiteralInlineMax;
                 header += extra;
                 if (header > src_size - src_pos) {
-                    return CUDEC_ERR_CORRUPT_INPUT; /* header past the end */
+                    /* Header past the end. */
+                    return SnappyRefuse(kSnappyRejectLiteralHeaderTruncated,
+                                        CUDEC_ERR_CORRUPT_INPUT, &reject);
                 }
                 length = 0;
                 for (uint64_t i = 0; i < extra; i++) {
@@ -300,10 +358,14 @@ struct SnappyParser {
             length += 1;
             src_pos += header;
             if (length > src_size - src_pos) {
-                return CUDEC_ERR_CORRUPT_INPUT; /* literal bytes missing */
+                /* Literal bytes missing. */
+                return SnappyRefuse(kSnappyRejectLiteralPayloadTruncated,
+                                    CUDEC_ERR_CORRUPT_INPUT, &reject);
             }
             if (length > declared - dst_pos) {
-                return CUDEC_ERR_CORRUPT_INPUT; /* over-production */
+                /* Over-production. */
+                return SnappyRefuse(kSnappyRejectLiteralOverProduction,
+                                    CUDEC_ERR_CORRUPT_INPUT, &reject);
             }
             element->from = src_pos;
             element->to = dst_pos;
@@ -322,7 +384,9 @@ struct SnappyParser {
         }
         const uint64_t header = kSnappyTagBytes + offset_bytes;
         if (header > src_size - src_pos) {
-            return CUDEC_ERR_CORRUPT_INPUT; /* header past the end */
+            /* Header past the end. */
+            return SnappyRefuse(kSnappyRejectCopyHeaderTruncated,
+                                CUDEC_ERR_CORRUPT_INPUT, &reject);
         }
         uint64_t offset = 0;
         for (uint64_t i = 0; i < offset_bytes; i++) {
@@ -349,13 +413,18 @@ struct SnappyParser {
          * closed-form gather reduces by offset, so a zero reaching the
          * device copy engine would be a modulo by zero. */
         if (offset == 0) {
-            return CUDEC_ERR_CORRUPT_INPUT;
+            return SnappyRefuse(kSnappyRejectCopyOffsetZero,
+                                CUDEC_ERR_CORRUPT_INPUT, &reject);
         }
         if (offset > dst_pos) {
-            return CUDEC_ERR_CORRUPT_INPUT; /* reads before the output start */
+            /* Reads before the output start. */
+            return SnappyRefuse(kSnappyRejectCopyOffsetBeforeStart,
+                                CUDEC_ERR_CORRUPT_INPUT, &reject);
         }
         if (length > declared - dst_pos) {
-            return CUDEC_ERR_CORRUPT_INPUT; /* over-production */
+            /* Over-production. */
+            return SnappyRefuse(kSnappyRejectCopyOverProduction,
+                                CUDEC_ERR_CORRUPT_INPUT, &reject);
         }
         element->from = dst_pos - offset;
         element->to = dst_pos;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -495,6 +495,446 @@ foreach(_source IN LISTS _batch_limit_sources)
   endif()
 endforeach()
 
+# Reads a source and hands back its lines with C comments blanked in place,
+# one list element per source line, so a rule can quote the line number a
+# reader will open. Comments go first for the reason issue #72's scanner
+# strips them: prose beside a rule must neither trip it nor mask it, and this
+# header's rejects are documented in prose sitting right on top of them.
+#
+# FOUR characters CMake's list syntax eats are protected across the split and
+# left protected in the result. A ';' would separate elements and a trailing
+# '\' would escape the separator, which is what once numbered every line under
+# a continuation short (issue #251). A '[' opens a bracket that swallows every
+# separator until its ']', so ONE unbalanced bracket in a source - `src[from`
+# wrapped across a line, or a lone one in a comment - joins the whole rest of
+# the file into a single element and every line below it stops being a line.
+# That is not hypothetical: it is measured on this very header, and issue #294
+# carries it for the scanner that has the same reader.
+#
+# The placeholders are control bytes, and a source that carries one of those
+# itself is refused rather than scanned - restoring it afterwards would be a
+# way to smuggle a separator in.
+function(cudec_code_lines path out_lines)
+  string(ASCII 1 _tok_backslash)
+  string(ASCII 2 _tok_semicolon)
+  string(ASCII 3 _tok_open)
+  string(ASCII 4 _tok_close)
+  file(READ "${path}" _raw)
+  if(_raw MATCHES "${_tok_backslash}|${_tok_semicolon}|${_tok_open}|${_tok_close}")
+    message(FATAL_ERROR "${path} carries a control byte (0x01 to 0x04) and "
+                        "cannot be read as text by this scan (issue #173)")
+  endif()
+  string(REPLACE "\\" "${_tok_backslash}" _raw "${_raw}")
+  string(REPLACE ";" "${_tok_semicolon}" _raw "${_raw}")
+  string(REPLACE "[" "${_tok_open}" _raw "${_raw}")
+  string(REPLACE "]" "${_tok_close}" _raw "${_raw}")
+  string(REPLACE "\r\n" "\n" _raw "${_raw}")
+  string(REPLACE "\r" "\n" _raw "${_raw}")
+  string(REGEX REPLACE "\n$" "" _raw "${_raw}")
+  # What a whole read must produce, counted before the split rather than
+  # inferred from it: one line per remaining newline, plus the last line,
+  # which the strip above left without one.
+  string(REGEX MATCHALL "\n" _newlines "${_raw}")
+  list(LENGTH _newlines _expected)
+  math(EXPR _expected "${_expected} + 1")
+  if(_raw STREQUAL "")
+    message(FATAL_ERROR "${path} is empty: a source this scan is asked to "
+                        "read whole has at least one line (issue #173)")
+  endif()
+  string(REPLACE "\n" ";" _raw_lines "${_raw}")
+  set(_out "")
+  set(_in_comment FALSE)
+  foreach(_line IN LISTS _raw_lines)
+    if(_in_comment)
+      if(_line MATCHES "\\*/")
+        string(REGEX REPLACE "^.*\\*/" " " _line "${_line}")
+        set(_in_comment FALSE)
+      else()
+        set(_line " ")
+      endif()
+    endif()
+    string(REGEX REPLACE "//.*$" " " _line "${_line}")
+    if(_line MATCHES "/\\*")
+      string(REGEX REPLACE "/\\*.*$" " " _head "${_line}")
+      if(_line MATCHES "/\\*.*\\*/")
+        string(REGEX REPLACE "^.*\\*/" " " _tail "${_line}")
+        set(_line "${_head} ${_tail}")
+      else()
+        set(_line "${_head}")
+        set(_in_comment TRUE)
+      endif()
+    endif()
+    # An empty element would vanish from the list and shift every line number
+    # below it; a space holds the slot.
+    if(_line STREQUAL "")
+      set(_line " ")
+    endif()
+    list(APPEND _out "${_line}")
+  endforeach()
+  # A partial read must not look like a clean one. The protections above are
+  # what make the counts agree, so this is the check that says they still do -
+  # and the one that will red if a fifth character with list meaning turns up.
+  list(LENGTH _out _produced)
+  if(NOT _produced EQUAL _expected)
+    message(FATAL_ERROR
+            "${path} was read as ${_produced} lines and carries ${_expected}: "
+            "this scan cannot read it whole, and a partial read reports the "
+            "same silence as a clean one (issue #173)")
+  endif()
+  set(${out_lines} "${_out}" PARENT_SCOPE)
+endfunction()
+
+# ---- The Snappy parser core, locked (issue #173). Two rules over one source
+# set, applied by ONE function so they can be run against planted probes
+# before they are trusted against the tree - the discipline issue #72's
+# scanner established, applied here because these two rules are the only
+# thing standing between a second copy of the ladder and nobody noticing.
+#
+# Honest scope, the same as every check above: these are drift detectors
+# under the KNOWN SPELLINGS, not tamper-proofing. A ladder re-copied under
+# fresh type names, or a refusal spelled through a local variable instead of
+# a `return`, is out of reach of a text scan and is what review is for.
+#
+# Rule 1, single source. src/snappy_block.h exists and defines the parser
+# types; no other source under src/ defines them, and a source that names
+# SnappyParser includes the header rather than restating the ladder. This is
+# the cuda_raii.h lock (issue #40) applied to the format core: the M3 kernel
+# instantiates this parser, and a kernel-local copy of a validation ladder is
+# a fail-open the moment the two stop agreeing.
+#
+# Rule 2, the branch count. Every refusal in the header returns through
+# SnappyRefuse naming a branch the enumeration declares, and each declared
+# branch is named by EXACTLY ONE site. That makes the ladder's branch set
+# derived from the code rather than restated beside it, and it is the static
+# half of a pair: tests/snappy_parser_twin.cpp holds the other half at run
+# time, requiring a negative to reach every declared branch. Adding a rung
+# therefore costs a new enumerator here and a new negative there, and a rung
+# that quietly reuses a neighbour's enumerator to avoid both is what the
+# exactly-one count refuses.
+function(cudec_check_snappy_locks src_dir out_violations)
+  set(_violations "")
+  set(_header ${src_dir}/snappy_block.h)
+  if(NOT EXISTS ${_header})
+    string(APPEND _violations
+           "  ${src_dir}/snappy_block.h is missing: the Snappy validation "
+           "ladder must be single-sourced there (issue #173)\n")
+    set(${out_violations} "${_violations}" PARENT_SCOPE)
+    return()
+  endif()
+
+  # Comments are stripped before any rule reads a line, so the prose above a
+  # refusal can neither trip a rule nor mask one - and the line numbers stay
+  # exact, because the stripping replaces comment text in place instead of
+  # dropping lines.
+  cudec_code_lines(${_header} _header_lines)
+  foreach(_type SnappyParser SnappyElement)
+    set(_defines FALSE)
+    foreach(_line IN LISTS _header_lines)
+      if(_line MATCHES "struct ${_type}")
+        set(_defines TRUE)
+      endif()
+    endforeach()
+    if(NOT _defines)
+      string(APPEND _violations
+             "  snappy_block.h no longer defines 'struct ${_type}': the "
+             "Snappy parser core is single-sourced there (issue #173)\n")
+    endif()
+  endforeach()
+
+  # Every other source under src/ - a glob rather than a list somebody has to
+  # remember to extend, for the same reason the batch-limit sweep is one.
+  file(GLOB_RECURSE _sources RELATIVE ${src_dir} CONFIGURE_DEPENDS
+       ${src_dir}/*.c ${src_dir}/*.cc ${src_dir}/*.cpp ${src_dir}/*.cu
+       ${src_dir}/*.cuh ${src_dir}/*.h ${src_dir}/*.hpp ${src_dir}/*.inl)
+  foreach(_source IN LISTS _sources)
+    if(_source STREQUAL "snappy_block.h")
+      continue()
+    endif()
+    cudec_code_lines(${src_dir}/${_source} _source_lines)
+    set(_names_parser FALSE)
+    set(_includes_header FALSE)
+    foreach(_line IN LISTS _source_lines)
+      foreach(_type SnappyParser SnappyElement)
+        if(_line MATCHES "struct ${_type}[ \t]*[{:]")
+          string(APPEND _violations
+                 "  ${_source} defines a local 'struct ${_type}': the Snappy "
+                 "parser core is single-sourced in snappy_block.h "
+                 "(issue #173)\n")
+        endif()
+      endforeach()
+      if(_line MATCHES "SnappyParser|SnappyElement|SnappyDeclaredLength")
+        set(_names_parser TRUE)
+      endif()
+      if(_line MATCHES "#include[ \t]+\"snappy_block.h\"")
+        set(_includes_header TRUE)
+      endif()
+    endforeach()
+    if(_names_parser AND NOT _includes_header)
+      string(APPEND _violations
+             "  ${_source} names the Snappy parser without including "
+             "snappy_block.h: it must reuse the single-sourced ladder rather "
+             "than restate it (issue #173)\n")
+    endif()
+  endforeach()
+
+  # Rule 2. The declared branches first, read out of the enumeration between
+  # its None and Count sentinels; then the refusal sites.
+  set(_declared "")
+  set(_in_enum FALSE)
+  foreach(_line IN LISTS _header_lines)
+    if(_line MATCHES "enum SnappyReject[ \t]*{")
+      set(_in_enum TRUE)
+      continue()
+    endif()
+    if(_in_enum)
+      if(_line MATCHES "kSnappyRejectCount")
+        set(_in_enum FALSE)
+        continue()
+      endif()
+      if(_line MATCHES "^[ \t]*(kSnappyReject[A-Za-z0-9_]*)")
+        if(NOT CMAKE_MATCH_1 STREQUAL "kSnappyRejectNone")
+          list(APPEND _declared ${CMAKE_MATCH_1})
+        endif()
+      endif()
+    endif()
+  endforeach()
+  if(NOT _declared)
+    string(APPEND _violations
+           "  snappy_block.h declares no reject ladder: 'enum SnappyReject' "
+           "must enumerate one branch per reject reason (issue #173)\n")
+  endif()
+
+  set(_named "")
+  set(_lineno 0)
+  foreach(_line IN LISTS _header_lines)
+    math(EXPR _lineno "${_lineno} + 1")
+    # The choke point, refused first: a refusal that never reaches
+    # SnappyRefuse is invisible to every count below, so it is the one shape
+    # that could add a rung and leave both halves of this pair green.
+    if(_line MATCHES "return[ \t]+CUDEC_ERR_")
+      string(APPEND _violations
+             "  snappy_block.h:${_lineno}: refuses without going through "
+             "SnappyRefuse - every refusal names its ladder branch "
+             "(issue #173)\n")
+    endif()
+    if(_line MATCHES "return[ \t]+SnappyRefuse\\(")
+      # The branch has to be on the line the call opens on. A wrapped first
+      # argument would hide the name from this scan exactly as a wrapped mask
+      # hides from the collective rule.
+      if(_line MATCHES "return[ \t]+SnappyRefuse\\((kSnappyReject[A-Za-z0-9_]*)")
+        list(APPEND _named ${CMAKE_MATCH_1})
+      else()
+        string(APPEND _violations
+               "  snappy_block.h:${_lineno}: a SnappyRefuse call with no "
+               "ladder branch on its own line (issue #173)\n")
+      endif()
+    endif()
+  endforeach()
+
+  foreach(_branch IN LISTS _declared)
+    set(_count 0)
+    foreach(_site IN LISTS _named)
+      if(_site STREQUAL _branch)
+        math(EXPR _count "${_count} + 1")
+      endif()
+    endforeach()
+    if(_count EQUAL 0)
+      string(APPEND _violations
+             "  ladder branch '${_branch}' is declared and no refusal site "
+             "names it (issue #173)\n")
+    elseif(NOT _count EQUAL 1)
+      string(APPEND _violations
+             "  ladder branch '${_branch}' is named by ${_count} refusal "
+             "sites: a new rung takes a new branch, so that the twin's "
+             "negative for it cannot be satisfied by its neighbour "
+             "(issue #173)\n")
+    endif()
+  endforeach()
+  foreach(_site IN LISTS _named)
+    if(NOT _site IN_LIST _declared)
+      string(APPEND _violations
+             "  a refusal site names '${_site}', which 'enum SnappyReject' "
+             "does not declare (issue #173)\n")
+    endif()
+  endforeach()
+
+  set(${out_violations} "${_violations}" PARENT_SCOPE)
+endfunction()
+
+# The rules above are run against planted source trees before they are
+# trusted against the real one, and every violating probe is matched against
+# the TEXT its own rule emits rather than against a non-empty result - so one
+# rule cannot cover for another that has quietly stopped matching. The probe
+# headers are read, never compiled, which is why they are this terse.
+set(_snappy_probe_root ${CMAKE_CURRENT_BINARY_DIR}/snappy-lock-probes)
+file(REMOVE_RECURSE ${_snappy_probe_root})
+
+# A compliant header: two rungs, two sites, one choke point. Each block is
+# ONE string rather than a list of lines, because the variants below are cut
+# from it with string(REPLACE) and a list would come back joined on
+# semicolons - which is a stray separator written into a C header.
+#
+# The head is 21 lines, so an injected rung starts at line 22, which is the
+# number the two line-scoped rules are asserted on below.
+set(_probe_header_head "#ifndef PROBE_SNAPPY_H
+#define PROBE_SNAPPY_H
+namespace cudec_detail {
+enum SnappyReject {
+    kSnappyRejectNone = 0,
+    kSnappyRejectAlpha,
+    kSnappyRejectBeta,
+    kSnappyRejectCount
+};
+inline cudec_status SnappyRefuse(SnappyReject branch,
+                                 cudec_status status,
+                                 SnappyReject* out) {
+    return status;
+}
+struct SnappyElement {
+    uint64_t from;
+};
+struct SnappyParser {
+    SnappyReject reject;
+    cudec_status Next(bool first) {
+        if (first) {
+")
+set(_probe_header_tail "        }
+        return SnappyRefuse(kSnappyRejectBeta, CUDEC_ERR_CORRUPT_INPUT,
+                            &reject);
+    }
+};
+}  // namespace cudec_detail
+#endif
+")
+set(_probe_alpha_site "            return SnappyRefuse(kSnappyRejectAlpha,
+                                CUDEC_ERR_CORRUPT_INPUT, &reject);
+")
+
+file(WRITE ${_snappy_probe_root}/clean/snappy_block.h ${_probe_header_head}
+     ${_probe_alpha_site} ${_probe_header_tail})
+# The tree with no core at all.
+file(WRITE ${_snappy_probe_root}/missing_header/other.cu "void probe() {}\n")
+# A header that stopped defining the parser type it exists to own.
+string(REPLACE "struct SnappyParser {" "struct SomethingElse {"
+               _probe_no_parser "${_probe_header_head}")
+file(WRITE ${_snappy_probe_root}/no_parser/snappy_block.h ${_probe_no_parser}
+     ${_probe_alpha_site} ${_probe_header_tail})
+# A second source carrying its own copy of the parser type.
+file(WRITE ${_snappy_probe_root}/local_copy/snappy_block.h
+     ${_probe_header_head} ${_probe_alpha_site} ${_probe_header_tail})
+file(WRITE ${_snappy_probe_root}/local_copy/kernel.cu
+     "#include \"snappy_block.h\"\n" "struct SnappyParser {\n"
+     "    uint64_t src_pos;\n" "};\n")
+# A source driving the parser without reaching for the single source.
+file(WRITE ${_snappy_probe_root}/no_include/snappy_block.h
+     ${_probe_header_head} ${_probe_alpha_site} ${_probe_header_tail})
+file(WRITE ${_snappy_probe_root}/no_include/kernel.cu
+     "void probe(cudec_detail::SnappyParser* p) {\n" "    (void)p;\n" "}\n")
+# The same source with the include: the permitted shape, which must stay
+# silent, or the rule above would refuse the kernel this lock exists to admit.
+file(WRITE ${_snappy_probe_root}/with_include/snappy_block.h
+     ${_probe_header_head} ${_probe_alpha_site} ${_probe_header_tail})
+file(WRITE ${_snappy_probe_root}/with_include/kernel.cu
+     "#include \"snappy_block.h\"\n"
+     "void probe(cudec_detail::SnappyParser* p) {\n" "    (void)p;\n" "}\n")
+# A rung that refuses without naming itself.
+file(WRITE ${_snappy_probe_root}/bare_return/snappy_block.h
+     ${_probe_header_head} "            return CUDEC_ERR_CORRUPT_INPUT;\n"
+     ${_probe_header_tail})
+# A rung whose branch is wrapped onto the next line, out of a line-scoped
+# scan's sight.
+file(WRITE ${_snappy_probe_root}/wrapped_refuse/snappy_block.h
+     ${_probe_header_head} "            return SnappyRefuse(\n"
+     "                kSnappyRejectAlpha, CUDEC_ERR_CORRUPT_INPUT, &reject);\n"
+     ${_probe_header_tail})
+# A branch nothing refuses through: the shape a deleted rung leaves behind.
+string(REPLACE "    kSnappyRejectBeta,
+" "    kSnappyRejectBeta,
+    kSnappyRejectGamma,
+" _probe_extra_branch "${_probe_header_head}")
+file(WRITE ${_snappy_probe_root}/branch_unused/snappy_block.h
+     ${_probe_extra_branch} ${_probe_alpha_site} ${_probe_header_tail})
+# A site naming a branch the enumeration does not carry: the shape a rung
+# added without an enumerator leaves behind.
+file(WRITE ${_snappy_probe_root}/site_undeclared/snappy_block.h
+     ${_probe_header_head}
+     "            return SnappyRefuse(kSnappyRejectGamma,\n"
+     "                                CUDEC_ERR_CORRUPT_INPUT, &reject);\n"
+     ${_probe_header_tail})
+# Two rungs behind one branch - a new rung borrowing its neighbour's
+# enumerator, which would let the twin's negative for the old rung stand in
+# for the new one.
+file(WRITE ${_snappy_probe_root}/branch_shared/snappy_block.h
+     ${_probe_header_head} ${_probe_alpha_site}
+     "        if (!first) {\n"
+     "            return SnappyRefuse(kSnappyRejectAlpha,\n"
+     "                                CUDEC_ERR_CORRUPT_INPUT, &reject);\n"
+     "        }\n" ${_probe_header_tail})
+# No enumeration at all.
+string(REGEX REPLACE "enum SnappyReject" "enum SomethingElse" _probe_no_enum
+                     "${_probe_header_head}")
+file(WRITE ${_snappy_probe_root}/no_enum/snappy_block.h ${_probe_no_enum}
+     ${_probe_alpha_site} ${_probe_header_tail})
+# An unbalanced bracket above a violation - the shape that reads only the top
+# of a file (issue #294). The rule below the bracket must still report, and at
+# the line it is on.
+file(WRITE ${_snappy_probe_root}/bracket_above/snappy_block.h
+     ${_probe_header_head}
+     "            /* Reading from src[from .. as the real header does. */\n"
+     "            return CUDEC_ERR_CORRUPT_INPUT;\n" ${_probe_header_tail})
+# Prose is not code. This header is compliant and its comments spell out both
+# a bare refusal and a second parser definition; a scan that read comments
+# would refuse the file that documents itself best.
+file(WRITE ${_snappy_probe_root}/prose/snappy_block.h ${_probe_header_head}
+     "            /* Not: return CUDEC_ERR_CORRUPT_INPUT; and not a second\n"
+     "             * struct SnappyParser { either. */\n" ${_probe_alpha_site}
+     ${_probe_header_tail})
+
+set(_snappy_lock_probes
+    "clean|"
+    "with_include|"
+    "prose|"
+    "missing_header|snappy_block.h is missing"
+    "no_parser|no longer defines 'struct SnappyParser'"
+    "local_copy|kernel.cu defines a local 'struct SnappyParser'"
+    "no_include|kernel.cu names the Snappy parser without including"
+    "bare_return|snappy_block.h:22: refuses without going through SnappyRefuse"
+    "wrapped_refuse|snappy_block.h:22: a SnappyRefuse call with no ladder branch"
+    "branch_unused|ladder branch 'kSnappyRejectGamma' is declared and no refusal"
+    "site_undeclared|a refusal site names 'kSnappyRejectGamma', which"
+    "branch_shared|ladder branch 'kSnappyRejectAlpha' is named by 2 refusal"
+    "no_enum|declares no reject ladder"
+    "bracket_above|snappy_block.h:23: refuses without going through")
+foreach(_entry IN LISTS _snappy_lock_probes)
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\2" _expected "${_entry}")
+  cudec_check_snappy_locks(${_snappy_probe_root}/${_probe} _probe_result)
+  if(_expected STREQUAL "")
+    # Checked here rather than through string(FIND): an empty needle is found
+    # at position 0 in every string, so the branch below would assert nothing.
+    if(_probe_result)
+      message(FATAL_ERROR "the Snappy lock refuses a compliant probe: "
+                          "'${_probe}' must come back silent (issue #173). It "
+                          "reported:\n${_probe_result}")
+    endif()
+  else()
+    string(FIND "${_probe_result}" "${_expected}" _found_at)
+    if(_found_at EQUAL -1)
+      message(FATAL_ERROR "the Snappy lock is dead for one rule: probe "
+                          "'${_probe}' did not report \"${_expected}\" "
+                          "(issue #173). It reported:\n${_probe_result}")
+    endif()
+  endif()
+endforeach()
+
+# And now against the tree the rules are for.
+cudec_check_snappy_locks(${CMAKE_CURRENT_SOURCE_DIR}/../src _snappy_violations)
+if(_snappy_violations)
+  message(FATAL_ERROR "the Snappy parser core is not single-sourced, or its "
+                      "reject ladder and its refusal sites have drifted "
+                      "apart (issue #173):\n${_snappy_violations}")
+endif()
+
 # ---- Termination, warp-collective integrity, and determinism as structural
 # rules (issue #72). Same honest scope as the checks above: drift detectors
 # under the known spellings, not tamper-proofing. Every rule below is applied

--- a/tests/snappy_parser_twin.cpp
+++ b/tests/snappy_parser_twin.cpp
@@ -43,6 +43,24 @@ using Bytes = std::vector<unsigned char>;
  * those removals left a verdict-only suite green. */
 size_t g_bounds_violations = 0;
 
+/* Which ladder branches this run reached (issue #173). The enumeration lives
+ * once, in src/snappy_block.h, and main() requires the set below to be the
+ * whole of it apart from the one branch declared unreachable there - so a
+ * branch that gains no negative reds this test, and a negative whose deletion
+ * leaves a branch unreached reds it too. Every observation point that can see
+ * a reject records it, because the branches are not all reachable through one
+ * driver: the capacity rung refuses before any element exists, and the
+ * past-terminal rung is only reached by a driver that ignores *done. */
+bool g_reject_seen[cudec_detail::kSnappyRejectCount] = {false};
+cudec_detail::SnappyReject g_last_reject = cudec_detail::kSnappyRejectNone;
+
+void NoteReject(cudec_detail::SnappyReject branch) {
+    g_last_reject = branch;
+    if (branch != cudec_detail::kSnappyRejectNone) {
+        g_reject_seen[branch] = true;
+    }
+}
+
 /* Sequential reference execution of the parsed elements. A copy is the
  * chasing byte copy - reads may land on just-written bytes, which is the
  * pattern-repeating semantics an overlapping Snappy copy has. */
@@ -70,6 +88,7 @@ cudec_status Drive(const unsigned char* src, uint64_t src_size,
         if (status != CUDEC_OK) {
             /* A rejected stream produces nothing, the same contract
              * SnappyOracleDecodes holds its caller to. */
+            NoteReject(parser.reject);
             out->clear();
             return status;
         }
@@ -145,6 +164,7 @@ cudec_status TwinDecode(const Bytes& stream, Bytes* out) {
                                      kSnappyOracleMaxOutput};
     const cudec_status header = probe.Begin();
     if (header != CUDEC_OK) {
+        NoteReject(probe.reject);
         return header;
     }
     return Drive(tight.get(), stream_size, probe.declared, out);
@@ -175,6 +195,7 @@ bool LivenessHolds(const Bytes& stream, const char** why) {
         const uint64_t before = parser.src_pos;
         const cudec_status status = parser.Next(&element, &done);
         if (status != CUDEC_OK) {
+            NoteReject(parser.reject);
             return true; /* a reject ends any driver loop */
         }
         if (done) {
@@ -185,6 +206,7 @@ bool LivenessHolds(const Bytes& stream, const char** why) {
                 *why = "a call after the terminal element succeeded";
                 return false;
             }
+            NoteReject(parser.reject);
             return true;
         }
         if (parser.src_pos <= before) {
@@ -271,6 +293,13 @@ struct CraftedNegative {
     const char* name;
     Bytes stream;
     cudec_status expected;
+    /* The ladder branch this stream must reach, named from the enumeration
+     * in src/snappy_block.h. Pinned per entry rather than only in aggregate:
+     * a negative that keeps rejecting for a DIFFERENT reason than the one it
+     * was written for still leaves its own branch unproven, and the coverage
+     * count alone would not notice as long as some other entry happened to
+     * reach it. */
+    cudec_detail::SnappyReject branch;
 };
 
 /* One crafted stream per validation-ladder branch. Each pins the twin's
@@ -282,29 +311,39 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
     std::vector<CraftedNegative> out;
 
     /* Preamble: no byte at all. */
-    out.push_back({"preamble-absent", {}, CUDEC_ERR_CORRUPT_INPUT});
+    out.push_back({"preamble-absent",
+                   {},
+                   CUDEC_ERR_CORRUPT_INPUT,
+                   cudec_detail::kSnappyRejectPreambleByteMissing});
     /* Preamble: a continuation bit with nothing behind it. */
-    out.push_back({"preamble-truncated", {0x80}, CUDEC_ERR_CORRUPT_INPUT});
+    out.push_back({"preamble-truncated",
+                   {0x80},
+                   CUDEC_ERR_CORRUPT_INPUT,
+                   cudec_detail::kSnappyRejectPreambleByteMissing});
     /* Preamble: a sixth group. The fifth byte still carries the
      * continuation bit, which the reference refuses outright. */
     out.push_back({"preamble-six-groups",
                    {0x80, 0x80, 0x80, 0x80, 0x80, 0x00},
-                   CUDEC_ERR_CORRUPT_INPUT});
+                   CUDEC_ERR_CORRUPT_INPUT,
+                   cudec_detail::kSnappyRejectPreambleFinalGroup});
     /* Preamble: five groups whose value needs a 33rd bit. */
     out.push_back({"preamble-overflows-32-bit",
                    {0x80, 0x80, 0x80, 0x80, 0x10},
-                   CUDEC_ERR_CORRUPT_INPUT});
+                   CUDEC_ERR_CORRUPT_INPUT,
+                   cudec_detail::kSnappyRejectPreambleFinalGroup});
 
     /* Elements: a declaration with no elements behind it. */
     {
         Bytes s = Preamble(4);
-        out.push_back({"under-production-empty", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"under-production-empty", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectUnderProduction});
     }
     /* Elements: production stops short of the declaration. */
     {
         Bytes s = Preamble(8);
         Append(&s, Literal(abcd));
-        out.push_back({"under-production-short", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"under-production-short", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectUnderProduction});
     }
     /* A long-form literal whose length bytes run past the source end. The
      * declaration is deliberately larger than any length those missing
@@ -317,13 +356,15 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
         Bytes s = Preamble(300);
         s.push_back(0xF0); /* class 60: one length byte follows, and none does */
         out.push_back({"literal-header-truncated", s,
-                       CUDEC_ERR_CORRUPT_INPUT});
+                       CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectLiteralHeaderTruncated});
     }
     {
         Bytes s = Preamble(70000);
         s.push_back(0xF4); /* class 61: two length bytes follow, and none do */
         out.push_back({"literal-header-truncated-wide", s,
-                       CUDEC_ERR_CORRUPT_INPUT});
+                       CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectLiteralHeaderTruncated});
     }
     /* A literal whose payload runs past the source end. */
     {
@@ -331,21 +372,24 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
         Append(&s, Literal(abcd));
         s.resize(s.size() - 2);
         out.push_back({"literal-payload-truncated", s,
-                       CUDEC_ERR_CORRUPT_INPUT});
+                       CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectLiteralPayloadTruncated});
     }
     /* A literal longer than the declaration leaves room for. */
     {
         Bytes s = Preamble(2);
         Append(&s, Literal(abcd));
         out.push_back({"literal-over-production", s,
-                       CUDEC_ERR_CORRUPT_INPUT});
+                       CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectLiteralOverProduction});
     }
     /* A copy whose offset bytes run past the source end. */
     {
         Bytes s = Preamble(8);
         Append(&s, Literal(abcd));
         s.push_back(0x0E); /* a two-byte-offset copy tag, with no offset */
-        out.push_back({"copy-header-truncated", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"copy-header-truncated", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyHeaderTruncated});
     }
     /* The same for the narrow form, whose header is one byte shorter and
      * whose guard is therefore a separate branch. */
@@ -353,7 +397,8 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
         Bytes s = Preamble(8);
         Append(&s, Literal(abcd));
         s.push_back(0x01); /* a one-byte-offset copy tag, with no offset */
-        out.push_back({"copy1-header-truncated", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"copy1-header-truncated", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyHeaderTruncated});
     }
     /* And for the four-byte-offset form, which is missing three of them. */
     {
@@ -361,7 +406,8 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
         Append(&s, Literal(abcd));
         Append(&s, Copy4(4, 4));
         s.resize(s.size() - 3);
-        out.push_back({"copy4-header-truncated", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"copy4-header-truncated", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyHeaderTruncated});
     }
     /* A copy with no byte to replicate, in each of the three forms, both
      * with output behind it and with none. */
@@ -369,25 +415,29 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
         Bytes s = Preamble(8);
         Append(&s, Literal(abcd));
         Append(&s, Copy2(4, 0));
-        out.push_back({"copy-offset-zero-tag-10", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"copy-offset-zero-tag-10", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyOffsetZero});
     }
     {
         Bytes s = Preamble(8);
         Append(&s, Literal(abcd));
         Append(&s, Copy4(4, 0));
-        out.push_back({"copy-offset-zero-tag-11", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"copy-offset-zero-tag-11", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyOffsetZero});
     }
     {
         Bytes s = Preamble(8);
         Append(&s, Literal(abcd));
         Append(&s, Copy1(4, 0));
-        out.push_back({"copy-offset-zero-tag-01", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"copy-offset-zero-tag-01", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyOffsetZero});
     }
     {
         Bytes s = Preamble(4);
         Append(&s, Copy2(4, 0));
         out.push_back({"copy-offset-zero-at-start", s,
-                       CUDEC_ERR_CORRUPT_INPUT});
+                       CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyOffsetZero});
     }
     /* A copy reaching before the start of the produced output. */
     {
@@ -395,7 +445,8 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
         Append(&s, Literal(abcd));
         Append(&s, Copy2(4, 5));
         out.push_back({"copy-offset-before-start", s,
-                       CUDEC_ERR_CORRUPT_INPUT});
+                       CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyOffsetBeforeStart});
     }
     /* The same, through the four-byte-offset form, where the offset is
      * wide enough to be a pointer-sized mistake rather than a small one. */
@@ -403,14 +454,16 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
         Bytes s = Preamble(8);
         Append(&s, Literal(abcd));
         Append(&s, Copy4(4, 0xFFFFFFFFu));
-        out.push_back({"copy-offset-huge", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"copy-offset-huge", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyOffsetBeforeStart});
     }
     /* A copy longer than the declaration leaves room for. */
     {
         Bytes s = Preamble(6);
         Append(&s, Literal(abcd));
         Append(&s, Copy2(4, 1));
-        out.push_back({"copy-over-production", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"copy-over-production", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectCopyOverProduction});
     }
     /* A complete stream with one more element behind it: the declared
      * length is already produced, so the trailing element over-produces. */
@@ -418,7 +471,8 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
         Bytes s = Preamble(4);
         Append(&s, Literal(abcd));
         Append(&s, Literal(Ascii("x")));
-        out.push_back({"trailing-element", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"trailing-element", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectLiteralOverProduction});
     }
     /* A complete stream with one dangling tag byte: the source is not
      * consumed exactly, and the tag's own payload is missing too. */
@@ -426,7 +480,8 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
         Bytes s = Preamble(4);
         Append(&s, Literal(abcd));
         s.push_back(0x00);
-        out.push_back({"trailing-tag", s, CUDEC_ERR_CORRUPT_INPUT});
+        out.push_back({"trailing-tag", s, CUDEC_ERR_CORRUPT_INPUT,
+                       cudec_detail::kSnappyRejectLiteralPayloadTruncated});
     }
     return out;
 }
@@ -605,8 +660,16 @@ int main() {
     const auto crafted = MakeCraftedNegatives();
     for (const auto& c : crafted) {
         Bytes twin_out;
+        g_last_reject = cudec_detail::kSnappyRejectNone;
         REQUIRE_CTX(TwinDecode(c.stream, &twin_out) == c.expected,
                     "crafted %s", c.name);
+        /* The branch, not merely the status: eight of these entries share
+         * CUDEC_ERR_CORRUPT_INPUT with some other entry, so a status
+         * comparison cannot tell which rung refused. */
+        REQUIRE_CTX(g_last_reject == c.branch,
+                    "crafted %s: reached ladder branch %d, not %d", c.name,
+                    static_cast<int>(g_last_reject),
+                    static_cast<int>(c.branch));
         REQUIRE_CTX(twin_out.empty(),
                     "crafted %s: a rejected stream produced output", c.name);
         Bytes oracle_out;
@@ -822,13 +885,52 @@ int main() {
      * could execute it in, on any stream above. */
     REQUIRE(g_bounds_violations == 0);
 
+    /* The branch-count lock (issue #173): every rung of the ladder in
+     * src/snappy_block.h was reached by something above, and the one rung
+     * declared unreachable there was not.
+     *
+     * The enumeration is not restated here - it is walked. A branch added to
+     * the header with no negative behind it leaves a hole this loop names,
+     * and deleting the only negative that reached a branch opens the same
+     * hole; tests/CMakeLists.txt holds the other end, refusing a refusal that
+     * does not pass through the enumerated choke point at all.
+     *
+     * The unreachable rung is fail-closed in BOTH directions. It carries no
+     * negative because the argument for it is that no input reaches it - so
+     * if one ever does, the argument was wrong and that has to red rather
+     * than pass as extra coverage. */
+    {
+        size_t branches_reached = 0;
+        for (int branch = cudec_detail::kSnappyRejectNone + 1;
+             branch < cudec_detail::kSnappyRejectCount; branch++) {
+            const bool seen = g_reject_seen[branch];
+            if (branch == cudec_detail::kSnappyRejectPreambleUnreachable) {
+                REQUIRE_CTX(!seen,
+                            "ladder branch %d is declared unreachable in "
+                            "src/snappy_block.h and was reached",
+                            branch);
+                continue;
+            }
+            REQUIRE_CTX(seen,
+                        "ladder branch %d has no negative that reaches it - "
+                        "add one, or the branch is untested (issue #173)",
+                        branch);
+            branches_reached++;
+        }
+        REQUIRE(branches_reached ==
+                static_cast<size_t>(cudec_detail::kSnappyRejectCount) - 2);
+    }
+
     std::printf("PASS: %zu snappy fixtures + %zu mutants in oracle parity "
                 "(%zu oracle-rejected, %zu stricter-than-snappy); %zu crafted "
                 "negatives; %zu accept cases held open; wide-offset sweep and "
                 "the capacity axis pinned; the 32-bit literal-length wrap "
-                "pinned as the one divergence; liveness on %zu streams\n",
+                "pinned as the one divergence; liveness on %zu streams; %d of "
+                "%d ladder branches reached, 1 declared unreachable\n",
                 fixtures.size(), mutant_total, rejected_total,
                 stricter_than_oracle, crafted.size(), accepted.size(),
-                liveness_streams);
+                liveness_streams,
+                static_cast<int>(cudec_detail::kSnappyRejectCount) - 2,
+                static_cast<int>(cudec_detail::kSnappyRejectCount) - 1);
     return 0;
 }

--- a/tests/snappy_parser_twin.cpp
+++ b/tests/snappy_parser_twin.cpp
@@ -43,21 +43,33 @@ using Bytes = std::vector<unsigned char>;
  * those removals left a verdict-only suite green. */
 size_t g_bounds_violations = 0;
 
-/* Which ladder branches this run reached (issue #173). The enumeration lives
- * once, in src/snappy_block.h, and main() requires the set below to be the
- * whole of it apart from the one branch declared unreachable there - so a
- * branch that gains no negative reds this test, and a negative whose deletion
- * leaves a branch unreached reds it too. Every observation point that can see
- * a reject records it, because the branches are not all reachable through one
- * driver: the capacity rung refuses before any element exists, and the
- * past-terminal rung is only reached by a driver that ignores *done. */
-bool g_reject_seen[cudec_detail::kSnappyRejectCount] = {false};
+/* Which ladder branch refused last, recorded wherever a driver sees a reject.
+ * Diagnostic: it says which rung, where the returned status only says that
+ * some rung refused, and eight of the crafted negatives share one status. */
 cudec_detail::SnappyReject g_last_reject = cudec_detail::kSnappyRejectNone;
 
-void NoteReject(cudec_detail::SnappyReject branch) {
+void ObserveReject(cudec_detail::SnappyReject branch) {
     g_last_reject = branch;
+}
+
+/* Which ladder rungs a DECLARED NEGATIVE reached (issue #173). The
+ * enumeration lives once, in src/snappy_block.h, and main() requires this set
+ * to be the whole of it apart from the one rung declared unreachable there.
+ * So a rung added to the ladder with no negative behind it reds this test,
+ * and deleting the negative that reached a rung reds it too.
+ *
+ * ONLY the declared negative sets mark coverage - never the fixtures, never
+ * the mutation corpus. That is the difference between this check biting and
+ * merely looking as if it does, and it is MEASURED: with the corpus counted,
+ * deleting the copy-over-production negative left this test green, because a
+ * mutant that happened to trip the same rung stood in for it. A rung is
+ * tested when a stream written to reach it reaches it, not when some stream
+ * does. */
+bool g_reject_covered[cudec_detail::kSnappyRejectCount] = {false};
+
+void CoverBranch(cudec_detail::SnappyReject branch) {
     if (branch != cudec_detail::kSnappyRejectNone) {
-        g_reject_seen[branch] = true;
+        g_reject_covered[branch] = true;
     }
 }
 
@@ -88,7 +100,7 @@ cudec_status Drive(const unsigned char* src, uint64_t src_size,
         if (status != CUDEC_OK) {
             /* A rejected stream produces nothing, the same contract
              * SnappyOracleDecodes holds its caller to. */
-            NoteReject(parser.reject);
+            ObserveReject(parser.reject);
             out->clear();
             return status;
         }
@@ -164,7 +176,7 @@ cudec_status TwinDecode(const Bytes& stream, Bytes* out) {
                                      kSnappyOracleMaxOutput};
     const cudec_status header = probe.Begin();
     if (header != CUDEC_OK) {
-        NoteReject(probe.reject);
+        ObserveReject(probe.reject);
         return header;
     }
     return Drive(tight.get(), stream_size, probe.declared, out);
@@ -195,7 +207,7 @@ bool LivenessHolds(const Bytes& stream, const char** why) {
         const uint64_t before = parser.src_pos;
         const cudec_status status = parser.Next(&element, &done);
         if (status != CUDEC_OK) {
-            NoteReject(parser.reject);
+            ObserveReject(parser.reject);
             return true; /* a reject ends any driver loop */
         }
         if (done) {
@@ -206,7 +218,7 @@ bool LivenessHolds(const Bytes& stream, const char** why) {
                 *why = "a call after the terminal element succeeded";
                 return false;
             }
-            NoteReject(parser.reject);
+            ObserveReject(parser.reject);
             return true;
         }
         if (parser.src_pos <= before) {
@@ -486,6 +498,31 @@ std::vector<CraftedNegative> MakeCraftedNegatives() {
     return out;
 }
 
+/* The rung no malformed stream can reach, and the reason it needs its own set
+ * rather than an entry above: it is not a statement about the bytes. The
+ * capacity rung refuses a stream snappy ACCEPTS, because the destination the
+ * caller owns is too small for the length the stream declares - so the loop
+ * above, which requires the reference to reject the same bytes, cannot hold
+ * one. */
+struct CapacityNegative {
+    const char* name;
+    Bytes stream;
+    uint64_t capacity;
+    cudec_detail::SnappyReject branch;
+};
+
+std::vector<CapacityNegative> MakeCapacityNegatives() {
+    const Bytes abcd = Ascii("abcd");
+    std::vector<CapacityNegative> out;
+    Bytes s = Preamble(4);
+    Append(&s, Literal(abcd));
+    out.push_back({"capacity-one-short", s, 3,
+                   cudec_detail::kSnappyRejectDeclaredOverCapacity});
+    out.push_back({"capacity-zero", s, 0,
+                   cudec_detail::kSnappyRejectDeclaredOverCapacity});
+    return out;
+}
+
 /* Streams the reference accepts, which the ladder must not over-reject.
  * Over-strictness is a parity failure and not extra safety: every entry
  * here is a shape snappy's own compressor never emits, so nothing in the
@@ -667,9 +704,10 @@ int main() {
          * CUDEC_ERR_CORRUPT_INPUT with some other entry, so a status
          * comparison cannot tell which rung refused. */
         REQUIRE_CTX(g_last_reject == c.branch,
-                    "crafted %s: reached ladder branch %d, not %d", c.name,
+                    "crafted %s: reached ladder rung %d, not %d", c.name,
                     static_cast<int>(g_last_reject),
                     static_cast<int>(c.branch));
+        CoverBranch(g_last_reject);
         REQUIRE_CTX(twin_out.empty(),
                     "crafted %s: a rejected stream produced output", c.name);
         Bytes oracle_out;
@@ -678,6 +716,53 @@ int main() {
         REQUIRE_CTX(!SnappyOracleAccepts(c.stream),
                     "crafted %s: snappy's validator unexpectedly accepts",
                     c.name);
+    }
+
+    /* The capacity rung, on streams the reference accepts. Its ACCEPTANCE is
+     * asserted here where the crafted loop asserts rejection: a capacity
+     * negative that had drifted into being malformed would otherwise pass for
+     * the wrong reason and leave the rung untested while looking covered. */
+    const auto capacity_negatives = MakeCapacityNegatives();
+    for (const auto& c : capacity_negatives) {
+        Bytes oracle_out;
+        REQUIRE_CTX(SnappyOracleDecodes(c.stream, &oracle_out),
+                    "capacity %s: snappy rejects the stream itself", c.name);
+        Bytes twin_out;
+        g_last_reject = cudec_detail::kSnappyRejectNone;
+        REQUIRE_CTX(Drive(c.stream.data(), c.stream.size(), c.capacity,
+                          &twin_out) == CUDEC_ERR_OUTPUT_TOO_SMALL,
+                    "capacity %s", c.name);
+        REQUIRE_CTX(g_last_reject == c.branch,
+                    "capacity %s: reached ladder rung %d, not %d", c.name,
+                    static_cast<int>(g_last_reject),
+                    static_cast<int>(c.branch));
+        CoverBranch(g_last_reject);
+        REQUIRE_CTX(twin_out.empty(),
+                    "capacity %s: a refused decode produced output", c.name);
+    }
+
+    /* The past-terminal rung, which no stream reaches either: it takes a
+     * DRIVER that ignores *done, and that is the case it exists for - a warp
+     * lane looping past the terminal element must be refused rather than left
+     * to spin against the launch. LivenessHolds proves the refusal over every
+     * stream this test has; this case is what NAMES the rung, so deleting it
+     * leaves the rung uncovered. */
+    {
+        Bytes valid = Preamble(4);
+        Append(&valid, Literal(Ascii("abcd")));
+        cudec_detail::SnappyParser parser{valid.data(), valid.size(), 4};
+        cudec_detail::SnappyElement element;
+        bool done = false;
+        uint64_t fuel = valid.size() + 2;
+        while (!done) {
+            REQUIRE(fuel-- != 0);
+            REQUIRE(parser.Next(&element, &done) == CUDEC_OK);
+        }
+        bool again = false;
+        REQUIRE(parser.Next(&element, &again) == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(!again);
+        REQUIRE(parser.reject == cudec_detail::kSnappyRejectPastTerminal);
+        CoverBranch(parser.reject);
     }
 
     /* The deliberate divergence, pinned explicitly. The four-byte literal
@@ -886,38 +971,38 @@ int main() {
     REQUIRE(g_bounds_violations == 0);
 
     /* The branch-count lock (issue #173): every rung of the ladder in
-     * src/snappy_block.h was reached by something above, and the one rung
-     * declared unreachable there was not.
+     * src/snappy_block.h was reached by a DECLARED NEGATIVE, and the one rung
+     * declared unreachable there was reached by none of them.
      *
-     * The enumeration is not restated here - it is walked. A branch added to
+     * The enumeration is not restated here - it is walked. A rung added to
      * the header with no negative behind it leaves a hole this loop names,
-     * and deleting the only negative that reached a branch opens the same
-     * hole; tests/CMakeLists.txt holds the other end, refusing a refusal that
-     * does not pass through the enumerated choke point at all.
+     * and deleting the negative that reached a rung opens the same hole;
+     * tests/CMakeLists.txt holds the other end, refusing a refusal that does
+     * not pass through the enumerated choke point at all.
      *
      * The unreachable rung is fail-closed in BOTH directions. It carries no
      * negative because the argument for it is that no input reaches it - so
      * if one ever does, the argument was wrong and that has to red rather
      * than pass as extra coverage. */
     {
-        size_t branches_reached = 0;
+        size_t branches_covered = 0;
         for (int branch = cudec_detail::kSnappyRejectNone + 1;
              branch < cudec_detail::kSnappyRejectCount; branch++) {
-            const bool seen = g_reject_seen[branch];
+            const bool covered = g_reject_covered[branch];
             if (branch == cudec_detail::kSnappyRejectPreambleUnreachable) {
-                REQUIRE_CTX(!seen,
-                            "ladder branch %d is declared unreachable in "
-                            "src/snappy_block.h and was reached",
+                REQUIRE_CTX(!covered,
+                            "ladder rung %d is declared unreachable in "
+                            "src/snappy_block.h and a negative reached it",
                             branch);
                 continue;
             }
-            REQUIRE_CTX(seen,
-                        "ladder branch %d has no negative that reaches it - "
-                        "add one, or the branch is untested (issue #173)",
+            REQUIRE_CTX(covered,
+                        "ladder rung %d has no declared negative that reaches "
+                        "it - add one, or the rung is untested (issue #173)",
                         branch);
-            branches_reached++;
+            branches_covered++;
         }
-        REQUIRE(branches_reached ==
+        REQUIRE(branches_covered ==
                 static_cast<size_t>(cudec_detail::kSnappyRejectCount) - 2);
     }
 
@@ -926,7 +1011,8 @@ int main() {
                 "negatives; %zu accept cases held open; wide-offset sweep and "
                 "the capacity axis pinned; the 32-bit literal-length wrap "
                 "pinned as the one divergence; liveness on %zu streams; %d of "
-                "%d ladder branches reached, 1 declared unreachable\n",
+                "%d ladder rungs covered by a declared negative, 1 declared "
+                "unreachable\n",
                 fixtures.size(), mutant_total, rejected_total,
                 stricter_than_oracle, crafted.size(), accepted.size(),
                 liveness_streams,


### PR DESCRIPTION
# What & why

Closes #173.

The Snappy validation ladder was held single-sourced and fully negative-tested by review habit. This makes both refusable.

Every refusal in `src/snappy_block.h` now returns through one choke point, `SnappyRefuse`, naming a rung of an enumeration the header declares once. The branch set is therefore derived from the code instead of restated beside it, and two gates read it:

- `tests/CMakeLists.txt`, at configure time, refuses a refusal that skips the choke point, a declared rung no site names, a site naming a rung the enumeration does not carry, two sites sharing one rung, a second definition of the parser types anywhere under `src/`, and a source that names them without including the header.
- `tests/snappy_parser_twin.cpp`, at test time, pins each declared negative to the rung it must reach, then requires every declared rung to have been reached by one, with the single rung the header argues is unreachable required NOT to have been.

So a rung added to a fail-closed ladder with no negative behind it reds, and deleting the negative that covered a rung reds too. The neighbouring failure is covered by the same pair: a copy of the ladder inside the M3 kernel that drifts from this one.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Build / CI / supply chain

## What the coverage check counts, and why that changed once

The first version of the coverage check accepted a rung as tested when any stream in the run reached it, and the fixtures and the 1069-mutant corpus are streams. It did not bite. Measured by deleting the `copy-over-production` crafted negative: the test stayed green, because a mutant tripped the same rung and stood in for it.

Coverage is now marked by the declared negative sets and by nothing else. That left two rungs no malformed stream can reach, and each got a declared set rather than a hole in the count:

- the capacity rung refuses a stream snappy ACCEPTS, because the destination the caller owns is too small for the declared length, so its cases assert the reference accepts the bytes where the crafted loop asserts rejection;
- the past-terminal rung takes a driver that ignores `*done`, so one case drives a valid stream past its terminal element.

## Engineering checklist

- [x] Fail-closed preserved. No decode decision reads the new field; the verdict a caller acts on is still the returned `cudec_status`, and every rung returns exactly the status it returned before. The accept set and the reject set are unchanged, and the 1069-mutant oracle parity run plus the 16 accept cases are the evidence.
- [x] Oracle coverage: unchanged and still green, including the one recorded divergence (the 32-bit literal-length wrap).
- [x] Determinism preserved: no decode path branches on anything new.
- [x] No exceptions cross the C ABI. This header is internal, and its only signature change is a defaulted out-parameter on `SnappyDeclaredLength`.
- [ ] An adversarial review was NOT run on this change. There was no second reader for it. The proofs below are what stands in its place, and they are less than a review rather than equal to one.
- [ ] Review record: none, for the same reason. CONFIRMED 0 / PLAUSIBLE 0 as raised, because nothing was raised by anybody.

## The guards, proven by breaking them

Each proof mutates the tree, runs the gate, and reverts. Container: `nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`, with cmake added from the Ubuntu archive.

Delete the crafted negative that covers one rung:

    sed -i '/copy-over-production/,+1d' tests/snappy_parser_twin.cpp
    ctest --test-dir build-cuda -R snappy_parser_twin --output-on-failure
    FAIL /w/tests/snappy_parser_twin.cpp:995: covered | ladder rung 13 has no declared negative that reaches it - add one, or the rung is untested (issue #173)
    0% tests passed, 1 tests failed out of 1

Delete the past-terminal case:

    sed -i '/REQUIRE(parser.reject == cudec_detail::kSnappyRejectPastTerminal);/,+1d' tests/snappy_parser_twin.cpp
    FAIL /w/tests/snappy_parser_twin.cpp:993: covered | ladder rung 5 has no declared negative that reaches it - add one, or the rung is untested (issue #173)
    0% tests passed, 1 tests failed out of 1

Point one refusal site at its neighbour's rung, which is how a new rung would avoid needing a negative of its own:

    sed -i 's/SnappyRefuse(kSnappyRejectCopyOffsetBeforeStart,/SnappyRefuse(kSnappyRejectCopyOffsetZero,/' src/snappy_block.h
    cmake -B /tmp/p1 -S /w -DCUDEC_ENABLE_CUDA=ON
    CMake Error: the Snappy parser core is not single-sourced, or its reject ladder and its
    refusal sites have drifted apart (issue #173):
      ladder branch 'kSnappyRejectCopyOffsetZero' is named by 2 refusal sites: a new rung takes a new branch, so that the twin's negative for it cannot be satisfied by its neighbour (issue #173)
      ladder branch 'kSnappyRejectCopyOffsetBeforeStart' is declared and no refusal site names it (issue #173)

Refuse without the choke point, which is the one shape that could add a rung invisible to both halves:

    sed -i 's|return SnappyRefuse(kSnappyRejectCopyOffsetZero,|return CUDEC_ERR_CORRUPT_INPUT; /*x|' src/snappy_block.h
    cmake -B /tmp/p2 -S /w -DCUDEC_ENABLE_CUDA=ON
    CMake Error: ...
      snappy_block.h:416: refuses without going through SnappyRefuse - every refusal names its ladder branch (issue #173)
      snappy_block.h:421: refuses without going through SnappyRefuse - every refusal names its ladder branch (issue #173)
      ladder branch 'kSnappyRejectCopyOffsetZero' is declared and no refusal site names it (issue #173)

Beyond those four, both rules are run at configure time against 16 planted probe trees before they are trusted against the real one: three that must come back silent, and thirteen that must each report the TEXT of the rule they violate, so a rule that has quietly stopped matching reds instead of passing. A dead rule is caught by its own probe rather than by review.

## A defect found while building this, filed as #294

The reader these rules share carries one protection the structural scanner in the same file does not. CMake list expansion lets `[` swallow every separator until its `]`, so one unbalanced bracket joins the rest of a file into a single element.

Measured against `main` rather than against this branch. `git archive origin/main src` into a clean directory, then the scanner's own reader over it:

    snappy_block.h: file has 371 lines, the scan loop sees 106

The other nine sources are whole. #294 carries the repair; nothing here changes that scanner.

This branch's reader protects both brackets and then refuses any file whose line count it cannot reproduce, because a partial read reports the same silence as a clean one. One of the 16 probes plants exactly that shape: an unbalanced bracket in a comment above a violation the scan must still report, matched on the line number it must still be reported at.

## Verification

Run in the pinned container. The runner has no GPU; no device code is touched by this change and no gpu-labeled result is claimed here.

    cmake -B build && cmake --build build
    host-only build: OK

    cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
    cuda build: OK

    ctest --test-dir build-cuda -LE gpu --no-tests=error --output-on-failure
    100% tests passed, 0 tests failed out of 14

    ./build-cuda/tests/snappy_parser_twin
    PASS: 21 snappy fixtures + 1069 mutants in oracle parity (941 oracle-rejected,
    0 stricter-than-snappy); 22 crafted negatives; 16 accept cases held open;
    wide-offset sweep and the capacity axis pinned; the 32-bit literal-length wrap
    pinned as the one divergence; liveness on 66921 streams; 12 of 13 ladder rungs
    covered by a declared negative, 1 declared unreachable

    cmake -B /tmp/san -S /w -DCUDEC_ENABLE_CUDA=ON -DCUDEC_SANITIZE=address,undefined
    cmake --build /tmp/san -j
    ctest --test-dir /tmp/san --no-tests=error -R "^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|frame_host_negative|termination)$"
    100% tests passed, 0 tests failed out of 6

- [x] Prettier: no `.md`, `.yml` or `.yaml` file is touched by this change.
- [x] Docs synced: nothing here changes behaviour, API or performance.

## Honest scope

Both rules are drift detectors under the known spellings, the same scope the neighbouring locks state for themselves. A ladder re-copied under fresh type names, or a refusal spelled through a local variable rather than a `return`, is out of reach of a text scan. The comment beside each rule says so.
