### PR TITLE
Pin zstd 1.5.7 and build the decode-only oracle [#181]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,12 +126,137 @@ set_target_properties(snappy_oracle PROPERTIES CXX_STANDARD 11
 # corpora during fixture generation.
 target_compile_options(snappy_oracle PRIVATE -O2)
 
-# PRIVATE on purpose: the archive still links through, but the lz4 and snappy
-# include paths stay out of every consumer's command line - so an accidental
-# #include <lz4.h> or <snappy.h> in a .cu test is a compile error, and the
-# "nvcc never sees the oracle headers" rule is enforced, not just observed.
+# facebook/zstd, the M5 oracle, pinned by the SHA-256 of the
+# MAINTAINER-UPLOADED release asset - the shape the pinning policy prefers and
+# lz4 already uses, rather than the auto-generated /archive/ tarball snappy
+# had to fall back to.
+#
+# The pin, and how it was established at pin time (2026-08-06):
+#
+#   curl -sSL -o zstd-1.5.7.tar.gz \
+#     https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz
+#   sha256sum zstd-1.5.7.tar.gz
+#   eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3
+#
+# self-computed, and it agrees with all of: the published
+# zstd-1.5.7.tar.gz.sha256 asset beside it, and conan-center-index's
+# recipes/zstd/all/conandata.yml for 1.5.7 - one second packaging ecosystem,
+# as the policy asks. 2434947 bytes.
+#
+# A detached zstd-1.5.7.tar.gz.sig IS published (HTTP 200 at the same release)
+# and it was DELIBERATELY NOT VERIFIED. Verifying it needs the signing key,
+# and the only route to that key from here is the same host that serves the
+# artifact and the signature, which makes the check circular rather than
+# independent. The three hashes above come from two different parties, which
+# is the property actually wanted. Said plainly so a later reader does not
+# read this pin as signature-verified.
+#
+# Licence: zstd is dual-licensed BSD-2-Clause OR GPL-2.0 (LICENSE and COPYING
+# in the tarball). cudec ELECTS BSD-2-Clause. Recorded here rather than only
+# in a pull request because the election is a fact about this repository: the
+# GPL arm is not taken, and nothing here may be read as taking it. cudec
+# neither vendors nor redistributes these sources - the tarball is fetched at
+# build time into the build tree and no cudec artifact contains it - so
+# BSD-2-Clause's notice obligation attaches to no artifact shipped today. It
+# attaches the moment a binary linking it is distributed, which is a thing
+# this tree does not do and would have to decide to start.
+FetchContent_Declare(
+  zstd
+  URL https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz
+  URL_HASH
+    SHA256=eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+FetchContent_MakeAvailable(zstd)
+
+# The uploaded tarball carries no top-level CMakeLists (zstd's lives in
+# build/cmake), so MakeAvailable only populates the source tree, exactly as
+# with lz4 - and the same statement as a check rather than as a comment: if a
+# future layout DID add one, MakeAvailable would build zstd's own project and
+# these targets would collide with its.
+if(TARGET libzstd_static)
+  message(FATAL_ERROR "zstd's own build system was added to this tree - the "
+                      "oracle rule is one target over the sources the decode "
+                      "path needs, never the project's build system")
+endif()
+
+# The decode path, as an EXPLICIT translation-unit list rather than the
+# amalgamated single-file decoder. Both were available; the list wins on the
+# tree's own means test. The amalgamation is produced by running
+# build/single_file_libs/combine.py at configure time, which puts a Python
+# runtime on the build's critical path for every configure in CI and in the
+# container - a language this tree does not otherwise carry - and hands the
+# compiler a generated file no reviewer reads. The list below is nine names
+# in a diff, and a tenth appearing is a reviewable event.
+#
+# The names are zstddeclib-in.c's own set, which is what the single-file
+# decoder amalgamates, plus common/xxhash.c: a zstd frame may carry an XXH64
+# content checksum, so the decoder reaches it. If that TU turns out to be
+# unnecessary the link is what says so.
+set(_zstd_decode_sources
+    ${zstd_SOURCE_DIR}/lib/common/debug.c
+    ${zstd_SOURCE_DIR}/lib/common/entropy_common.c
+    ${zstd_SOURCE_DIR}/lib/common/error_private.c
+    ${zstd_SOURCE_DIR}/lib/common/fse_decompress.c
+    ${zstd_SOURCE_DIR}/lib/common/xxhash.c
+    ${zstd_SOURCE_DIR}/lib/common/zstd_common.c
+    ${zstd_SOURCE_DIR}/lib/decompress/huf_decompress.c
+    ${zstd_SOURCE_DIR}/lib/decompress/zstd_ddict.c
+    ${zstd_SOURCE_DIR}/lib/decompress/zstd_decompress.c
+    ${zstd_SOURCE_DIR}/lib/decompress/zstd_decompress_block.c)
+foreach(_zstd_source IN LISTS _zstd_decode_sources)
+  if(NOT EXISTS ${_zstd_source})
+    message(FATAL_ERROR "the zstd decode source ${_zstd_source} is missing: "
+                        "the pinned tarball's layout has moved and this list "
+                        "is stale")
+  endif()
+endforeach()
+
+# ZSTD_LEGACY_SUPPORT=0 keeps the pre-v0.8 frame decoders out: cudec decodes
+# the v1 subset and an oracle that accepts more than the thing under test
+# would report a divergence that is not one. ZSTD_DISABLE_ASM=1 drops the
+# BMI2 assembly path, which is x86-specific and irrelevant to a reference
+# verdict. ZSTD_STRIP_ERROR_STRINGS because the harness reads
+# ZSTD_getErrorCode, an enum, and never a message.
+set(_zstd_defines ZSTD_LEGACY_SUPPORT=0 ZSTD_DISABLE_ASM=1
+                  ZSTD_STRIP_ERROR_STRINGS)
+
+add_library(zstd_oracle STATIC ${_zstd_decode_sources})
+target_include_directories(zstd_oracle SYSTEM PUBLIC ${zstd_SOURCE_DIR}/lib)
+target_compile_definitions(zstd_oracle PRIVATE ${_zstd_defines})
+# SYSTEM include, none of the project's strict flags, -O2 unconditionally -
+# the rule lz4_oracle and snappy_oracle both follow, for the same two reasons:
+# third-party code is audited by hash rather than reformatted, and the
+# documented container command sets no CMAKE_BUILD_TYPE.
+target_compile_options(zstd_oracle PRIVATE -O2)
+
+# The compressor as well, from the SAME populated tree, for corpus
+# generation: an M5 corpus of level-swept, forced-mode frames cannot be
+# written by hand. Only the oracle-diff target stays minimal, so the two are
+# separate rather than one.
+#
+# They must never meet in one link. Every decode symbol is in both archives,
+# so a binary reaching for both would resolve some from each and the linker
+# would refuse it - correctly. A consumer takes zstd_oracle when it needs a
+# verdict and zstd_full when it needs to produce a frame.
+file(GLOB _zstd_full_sources CONFIGURE_DEPENDS ${zstd_SOURCE_DIR}/lib/common/*.c
+     ${zstd_SOURCE_DIR}/lib/compress/*.c ${zstd_SOURCE_DIR}/lib/decompress/*.c)
+if(NOT _zstd_full_sources)
+  message(FATAL_ERROR "the zstd library sweep found no sources under "
+                      "${zstd_SOURCE_DIR}/lib - the glob has stopped matching")
+endif()
+add_library(zstd_full STATIC ${_zstd_full_sources})
+target_include_directories(zstd_full SYSTEM PUBLIC ${zstd_SOURCE_DIR}/lib)
+target_compile_definitions(zstd_full PRIVATE ${_zstd_defines})
+target_compile_options(zstd_full PRIVATE -O2)
+
+# PRIVATE on purpose: the archive still links through, but the lz4, snappy and
+# zstd include paths stay out of every consumer's command line - so an
+# accidental #include <lz4.h>, <snappy.h> or <zstd.h> in a .cu test is a
+# compile error, and the "nvcc never sees the oracle headers" rule is
+# enforced, not just observed.
 add_library(cudec_test_fixtures STATIC fixtures.cpp)
-target_link_libraries(cudec_test_fixtures PRIVATE lz4_oracle snappy_oracle)
+target_link_libraries(cudec_test_fixtures PRIVATE lz4_oracle snappy_oracle
+                                                  zstd_oracle)
 target_include_directories(cudec_test_fixtures PUBLIC .)
 set_target_properties(cudec_test_fixtures PROPERTIES CXX_STANDARD 17
                                                      CXX_STANDARD_REQUIRED ON)
@@ -236,6 +361,14 @@ if(TARGET snappy_block_device)
   target_include_directories(snappy_block_device
                              PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 endif()
+# The M5 oracle proving itself (issue #181): the pin downloads, the two
+# flavours build, and the compressor and the decode entry points agree on real
+# bytes - plus one refusal per error class the fail-closed matrix will read.
+# It links zstd_full and NOT cudec_test_fixtures: the fixtures archive carries
+# the decode-only zstd, every decode symbol is in both archives, and a binary
+# reaching for both would be refused by the linker. Host-side and GPU-less;
+# nothing here is about cudec's own Zstd path, which does not exist yet.
+cudec_add_test(zstd_oracle_smoke SOURCES zstd_oracle_smoke.cpp LIBS zstd_full)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/fixtures.cpp
+++ b/tests/fixtures.cpp
@@ -2,6 +2,8 @@
 
 #include <lz4.h>
 #include <snappy.h>
+#include <zstd.h>
+#include <zstd_errors.h>
 
 #include <cstdlib>
 #include <cstring>
@@ -448,4 +450,93 @@ std::vector<unsigned char> SnappyCompressBlock(
     }
     compressed.resize(written);
     return compressed;
+}
+
+bool ZstdOracleContentSize(const std::vector<unsigned char>& stream,
+                           uint64_t* size, bool* unknown) {
+    *size = 0;
+    *unknown = false;
+    if (stream.empty()) {
+        return false; /* never hand zstd a null source pointer */
+    }
+    const unsigned long long declared =
+        ZSTD_getFrameContentSize(stream.data(), stream.size());
+    if (declared == ZSTD_CONTENTSIZE_ERROR) {
+        return false;
+    }
+    if (declared == ZSTD_CONTENTSIZE_UNKNOWN) {
+        *unknown = true;
+        return true;
+    }
+    *size = static_cast<uint64_t>(declared);
+    return true;
+}
+
+bool ZstdOracleDecodes(const std::vector<unsigned char>& stream,
+                       std::vector<unsigned char>* decoded) {
+    decoded->clear();
+    uint64_t declared = 0;
+    bool unknown = false;
+    if (!ZstdOracleContentSize(stream, &declared, &unknown)) {
+        return false;
+    }
+    if (unknown) {
+        /* A frame that declares no content size needs a caller-owned bound,
+         * and this wrapper is the exact-produce parity call - it has none to
+         * offer. Refusing is not a verdict on the frame, so no test may read
+         * it as one; the size-taking surface above is where that case is
+         * driven from. */
+        return false;
+    }
+    if (declared > kZstdOracleMaxOutput) {
+        return false; /* the wrapper's bound, documented in fixtures.h */
+    }
+    decoded->assign(static_cast<size_t>(declared), 0);
+    const size_t produced = ZSTD_decompress(
+        decoded->data(), decoded->size(), stream.data(), stream.size());
+    if (ZSTD_isError(produced) || produced != declared) {
+        /* A rejected stream produces no output, the same contract the lz4 and
+         * snappy wrappers hold their callers to. The produced-equals-declared
+         * arm is not redundant: it is the exact-produce half of parity, and a
+         * frame whose header promises more than its blocks deliver has to
+         * fail here rather than leave a short buffer looking decoded. */
+        decoded->clear();
+        return false;
+    }
+    return true;
+}
+
+int ZstdOracleErrorCode(const std::vector<unsigned char>& stream) {
+    if (stream.empty()) {
+        /* The one value here zstd did not produce, and it is negative so it
+         * cannot be mistaken for a ZSTD_ErrorCode. An empty buffer is not a
+         * frame and zstd is never handed a null source pointer, so there is
+         * no verdict of its to report. */
+        return kZstdOracleNotAFrame;
+    }
+    /* Size the destination from the frame where the frame says so, and from
+     * nothing where it does not: an unknown or malformed content size leaves
+     * a small probe buffer, and zstd answers on the bytes anyway. Where that
+     * answer is ZSTD_error_dstSize_tooSmall it is a verdict on THIS CALL's
+     * buffer rather than on the frame, which is why the size-taking surface
+     * exists beside this one.
+     *
+     * Nothing is synthesized. Every non-negative value returned here came out
+     * of ZSTD_getErrorCode, and 0 means zstd's own decode succeeded. Whether
+     * the frame also produced exactly what it declared is ZstdOracleDecodes's
+     * question, not this one's. */
+    uint64_t declared = 0;
+    bool unknown = false;
+    size_t room = 64;
+    if (ZstdOracleContentSize(stream, &declared, &unknown) && !unknown &&
+        declared != 0 && declared <= kZstdOracleMaxOutput) {
+        room = static_cast<size_t>(declared);
+    }
+    std::vector<unsigned char> out(room, 0);
+    const size_t produced =
+        ZSTD_decompress(out.data(), out.size(), stream.data(), stream.size());
+    if (ZSTD_isError(produced)) {
+        return static_cast<int>(ZSTD_getErrorCode(produced));
+    }
+    return 0;
 }

--- a/tests/fixtures.h
+++ b/tests/fixtures.h
@@ -98,4 +98,52 @@ std::vector<Fixture> MakeSnappyFixtures();
 std::vector<Mutant> MutateSnappyStream(const std::vector<unsigned char>& stream,
                                        uint64_t seed);
 
+/* The Zstd oracle (facebook/zstd, pinned in tests/CMakeLists.txt), the same
+ * authority over stream validity that liblz4 holds for LZ4 and snappy for
+ * Snappy. Decode only: the wrapper links the decode-only archive, so nothing
+ * reachable from here can compress.
+ *
+ * A zstd frame carries its own content size when the compressor wrote one, so
+ * the parity call needs no size argument in the common case. Two values it can
+ * return instead are NOT sizes and are refused here rather than passed on as
+ * one: ZSTD_CONTENTSIZE_UNKNOWN, which a streaming-produced frame legitimately
+ * carries, and ZSTD_CONTENTSIZE_ERROR, which is the header itself being
+ * malformed. A caller that wants the first case decoded must say how large a
+ * buffer it is willing to own, which is what the size argument below is for.
+ *
+ * kZstdOracleMaxOutput is this wrapper's bound and not zstd's, for the same
+ * reason kSnappyOracleMaxOutput is: a mutated frame will declare a content
+ * size no corpus here produces, and the harness refuses to allocate on it. */
+const size_t kZstdOracleMaxOutput = 256u * 1024u * 1024u;
+bool ZstdOracleDecodes(const std::vector<unsigned char>& stream,
+                       std::vector<unsigned char>* decoded);
+
+/* The declared-size surface on its own, for the tests that are about the
+ * frame header rather than about the payload. Returns false when zstd calls
+ * the header malformed; sets *unknown when the frame declares no content
+ * size, which is a valid frame and not a rejection. */
+bool ZstdOracleContentSize(const std::vector<unsigned char>& stream,
+                           uint64_t* size, bool* unknown);
+
+/* zstd's own error CLASS for a stream it refuses, so a fail-closed matrix row
+ * can name the rejection reason instead of settling for a bare non-zero.
+ * Returns 0 when zstd's decode succeeded. The values are ZSTD_ErrorCode from
+ * zstd_errors.h, kept as an int here so no test translation unit needs the
+ * oracle header - the include paths are PRIVATE to the fixtures archive by
+ * design.
+ *
+ * MEASURED, and it bounds what a matrix row may claim: on zstd 1.5.7's simple
+ * API the code alone does NOT separate the refusal shapes. An unrecognised
+ * prefix, a pre-v0.8 legacy magic with the legacy decoders compiled out, and a
+ * valid frame with its last four bytes removed all come back
+ * ZSTD_error_srcSize_wrong (72). What separates them is the pair of this value
+ * and the content-size verdict above: the truncated frame's header still
+ * parses and yields its real size, the other two do not parse at all.
+ * tests/zstd_oracle_smoke.cpp pins all three. */
+int ZstdOracleErrorCode(const std::vector<unsigned char>& stream);
+
+/* Returned when this wrapper refused before zstd was reached. Negative, so it
+ * cannot collide with a ZSTD_ErrorCode, which is an unsigned enumeration. */
+const int kZstdOracleNotAFrame = -1;
+
 #endif /* CUDEC_TESTS_FIXTURES_H */

--- a/tests/zstd_oracle_smoke.cpp
+++ b/tests/zstd_oracle_smoke.cpp
@@ -1,0 +1,165 @@
+/* The pinned zstd oracle, proving itself (issue #181). A pin that downloads
+ * and links is not yet an oracle: what makes it one is that its decode entry
+ * points agree with its own compressor on real bytes, and that the two flavours
+ * the tree builds from the pinned tree are the flavours it thinks they are.
+ *
+ * This test links zstd_full, the compressor-carrying archive, and nothing
+ * else - not cudec_test_fixtures. The two zstd archives must never meet in one
+ * link, because every decode symbol is in both; the fixtures archive holds the
+ * decode-only one, so a test needing a compressor has to stand alone. Stated
+ * in tests/CMakeLists.txt beside the targets and repeated here because this is
+ * the file where the rule is felt. */
+#include "require.h"
+
+#include <zstd.h>
+#include <zstd_errors.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* Compressible without being trivially so: a run of zeros round-trips through
+ * any decoder that only reads its own header correctly. */
+Bytes TextLike(size_t size) {
+    static const char* const kWords[] = {"the",   "quick", "brown", "fox",
+                                         "warp",  "lane",  "chunk", "frame",
+                                         "block", "zstd"};
+    Bytes out;
+    out.reserve(size + 16);
+    uint64_t s = 0x9e3779b97f4a7c15ull;
+    while (out.size() < size) {
+        s = s * 6364136223846793005ull + 1442695040888963407ull;
+        const char* word = kWords[(s >> 33) % 10];
+        out.insert(out.end(), word, word + std::strlen(word));
+        out.push_back(' ');
+    }
+    out.resize(size);
+    return out;
+}
+
+/* Aborts rather than REQUIREs, for the reason Lz4CompressBlock and
+ * SnappyCompressBlock do: producing the input is infrastructure, not the
+ * thing under test, and a compressor that failed here would leave every
+ * assertion below testing nothing. */
+Bytes Compress(const Bytes& original, int level) {
+    Bytes frame(ZSTD_compressBound(original.size()));
+    const size_t written = ZSTD_compress(frame.data(), frame.size(),
+                                         original.data(), original.size(),
+                                         level);
+    if (ZSTD_isError(written) || written == 0) {
+        std::abort();
+    }
+    frame.resize(written);
+    return frame;
+}
+
+}  // namespace
+
+int main() {
+    /* The version the harness linked, not the version somebody meant to pin.
+     * A FetchContent pin that silently resolved to a system copy would show
+     * up here and nowhere else in this file. */
+    REQUIRE(ZSTD_versionNumber() == 10507);
+    REQUIRE(std::string(ZSTD_versionString()) == "1.5.7");
+
+    size_t frames = 0;
+    for (const size_t n : {size_t{1}, size_t{2}, size_t{255}, size_t{4096},
+                           size_t{65536}, size_t{200000}}) {
+        const Bytes original = TextLike(n);
+        for (const int level : {1, 9, 19}) {
+            const Bytes frame = Compress(original, level);
+
+            /* The declared-size surface, which is the half the M5 ladder reads
+             * before it sizes anything: ZSTD_compress writes the content size
+             * into the frame header, so it must be there and it must be the
+             * size the payload actually produces. */
+            const unsigned long long declared =
+                ZSTD_getFrameContentSize(frame.data(), frame.size());
+            REQUIRE(declared != ZSTD_CONTENTSIZE_ERROR);
+            REQUIRE(declared != ZSTD_CONTENTSIZE_UNKNOWN);
+            REQUIRE_CTX(declared == n, "level %d, %zu bytes", level, n);
+
+            Bytes decoded(static_cast<size_t>(declared), 0);
+            const size_t produced = ZSTD_decompress(
+                decoded.data(), decoded.size(), frame.data(), frame.size());
+            REQUIRE(!ZSTD_isError(produced));
+            REQUIRE(produced == n);
+            REQUIRE(std::memcmp(decoded.data(), original.data(), n) == 0);
+            frames++;
+        }
+    }
+
+    /* And the refusing direction, because an oracle that accepts everything
+     * would pass every check above.
+     *
+     * What the three cases below pin is not what was expected of them, and
+     * the difference is the point. The error CLASS was going to be the thing
+     * the M5 fail-closed matrix read per rejection shape - but on the simple
+     * API all three come back ZSTD_error_srcSize_wrong, measured here rather
+     * than assumed. So the discriminating verdict is the PAIR: the error code
+     * says a frame was refused, and ZSTD_getFrameContentSize says whether the
+     * header parsed at all. A matrix row that named a class per shape would
+     * have been writing down something zstd does not report on this surface.
+     *
+     * ZSTD_STRIP_ERROR_STRINGS removes the messages, so this enum and that
+     * pair are the whole account of why a frame was refused. */
+    const int kSrcSizeWrong = static_cast<int>(ZSTD_error_srcSize_wrong);
+    {
+        /* An unrecognised prefix: no frame header at all. */
+        const Bytes garbage = {0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33};
+        Bytes out(64, 0);
+        const size_t produced = ZSTD_decompress(out.data(), out.size(),
+                                                garbage.data(),
+                                                garbage.size());
+        REQUIRE(ZSTD_isError(produced));
+        REQUIRE(static_cast<int>(ZSTD_getErrorCode(produced)) == kSrcSizeWrong);
+        REQUIRE(ZSTD_getFrameContentSize(garbage.data(), garbage.size()) ==
+                ZSTD_CONTENTSIZE_ERROR);
+    }
+    {
+        /* The legacy decoders are compiled out (ZSTD_LEGACY_SUPPORT=0), so a
+         * pre-v0.8 magic number is refused rather than decoded. Asserted
+         * because an oracle that accepts more than the thing under test would
+         * report a divergence that is not one. */
+        const Bytes legacy = {0x25, 0xb5, 0x2a, 0xfd, 0x00, 0x00, 0x00, 0x00};
+        Bytes out(64, 0);
+        const size_t produced = ZSTD_decompress(out.data(), out.size(),
+                                                legacy.data(), legacy.size());
+        REQUIRE(ZSTD_isError(produced));
+        REQUIRE(static_cast<int>(ZSTD_getErrorCode(produced)) == kSrcSizeWrong);
+        REQUIRE(ZSTD_getFrameContentSize(legacy.data(), legacy.size()) ==
+                ZSTD_CONTENTSIZE_ERROR);
+    }
+    {
+        /* A real frame with its tail removed: the header is fine and the
+         * blocks are not. Same error code as both cases above, and the
+         * content-size call is what tells it apart from them - which is the
+         * whole reason this case sits beside them rather than instead of
+         * them. */
+        const Bytes original = TextLike(4096);
+        Bytes frame = Compress(original, 3);
+        REQUIRE(frame.size() > 8);
+        frame.resize(frame.size() - 4);
+        Bytes out(4096, 0);
+        const size_t produced =
+            ZSTD_decompress(out.data(), out.size(), frame.data(), frame.size());
+        REQUIRE(ZSTD_isError(produced));
+        REQUIRE(static_cast<int>(ZSTD_getErrorCode(produced)) == kSrcSizeWrong);
+        REQUIRE(ZSTD_getFrameContentSize(frame.data(), frame.size()) == 4096);
+    }
+
+    std::printf("PASS: zstd %s pinned and linked; %zu frames round-tripped "
+                "with the declared content size agreeing on every one; "
+                "unknown prefix, legacy magic and truncated tail all refused, "
+                "all three as srcSize_wrong, told apart by the content-size "
+                "verdict\n",
+                ZSTD_versionString(), frames);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #181.

The M5 oracle. libzstd 1.5.7 is pinned by the SHA-256 of mine-uploaded release asset, builds in the container as a decode-only archive beside a full one for corpus generation, and proves itself with a smoke test rather than only linking.

## Type of change

- [x] Build / CI / supply chain
- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)

## The pin, and how it was established

Run at pin time, 2026-08-06:

    curl -sSL -o zstd-1.5.7.tar.gz \
      https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz
    sha256sum zstd-1.5.7.tar.gz
    eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3  zstd-1.5.7.tar.gz

    curl -sSL https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz.sha256
    eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3  zstd-1.5.7.tar.gz

    curl -sSL https://raw.githubusercontent.com/conan-io/conan-center-index/master/recipes/zstd/all/conandata.yml
    "1.5.7":
      url: "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz"
      sha256: "eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3"

Self-computed, agreeing with the published `.sha256` asset and with one second packaging ecosystem, which is what the policy in `docs/MASTERPLAN.md` section 5 asks for. 2434947 bytes. It is an uploaded asset, not the auto-generated `/archive/` tarball, so it is the shape the policy prefers rather than the fallback snappy needed.

A detached `.sig` IS published:

    curl -s -o /dev/null -w '%{http_code}\n' -L \
      https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz.sig
    200

**It was deliberately not verified.** The only route to the signing key from this machine is the same host that serves the artifact and the signature, which makes that check circular rather than independent; the three hashes above come from two different parties, which is the property actually wanted. Written into the CMake comment as well as here, so a later reader cannot mistake this pin for signature-verified.

## Licence

zstd is dual-licensed **BSD-2-Clause OR GPL-2.0** (`LICENSE` and `COPYING` in the tarball). This tree **elects BSD-2-Clause**, and the election is recorded in `tests/CMakeLists.txt` beside the pin rather than only here, because it is a fact about the repository.

cudec neither vendors nor redistributes these sources: the tarball is fetched at build time into the build tree, and no cudec artifact contains it. BSD-2-Clause's notice obligation therefore attaches to nothing shipped today. It attaches the moment a binary linking it is distributed, which this tree does not do and would have to decide to start. Said that way rather than as "no obligation".

## Amalgamated or explicit, and why explicit

Both were available. The explicit ten-translation-unit list wins on the tree's own means test:

- the amalgamation is produced by running `build/single_file_libs/combine.py` at configure time, which puts a **Python runtime on the critical path of every configure** in CI and in the container - a language this tree does not otherwise carry;
- it hands the compiler a generated file no reviewer reads, where the list is ten names in a diff and an eleventh appearing is a reviewable event;
- a missing source is a hard error naming the file, so a moved upstream layout reds the configure instead of quietly shrinking the oracle.

The names are `zstddeclib-in.c`'s own set plus `common/xxhash.c`: a zstd frame may carry an XXH64 content checksum, so the decoder reaches it. That was not assumed - the link is what said so.

Flags: `ZSTD_LEGACY_SUPPORT=0` (an oracle that accepts more than the thing under test would report a divergence that is not one), `ZSTD_DISABLE_ASM=1`, `ZSTD_STRIP_ERROR_STRINGS` (the harness reads `ZSTD_getErrorCode`, an enum, never a message). SYSTEM include, none of the project's strict flags, `-O2` unconditionally - the rule `lz4_oracle` and `snappy_oracle` both follow.

## Two targets that must never meet

`zstd_full` builds the compressor as well, from the same populated tree, because an M5 corpus of level-swept, forced-mode frames cannot be written by hand. Every decode symbol is in both archives, so a binary reaching for both would be refused by the linker - correctly. `cudec_test_fixtures` links the decode-only one; the smoke test links the full one and deliberately does not link the fixtures archive. Stated in a comment at both ends.

## What the smoke test found

It was written to assert an error CLASS per rejection shape, on the assumption the M5 fail-closed matrix could read one. **Measured, it cannot.** On zstd 1.5.7's simple API these three all come back `ZSTD_error_srcSize_wrong` (72):

- an unrecognised prefix,
- a pre-v0.8 legacy magic number with the legacy decoders compiled out,
- a valid frame with its last four bytes removed.

What separates them is the PAIR of that code and `ZSTD_getFrameContentSize`: the truncated frame's header still parses and yields its real size (4096), the other two return `ZSTD_CONTENTSIZE_ERROR`. All three cases are pinned in the test with that pairing, and the bound is written into `tests/fixtures.h` so a later matrix row cannot claim a per-shape class the reference does not report.

Probed before it was written down:

    garbage:   isError=1 code=72
    legacy:    isError=1 code=72
    truncated: isError=1 code=72
    codes: prefix_unknown=10 srcSize_wrong=72 corruption=20 dstSize_tooSmall=70

`ZstdOracleErrorCode` synthesizes no code as a result. Every value it returns above zero came out of `ZSTD_getErrorCode`; zero means zstd's own decode succeeded; the single negative value means the wrapper refused before zstd was reached, and it is negative so it cannot be mistaken for a `ZSTD_ErrorCode`.

## Engineering checklist

- [x] Fail-closed preserved: no cudec decode path is touched. This change adds a test-only dependency, two test-only archives, three harness wrappers and one test.
- [x] Oracle coverage: this IS the oracle. The existing lz4 and snappy oracle diffs are unchanged and still green.
- [x] Determinism preserved: nothing in the library changes.
- [x] The oracle headers stay PRIVATE to the fixtures archive, so `#include <zstd.h>` in a `.cu` test is still a compile error, as it is for `<lz4.h>` and `<snappy.h>`.
- [ ] An adversarial review was NOT run on this change, and there was no second reader for it. The evidence below stands in its place and is less than a review rather than equal to one.
- [ ] Review record: none, for the same reason. CONFIRMED 0 / PLAUSIBLE 0 as raised, because nothing was raised by anybody.

## Not done, stated plainly

`zstd_oracle_smoke` is registered with ctest and runs in the `-LE gpu` selection, but it is **not** named in the per-test identity greps in `.github/workflows/ci.yml`. Those greps are what make a test silently losing its registration red the gate; this one does not have that protection yet, so its disappearance would shrink the selection unnoticed. The workflow file is not touched by this change.

## Verification

Run in the pinned container `nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8` with cmake from the Ubuntu archive. The runner has no GPU; no device code is touched and no gpu-labeled result is claimed.

    cmake -B build && cmake --build build
    host-only build: OK

    cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
    cuda build: OK

    ctest --test-dir build-cuda -LE gpu --no-tests=error --output-on-failure
    100% tests passed, 0 tests failed out of 15

    ./build-cuda/tests/zstd_oracle_smoke
    PASS: zstd 1.5.7 pinned and linked; 18 frames round-tripped with the declared
    content size agreeing on every one; unknown prefix, legacy magic and truncated
    tail all refused, all three as srcSize_wrong, told apart by the content-size
    verdict

    cmake -B /tmp/san -S /w -DCUDEC_ENABLE_CUDA=ON -DCUDEC_SANITIZE=address,undefined
    cmake --build /tmp/san -j && ctest --test-dir /tmp/san --no-tests=error
    100% tests passed, 0 tests failed out of 12

The host test count moves from 14 to 15, which is the new test and nothing else.

- [x] Prettier: no `.md`, `.yml` or `.yaml` file is touched.
- [x] Docs synced: nothing to add. The manual-bump policy already covers this pin without naming it - `docs/MASTERPLAN.md` section 5 reads "FetchContent pins are invisible to Dependabot - oracle bumps are deliberate manual PRs owned by the supply-chain sweep." Restating it per oracle is the drift this repository has a name for.
