### PR TITLE
Refuse CUDEC_ENABLE_HIP without a HIP toolchain or device sources [#209]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,48 @@ jobs:
       - name: Configure and build (host-only)
         run: cmake -B build && cmake --build build
 
+      # The fail-closed half of CUDEC_ENABLE_HIP (issue #209), gated on every
+      # PR without a ROCm runner: this image has no HIP toolchain, so asking
+      # for the HIP engine must refuse rather than quietly hand back the
+      # host-only library. Three legs, because "it exited non-zero" is not the
+      # claim - the claim is that it refused FOR THE REASON IT NAMES, and a
+      # configure that died on an unrelated typo would satisfy a bare exit-code
+      # check while proving nothing. The build directory is separate from
+      # `build` above so a refused configure cannot poison the one the rest of
+      # the job uses.
+      - name: CUDEC_ENABLE_HIP refuses without a HIP toolchain
+        run: |
+          if cmake -B build-hip-negative -DCUDEC_ENABLE_HIP=ON > hip.log 2>&1; then
+            echo "FAIL: configure succeeded with no HIP toolchain present"
+            cat hip.log
+            exit 1
+          fi
+          grep -q "CUDEC_ENABLE_HIP requires a HIP toolchain" hip.log || {
+            echo "FAIL: configure failed, but not on the toolchain refusal"
+            cat hip.log
+            exit 1
+          }
+          cat hip.log
+
+      # The mutual exclusion, same shape: two device backends in one build tree
+      # would give two definitions of the decode symbols and a link whose
+      # winner depends on ordering. It refuses before either language is
+      # enabled, so this leg needs neither toolchain.
+      - name: CUDEC_ENABLE_CUDA and CUDEC_ENABLE_HIP refuse each other
+        run: |
+          if cmake -B build-both-negative -DCUDEC_ENABLE_CUDA=ON \
+               -DCUDEC_ENABLE_HIP=ON > both.log 2>&1; then
+            echo "FAIL: configure accepted both device backends at once"
+            cat both.log
+            exit 1
+          fi
+          grep -q "mutually exclusive" both.log || {
+            echo "FAIL: configure failed, but not on the mutual exclusion"
+            cat both.log
+            exit 1
+          }
+          cat both.log
+
       # The install surface is proven by consuming it, never by inspecting it
       # (issue #79). Install the host-only build into a prefix, then configure,
       # build AND RUN a project outside this tree that knows nothing but

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,46 +67,109 @@ jobs:
         run: cmake -B build && cmake --build build
 
       # The fail-closed half of CUDEC_ENABLE_HIP (issue #209), gated on every
-      # PR without a ROCm runner: this image has no HIP toolchain, so asking
-      # for the HIP engine must refuse rather than quietly hand back the
-      # host-only library. Three legs, because "it exited non-zero" is not the
-      # claim - the claim is that it refused FOR THE REASON IT NAMES, and a
-      # configure that died on an unrelated typo would satisfy a bare exit-code
-      # check while proving nothing. The build directory is separate from
-      # `build` above so a refused configure cannot poison the one the rest of
-      # the job uses.
-      - name: CUDEC_ENABLE_HIP refuses without a HIP toolchain
+      # PR without a ROCm runner. Exiting non-zero is not the claim: the claim
+      # is that each configure refused FOR THE REASON IT NAMES, and a configure
+      # that died on an unrelated typo satisfies a bare exit-code check while
+      # proving nothing. So every leg matches the message text.
+      #
+      # Three legs, and the third is the one that costs something. This image
+      # has no HIP toolchain, so legs 1 and 2 only ever exercise the toolchain
+      # refusal; the SECOND refusal - the one that stops a decoder-less HIP
+      # build on a machine that does have ROCm - would then be gated by
+      # nothing. Leg 3 reaches it by handing the configure a compiler, which is
+      # why the block probes CMAKE_HIP_COMPILER itself instead of using
+      # check_language (that module skips its probe when the variable is
+      # already set, and the refusal would be skipped with it).
+      #
+      # Messages are matched after collapsing whitespace: CMake re-wraps
+      # FATAL_ERROR text to its own width, so a phrase can arrive split across
+      # lines and a plain grep would pass or fail on where the wrap fell.
+      #
+      # Everything is written under the runner temp directory, not the
+      # checkout: a refused configure leaves a build tree behind, and .gitignore
+      # covers the build directories this repo produces on purpose, not these.
+      - name: CUDEC_ENABLE_HIP refuses, and names which half is missing
         run: |
-          if cmake -B build-hip-negative -DCUDEC_ENABLE_HIP=ON > hip.log 2>&1; then
+          flat() { tr -s '[:space:]' ' ' < "$1"; }
+          out="$RUNNER_TEMP/hip-negative"
+          mkdir -p "$out"
+
+          # Leg 1: no toolchain anywhere -> the toolchain refusal.
+          if cmake -B "$out/no-toolchain" -DCUDEC_ENABLE_HIP=ON \
+               > "$out/1.log" 2>&1; then
             echo "FAIL: configure succeeded with no HIP toolchain present"
-            cat hip.log
+            cat "$out/1.log"
             exit 1
           fi
-          grep -q "CUDEC_ENABLE_HIP requires a HIP toolchain" hip.log || {
+          flat "$out/1.log" | grep -q \
+            "CUDEC_ENABLE_HIP requires a HIP toolchain" || {
             echo "FAIL: configure failed, but not on the toolchain refusal"
-            cat hip.log
+            cat "$out/1.log"
             exit 1
           }
-          cat hip.log
+
+          # Leg 2: the refusal must be re-derived, not remembered. A refused
+          # tree may not carry a cached HIP-compiler verdict, or a build
+          # directory configured before ROCm was installed would keep saying
+          # "none was found" without looking again. check_language(HIP) caches
+          # exactly that, which is why the block probes for itself.
+          if grep -q "CMAKE_HIP_COMPILER" "$out/no-toolchain/CMakeCache.txt"; then
+            echo "FAIL: a HIP compiler verdict was cached in a refused tree"
+            grep "CMAKE_HIP_COMPILER" "$out/no-toolchain/CMakeCache.txt"
+            exit 1
+          fi
+          if cmake -B "$out/no-toolchain" -S . > "$out/2.log" 2>&1; then
+            echo "FAIL: re-configure of a refused tree succeeded"
+            cat "$out/2.log"
+            exit 1
+          fi
+          flat "$out/2.log" | grep -q \
+            "CUDEC_ENABLE_HIP requires a HIP toolchain" || {
+            echo "FAIL: the re-configure refused for a different reason"
+            cat "$out/2.log"
+            exit 1
+          }
+
+          # Leg 3: a caller-supplied compiler passes the toolchain arm, so the
+          # device-sources refusal is the one that must fire. /bin/sh is not a
+          # HIP compiler and is not asked to be one - nothing here compiles.
+          if cmake -B "$out/no-sources" -DCUDEC_ENABLE_HIP=ON \
+               -DCMAKE_HIP_COMPILER=/bin/sh > "$out/3.log" 2>&1; then
+            echo "FAIL: configure succeeded with no HIP device sources"
+            cat "$out/3.log"
+            exit 1
+          fi
+          flat "$out/3.log" | grep -q \
+            "cudec carries no HIP device sources yet" || {
+            echo "FAIL: a supplied compiler did not reach the sources refusal"
+            cat "$out/3.log"
+            exit 1
+          }
+
+          cat "$out/1.log" "$out/2.log" "$out/3.log"
 
       # The mutual exclusion, same shape: two device backends in one build tree
       # would give two definitions of the decode symbols and a link whose
       # winner depends on ordering. It refuses before either language is
-      # enabled, so this leg needs neither toolchain.
+      # enabled, so this leg needs neither toolchain. The matched phrase is the
+      # long one rather than "mutually exclusive": the short phrase would also
+      # match a future unrelated refusal and would stop distinguishing.
       - name: CUDEC_ENABLE_CUDA and CUDEC_ENABLE_HIP refuse each other
         run: |
-          if cmake -B build-both-negative -DCUDEC_ENABLE_CUDA=ON \
-               -DCUDEC_ENABLE_HIP=ON > both.log 2>&1; then
+          out="$RUNNER_TEMP/both-negative"
+          if cmake -B "$out" -DCUDEC_ENABLE_CUDA=ON -DCUDEC_ENABLE_HIP=ON \
+               > "$out.log" 2>&1; then
             echo "FAIL: configure accepted both device backends at once"
-            cat both.log
+            cat "$out.log"
             exit 1
           fi
-          grep -q "mutually exclusive" both.log || {
+          tr -s '[:space:]' ' ' < "$out.log" | grep -q \
+            "mutually exclusive: one device backend per build tree" || {
             echo "FAIL: configure failed, but not on the mutual exclusion"
-            cat both.log
+            cat "$out.log"
             exit 1
           }
-          cat both.log
+          cat "$out.log"
 
       # The install surface is proven by consuming it, never by inspecting it
       # (issue #79). Install the host-only build into a prefix, then configure,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ today.
   prefix does require the toolkit on the consuming machine and a project that
   enables C++, both stated in [README.md](README.md).
 
+- **`CUDEC_ENABLE_HIP`, a build option that currently refuses.** It is here so
+  the HIP port has a fail-closed contract to land against, and it fails the
+  configure on every machine: without a HIP toolchain it says so, and with one
+  it says that cudec carries no HIP device sources yet. Neither case falls back
+  to a host-only build, because a build that quietly dropped the device engine
+  and reported success would read exactly like a working port. It is also
+  mutually exclusive with `CUDEC_ENABLE_CUDA` in one build tree.
+
 ### Changed
 
 - **`BUILD_SHARED_LIBS=ON` is refused in a top-level cudec build** rather than

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,23 @@ include(GNUInstallDirs)
 # gate). CI flips this on together with the CUDA toolchain (issue #3).
 option(CUDEC_ENABLE_CUDA "Build the CUDA decode engine and its tests" OFF)
 
+# The HIP engine is opt-in and fail-closed for the same reason and in the same
+# shape (issue #209): asking for it without a HIP toolchain is a hard configure
+# error, never a silent host-only fallback. A ROCm CI job that went green
+# because it quietly built the host-only library would be a gate that proves
+# nothing while reading exactly like one that proves the port compiles.
+option(CUDEC_ENABLE_HIP "Build the HIP decode engine and its tests" OFF)
+
+# One device backend per build tree. Both languages in one tree would give two
+# definitions of the same decode symbols and a link whose winner depends on
+# ordering, so the answer is refusal rather than a documented precedence.
+if(CUDEC_ENABLE_CUDA AND CUDEC_ENABLE_HIP)
+  message(
+    FATAL_ERROR
+      "CUDEC_ENABLE_CUDA and CUDEC_ENABLE_HIP are mutually exclusive: one "
+      "device backend per build tree. Configure two build directories.")
+endif()
+
 # Host-side sanitizer gate (issue #42): opt-in, default OFF. When set (e.g.
 # -DCUDEC_SANITIZE=address,undefined) it instruments the HOST untrusted-input
 # attack surface - the frame parse (src/frame.cpp), the single-sourced block
@@ -240,6 +257,60 @@ if(CUDEC_ENABLE_CUDA)
   # Last, so it sees every directory both subdirectories added: no ctest entry
   # anywhere in the tree may have escaped the timeout check (issue #72).
   cudec_sweep_test_timeouts(${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+# ---- The HIP language path (issue #209).
+#
+# Two refusals, and the order matters: the toolchain first, because that is the
+# one a CI runner without ROCm exercises on every PR, and the device sources
+# second, because that is the one that keeps this option from ever going green
+# on a machine that HAS ROCm while compiling no decoder at all.
+if(CUDEC_ENABLE_HIP)
+  # check_language probes for a HIP compiler without enabling the language, so
+  # the refusal below is this project's message rather than CMake's generic
+  # one, and it names what is missing. enable_language(HIP) would also fail
+  # here, later and less legibly.
+  include(CheckLanguage)
+  check_language(HIP)
+  if(NOT CMAKE_HIP_COMPILER)
+    message(
+      FATAL_ERROR
+        "CUDEC_ENABLE_HIP requires a HIP toolchain (ROCm's hipcc, or a clang "
+        "that accepts --offload-arch) and none was found. This never falls "
+        "back to a host-only build: a configuration that dropped the device "
+        "engine and still succeeded would be a fail-open gate.")
+  endif()
+
+  # gfx90a is wave64 (CDNA2) and gfx1030 is wave32 (RDNA2), so the default
+  # spans both wave widths the kernel family is parameterized over rather than
+  # picking one and leaving the other uncompiled. The CI job owns the real
+  # list; this only has to accept and forward one, so it is overridable from
+  # the command line exactly as CMAKE_CUDA_ARCHITECTURES is.
+  if(NOT DEFINED CMAKE_HIP_ARCHITECTURES)
+    set(CMAKE_HIP_ARCHITECTURES gfx90a gfx1030)
+  endif()
+  enable_language(HIP)
+  # Same reason as the CUDA path: the test net and the bench harness add .cpp
+  # translation units, and a language enabled inside one subdirectory is
+  # invisible to its siblings.
+  enable_language(CXX)
+  enable_testing()
+
+  # The second refusal, and the one this file cannot drop until the port
+  # lands. cudec has no HIP device sources and no vendor shim yet, so
+  # everything above could succeed on a ROCm machine and produce a cudec
+  # containing no decoder - a build that reports success while compiling
+  # nothing is the exact failure the option exists to prevent, and it would
+  # read identically to a working port. When the shim and the
+  # width-parameterized kernels land, this refusal is replaced by the
+  # target_sources and hip::device link that compile them.
+  message(
+    FATAL_ERROR
+      "CUDEC_ENABLE_HIP found a HIP toolchain (${CMAKE_HIP_COMPILER}) but "
+      "cudec carries no HIP device sources yet, so this configuration would "
+      "build a library with no decoder in it and report success. The port "
+      "lands them; until then this option holds the fail-closed contract "
+      "rather than producing a build.")
 endif()
 
 # ---- The install surface (issue #79). A release nobody can install is not a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,10 @@ option(CUDEC_ENABLE_CUDA "Build the CUDA decode engine and its tests" OFF)
 # error, never a silent host-only fallback. A ROCm CI job that went green
 # because it quietly built the host-only library would be a gate that proves
 # nothing while reading exactly like one that proves the port compiles.
-option(CUDEC_ENABLE_HIP "Build the HIP decode engine and its tests" OFF)
+option(
+  CUDEC_ENABLE_HIP
+  "Build the HIP decode engine and its tests (refuses until the port lands)"
+  OFF)
 
 # One device backend per build tree. Both languages in one tree would give two
 # definitions of the same decode symbols and a link whose winner depends on
@@ -261,56 +264,77 @@ endif()
 
 # ---- The HIP language path (issue #209).
 #
-# Two refusals, and the order matters: the toolchain first, because that is the
-# one a CI runner without ROCm exercises on every PR, and the device sources
-# second, because that is the one that keeps this option from ever going green
-# on a machine that HAS ROCm while compiling no decoder at all.
+# Read this before reading the code, because the block is deliberately smaller
+# than it looks like it should be: cudec has NO HIP device sources and no
+# vendor shim yet, so there is no configuration of this option, on any machine,
+# that can produce a HIP build today. The option exists to hold the
+# fail-closed contract while the port is written, and it refuses in two named
+# ways rather than one so that the refusal a reader hits tells them which of
+# the two things is missing.
+#
+# The order is chosen so a runner with no ROCm exercises the toolchain refusal
+# on every PR, and a caller who supplies a compiler reaches the second one -
+# which is what lets the build job gate BOTH arms without a ROCm runner.
+#
+# Nothing between the two refusals: no enable_language, no architecture
+# default, no test registration. Every one of those would be configuration
+# whose result cannot reach a target, and enable_language(HIP) would in
+# addition abort the configure with CMake's own message before the second
+# refusal could name the real reason. They land with the sources they serve.
 if(CUDEC_ENABLE_HIP)
-  # check_language probes for a HIP compiler without enabling the language, so
-  # the refusal below is this project's message rather than CMake's generic
-  # one, and it names what is missing. enable_language(HIP) would also fail
-  # here, later and less legibly.
-  include(CheckLanguage)
-  check_language(HIP)
-  if(NOT CMAKE_HIP_COMPILER)
+  # Deliberately NOT check_language(HIP). That module wraps its probe in
+  # `if(NOT DEFINED CMAKE_HIP_COMPILER)`, so a value from a toolchain file, a
+  # superbuild, a -D on the command line, or this build tree's own cache makes
+  # it a silent no-op and the refusal below would be skipped over a compiler
+  # nothing validated. It also FORCE-caches a negative result, which pins a
+  # build directory to "none was found" even after ROCm is installed. Probing
+  # here keeps both properties out: the probe runs every configure, and it
+  # writes no cache entry of its own.
+  set(_cudec_hip_compiler "")
+  if(CMAKE_HIP_COMPILER)
+    set(_cudec_hip_compiler "${CMAKE_HIP_COMPILER}")
+  else()
+    find_program(
+      _cudec_hip_compiler_probe
+      NAMES hipcc
+      HINTS ENV ROCM_PATH /opt/rocm
+      PATH_SUFFIXES bin
+      NO_CACHE)
+    if(_cudec_hip_compiler_probe)
+      set(_cudec_hip_compiler "${_cudec_hip_compiler_probe}")
+    endif()
+  endif()
+
+  if(NOT _cudec_hip_compiler)
+    # ROCm rather than a specific binary: CMake drives the HIP language with a
+    # clang that it locates from the ROCm installation, and rejects some
+    # drivers passed directly as CMAKE_HIP_COMPILER. Naming the toolkit is
+    # what a reader can act on; naming one executable would send them at a
+    # value CMake may refuse.
     message(
       FATAL_ERROR
-        "CUDEC_ENABLE_HIP requires a HIP toolchain (ROCm's hipcc, or a clang "
-        "that accepts --offload-arch) and none was found. This never falls "
-        "back to a host-only build: a configuration that dropped the device "
-        "engine and still succeeded would be a fail-open gate.")
+        "CUDEC_ENABLE_HIP requires a HIP toolchain (a ROCm installation, or "
+        "CMAKE_HIP_COMPILER pointing at a compiler CMake accepts for the HIP "
+        "language) and none was found. This never falls back to a host-only "
+        "build: a configuration that dropped the device engine and still "
+        "succeeded would be a fail-open gate.")
   endif()
 
-  # gfx90a is wave64 (CDNA2) and gfx1030 is wave32 (RDNA2), so the default
-  # spans both wave widths the kernel family is parameterized over rather than
-  # picking one and leaving the other uncompiled. The CI job owns the real
-  # list; this only has to accept and forward one, so it is overridable from
-  # the command line exactly as CMAKE_CUDA_ARCHITECTURES is.
-  if(NOT DEFINED CMAKE_HIP_ARCHITECTURES)
-    set(CMAKE_HIP_ARCHITECTURES gfx90a gfx1030)
-  endif()
-  enable_language(HIP)
-  # Same reason as the CUDA path: the test net and the bench harness add .cpp
-  # translation units, and a language enabled inside one subdirectory is
-  # invisible to its siblings.
-  enable_language(CXX)
-  enable_testing()
-
-  # The second refusal, and the one this file cannot drop until the port
-  # lands. cudec has no HIP device sources and no vendor shim yet, so
-  # everything above could succeed on a ROCm machine and produce a cudec
-  # containing no decoder - a build that reports success while compiling
-  # nothing is the exact failure the option exists to prevent, and it would
-  # read identically to a working port. When the shim and the
-  # width-parameterized kernels land, this refusal is replaced by the
-  # target_sources and hip::device link that compile them.
+  # The second refusal. It is unconditional on purpose and it is the whole
+  # answer to "what does this option do on a machine that HAS ROCm": it
+  # refuses, because everything it would need to compile is still unwritten.
+  # A configure that succeeded here would hand back a cudec with no decoder in
+  # it and report success, which reads identically to a working port and is
+  # the exact failure this option exists to prevent. The port replaces this
+  # message with the sources, the architecture default and the hip::device
+  # link; until then the message is the contract.
   message(
     FATAL_ERROR
-      "CUDEC_ENABLE_HIP found a HIP toolchain (${CMAKE_HIP_COMPILER}) but "
+      "CUDEC_ENABLE_HIP found a HIP toolchain (${_cudec_hip_compiler}) but "
       "cudec carries no HIP device sources yet, so this configuration would "
       "build a library with no decoder in it and report success. The port "
-      "lands them; until then this option holds the fail-closed contract "
-      "rather than producing a build.")
+      "lands them; until then this option refuses rather than producing a "
+      "build.")
 endif()
 
 # ---- The install surface (issue #79). A release nobody can install is not a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,5 +71,10 @@ and need a CUDA 12.x toolchain plus a GPU for the tests - see the README's
 container command for the maintained path (build directory `build-cuda`,
 `ctest --test-dir build-cuda`).
 
+`-DCUDEC_ENABLE_HIP=ON` exists and currently refuses on every machine: there
+are no HIP device sources yet, so the option fails the configure rather than
+handing back a host-only library that looks like a working port. The two
+options are mutually exclusive in one build tree.
+
 All repo artifacts - code, comments, commits, PRs, issues - are written in
 English.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -477,11 +477,13 @@ rather than a silence.
 this file was taken on one NVIDIA device (RTX 3080, sm_86, CUDA 12.6). The
 maintainer hardware is NVIDIA-only, so no AMD GPU has ever executed this
 decoder for the project, and no AMD measurement exists to record. There is also
-no AMD build: the HIP port is a planned M6 milestone, `CUDEC_ENABLE_HIP` does
-not exist in `CMakeLists.txt` today, and no CI job compiles for a `gfx` target.
-So the honest state is neither measured nor compiled, which is one rung below
-where this section will sit once the HIP compile gate lands (issues #209 and
-#111) and the "compiled" half becomes a thing a workflow run can be pointed at.
+no AMD build. `CUDEC_ENABLE_HIP` now exists in `CMakeLists.txt`, and it refuses
+on every machine: cudec has no HIP device sources yet, so the option holds the
+fail-closed contract rather than producing a build, and no CI job compiles for
+a `gfx` target. So the honest state is still neither measured nor compiled,
+which is one rung below where this section will sit once the port and the HIP
+compile gate land (issue #111) and the "compiled" half becomes a thing a
+workflow run can be pointed at.
 
 **What a community result is, and what it is not.** A third-party measurement
 on hardware the maintainer does not have and cannot re-run. It is recorded as


### PR DESCRIPTION
# What & why

Closes #209.

`-DCUDEC_ENABLE_HIP=ON` now refuses the configure instead of quietly
handing back a host-only library. There are two refusals rather than one,
and which one a reader hits tells them which half is missing.

The issue's constraint asked this PR to say which shape it took: **it is
gated on the port's absence.** cudec carries no HIP device sources and no
vendor shim, so there is no configuration of this option, on any machine,
that can produce a HIP build today. That is stated in the option's own help
string, in `CONTRIBUTING.md`, in the changelog and in the second refusal's
text, so the option never advertises a build it cannot produce. The port
replaces that refusal with the sources, the architecture default and the
device link.

Both backends in one build tree is refused before either language is
enabled: two definitions of the decode symbols and a link whose winner
depends on ordering is not a thing to document a precedence for.

## Type of change

- [x] Build / CI / supply chain
- [x] Docs (the three files the option makes stale or silent)

## Engineering checklist

- [x] Fail-closed preserved. It is the whole subject of the change: no
      parse path, decode path or CUDA call is touched, and the refusals
      exist so a configuration that dropped the device engine cannot report
      success.
- [x] No format path touched, so oracle coverage and determinism are
      unaffected. `git diff --name-only origin/main...HEAD` names no file
      under `src/`, `include/` or `tests/`.
- [x] An adversarial review was run. Five lenses, record below.
- [x] Review record below, with dispositions.

## Review record

Five refute-by-default lenses over the CMake and CI surface, run against
the first shape of this change. **All five returned NEEDS_IMPROVEMENT.**
Counts as raised: **CONFIRMED 12 / PLAUSIBLE 14** across the five, with
heavy overlap; the distinct defects are the ten below.

| Finding | Confidence | Disposition |
| --- | --- | --- |
| `check_language(HIP)` is a no-op when `CMAKE_HIP_COMPILER` is already defined, so the named refusal is bypassed and CMake's generic error is what the user gets | CONFIRMED, with a reproduction | FIX - the block probes for itself |
| `check_language` FORCE-caches `CMAKE_HIP_COMPILER=NOTFOUND`, pinning a build directory to "none was found" after ROCm is installed | CONFIRMED, with a reproduction | FIX - the probe writes no cache entry, and a CI leg asserts none is written |
| The refusal names `hipcc` as the remedy; CMake refuses some drivers passed directly as `CMAKE_HIP_COMPILER` | CONFIRMED | FIX - it names the toolkit |
| Everything between the two refusals is configuration whose result cannot reach a target, and `enable_language(HIP)` preempts the second refusal with CMake's own message | CONFIRMED | FIX - removed; it lands with the sources it serves |
| The second refusal is gated by nothing a runner without ROCm can reach | CONFIRMED | FIX - a third CI leg supplies a compiler and lands on it |
| `docs/BENCHMARKS.md` states that `CUDEC_ENABLE_HIP` does not exist; the option ships in no user-facing file and no changelog entry | CONFIRMED | FIX - all three updated |
| The mutual-exclusion leg greps a generic phrase, and both legs ride on where CMake's line wrap falls | PLAUSIBLE / CONFIRMED | FIX - the long phrase, matched after collapsing whitespace |
| A step comment claims three legs for two assertions | CONFIRMED | FIX - there are three legs now, and the comment says what each is for |
| The install and export surface and the package config learned nothing about a second backend | PLAUSIBLE | DECLINE - there is no second backend to export. A package config claiming a HIP dependency the library does not have would be the fail-open shape this issue exists to prevent. It lands with the port. |
| The option answers the sixth criterion with a third shape it was not offered | PLAUSIBLE | DECLINE - the criterion offers "gated on the shim's presence", and that is what this is. Gating on a filename the shim issue has not chosen would couple this change to a name that does not exist yet, so the gate is a refusal the port removes. Stated in the PR and in the code. |

No lens was replied to; every disposition was taken outside lens context.

## Performance checklist

Not applicable to the hot path. The CI cost is two extra configures on a
job that already runs several; each is a configure only, no compile.

## Quality checklist

- [x] Minimal: after the review the CMake block is a probe and two
      refusals, with nothing between them.
- [x] Comments explain why. The block opens with why it is smaller than it
      looks like it should be.
- [x] The new structural properties are locked by the CI legs, and each leg
      is demonstrated to bite below.

## Verification

Run in the pinned container (`nvidia/cuda:12.6.2-devel-ubuntu24.04`, digest
`738fba0f...`, cmake 3.28.3, no ROCm), at this commit. `M0` is the shipped
tree; `M1` to `M5` delete or reword one guard each and re-run the CI steps'
own logic against the mutant.

```
=== M0: unmodified tree, both steps should PASS
step PASS
hip step exit=0
step PASS
both step exit=0
--- leg 1 refusal:
CMake Error at CMakeLists.txt:314 (message):
  CUDEC_ENABLE_HIP requires a HIP toolchain (a ROCm installation, or
  CMAKE_HIP_COMPILER pointing at a compiler CMake accepts for the HIP
  language) and none was found.  This never falls back to a host-only build:
  a configuration that dropped the device engine and still succeeded would be
  a fail-open gate.
--- leg 2 (re-configure) still refuses on the toolchain: 1
--- leg 3 refusal (compiler supplied, sources missing):
CMake Error at CMakeLists.txt:331 (message):
  CUDEC_ENABLE_HIP found a HIP toolchain (/bin/sh) but cudec carries no HIP
  device sources yet, so this configuration would build a library with no
  decoder in it and report success.  The port lands them; until then this
  option refuses rather than producing a build.

=== M1: the whole if(CUDEC_ENABLE_HIP) block deleted
FAIL: configure succeeded with no HIP toolchain present       -> step exit 1

=== M2: only the device-sources refusal deleted
FAIL: configure succeeded with no HIP device sources          -> step exit 1

=== M3: the toolchain refusal reworded
FAIL: configure failed, but not on the toolchain refusal      -> step exit 1

=== M4: the mutual-exclusion refusal deleted
FAIL: configure failed, but not on the mutual exclusion       -> step exit 1

=== M5: check_language reinstated (the bypass the fix removed)
FAIL: a HIP compiler verdict was cached in a refused tree     -> step exit 1

=== host-only configure and build, unchanged
host configure exit=0
host build exit=0
/tmp/bhost/libcudec.a
```

Every leg is load-bearing: M2 kills leg 3, M5 kills leg 2, M3 kills leg 1's
message match, M1 kills leg 1's exit check, and M4 kills the
mutual-exclusion step.

The CUDA configuration, unchanged, same container:

```
=== configure (CUDA engine)
configure exit=0
-- Build files have been written to: /tmp/bcuda
=== build
build exit=0
[100%] Built target termination_gpu
=== host-side ctest (gpu label excluded, no device attached)
100% tests passed, 0 tests failed out of 16
Total Test time (real) =   2.18 sec
```

```
$ npx prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

- [x] `cmake --build build` - clean, host-only and CUDA both above.
- [x] `ctest` - 16 of 16 host-side. The gpu-labelled tests were **not**
      run: no device was attached to this container, and this diff touches
      no device code, so their absence is disclosed rather than papered
      over.
- [x] Prettier - clean.
- [x] Docs synced: `docs/BENCHMARKS.md`, `CONTRIBUTING.md`, `CHANGELOG.md`.

## Notes

No second reader on this change. The five-lens gate and the mutant table
above stand in place of one, and the gate did not rubber-stamp it: all five
lenses returned NEEDS_IMPROVEMENT on the first shape, and the defects they
found are fixed here.

Two declines are recorded in the review table rather than acted on. Neither
is deferred to a new issue: both are work the port already owns.

What this change does **not** establish, stated so the green does not read
as broader than it is: nothing here has compiled a single line of HIP, no
AMD device has executed anything, and the positive branch of the toolchain
check has never been exercised against a real ROCm installation. Leg 3
reaches the second refusal with `/bin/sh` named as the compiler, which
proves the control flow and nothing about ROCm.
