### PR TITLE
Add examples/decode_frame.c, a public-header-only frame consumer [#158]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,8 @@ jobs:
           test -x build-cuda/tests/stream_twin &&
           test -x build-cuda/tests/termination_gpu &&
           test -x build-cuda/tests/determinism_gpu &&
-          test -x build-cuda/tests/snappy_block_device
+          test -x build-cuda/tests/snappy_block_device &&
+          test -x build-cuda/examples/example_decode_frame
 
       # The other half of the install proof (issue #137). The host-only prefix
       # is the easy flavour: nothing reaches the exported interface. The CUDA

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,21 @@ if(CUDEC_ENABLE_HIP)
       "build.")
 endif()
 
+# ---- The examples (issue #158). Built in BOTH configurations, which is the
+# point: they include nothing but the public header, so they compile wherever
+# the header is usable and link wherever the decoder is built. Top-level only,
+# for the reason the install surface below is - a project that vendors cudec
+# asked for the library, not for its example binaries.
+#
+# After the CUDA block rather than inside it: the host-only configuration needs
+# them too, and in the CUDA configuration this is the first point where CXX is
+# enabled and the cudec target is complete. examples/CMakeLists.txt holds
+# itself to registering no ctest entry, since the timeout sweep above has
+# already run by the time this line is read.
+if(PROJECT_IS_TOP_LEVEL)
+  add_subdirectory(examples)
+endif()
+
 # ---- The install surface (issue #79). A release nobody can install is not a
 # release, and until this existed every consumer had to vendor the tree.
 #

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ build. The version compatibility rule is `SameMinorVersion`: while the version
 is 0.x, this project treats a minor bump as the breaking one, so a consumer
 asking for 0.0 is not handed 0.1.
 
+## Usage
+
+[examples/decode_frame.c](examples/decode_frame.c) decodes a `.lz4` frame using
+the public header and libc, and nothing else. Both builds compile it, and the
+CUDA build links it into `build-cuda/examples/example_decode_frame`.
+
 ## Contributing
 
 Issue-driven: every change starts as an issue and lands as a gated PR - see

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,39 @@
+# The examples are consumers of the public header, built by the same gate that
+# builds the library so a change to include/cudec.h that breaks a consumer reds
+# a PR instead of a user's build (issue #158).
+#
+# Two shapes, because the host-only configuration is toolchain-free by design:
+# it compiles src/version.c alone, so cudec_lz4f_decompress is not in the
+# archive and nothing that calls it can LINK there. Compiling it is still the
+# half that carries the property this directory exists for, since a header a
+# consumer cannot compile against is broken in both configurations. The CUDA
+# configuration links and produces the binary CI then checks for.
+if(CUDEC_ENABLE_CUDA)
+  add_executable(example_decode_frame decode_frame.c)
+  # cudec's frame orchestration is C++, so the archive carries objects that
+  # need the C++ runtime; CMake picks the link driver from the consuming
+  # target's languages, and a C-only one would not get it. The same
+  # consumer-side half tests/consumer/CMakeLists.txt states for the package.
+  set_target_properties(example_decode_frame PROPERTIES LINKER_LANGUAGE CXX)
+else()
+  add_library(example_decode_frame OBJECT decode_frame.c)
+endif()
+
+# The library target, for its include directory and (in the CUDA
+# configuration) its objects. PRIVATE: an example is consumed by nobody.
+target_link_libraries(example_decode_frame PRIVATE cudec)
+
+# This directory registers no ctest entries, and it is added after the sweep
+# that makes a missing TIMEOUT unforgettable (the top-level
+# cudec_sweep_test_timeouts call), so a test added here would escape the sweep
+# rather than be caught by it. Say so to the tree instead of in a comment: an
+# add_test below this line reds the configure, and whoever writes one moves
+# this directory above the sweep and deletes this block.
+get_property(_example_tests DIRECTORY PROPERTY TESTS)
+if(_example_tests)
+  message(
+    FATAL_ERROR
+      "examples/ registered a ctest entry (${_example_tests}), and this "
+      "directory is added after the timeout sweep that would have checked it "
+      "(issue #158)")
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,6 +23,21 @@ endif()
 # configuration) its objects. PRIVATE: an example is consumed by nobody.
 target_link_libraries(example_decode_frame PRIVATE cudec)
 
+# In the sanitizer configuration the archive this links is instrumented, so an
+# uninstrumented consumer of it does not link at all: the sanitizer runtime
+# calls compiled into src/frame.cpp resolve nowhere. Measured, on the first CI
+# run of this change - `undefined reference to __asan_report_load1` out of
+# frame.cpp while linking this target. The example takes the same flags the
+# tests do rather than being excluded from that configuration, because a
+# consumer that is not built there is a consumer nothing checks.
+if(CUDEC_SANITIZE)
+  target_compile_options(
+    example_decode_frame
+    PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:${CUDEC_SANITIZE_COMPILE_FLAGS}>)
+  target_link_options(example_decode_frame PRIVATE
+                      ${CUDEC_SANITIZE_LINK_FLAGS})
+endif()
+
 # This directory registers no ctest entries, and it is added after the sweep
 # that makes a missing TIMEOUT unforgettable (the top-level
 # cudec_sweep_test_timeouts call), so a test added here would escape the sweep

--- a/examples/decode_frame.c
+++ b/examples/decode_frame.c
@@ -1,0 +1,170 @@
+/* Decode a .lz4 frame on the GPU with cudec.
+ *
+ * Builds against the installed public header and libc, and nothing else: no
+ * test helper, no CUDA header, no cudec source. If this file stops compiling
+ * or stops linking, the public surface stopped being enough to write a
+ * consumer with, which is the property CI reads it for (issue #158).
+ *
+ *   decode_frame <input.lz4> <output>
+ *
+ * The frame must be block-INDEPENDENT (LZ4F_blockIndependent); the header
+ * says what else is unsupported and what each error means.
+ */
+
+#include <cudec.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static const char* status_text(cudec_status status) {
+    switch (status) {
+        case CUDEC_OK:
+            return "ok";
+        case CUDEC_ERR_INVALID_ARGUMENT:
+            return "invalid argument";
+        case CUDEC_ERR_CORRUPT_INPUT:
+            return "corrupt input: malformed frame or checksum mismatch";
+        case CUDEC_ERR_OUTPUT_TOO_SMALL:
+            return "output buffer too small";
+        case CUDEC_ERR_CUDA:
+            return "a CUDA device or host resource failure";
+        case CUDEC_ERR_NOT_IMPLEMENTED:
+            return "not implemented";
+        case CUDEC_ERR_UNSUPPORTED:
+            return "valid frame, but not a subset cudec decodes";
+    }
+    /* No default label, so a status added to the header reds this switch
+     * under -Wswitch rather than falling through to a wrong message. */
+    return "unknown status";
+}
+
+/* Reads the whole file into a malloc'd buffer. Returns NULL and reports why
+ * on any failure, including a file that does not fit in memory. */
+static unsigned char* read_file(const char* path, size_t* out_size) {
+    FILE* file = fopen(path, "rb");
+    if (file == NULL) {
+        fprintf(stderr, "cannot open %s\n", path);
+        return NULL;
+    }
+    if (fseek(file, 0, SEEK_END) != 0) {
+        fprintf(stderr, "cannot seek %s\n", path);
+        fclose(file);
+        return NULL;
+    }
+    long end = ftell(file);
+    if (end < 0) {
+        fprintf(stderr, "cannot size %s\n", path);
+        fclose(file);
+        return NULL;
+    }
+    rewind(file);
+
+    size_t size = (size_t)end;
+    /* malloc(0) may return NULL without failing, and an empty file is not a
+     * frame anyway; one byte keeps the NULL below unambiguous. */
+    unsigned char* buffer = (unsigned char*)malloc(size + 1);
+    if (buffer == NULL) {
+        fprintf(stderr, "out of memory reading %s\n", path);
+        fclose(file);
+        return NULL;
+    }
+    if (size != 0 && fread(buffer, 1, size, file) != size) {
+        fprintf(stderr, "short read on %s\n", path);
+        free(buffer);
+        fclose(file);
+        return NULL;
+    }
+    fclose(file);
+    *out_size = size;
+    return buffer;
+}
+
+static int write_file(const char* path, const unsigned char* data,
+                      size_t size) {
+    FILE* file = fopen(path, "wb");
+    if (file == NULL) {
+        fprintf(stderr, "cannot open %s for writing\n", path);
+        return 0;
+    }
+    if (size != 0 && fwrite(data, 1, size, file) != size) {
+        fprintf(stderr, "short write on %s\n", path);
+        fclose(file);
+        return 0;
+    }
+    if (fclose(file) != 0) {
+        fprintf(stderr, "cannot close %s\n", path);
+        return 0;
+    }
+    return 1;
+}
+
+/* A frame carries no size the caller can trust, so the output buffer is
+ * grown against the decoder's own answer: CUDEC_ERR_OUTPUT_TOO_SMALL is a
+ * defined status with no partial output behind it, which makes retrying with
+ * a larger buffer safe and makes the growth loop the shortest honest way to
+ * size the destination. The cap is what keeps a hostile frame from walking
+ * this consumer up to the machine's memory limit. */
+#define DECODE_CAPACITY_CAP ((size_t)1 << 30)
+
+int main(int argc, char** argv) {
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s <input.lz4> <output>\n", argv[0]);
+        return 2;
+    }
+
+    size_t frame_size = 0;
+    unsigned char* frame = read_file(argv[1], &frame_size);
+    if (frame == NULL) {
+        return 1;
+    }
+
+    size_t capacity = 4 * frame_size + 1024;
+    if (capacity > DECODE_CAPACITY_CAP) {
+        capacity = DECODE_CAPACITY_CAP;
+    }
+
+    unsigned char* out = NULL;
+    size_t written = 0;
+    cudec_status status = CUDEC_ERR_OUTPUT_TOO_SMALL;
+    while (status == CUDEC_ERR_OUTPUT_TOO_SMALL) {
+        free(out);
+        out = (unsigned char*)malloc(capacity);
+        if (out == NULL) {
+            fprintf(stderr, "out of memory: %zu bytes\n", capacity);
+            free(frame);
+            return 1;
+        }
+        status = cudec_lz4f_decompress(frame, frame_size, out, capacity,
+                                       &written);
+        if (status != CUDEC_ERR_OUTPUT_TOO_SMALL) {
+            break;
+        }
+        if (capacity >= DECODE_CAPACITY_CAP) {
+            fprintf(stderr, "decoded output exceeds the %zu byte cap this "
+                            "example allows\n",
+                    (size_t)DECODE_CAPACITY_CAP);
+            free(out);
+            free(frame);
+            return 1;
+        }
+        capacity = capacity > DECODE_CAPACITY_CAP / 2 ? DECODE_CAPACITY_CAP
+                                                      : capacity * 2;
+    }
+    free(frame);
+
+    if (status != CUDEC_OK) {
+        fprintf(stderr, "%s: %s (cudec_status %d)\n", argv[1],
+                status_text(status), (int)status);
+        free(out);
+        return 1;
+    }
+
+    if (!write_file(argv[2], out, written)) {
+        free(out);
+        return 1;
+    }
+    free(out);
+
+    printf("%s -> %s, %zu bytes\n", argv[1], argv[2], written);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #158.

`include/cudec.h` is the whole surface a consumer gets, and nothing in the tree
compiled against it the way a consumer would. The tests reach for `tests/`
headers and fixtures, so a change that made the public header unusable on its
own would have reached a user before it reached CI.

`examples/decode_frame.c` reads a `.lz4` file, calls `cudec_lz4f_decompress`,
writes the decoded bytes out and maps every `cudec_status` onto a message and a
non-zero exit. It includes `<cudec.h>` and libc, nothing else: no `tests/`
header, no CUDA header, no cudec source.

The destination is sized against the decoder's own answer rather than guessed.
`CUDEC_ERR_OUTPUT_TOO_SMALL` is a defined status with no partial output behind
it, which is what makes a retry with a bigger buffer safe, and the growth loop
carries a cap so a hostile frame cannot walk the example up to the machine's
memory.

## The host-only constraint

The host-only configuration compiles `src/version.c` alone, by design, so
`cudec_lz4f_decompress` is not in the archive and nothing that calls it can
link there. The example is an object target in that configuration and an
executable in the CUDA one. Compiling is the half that carries the property
this file exists for: a header a consumer cannot compile against is broken in
both flavours. The CUDA build links it and CI names the binary in the `test -x`
list beside the GPU test binaries, so a dropped target reds the step instead of
vanishing quietly.

## Type of change

- [x] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [ ] Fail-closed. No parse or decode path is added. The example itself maps
      every status to a non-zero exit and writes an output file only after a
      `CUDEC_OK`, so a rejected frame produces no output file at all.
- [ ] Oracle coverage. Not applicable, no format path is touched.
- [ ] Determinism. Not applicable.
- [ ] CUDA API errors. No CUDA call is added; the example calls one public
      entry point.
- [x] Adversarial review over the diff, recorded below.
- [x] Review record below.

### Review record

This section was produced by an automated re-run, not by a second person. This
board had no second reader for this change, so the probes below carry the
evidence in place of one, and CI is the gate for the CUDA half.

Correctness lens, verdict clean, CONFIRMED 0 / PLAUSIBLE 0 left standing. The
growth loop was the one place worth arguing with: it frees the previous buffer
before each attempt, breaks on any status that is not
`CUDEC_ERR_OUTPUT_TOO_SMALL`, refuses to grow past the cap rather than
wrapping, and the doubling itself is clamped to the cap, so no `size_t`
multiplication overflows.

Integration lens, verdict clean, CONFIRMED 0 / PLAUSIBLE 0. The example
directory is added at top level only, so a project vendoring cudec by
`add_subdirectory` or FetchContent gets the library and not the example
binaries, the same guard the install surface carries. The added
`add_subdirectory(examples)` sits after the CUDA block, which is the first
point where CXX is enabled and the `cudec` target is complete, and after
`tests/`, so nothing here can slip a property past the conformance snapshot
inside it.

Robustness lens, one finding, disposition FIX, applied before this PR was
opened. `examples/` is added after `cudec_sweep_test_timeouts`, the sweep that
makes a missing ctest `TIMEOUT` unforgettable, so a test registered there would
have escaped the sweep instead of being caught by it. Rather than a comment
saying "do not add tests here", `examples/CMakeLists.txt` reads the directory's
own `TESTS` property and reds the configure if it is non-empty.

## Verification

Both legs of the host-only half were run on this machine. The CUDA leg was NOT
run here: the container that carries a CUDA toolchain was unreachable while
this was written, the Docker daemon does not answer, and this machine has no
CUDA toolkit of its own. CI builds and links that half.

The example compiles in the host-only build, cmake 4.3.3 and gcc 16.1.0:

    cmake -S . -B build-h -G Ninja -DCMAKE_C_COMPILER=gcc
    cmake --build build-h
    [1/3] Building C object CMakeFiles/cudec.dir/src/version.c.obj
    [2/3] Building C object examples/CMakeFiles/example_decode_frame.dir/decode_frame.c.obj
    [3/3] Linking C static library libcudec.a

The probe the issue asks for, in the spelling that actually bites. Renaming a
PARAMETER of `cudec_lz4f_decompress` changes nothing for a C consumer, so the
probe is the entry point itself: renaming it in `include/cudec.h` reds the
example build, which is what says the example is compiled against the public
header rather than against something else.

    sed -i 's/^cudec_status cudec_lz4f_decompress(const void\* frame/cudec_status cudec_lz4f_decompress_renamed(const void* frame/' include/cudec.h
    cmake --build build-h
    examples/decode_frame.c:137:18: error: implicit declaration of function
      'cudec_lz4f_decompress'; did you mean 'cudec_lz4_decompress_batch'?
      [-Wimplicit-function-declaration]
    ninja: build stopped: subcommand failed.

The header was restored afterwards and the build is green again; `git diff`
against it is empty in this branch.

- [x] `cmake --build build` builds clean, host-only, including the example.
- [ ] `ctest` not run: the test net configures only with `CUDEC_ENABLE_CUDA=ON`
      and this machine has no CUDA toolchain reachable tonight. This change
      registers no ctest entry and refuses one.
- [x] Prettier clean over the tracked set:

      npx prettier@3 --check $(git ls-files '*.md' '*.yml' '*.yaml')
      All matched files use Prettier code style!

- [x] Docs synced. README gains a `## Usage` section above `## Contributing`,
      one line and a link, with no walkthrough prose to rot.

## Notes

The batch example is its own issue and is not in this change. This PR creates
the `examples/CMakeLists.txt` scaffolding it hangs off; adding it there is one
`add_executable` plus one `target_link_libraries`, and the no-ctest guard at
the bottom of that file applies to it unchanged.

The binary is named `example_decode_frame` rather than `decode_frame`, because
the target name is global in a CMake project and a bare `decode_frame` is the
kind of name a future test or tool would collide with. The file keeps the name
the issue asked for.

## What the first CI run found

The first run of this branch was green on build, format and dependency-review
and RED on sanitize, at the link step of this very target:

    /usr/bin/ld: ../libcudec.a(frame.cpp.o): undefined reference to
      `__asan_report_load1'
    gmake[2]: *** [examples/CMakeFiles/example_decode_frame.dir/build.make:99:
      examples/example_decode_frame] Error 1

The sanitize configuration instruments the library's host translation units, so
a consumer compiled without those flags cannot link against it. The second
commit gives the example the same flags the tests take. It is not excluded from
that configuration the way bench is: bench is nvcc-linked and would drag the
sanitizer onto the device link, while the example is host C against a host
archive, and a consumer that is not built under the gate is a consumer the gate
says nothing about.

The failure is left in this body rather than tidied away, because it is also
the answer to the question of whether the example is really built by the gates
that matter.
