### PR TITLE
Add the Zstd backward bitstream reader as a host-twinnable unit [#215]

### DIFF
--- a/src/zstd_bitstream.h
+++ b/src/zstd_bitstream.h
@@ -1,0 +1,229 @@
+/* The Zstd backward bitstream reader - the one bit source every serial core
+ * in M5 runs over: the FSE table-description decode, the three-state sequence
+ * loop, and each of the four literal streams. Single-sourced for host and
+ * device, the sibling of src/lz4_block.h and src/snappy_block.h. Internal
+ * header, not part of the ABI.
+ *
+ * A Zstd bitstream is written FORWARD by the encoder and read BACKWARD by the
+ * decoder. The decoder starts at the last byte of the stream, which carries a
+ * start marker: that byte must be non-zero, its highest set bit is the marker
+ * and is consumed, and every bit below it is live data. Decoding then walks
+ * down through the remaining bytes, each contributing its eight bits from bit
+ * 7 to bit 0. RFC 8878 section 4.2.1.1 states the rule and the reference
+ * implements it in lib/common/bitstream.h, BIT_initDStream: `lastByte == 0`
+ * is an error there, not a value to clamp.
+ *
+ * The fail-open this unit exists to prevent is READING ZEROS PAST THE START.
+ * A reader that runs out of bits and returns zeros hands its caller a symbol
+ * that was never in the stream, and every ladder above it then validates a
+ * value the attacker chose by truncating. So exhaustion is sticky and
+ * observable: the first read that cannot be satisfied refuses, and every read
+ * after it refuses too, without the caller having to remember.
+ *
+ * SHAPE, stated because the alternative is the obvious one. Bits are located
+ * by a closed-form position rather than by a refilled 64-bit container. The
+ * container is a performance shape and it belongs with the kernel that needs
+ * it; what this unit owes is a contract - which value, and which reject -
+ * that a faster reader can be twin-tested against. A closed form has no
+ * refill boundary, which is where an off-by-one in a backward walk hides.
+ *
+ * Widths: a stream is bounded by the block it sits in, so a bit index fits in
+ * 64 bits with room to spare. The size is a uint64_t because the caller's is,
+ * and mixing widths in a bound comparison is where an overflow would hide. */
+#ifndef CUDEC_ZSTD_BITSTREAM_H
+#define CUDEC_ZSTD_BITSTREAM_H
+
+#include "cudec.h"
+
+#include <stdint.h>
+
+/* Guarded: src/lz4_block.h and src/snappy_block.h define the same macro for
+ * the same reason, and a device translation unit that decodes more than one
+ * format includes more than one header. The definitions are identical, so an
+ * unguarded second one is legal rather than an error - which is exactly why
+ * it would go unnoticed if they ever stopped being identical. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+constexpr unsigned kZstdBitsPerByte = 8;
+
+/* The widest single read this reader accepts. The reference's own limit is
+ * the same shape and for the same reason: a value assembled in a 64-bit
+ * accumulator leaves room for a partial byte at each end, so the usable width
+ * stops short of the accumulator's. Nothing in the Zstd format needs more -
+ * the widest field is an FSE accuracy-log-bounded state at 9 bits and an
+ * offset code's extra bits at 31. */
+constexpr unsigned kZstdBitReadMax = 57;
+
+/* The reject ladder, enumerated once, in the shape src/snappy_block.h uses:
+ * every refusal returns through one choke point naming its rung, so the twin
+ * can require a negative per rung instead of counting statuses that repeat. */
+enum ZstdBitReject {
+    kZstdBitRejectNone = 0,
+    kZstdBitRejectEmptyStream,
+    kZstdBitRejectNoStartMarker,
+    kZstdBitRejectNotStarted,
+    kZstdBitRejectReadTooWide,
+    kZstdBitRejectPastStart,
+    kZstdBitRejectAlreadyOverrun,
+    kZstdBitRejectCount
+};
+
+CUDEC_HOST_DEVICE inline cudec_status ZstdBitRefuse(ZstdBitReject rung,
+                                                    cudec_status status,
+                                                    ZstdBitReject* out) {
+    if (out != 0) {
+        *out = rung;
+    }
+    return status;
+}
+
+/* Position of the highest set bit, 0-indexed from bit 0. Only ever called on
+ * a non-zero byte - the caller refuses a zero final byte before reaching it -
+ * so there is no "no bits set" answer to define. A counted loop over a
+ * compile-time bound rather than an intrinsic, because this header compiles
+ * for both the host and the device and __clz is not on both. */
+CUDEC_HOST_DEVICE inline unsigned ZstdHighestSetBit(unsigned char byte) {
+    unsigned highest = 0;
+    for (unsigned bit = 0; bit < kZstdBitsPerByte; bit++) {
+        if ((byte >> bit) & 1u) {
+            highest = bit;
+        }
+    }
+    return highest;
+}
+
+struct ZstdBitReader {
+    const unsigned char* src;
+    uint64_t size;
+    /* Live bits: the ones below the start marker in the last byte, plus every
+     * bit of every byte before it. Valid once Start has succeeded. */
+    uint64_t bits_total = 0;
+    uint64_t bits_read = 0;
+    /* Bits of the final byte that sit below the start marker. Kept because
+     * every bit position below is measured from it. */
+    unsigned marker_bits = 0;
+    bool started = false;
+    /* Sticky. Once a read has been refused for want of bits, every later read
+     * is refused too: a caller that misses one return value must not be able
+     * to walk back into a stream that already ended. */
+    bool overrun = false;
+    ZstdBitReject reject = kZstdBitRejectNone;
+
+    /* Reads the start marker and fixes the live-bit count. Idempotent. */
+    CUDEC_HOST_DEVICE cudec_status Start() {
+        if (started) {
+            return CUDEC_OK;
+        }
+        if (size == 0) {
+            return ZstdBitRefuse(kZstdBitRejectEmptyStream,
+                                 CUDEC_ERR_CORRUPT_INPUT, &reject);
+        }
+        const unsigned char last = src[size - 1];
+        if (last == 0) {
+            /* No marker, so where the data starts is undefined. The reference
+             * refuses this rather than assuming a width, and so does this: a
+             * decoder that picked one would be decoding a bit sequence the
+             * encoder never wrote. */
+            return ZstdBitRefuse(kZstdBitRejectNoStartMarker,
+                                 CUDEC_ERR_CORRUPT_INPUT, &reject);
+        }
+        marker_bits = ZstdHighestSetBit(last);
+        /* (size - 1) whole bytes plus the bits below the marker. size >= 1
+         * here, so the subtraction does not underflow, and the multiplication
+         * cannot overflow for any size a block can hold. */
+        bits_total = (size - 1) * kZstdBitsPerByte + marker_bits;
+        bits_read = 0;
+        started = true;
+        return CUDEC_OK;
+    }
+
+    /* Bits not yet consumed. Valid only after Start has succeeded; a caller
+     * asserting exact consumption compares this against zero. */
+    CUDEC_HOST_DEVICE uint64_t BitsRemaining() const {
+        return bits_total - bits_read;
+    }
+
+    CUDEC_HOST_DEVICE bool AtEnd() const { return bits_read == bits_total; }
+
+    /* The value of one live bit, by index in consumption order. Closed form,
+     * no cursor: index 0 is the bit just below the start marker in the final
+     * byte, and the walk moves down through the bytes from there.
+     *
+     * The caller has already proved index < bits_total, which is what makes
+     * every subtraction below non-negative: for index >= marker_bits, the
+     * byte index is size - 2 - (index - marker_bits) / 8, and index <
+     * bits_total = (size - 1) * 8 + marker_bits bounds that quotient by
+     * size - 2. */
+    CUDEC_HOST_DEVICE unsigned BitAt(uint64_t index) const {
+        if (index < marker_bits) {
+            const unsigned shift =
+                static_cast<unsigned>(marker_bits - 1 - index);
+            return (src[size - 1] >> shift) & 1u;
+        }
+        const uint64_t below = index - marker_bits;
+        const uint64_t byte = size - 2 - below / kZstdBitsPerByte;
+        const unsigned shift = static_cast<unsigned>(
+            kZstdBitsPerByte - 1 - below % kZstdBitsPerByte);
+        return (src[byte] >> shift) & 1u;
+    }
+
+    /* Reads `count` bits, most significant first in consumption order, into
+     * *value. A count of zero yields zero and moves no cursor - the callers
+     * that ask for a field of width zero are the FSE and Huffman decoders,
+     * where a zero-width field is a legal encoding rather than a mistake.
+     *
+     * On any refusal *value is set to zero AND a reject status is returned.
+     * Both, deliberately: the zero is so a caller that ignores the status
+     * cannot read stale stack, and the status is so it cannot mistake the
+     * zero for data. */
+    CUDEC_HOST_DEVICE cudec_status ReadBits(unsigned count, uint64_t* value) {
+        *value = 0;
+        if (overrun) {
+            return ZstdBitRefuse(kZstdBitRejectAlreadyOverrun,
+                                 CUDEC_ERR_CORRUPT_INPUT, &reject);
+        }
+        if (!started) {
+            /* Start is not called implicitly here. A reader whose Start
+             * failed must not become usable by calling ReadBits, and a
+             * caller that never called it has a bug this reports rather
+             * than papers over. */
+            return ZstdBitRefuse(kZstdBitRejectNotStarted,
+                                 CUDEC_ERR_CORRUPT_INPUT, &reject);
+        }
+        if (count > kZstdBitReadMax) {
+            return ZstdBitRefuse(kZstdBitRejectReadTooWide,
+                                 CUDEC_ERR_CORRUPT_INPUT, &reject);
+        }
+        if (count == 0) {
+            return CUDEC_OK;
+        }
+        if (count > BitsRemaining()) {
+            /* The fail-open this unit exists to prevent. Sticky from here. */
+            overrun = true;
+            return ZstdBitRefuse(kZstdBitRejectPastStart,
+                                 CUDEC_ERR_CORRUPT_INPUT, &reject);
+        }
+        uint64_t accumulated = 0;
+        /* Counted, with a compile-time bound: count <= kZstdBitReadMax was
+         * checked above, so this loop's trip count is not stream-derived and
+         * no lane can be held here by a hostile stream. */
+        for (unsigned i = 0; i < count; i++) {
+            accumulated = (accumulated << 1) | BitAt(bits_read + i);
+        }
+        bits_read += count;
+        *value = accumulated;
+        return CUDEC_OK;
+    }
+};
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_ZSTD_BITSTREAM_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -369,6 +369,13 @@ endif()
 # reaching for both would be refused by the linker. Host-side and GPU-less;
 # nothing here is about cudec's own Zstd path, which does not exist yet.
 cudec_add_test(zstd_oracle_smoke SOURCES zstd_oracle_smoke.cpp LIBS zstd_full)
+# The Zstd backward bitstream reader, executed on the host before any FSE or
+# Huffman code exists to run over it (issue #215). Every serial core in M5
+# reads through this one unit, so it is proven alone: hand-written bit strings
+# for expectations, one negative per reject rung. No oracle and no device.
+cudec_add_test(zstd_bitstream_twin SOURCES zstd_bitstream_twin.cpp)
+target_include_directories(zstd_bitstream_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/zstd_bitstream_twin.cpp
+++ b/tests/zstd_bitstream_twin.cpp
@@ -1,0 +1,330 @@
+/* The CPU twin of the Zstd backward bitstream reader (src/zstd_bitstream.h),
+ * the sibling of tests/parser_twin.cpp and tests/snappy_parser_twin.cpp: the
+ * single-source unit executed on the host, on the GPU-less CI runner, before
+ * any FSE or Huffman code exists to run over it.
+ *
+ * WHAT THE EXPECTATIONS ARE, because this is the whole weight of the test.
+ * Every vector below carries a hand-written bit string: the bits the reader
+ * must hand back, in the order it must hand them back, spelled out one
+ * character each. They are NOT computed from the reader's own formula, which
+ * would only prove the formula equals itself. A reviewer checks a vector by
+ * reading the two bytes and the string beside them.
+ *
+ * NOT DONE, and stated rather than left to be noticed: the vectors are not
+ * cross-checked against libzstd's own BIT_initDStream / BIT_readBits. That
+ * half of the proof belongs with the M5 oracle and is not reachable from this
+ * change. What stands here is arithmetic a person can check, which is less
+ * than a second implementation agreeing. */
+#include "require.h"
+#include "zstd_bitstream.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* Which reject rungs a declared negative reached. Same discipline as the
+ * Snappy twin: the enumeration lives once, in the header, and main() requires
+ * every rung to have been named by a negative written to reach it. A rung
+ * added to the reader with no negative behind it reds this test. */
+bool g_reject_covered[cudec_detail::kZstdBitRejectCount] = {false};
+
+void CoverRung(cudec_detail::ZstdBitReject rung) {
+    if (rung != cudec_detail::kZstdBitRejectNone) {
+        g_reject_covered[rung] = true;
+    }
+}
+
+/* A stream and the bits it must yield, in consumption order.
+ *
+ * The final byte carries the start marker: its highest set bit is consumed as
+ * the marker and every bit below it is live data, so the padding is the
+ * marker plus the zeros above it. The eight vectors below walk that padding
+ * from 1 bit wide to 8 bits wide, which is every legal width there is.
+ *
+ * Both bytes are written out in binary beside each vector so the expected
+ * string can be checked without decoding hex. */
+struct Vector {
+    const char* name;
+    Bytes stream;
+    const char* bits;
+};
+
+std::vector<Vector> MakeVectors() {
+    std::vector<Vector> out;
+    /* stream[0] = 0xA5 = 1010 0101 in every vector: eight live bits, read
+     * from bit 7 down to bit 0, after the final byte is exhausted. */
+
+    /* final 0xD5 = 1101 0101, marker at bit 7, padding 1 bit wide.
+     * live from the final byte: bits 6..0 = 101 0101 */
+    out.push_back({"padding-1", {0xA5, 0xD5}, "1010101" "10100101"});
+    /* final 0x55 = 0101 0101, marker at bit 6, padding 2 bits wide.
+     * live: bits 5..0 = 01 0101 */
+    out.push_back({"padding-2", {0xA5, 0x55}, "010101" "10100101"});
+    /* final 0x2A = 0010 1010, marker at bit 5, padding 3 bits wide.
+     * live: bits 4..0 = 0 1010 */
+    out.push_back({"padding-3", {0xA5, 0x2A}, "01010" "10100101"});
+    /* final 0x15 = 0001 0101, marker at bit 4, padding 4 bits wide.
+     * live: bits 3..0 = 0101 */
+    out.push_back({"padding-4", {0xA5, 0x15}, "0101" "10100101"});
+    /* final 0x0A = 0000 1010, marker at bit 3, padding 5 bits wide.
+     * live: bits 2..0 = 010 */
+    out.push_back({"padding-5", {0xA5, 0x0A}, "010" "10100101"});
+    /* final 0x05 = 0000 0101, marker at bit 2, padding 6 bits wide.
+     * live: bits 1..0 = 01 */
+    out.push_back({"padding-6", {0xA5, 0x05}, "01" "10100101"});
+    /* final 0x02 = 0000 0010, marker at bit 1, padding 7 bits wide.
+     * live: bit 0 = 0 */
+    out.push_back({"padding-7", {0xA5, 0x02}, "0" "10100101"});
+    /* final 0x01 = 0000 0001, marker at bit 0, padding 8 bits wide: the
+     * final byte contributes NOTHING but the marker, which is the degenerate
+     * end of the range and the one a reader that assumed at least one live
+     * bit per byte would get wrong. */
+    out.push_back({"padding-8", {0xA5, 0x01}, "10100101"});
+
+    /* One byte only, so the whole stream is the final byte: 0xB3 =
+     * 1011 0011, marker at bit 7, live bits 6..0 = 011 0011. */
+    out.push_back({"single-byte", {0xB3}, "0110011"});
+    /* One byte whose marker is its only set bit: zero live bits. A legal
+     * stream that carries no data, and the reader must report exactly that
+     * rather than reaching for a byte that is not there. */
+    out.push_back({"single-byte-empty", {0x01}, ""});
+    /* Three bytes, so the walk crosses more than one byte boundary going
+     * backwards. 0x0F = 0000 1111 marker at bit 3, live bits 2..0 = 111;
+     * then 0x00 = 0000 0000 whole; then 0xFF = 1111 1111 whole. The zero
+     * middle byte is deliberate: only the FINAL byte may not be zero. */
+    out.push_back({"three-bytes", {0xFF, 0x00, 0x0F},
+                   "111" "00000000" "11111111"});
+    return out;
+}
+
+uint64_t ValueOf(const std::string& bits) {
+    uint64_t value = 0;
+    for (const char c : bits) {
+        value = (value << 1) | static_cast<uint64_t>(c == '1' ? 1 : 0);
+    }
+    return value;
+}
+
+}  // namespace
+
+int main() {
+    const auto vectors = MakeVectors();
+    size_t bits_checked = 0;
+
+    for (const auto& v : vectors) {
+        const std::string expected = v.bits;
+
+        /* One bit at a time, against the string, character by character. */
+        {
+            cudec_detail::ZstdBitReader reader{v.stream.data(),
+                                               v.stream.size()};
+            REQUIRE_CTX(reader.Start() == CUDEC_OK, "vector %s", v.name);
+            REQUIRE_CTX(reader.BitsRemaining() == expected.size(),
+                        "vector %s: %llu live bits, expected %zu", v.name,
+                        static_cast<unsigned long long>(reader.BitsRemaining()),
+                        expected.size());
+            for (size_t i = 0; i < expected.size(); i++) {
+                uint64_t bit = 0;
+                REQUIRE_CTX(reader.ReadBits(1, &bit) == CUDEC_OK,
+                            "vector %s, bit %zu", v.name, i);
+                REQUIRE_CTX(bit == (expected[i] == '1' ? 1u : 0u),
+                            "vector %s, bit %zu: read %llu", v.name, i,
+                            static_cast<unsigned long long>(bit));
+                bits_checked++;
+            }
+            REQUIRE_CTX(reader.AtEnd(), "vector %s: bits left over", v.name);
+            REQUIRE_CTX(reader.BitsRemaining() == 0, "vector %s", v.name);
+        }
+
+        /* And in wider reads, which is how every caller will actually use it:
+         * the same bits must come back in the same order however they are
+         * grouped. Widths 2, 3, 5 and 7 are coprime with 8, so the groups
+         * straddle byte boundaries at every offset rather than lining up with
+         * them - which is where a backward walk goes wrong if it is going to.
+         */
+        for (const unsigned width : {2u, 3u, 5u, 7u}) {
+            cudec_detail::ZstdBitReader reader{v.stream.data(),
+                                               v.stream.size()};
+            REQUIRE(reader.Start() == CUDEC_OK);
+            size_t at = 0;
+            while (expected.size() - at >= width) {
+                uint64_t value = 0;
+                REQUIRE_CTX(reader.ReadBits(width, &value) == CUDEC_OK,
+                            "vector %s, width %u at %zu", v.name, width, at);
+                REQUIRE_CTX(value == ValueOf(expected.substr(at, width)),
+                            "vector %s, width %u at %zu: read %llu", v.name,
+                            width, at,
+                            static_cast<unsigned long long>(value));
+                at += width;
+            }
+            REQUIRE_CTX(reader.BitsRemaining() == expected.size() - at,
+                        "vector %s, width %u", v.name, width);
+        }
+
+        /* A zero-width read yields zero and moves nothing - the FSE and
+         * Huffman decoders ask for zero-width fields as a matter of course,
+         * and a reader that consumed a bit for one would desynchronise the
+         * whole stream silently. */
+        {
+            cudec_detail::ZstdBitReader reader{v.stream.data(),
+                                               v.stream.size()};
+            REQUIRE(reader.Start() == CUDEC_OK);
+            const uint64_t before = reader.BitsRemaining();
+            uint64_t value = 0xFFu;
+            REQUIRE(reader.ReadBits(0, &value) == CUDEC_OK);
+            REQUIRE(value == 0);
+            REQUIRE(reader.BitsRemaining() == before);
+        }
+    }
+
+    /* Start is idempotent: a caller that reaches for the live-bit count
+     * before reading must not consume anything by asking. */
+    {
+        const Bytes stream = {0xA5, 0xD5};
+        cudec_detail::ZstdBitReader reader{stream.data(), stream.size()};
+        REQUIRE(reader.Start() == CUDEC_OK);
+        const uint64_t total = reader.BitsRemaining();
+        REQUIRE(reader.Start() == CUDEC_OK);
+        REQUIRE(reader.BitsRemaining() == total);
+    }
+
+    /* The negatives, one per rung of the ladder in src/zstd_bitstream.h. Each
+     * pins the status AND the rung: the statuses repeat, so a status
+     * comparison alone cannot say which refusal was reached. */
+    {
+        /* Empty stream. */
+        cudec_detail::ZstdBitReader reader{nullptr, 0};
+        REQUIRE(reader.Start() == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(reader.reject == cudec_detail::kZstdBitRejectEmptyStream);
+        CoverRung(reader.reject);
+    }
+    {
+        /* A zero final byte carries no start marker. Not a clamp: the width
+         * of the padding would have to be invented, and an invented width
+         * decodes a bit sequence the encoder never wrote. */
+        const Bytes stream = {0xA5, 0x00};
+        cudec_detail::ZstdBitReader reader{stream.data(), stream.size()};
+        REQUIRE(reader.Start() == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(reader.reject == cudec_detail::kZstdBitRejectNoStartMarker);
+        CoverRung(reader.reject);
+        /* And it stays refused: Start is idempotent on success, never on
+         * failure. */
+        REQUIRE(reader.Start() == CUDEC_ERR_CORRUPT_INPUT);
+    }
+    {
+        /* ReadBits before Start. The reader does not start itself here: a
+         * reader whose Start failed must not become usable by asking it for
+         * bits instead. */
+        const Bytes stream = {0xA5, 0xD5};
+        cudec_detail::ZstdBitReader reader{stream.data(), stream.size()};
+        uint64_t value = 1;
+        REQUIRE(reader.ReadBits(1, &value) == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(reader.reject == cudec_detail::kZstdBitRejectNotStarted);
+        REQUIRE(value == 0);
+        CoverRung(reader.reject);
+    }
+    {
+        /* A read wider than the accumulator's usable width. */
+        const Bytes stream = {0xA5, 0xD5};
+        cudec_detail::ZstdBitReader reader{stream.data(), stream.size()};
+        REQUIRE(reader.Start() == CUDEC_OK);
+        uint64_t value = 1;
+        REQUIRE(reader.ReadBits(cudec_detail::kZstdBitReadMax + 1, &value) ==
+                CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(reader.reject == cudec_detail::kZstdBitRejectReadTooWide);
+        REQUIRE(value == 0);
+        CoverRung(reader.reject);
+        /* The widest legal read is still legal, so the bound is not off by
+         * one - it refuses on 58 and would have to accept 57 if the stream
+         * carried that many, which this one does not. The reject it gives
+         * instead is the exhaustion rung, not the width rung. */
+        cudec_detail::ZstdBitReader wide{stream.data(), stream.size()};
+        REQUIRE(wide.Start() == CUDEC_OK);
+        REQUIRE(wide.ReadBits(cudec_detail::kZstdBitReadMax, &value) ==
+                CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(wide.reject == cudec_detail::kZstdBitRejectPastStart);
+    }
+    {
+        /* Reading past the start of the buffer: the fail-open this unit
+         * exists to prevent. The stream carries 15 live bits; asking for 16
+         * must refuse rather than pad with zeros. */
+        const Bytes stream = {0xA5, 0xD5};
+        cudec_detail::ZstdBitReader reader{stream.data(), stream.size()};
+        REQUIRE(reader.Start() == CUDEC_OK);
+        REQUIRE(reader.BitsRemaining() == 15);
+        uint64_t value = 1;
+        REQUIRE(reader.ReadBits(16, &value) == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(reader.reject == cudec_detail::kZstdBitRejectPastStart);
+        REQUIRE(value == 0);
+        REQUIRE(reader.overrun);
+        CoverRung(reader.reject);
+
+        /* Sticky. The next read is refused for having overrun already, even
+         * though one bit would otherwise have been available - a caller that
+         * missed the first return value must not be able to walk back into a
+         * stream that already ended. */
+        REQUIRE(reader.ReadBits(1, &value) == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(reader.reject == cudec_detail::kZstdBitRejectAlreadyOverrun);
+        REQUIRE(value == 0);
+        CoverRung(reader.reject);
+    }
+    {
+        /* Exhaustion at exactly the boundary is NOT an overrun: consuming the
+         * last bit leaves the reader at end, and only the read after it
+         * refuses. The off-by-one in the other direction would refuse a
+         * legal final symbol. */
+        const Bytes stream = {0xA5, 0x01}; /* eight live bits */
+        cudec_detail::ZstdBitReader reader{stream.data(), stream.size()};
+        REQUIRE(reader.Start() == CUDEC_OK);
+        uint64_t value = 0;
+        REQUIRE(reader.ReadBits(8, &value) == CUDEC_OK);
+        REQUIRE(value == 0xA5u);
+        REQUIRE(reader.AtEnd());
+        REQUIRE(!reader.overrun);
+        REQUIRE(reader.ReadBits(1, &value) == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(reader.reject == cudec_detail::kZstdBitRejectPastStart);
+    }
+    {
+        /* Exact consumption as the callers will assert it: a stream left
+         * unconsumed reports bits remaining, which is the predicate the FSE
+         * and literal decoders end on. */
+        const Bytes stream = {0xA5, 0xD5};
+        cudec_detail::ZstdBitReader reader{stream.data(), stream.size()};
+        REQUIRE(reader.Start() == CUDEC_OK);
+        uint64_t value = 0;
+        REQUIRE(reader.ReadBits(7, &value) == CUDEC_OK);
+        REQUIRE(!reader.AtEnd());
+        REQUIRE(reader.BitsRemaining() == 8);
+    }
+
+    /* Every rung named by a negative written to reach it, walked rather than
+     * restated: a rung added to the reader with none behind it lands here as
+     * a hole with its number on it. */
+    {
+        size_t rungs_covered = 0;
+        for (int rung = cudec_detail::kZstdBitRejectNone + 1;
+             rung < cudec_detail::kZstdBitRejectCount; rung++) {
+            REQUIRE_CTX(g_reject_covered[rung],
+                        "reject rung %d has no declared negative that reaches "
+                        "it - add one, or the rung is untested",
+                        rung);
+            rungs_covered++;
+        }
+        REQUIRE(rungs_covered ==
+                static_cast<size_t>(cudec_detail::kZstdBitRejectCount) - 1);
+    }
+
+    std::printf("PASS: %zu vectors over every legal padding width, %zu bits "
+                "checked one at a time against hand-written expectations and "
+                "again at widths 2/3/5/7; %d of %d reject rungs covered by a "
+                "declared negative\n",
+                vectors.size(), bits_checked,
+                static_cast<int>(cudec_detail::kZstdBitRejectCount) - 1,
+                static_cast<int>(cudec_detail::kZstdBitRejectCount) - 1);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #215.

`src/zstd_bitstream.h` is the first Zstd file under `src/` and the one bit source every serial core in M5 will run over: the FSE table-description decode, the three-state sequence loop, and each of the four literal streams. It lands alone and before any of them, because a defect here is a defect in all of them.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)

## The fail-open it exists to prevent

A Zstd bitstream is written forward by the encoder and read backward by the decoder, starting at the last byte. That byte carries a start marker: it must be non-zero, its highest set bit is the marker and is consumed, and every bit below it is live data. RFC 8878 section 4.2.1.1 states the rule; the reference implements it in `lib/common/bitstream.h`, `BIT_initDStream`, where `lastByte == 0` is an error rather than a value to clamp.

**Reading zeros past the start is the defect.** A backward reader that runs out of bits and pads with zeros hands its caller a symbol the encoder never wrote, and every ladder above it then validates a value an attacker chose by truncating the stream. So:

- exhaustion is **sticky and observable**: the first read that cannot be satisfied refuses, and so does every read after it, without the caller having to remember;
- a zero final byte is **refused rather than clamped**: the padding width would have to be invented, and an invented width decodes a bit sequence that was never written;
- every refusal sets `*value = 0` **as well as** returning a reject status - the zero so a caller that ignores the status cannot read stale stack, the status so it cannot mistake the zero for data.

## The shape, and the one place it departs from the issue

The issue's scope names a refill step. This reader locates bits by a **closed form** instead: index 0 is the bit just below the start marker in the final byte, and the walk moves down through the bytes from there.

The refilled container is a performance shape and it belongs with the kernel that needs one. What this unit owes is a contract - which value, and which reject - that a faster reader can later be twin-tested against. A closed form has no refill boundary, which is exactly where an off-by-one in a backward walk hides. The trade is stated in the header rather than left for a reader to infer.

## What the expectations are

Every vector carries a **hand-written bit string**: the bits the reader must hand back, in order, one character each, with both bytes written out in binary beside it. They are not computed from the reader's own formula, which would prove only that the formula equals itself. A reviewer checks a vector by reading two bytes and the string next to them.

Eleven vectors, covering **every legal padding width from 1 to 8 bits**, including:

- the degenerate width of 8, where the final byte contributes nothing but its marker - the case a reader assuming at least one live bit per byte gets wrong;
- a single-byte stream whose marker is its only set bit, so the stream is legal and carries zero live bits;
- a three-byte stream whose middle byte is zero, because only the FINAL byte may not be zero.

Each vector is read bit by bit against the string, then again at widths 2, 3, 5 and 7 - coprime with 8, so the groups straddle byte boundaries at every offset instead of lining up with them.

## Every reject rung, with one negative naming it

The reader enumerates its rungs once and returns every refusal through one choke point naming its rung, the shape `src/snappy_block.h` took in #173. The twin walks the enumeration and requires a declared negative to have reached each one, so a rung added with none behind it lands as a hole with its number on it.

## The guards, proven by breaking them

    === PROOF A: pad with zeros on underflow instead of refusing ===
    (the exhaustion branch replaced with `return CUDEC_OK;`)
    FAIL /w/tests/zstd_bitstream_twin.cpp:248: wide.ReadBits(cudec_detail::kZstdBitReadMax, &value) == CUDEC_ERR_CORRUPT_INPUT
    0% tests passed, 1 tests failed out of 1

    === PROOF B: clamp a zero final byte instead of refusing ===
    (the no-marker branch replaced with `marker_bits = 0;`)
    FAIL /w/tests/zstd_bitstream_twin.cpp:212: reader.Start() == CUDEC_ERR_CORRUPT_INPUT
    0% tests passed, 1 tests failed out of 1

    === PROOF C: delete a whole declared negative ===
    (the not-started case removed)
    FAIL /w/tests/zstd_bitstream_twin.cpp:300: g_reject_covered[rung] | reject rung 3 has no declared negative that reaches it - add one, or the rung is untested
    0% tests passed, 1 tests failed out of 1

Proof C was run twice. The first attempt deleted only the rung assertion and left the coverage call behind it, and the suite stayed green - correctly, because the negative was still reaching the rung. Deleting the case is what deletes the negative, and that is what reds. Recorded because the weaker mutation looked like a proof and was not one.

## Engineering checklist

- [x] Fail-closed preserved: this unit is a new fail-closed surface and every one of its reject branches has a negative. No existing decode path is touched.
- [x] Oracle coverage: see "Not done" below - this half is not oracle-checked.
- [x] Determinism preserved: no floating point, no atomics, no warp collectives; the structural scan over `src/` passes with the new header in it.
- [x] `CUDEC_HOST_DEVICE` on every function, no allocation, no libc, so the header compiles `__device__` unchanged when a kernel needs it.
- [ ] An adversarial review was NOT run on this change, and there was no second reader for it. The proofs above stand in its place and are less than a review rather than equal to one.
- [ ] Review record: none, for the same reason. CONFIRMED 0 / PLAUSIBLE 0 as raised, because nothing was raised by anybody.

## Not done, stated plainly

- The vectors are **not** cross-checked against libzstd's own `BIT_initDStream` / `BIT_readBits`. That half of the issue's proof is conditional on the M5 entropy oracle work and is not reachable from this change. What stands here is arithmetic a person can check, which is less than a second implementation agreeing. The test says so at the top of the file, not only here.
- `zstd_bitstream_twin` is registered with ctest and runs in the `-LE gpu` selection, but it is **not** named in the per-test identity greps in `.github/workflows/ci.yml`, so a test silently losing its registration would shrink the selection unnoticed. The workflow file is not touched by this change.

## Verification

Run in the pinned container `nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8` with cmake from the Ubuntu archive. The runner has no GPU; no device code is touched and no gpu-labeled result is claimed.

    cmake -B build && cmake --build build
    host-only build: OK

    cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
    cuda build: OK

    ctest --test-dir build-cuda -LE gpu --no-tests=error
    100% tests passed, 0 tests failed out of 16

    ./build-cuda/tests/zstd_bitstream_twin
    PASS: 11 vectors over every legal padding width, 118 bits checked one at a
    time against hand-written expectations and again at widths 2/3/5/7; 6 of 6
    reject rungs covered by a declared negative

    cmake -B /tmp/san -S /w -DCUDEC_ENABLE_CUDA=ON -DCUDEC_SANITIZE=address,undefined
    cmake --build /tmp/san -j && ctest --test-dir /tmp/san --no-tests=error
    100% tests passed, 0 tests failed out of 13

The host test count moves from 15 to 16 and the sanitized count from 12 to 13, which is the new test and nothing else.

- [x] Prettier: no `.md`, `.yml` or `.yaml` file is touched.
- [x] Docs synced: no behaviour, API or performance change to record.
