### PR TITLE
Read every source line: protect the bracket the CMake split eats [#294]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1224,35 +1224,56 @@ function(cudec_scan_source path check_loops out_violations)
   # exact, and the join the loop rule needs is rebuilt below where the
   # element it belongs to is known.
   #
-  # The two characters CMake's list syntax eats are protected across the
-  # split: a ';' separates elements and a '\' escapes that separator. The
-  # placeholders are control bytes, which no source in this tree carries and
-  # which therefore cannot be produced by the source being scanned.
+  # The FOUR characters CMake's list syntax eats are protected across the
+  # split: a ';' separates elements, a '\' escapes that separator, and a '['
+  # opens a bracket that swallows every separator until its ']'. One
+  # unbalanced bracket - `src[from` wrapped across a line, or a lone one in a
+  # comment - therefore joins the whole rest of the file into a single
+  # element, and every line below it stops reaching a rule. Measured on
+  # src/snappy_block.h, where 290 of 440 lines went unread (issue #294); the
+  # reader in cudec_code_lines carries the same protection for the same
+  # reason. The placeholders are control bytes, which no source in this tree
+  # carries and which therefore cannot be produced by the source being
+  # scanned.
   string(ASCII 1 _tok_backslash)
   string(ASCII 2 _tok_semicolon)
+  string(ASCII 3 _tok_open)
+  string(ASCII 4 _tok_close)
   file(READ "${path}" _raw)
   # "No source carries one" is the assumption this reader rests on, so it is
   # stated to the file rather than trusted: a source that does carry one would
   # have it restored below as a backslash or as a separator, which is a way to
   # smuggle either past the split. Refuse the file instead of scanning it.
-  if(_raw MATCHES "${_tok_backslash}|${_tok_semicolon}")
+  if(_raw MATCHES
+     "${_tok_backslash}|${_tok_semicolon}|${_tok_open}|${_tok_close}")
     string(APPEND _violations
-           "  ${path}:1: a control byte (0x01 or 0x02) in a source read as "
+           "  ${path}:1: a control byte (0x01 to 0x04) in a source read as "
            "text - this scan cannot tell one from its own line markers, so "
            "the file is refused rather than scanned\n")
   endif()
   string(REPLACE "\\" "${_tok_backslash}" _raw "${_raw}")
   string(REPLACE ";" "${_tok_semicolon}" _raw "${_raw}")
+  string(REPLACE "[" "${_tok_open}" _raw "${_raw}")
+  string(REPLACE "]" "${_tok_close}" _raw "${_raw}")
   string(REPLACE "\r\n" "\n" _raw "${_raw}")
   string(REPLACE "\r" "\n" _raw "${_raw}")
   # A file's final newline terminates its last line rather than starting an
   # empty one; left in, it would add a line the file does not have.
   string(REGEX REPLACE "\n$" "" _raw "${_raw}")
+  # What a whole read must produce, counted from the bytes before the split
+  # rather than inferred from what the split returned: one line per remaining
+  # newline, plus the last line, which the strip above left without one. The
+  # comparison is at the bottom of the loop.
+  string(REGEX MATCHALL "\n" _newlines "${_raw}")
+  list(LENGTH _newlines _expected_lines)
+  math(EXPR _expected_lines "${_expected_lines} + 1")
   string(REPLACE "\n" ";" _lines "${_raw}")
   foreach(_src_line IN LISTS _lines)
     math(EXPR _lineno "${_lineno} + 1")
     string(REPLACE "${_tok_semicolon}" ";" _src_line "${_src_line}")
     string(REPLACE "${_tok_backslash}" "\\" _src_line "${_src_line}")
+    string(REPLACE "${_tok_open}" "[" _src_line "${_src_line}")
+    string(REPLACE "${_tok_close}" "]" _src_line "${_src_line}")
     set(_line "${_src_line}")
     if(_in_comment)
       if(_line MATCHES "\\*/")
@@ -1521,6 +1542,20 @@ function(cudec_scan_source path check_loops out_violations)
              "this project can test on\n")
     endif()
   endforeach()
+  # A partial read must never look like a clean scan: a source that reached no
+  # rule and one that reached every rule and satisfied them all leave the same
+  # trace, which is nothing. The protections above are what make the two counts
+  # agree, so this is the check that says they still do - and the one that
+  # reds if a fifth character with list meaning turns up (issue #294). A hard
+  # error rather than a violation: a reader that cannot read is not a finding
+  # about the source it was pointed at.
+  if(NOT _lineno EQUAL _expected_lines)
+    message(
+      FATAL_ERROR
+        "${path} was read as ${_lineno} lines and carries ${_expected_lines}: "
+        "this scan cannot read it whole, and a partial read reports the same "
+        "silence as a clean one (issue #294)")
+  endif()
   # A file whose last line ends in a backslash leaves an element the loop rule
   # never got to judge, so the construct inside it went unread. Reject rather
   # than return silently, for the same reason the unbalanced `for` header
@@ -1829,12 +1864,37 @@ file(WRITE ${_probe_dir}/scan_width_named_constant.cu
      "    return tid % kWaveLanes;
 " "}
 ")
-# The byte the reader borrows for its own bookkeeping, in the file it is
-# reading. It has to come back refused, or the borrowing is a way to write a
-# separator or a backslash the split will not see as one.
+# The bytes the reader borrows for its own bookkeeping, in the file it is
+# reading. They have to come back refused, or the borrowing is a way to write a
+# separator or a backslash the split will not see as one. One probe per end of
+# the borrowed range: 0x01 is the backslash marker and 0x04 the bracket marker
+# the bracket protection added (issue #294).
 string(ASCII 1 _probe_ctrl)
 file(WRITE ${_probe_dir}/scan_control_byte.cu
      "void probe() {\n" "    g(1);${_probe_ctrl}\n" "}\n")
+string(ASCII 4 _probe_ctrl_close)
+file(WRITE ${_probe_dir}/scan_control_byte_close.cu
+     "void probe() {\n" "    g(1);${_probe_ctrl_close}\n" "}\n")
+
+# An unbalanced bracket above a violation. Before the bracket protection, the
+# '[' on the first line swallowed every line separator after it, the whole file
+# arrived as one element numbered line 1, and the loop rule below it reached
+# nothing: a source that violates a fail-closed rule left exactly the trace of
+# one that satisfies it. The shape is copied from src/snappy_block.h, where a
+# bracket in a comment ended the scan 290 lines early (issue #294). The
+# expectation carries the LINE NUMBER, because a reader that swallows a
+# separator and still reports the rule would report it against the wrong line.
+file(
+  WRITE ${_probe_dir}/scan_bracket_partial.cu
+  "/* A LITERAL copies length bytes from src[from ..\n"
+  " * and the bracket this comment opened never closes.\n"
+  " */\n"
+  "unsigned probe(unsigned n) {\n"
+  "    while (n != 0) {\n"
+  "        n = n - 1;\n"
+  "    }\n"
+  "    return n;\n"
+  "}\n")
 
 cudec_scan_source(${_probe_dir}/scan_clean.cu TRUE _probe_clean)
 if(_probe_clean)
@@ -1878,7 +1938,9 @@ set(_scanner_probes
     "scan_line_after_continuation|scan_line_after_continuation.cu:7: a 'while' loop with no explicit"
     "scan_macro_for_opaque|scan_macro_for_opaque.cu:1: a 'for' header without a visible"
     "scan_continuation_at_eof|scan_continuation_at_eof.cu:4: a backslash continuation left open at end of file"
-    "scan_control_byte|a control byte (0x01 or 0x02) in a source read as text"
+    "scan_control_byte|a control byte (0x01 to 0x04) in a source read as text"
+    "scan_control_byte_close|a control byte (0x01 to 0x04) in a source read"
+    "scan_bracket_partial|scan_bracket_partial.cu:5: a 'while' loop with no explicit"
     "scan_width_literal_32|scan_width_literal_32.cu:3: bare wave-width literal '32'"
     "scan_width_literal_64|scan_width_literal_64.cu:3: bare wave-width literal '64'"
     "scan_width_from_parameter|"


### PR DESCRIPTION
# What & why

Closes #294.

The structural scanner in `tests/CMakeLists.txt` split each source into lines
by turning newlines into `;` and iterating the result as a CMake list. CMake's
list syntax reads `[` as opening a bracket that swallows every separator until
its `]`, so one unbalanced bracket joined the whole rest of the file into a
single element and every line below it reached no rule at all.

Reproduced against `origin/main` at `39b9528ce5b19d1fc5aad26f9a88592e63033b5e`
rather than against a working tree, with `git archive origin/main src` into a
clean directory and the reader out of the scanner over it, rule bodies replaced
by a line count:

    cmake -DDIR=<extracted>/src -DPROTECT=OFF -P measure.cmake
    batch.cu: file has 31 lines, the scan loop sees 31
    batch_limits.h: file has 38 lines, the scan loop sees 38
    cuda_raii.h: file has 142 lines, the scan loop sees 142
    frame.cpp: file has 335 lines, the scan loop sees 335
    lz4_block.h: file has 248 lines, the scan loop sees 248
    lz4_decode.cuh: file has 180 lines, the scan loop sees 180
    snappy_block.h: file has 440 lines, the scan loop sees 150
    stream.cpp: file has 533 lines, the scan loop sees 533
    version.c: file has 6 lines, the scan loop sees 6
    xxhash32.h: file has 90 lines, the scan loop sees 90
    zstd_bitstream.h: file has 229 lines, the scan loop sees 229

290 of the 440 lines of `src/snappy_block.h` reached nothing: not the
termination fuel rule, not the warp-collective rules, not the floating-point
rules, not the wave-width rule. The issue measured 371 lines with 106 seen; the
file has grown since and the shape is unchanged. The same run with the bracket
protection on reports 440 and 440, and every other source is whole either way.

## What the change does

`[` and `]` are protected across the split as control bytes 0x03 and 0x04 and
restored per line, the way `;` and `\` already were. The refusal of a source
that carries one of the borrowed control bytes now covers all four.

The reader also counts. What a whole read must produce is derived from the
bytes before the split, one line per remaining newline plus the last one, and
compared against the lines the loop actually iterated. A source the scan cannot
read whole is a hard error naming the file, so a partial read can no longer
report the same silence as a clean one. That is the shape the reader
`cudec_code_lines` in the same file already carries.

Two probes hold it, in the probe set the scanner already runs against itself at
configure time:

- `scan_bracket_partial.cu` carries an unbalanced `[` in a comment above an
  uncapped `while`, copied from the shape in `src/snappy_block.h`, and its
  expectation carries the line number, so a reader that swallows a separator
  and still reports the rule is caught reporting it against the wrong line.
- `scan_control_byte_close.cu` carries a literal 0x04 and must come back
  refused.

## Type of change

- [x] Build / CI / supply chain
- [x] Bug fix

## Engineering checklist

- [x] Fail-closed preserved. The change is to the configure-time scanner, not
      to a decode path, and it moves in the fail-closed direction: a source the
      reader cannot read whole is now a hard error instead of a silent partial
      scan.
- [ ] Oracle coverage. Not applicable, no format path is touched.
- [x] Determinism preserved. The reader is a text scan with no ordering
      dependence; the same source produces the same violation list.
- [ ] CUDA API errors. Not applicable, no CUDA call is touched.
- [x] An adversarial review was run over the diff. See the record below.
- [x] Review record below.

### Review record

This section was produced by an automated re-run, not by a second person.
This board had no second reader available for this change, so the deletion
experiments below stand in place of one, and the CI checks are the gate.

Correctness lens, verdict clean, CONFIRMED 0 / PLAUSIBLE 0 left standing. The
one behaviour change outside the reported defect is disclosed under Notes.

Robustness lens, verdict clean, CONFIRMED 0 / PLAUSIBLE 0. The restore inside
the loop cannot manufacture a separator or an escape: restoring 0x03 and 0x04
yields `[` and `]`, neither of which has list meaning once the split has
already happened, and a source carrying either borrowed byte itself is refused
before the split.

Integration lens, verdict clean, CONFIRMED 0 / PLAUSIBLE 0. One file changes,
and it is the only path in the diff:

    git diff --name-only origin/main...HEAD
    tests/CMakeLists.txt

The guards were proven by deleting them and watching the run go red. Four
experiments, each against the exact text of this branch:

1. Bracket protection deleted, whole-read check kept. Red on the new probe:
   `scan_bracket_partial.cu was read as 1 lines and carries 9: this scan cannot
   read it whole`.
2. Bracket protection and whole-read check both deleted. Red on the probe
   expectation: `the structural scanner is dead for one rule: probe
   'scan_bracket_partial' did not report "scan_bracket_partial.cu:5: a 'while'
   loop with no explicit"`, and what it reported instead was that same rule
   against line 1. That misnumbering is what the line number in the expectation
   exists to catch.
3. `${_tok_close}` dropped from the control-byte refusal. Red on
   `scan_control_byte_close`, which came back silent.
4. Bracket protection deleted and the two new probe entries removed, so the run
   reaches the real tree. Red on the tree itself: `src/snappy_block.h was read
   as 150 lines and carries 440`.

## Performance checklist

Not on the hot path. Nothing device-side is touched and no recorded number
moves.

## Quality checklist

- [x] Minimal. Two `string(REPLACE)` pairs, one widened `MATCHES`, one count
      comparison, two probes.
- [x] Self-documenting, and the comments say why the four characters are
      protected and what the count check is for.
- [x] The new structural property, that the reader reports what it could not
      read, is locked by the probes rather than stated in a comment.

## Verification

The gate for this change runs at configure time, inside the block that is only
added when `CUDEC_ENABLE_CUDA` is on, so the full route needs a CUDA toolchain.
The container that carries one was not reachable on this machine while this was
written: the Docker daemon does not answer.

    docker version --format '{{.Server.Version}}'
    failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine

So the CUDA build and `ctest` were NOT run for this change. What was run is the
scanner section itself, extracted from `tests/CMakeLists.txt` from the start of
the structural block to the end of the structural scan and executed under
`cmake -P` against this branch's own `src/`, which needs no compiler:

    cmake -P scan_harness_fixed.cmake
    (no output, exit 0)

That run is the whole probe set plus the scan of every source under `src/`, and
it passes, which also says that the 290 lines of `src/snappy_block.h` that were
unreachable before this change violate none of the rules that now reach them.
cmake 4.3.3 on the host.

- [ ] `cmake --build build` - not run, see above.
- [ ] `ctest --test-dir build` - not run, see above.
- [x] Prettier - no `.md`, `.yml` or `.yaml` file is touched.
- [ ] Docs synced - no behaviour, API or performance change to document.

CI is the reader for the build and sanitize checks here.

## Notes

One behaviour change beyond the reported defect, disclosed rather than left to
be met later: an EMPTY source under `src/` is now a hard error, because zero
iterated lines never equals the one line the count derives from an empty read.

    empty.cu was read as 0 lines and carries 1

`cudec_code_lines` refuses an empty source too, for the same reason, so the two
readers agree. The wording is imprecise for that one case, since such a file
carries no lines rather than one, and it names the file, which is what a reader
needs to act.

Out of scope: the other readers in this file. `cudec_code_lines` already
carries the protection and leaves both characters protected in what it hands
back, so the loops iterating its output are not exposed. The link-surface loop
iterates target properties rather than file text.
