### PR TITLE
Sweep the Snappy branch classes a mutation corpus cannot build [#172]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,13 +404,14 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|frame_host_negative|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|frame_host_negative|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
           grep -E ': oracle_lz4$' san-selected.txt &&
           grep -E ': parser_twin$' san-selected.txt &&
           grep -E ': snappy_parser_twin$' san-selected.txt &&
+          grep -E ': snappy_edge_sweep$' san-selected.txt &&
           grep -E ': frame_host_negative$' san-selected.txt &&
           grep -E ': termination$' san-selected.txt
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -351,6 +351,15 @@ cudec_add_test(snappy_parser_twin SOURCES snappy_parser_twin.cpp LIBS
                cudec_test_fixtures)
 target_include_directories(snappy_parser_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The classes a mutation corpus cannot structurally build (issue #172): the
+# literal length's extra bytes and the varint preamble's edge encodings, swept
+# by hand against both reference calls. Its own binary rather than a section of
+# the twin, because it is breadth over the same rungs the twin covers one
+# stream each - and because a sweep that reds says which class moved.
+cudec_add_test(snappy_edge_sweep SOURCES snappy_edge_sweep.cpp LIBS
+               cudec_test_fixtures)
+target_include_directories(snappy_edge_sweep
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 # The other half of "single-source host AND device" (issue #171): the twin
 # above compiles src/snappy_block.h with the host compiler and this one hands
 # the same header to nvcc, then requires the two to produce an identical

--- a/tests/snappy_edge_sweep.cpp
+++ b/tests/snappy_edge_sweep.cpp
@@ -1,0 +1,476 @@
+/* The two branch classes a mutation corpus cannot structurally build, swept
+ * against the twin and the oracle (issue #172).
+ *
+ * Mutating a real stream damages bytes; it does not synthesise a shape the
+ * compressor never emits. Both LZ4 fail-opens ever found here needed exactly
+ * such a shape, and for Snappy the two classes out of reach of the corpus are
+ * the literal length's extra bytes and the varint preamble's edge encodings.
+ * Every stream below is hand-built, and the verdict it is held to is the
+ * reference's own rather than this file's opinion: whenever snappy rejects,
+ * the twin must reject; where both accept, the bytes must match.
+ *
+ * The neighbouring test carries the per-rung negatives and the pinned 32-bit
+ * literal-length wrap, one stream per ladder branch. This one is breadth over
+ * those same branches: the width-class boundaries where an off-by-one in the
+ * header arithmetic lives, and the preamble encodings a compressor has no
+ * reason to write.
+ *
+ * Line citations are into the pinned tree, google/snappy 1.2.2, as fetched by
+ * the URL_HASH in tests/CMakeLists.txt. They move only when that pin moves. */
+#include "cudec.h"
+#include "fixtures.h"
+#include "require.h"
+#include "snappy_block.h"
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+size_t g_accept_side_divergences = 0;
+size_t g_reject_side_divergences = 0;
+size_t g_bounds_violations = 0;
+size_t g_cases = 0;
+
+void Append(Bytes* out, const Bytes& more) {
+    out->insert(out->end(), more.begin(), more.end());
+}
+
+/* The preamble, minimally encoded: seven bits per byte, low group first,
+ * continuation bit on every byte but the last
+ * (snappy-stubs-internal.h:477-490, Varint::Encode32). */
+Bytes VarintMinimal(uint32_t value) {
+    Bytes out;
+    uint32_t rest = value;
+    while (rest >= 0x80) {
+        out.push_back(static_cast<unsigned char>((rest & 0x7f) | 0x80));
+        rest >>= 7;
+    }
+    out.push_back(static_cast<unsigned char>(rest));
+    return out;
+}
+
+/* The same value in EXACTLY `groups` bytes, padding with continuation bytes
+ * that carry no payload. Nothing in the reference's preamble readers refuses
+ * an encoding that could have been shorter: Varint::Parse32WithLimit
+ * (snappy-stubs-internal.h:455-474) stops at the first byte below 128 and
+ * asks nothing about minimality, and ReadUncompressedLength (snappy.cc:1533)
+ * only refuses a shift of 32 or more and a group whose shifted value would
+ * overflow. So these must be ACCEPTED, which is the direction that matters:
+ * over-strictness here would reject streams the reference decodes. */
+Bytes VarintPadded(uint32_t value, unsigned groups) {
+    Bytes out;
+    uint32_t rest = value;
+    for (unsigned i = 0; i + 1 < groups; i++) {
+        out.push_back(static_cast<unsigned char>((rest & 0x7f) | 0x80));
+        rest >>= 7;
+    }
+    out.push_back(static_cast<unsigned char>(rest & 0x7f));
+    return out;
+}
+
+/* A literal in the short form: the tag's upper six bits hold length-1, which
+ * reaches 60 bytes before the length needs bytes of its own
+ * (snappy.cc:1613-1614, snappy.cc:1624). */
+Bytes Literal(const Bytes& data) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>((data.size() - 1) << 2));
+    Append(&out, data);
+    return out;
+}
+
+/* A literal whose length-1 travels in `extra` little-endian bytes, selected
+ * by tag values 60 to 63 (snappy.cc:1624-1626: the tag value above 59 is the
+ * count of length bytes, and the length is read little-endian from them). */
+Bytes LiteralHeader(uint32_t length_minus_one, unsigned extra) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>(((59 + extra) << 2)));
+    for (unsigned i = 0; i < extra; i++) {
+        out.push_back(static_cast<unsigned char>((length_minus_one >> (8 * i)) &
+                                                 0xff));
+    }
+    return out;
+}
+
+Bytes LongLiteral(const Bytes& data, unsigned extra) {
+    Bytes out = LiteralHeader(static_cast<uint32_t>(data.size() - 1), extra);
+    Append(&out, data);
+    return out;
+}
+
+Bytes Filler(size_t length) {
+    Bytes out;
+    out.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+        out.push_back(static_cast<unsigned char>('a' + (i % 26)));
+    }
+    return out;
+}
+
+/* Sequential execution of the parsed elements, from an EXACTLY-sized copy of
+ * the stream so an over-read past src_size lands in a redzone rather than in
+ * a vector's rounded-up slack. A copy is the chasing byte copy, which is the
+ * pattern-repeating semantics an overlapping Snappy copy has.
+ *
+ * The bounds counter is not decoration: a verdict alone cannot prove a bounds
+ * guard, because a cursor that ran past the end is usually caught by a later
+ * branch AFTER the read already happened. What the guard prevents is that
+ * read, so that is what is counted. */
+cudec_status TwinDecode(const Bytes& stream, Bytes* out) {
+    out->clear();
+    const size_t stream_size = stream.size();
+    auto tight = std::make_unique<unsigned char[]>(stream_size);
+    if (stream_size != 0) {
+        std::memcpy(tight.get(), stream.data(), stream_size);
+    }
+    cudec_detail::SnappyParser parser{tight.get(), stream_size,
+                                      kSnappyOracleMaxOutput};
+    const cudec_status header = parser.Begin();
+    if (header != CUDEC_OK) {
+        return header;
+    }
+    out->assign(static_cast<size_t>(parser.declared), 0);
+    cudec_detail::SnappyElement element;
+    bool done = false;
+    uint64_t fuel = static_cast<uint64_t>(stream_size) + 2;
+    while (true) {
+        if (fuel-- == 0) {
+            std::fprintf(stderr, "the parser did not terminate on a %zu-byte "
+                                 "stream\n",
+                         stream_size);
+            g_bounds_violations++;
+            out->clear();
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        const cudec_status status = parser.Next(&element, &done);
+        if (status != CUDEC_OK) {
+            out->clear();
+            return status;
+        }
+        const bool bounded =
+            parser.src_pos <= parser.src_size &&
+            parser.dst_pos <= parser.declared &&
+            element.to + element.length <= parser.dst_pos &&
+            (element.is_copy
+                 ? element.from < element.to
+                 : element.from + element.length <= parser.src_pos);
+        if (!bounded) {
+            std::fprintf(stderr, "the parser left its bounds on a %zu-byte "
+                                 "stream\n",
+                         stream_size);
+            g_bounds_violations++;
+            out->clear();
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        for (uint64_t i = 0; i < element.length; i++) {
+            const size_t to = static_cast<size_t>(element.to + i);
+            (*out)[to] = element.is_copy
+                             ? (*out)[static_cast<size_t>(element.from + i)]
+                             : tight[static_cast<size_t>(element.from + i)];
+        }
+        if (done) {
+            break;
+        }
+    }
+    out->resize(static_cast<size_t>(parser.dst_pos));
+    return CUDEC_OK;
+}
+
+/* One stream, both directions. The oracle decides: an accept the twin refuses
+ * is a divergence, a reject the twin accepts is a fail-open, and two accepts
+ * that produce different bytes are neither but are just as wrong.
+ *
+ * Two reference calls, each in the direction where it is authoritative. The
+ * decoding one carries the harness's own 256 MiB bound, so it is the one the
+ * verdicts are compared through; the no-write validator carries no bound at
+ * all, so it is asked only about streams the twin ACCEPTED, where the
+ * declaration is inside the bound by construction. A stream cudec accepts
+ * that snappy's own validator calls invalid is a fail-open however the
+ * decoding wrapper answered. */
+void Parity(const std::string& name, const Bytes& stream) {
+    g_cases++;
+    Bytes oracle_out;
+    const bool oracle_ok = SnappyOracleDecodes(stream, &oracle_out);
+    Bytes twin_out;
+    const cudec_status twin = TwinDecode(stream, &twin_out);
+
+    if (twin == CUDEC_OK && !SnappyOracleAccepts(stream)) {
+        std::fprintf(stderr,
+                     "%s: the twin accepts a stream IsValidCompressedBuffer "
+                     "refuses - a fail-open\n",
+                     name.c_str());
+        g_reject_side_divergences++;
+        return;
+    }
+
+    if (oracle_ok && twin != CUDEC_OK) {
+        std::fprintf(stderr,
+                     "%s: snappy accepts, the twin refuses with status %d\n",
+                     name.c_str(), static_cast<int>(twin));
+        g_accept_side_divergences++;
+        return;
+    }
+    if (!oracle_ok && twin == CUDEC_OK) {
+        std::fprintf(stderr, "%s: snappy refuses, the twin accepts - a "
+                             "fail-open\n",
+                     name.c_str());
+        g_reject_side_divergences++;
+        return;
+    }
+    if (oracle_ok && twin_out != oracle_out) {
+        std::fprintf(stderr,
+                     "%s: both accept and the bytes differ (%zu vs %zu)\n",
+                     name.c_str(), twin_out.size(), oracle_out.size());
+        g_accept_side_divergences++;
+    }
+}
+
+/* The literal-length extra bytes. The tag value selects HOW MANY bytes carry
+ * length-1 rather than carrying the length itself, so every transition
+ * between two width classes is an off-by-one waiting in the header
+ * arithmetic: 60 bytes is the last length the tag carries alone, 61 the first
+ * that needs a byte, and 2^8 and 2^16 are where the byte count steps again.
+ *
+ * Both sides of each transition, and each length in every width class that
+ * can express it - a length of 61 is legal in the 1, 2, 3 and 4-byte classes
+ * alike, and only the shortest is what a compressor writes. */
+void SweepLiteralLengths() {
+    const size_t transitions[] = {59, 60, 61, 254, 255, 256, 257, 65535, 65536,
+                                  65537};
+    for (size_t length : transitions) {
+        const Bytes payload = Filler(length);
+        if (length <= 60) {
+            Bytes s = VarintMinimal(static_cast<uint32_t>(length));
+            Append(&s, Literal(payload));
+            Parity("literal-inline-" + std::to_string(length), s);
+        }
+        for (unsigned extra = 1; extra <= 4; extra++) {
+            /* A class can only be used where length-1 fits its bytes. */
+            const uint64_t bound = static_cast<uint64_t>(1) << (8 * extra);
+            if (length - 1 >= bound) {
+                continue;
+            }
+            Bytes s = VarintMinimal(static_cast<uint32_t>(length));
+            Append(&s, LongLiteral(payload, extra));
+            Parity("literal-" + std::to_string(length) + "-in-" +
+                       std::to_string(extra) + "-byte-class",
+                   s);
+        }
+    }
+}
+
+/* The length bytes cut off inside the field, one truncation per width class,
+ * at every count of present bytes. The header runs past the end of the source
+ * here, which is the read the header-truncation rung exists to prevent, so
+ * this is also where a missing bound shows up as a bounds violation rather
+ * than as a verdict. */
+void SweepTruncatedLengthFields() {
+    for (unsigned extra = 2; extra <= 4; extra++) {
+        for (unsigned present = 1; present < extra; present++) {
+            Bytes s = VarintMinimal(64);
+            Bytes header = LiteralHeader(63, extra);
+            header.resize(1 + present);
+            Append(&s, header);
+            Parity("literal-header-" + std::to_string(extra) + "-byte-class-" +
+                       std::to_string(present) + "-present",
+                   s);
+        }
+    }
+    /* The tag byte alone, with the whole length field missing. */
+    for (unsigned extra = 1; extra <= 4; extra++) {
+        Bytes s = VarintMinimal(64);
+        s.push_back(static_cast<unsigned char>((59 + extra) << 2));
+        Parity("literal-header-" + std::to_string(extra) +
+                   "-byte-class-length-absent",
+               s);
+    }
+}
+
+/* A declared literal length that fits one bound and not the other, in both
+ * orders. These are the two rungs a literal can fail at after its header is
+ * read, and the pair matters because a decoder checking only one of them
+ * fails open on the other: a literal inside the source but past the declared
+ * output overruns the destination, and one inside the declaration but past
+ * the source over-reads the input. */
+void SweepLiteralAgainstBothBounds() {
+    /* Fits the remaining source, past the remaining declared output: 16
+     * literal bytes present, 8 declared. */
+    {
+        Bytes s = VarintMinimal(8);
+        Append(&s, LongLiteral(Filler(16), 1));
+        Parity("literal-inside-source-past-declaration", s);
+    }
+    /* The converse: 64 declared, a literal claiming 64 bytes, 16 present. */
+    {
+        Bytes s = VarintMinimal(64);
+        Append(&s, LiteralHeader(63, 1));
+        Append(&s, Filler(16));
+        Parity("literal-inside-declaration-past-source", s);
+    }
+    /* Both at once, at the top of the four-byte class: a length no source
+     * could carry, which is refused on both sides for the source bound. The
+     * neighbouring value, 0xFFFFFFFF, is where the reference's 32-bit
+     * accumulator wraps, and that ONE divergence is pinned in
+     * tests/snappy_parser_twin.cpp rather than swept here. */
+    {
+        Bytes s = VarintMinimal(64);
+        Append(&s, LiteralHeader(0xFFFFFFFEu, 4));
+        Append(&s, Filler(16));
+        Parity("literal-length-4294967295-no-source", s);
+    }
+    /* An exact fit against both bounds is the accept these rejects are
+     * measured against: without it, a parser that refused every long-form
+     * literal would pass this sweep. */
+    {
+        Bytes s = VarintMinimal(64);
+        Append(&s, LongLiteral(Filler(64), 4));
+        Parity("literal-exact-fit-both-bounds", s);
+    }
+}
+
+/* The preamble. A varint32 of one to five bytes, and the encodings a
+ * compressor has no reason to emit are exactly the ones an attacker writes:
+ * a value padded out to more groups than it needs, a fifth group carrying
+ * bits that would overflow 32, and a sixth group that cannot exist at all. */
+void SweepPreambleEncodings() {
+    const uint32_t values[] = {0, 1, 4, 127, 128, 16383, 16384};
+    for (uint32_t value : values) {
+        const Bytes payload = Filler(value);
+        /* Minimal, the shape the compressor writes. */
+        {
+            Bytes s = VarintMinimal(value);
+            if (value != 0) {
+                Append(&s, LongLiteral(payload, 4));
+            }
+            Parity("preamble-minimal-" + std::to_string(value), s);
+        }
+        /* Non-minimal, in every group count that can still hold the value.
+         * These must be ACCEPTED: refusing them would reject streams the
+         * reference decodes. */
+        for (unsigned groups = 2; groups <= 5; groups++) {
+            const unsigned needed = static_cast<unsigned>(
+                VarintMinimal(value).size());
+            if (groups < needed) {
+                continue;
+            }
+            Bytes s = VarintPadded(value, groups);
+            if (value != 0) {
+                Append(&s, LongLiteral(payload, 4));
+            }
+            Parity("preamble-" + std::to_string(value) + "-in-" +
+                       std::to_string(groups) + "-groups",
+                   s);
+        }
+    }
+    /* A fifth group at and above 16. Four bits are all the fifth group can
+     * contribute before a 32-bit accumulator overflows, which is why the
+     * reference refuses a fifth byte of 16 or more outright
+     * (snappy-stubs-internal.h:469, `if (b < 16) goto done;`) rather than
+     * masking the excess away.
+     *
+     * All three of these come back refused, and only the top two for that
+     * reason: a fifth group of 15 declares just under 4 GiB, which the
+     * harness wrapper refuses at its own 256 MiB bound and the twin refuses
+     * against the capacity it was given. What the case pins is that the two
+     * sides agree on the whole neighbourhood of the boundary, not which rung
+     * caught it. */
+    for (unsigned top = 15; top <= 17; top++) {
+        Bytes s = {0x80, 0x80, 0x80, 0x80, static_cast<unsigned char>(top)};
+        Append(&s, Literal(Filler(4)));
+        Parity("preamble-fifth-group-" + std::to_string(top), s);
+    }
+    /* A sixth group. The fifth byte carries its continuation bit, so the
+     * value never terminates inside the five bytes a varint32 has
+     * (snappy.cc:1538, `if (shift >= 32) return false`). */
+    {
+        Bytes s = {0x80, 0x80, 0x80, 0x80, 0x80, 0x00};
+        Append(&s, Literal(Filler(4)));
+        Parity("preamble-sixth-group", s);
+    }
+    /* The preamble cut off inside itself, at every length: every byte
+     * continues and the stream ends. */
+    for (unsigned present = 1; present <= 4; present++) {
+        Bytes s(present, 0x80);
+        Parity("preamble-truncated-" + std::to_string(present) + "-bytes", s);
+    }
+    /* No preamble at all. */
+    Parity("preamble-empty-stream", Bytes());
+}
+
+/* The capacity axis, which the format cannot express and the oracle therefore
+ * has no verdict on: the destination the CALLER owns, against the length the
+ * STREAM declares. Driven at the parser directly, and the status is required
+ * rather than merely non-OK, because the difference between "this stream is
+ * corrupt" and "your buffer is too small" is what a caller acts on. */
+void SweepDeclaredAgainstCapacity() {
+    struct Case {
+        uint32_t declared;
+        uint64_t capacity;
+        cudec_status expected;
+    };
+    const Case cases[] = {
+        /* Nothing declared fits any capacity, including none. */
+        {0, 0, CUDEC_OK},
+        {0, 1, CUDEC_OK},
+        {1, 0, CUDEC_ERR_OUTPUT_TOO_SMALL},
+        {1, 1, CUDEC_OK},
+        {2, 1, CUDEC_ERR_OUTPUT_TOO_SMALL},
+        /* The largest a varint32 can declare, against a capacity no machine
+         * here would hand it and against one it dwarfs. Nothing is allocated
+         * from the declaration on either path, which is the property. */
+        {0xFFFFFFFFu, 0xFFFFFFFFull, CUDEC_OK},
+        {0xFFFFFFFFu, 0xFFFFFFFEull, CUDEC_ERR_OUTPUT_TOO_SMALL},
+        {0xFFFFFFFFu, 1024, CUDEC_ERR_OUTPUT_TOO_SMALL},
+    };
+    for (const Case& c : cases) {
+        const Bytes preamble = VarintMinimal(c.declared);
+        cudec_detail::SnappyParser parser{preamble.data(), preamble.size(),
+                                          c.capacity};
+        const cudec_status status = parser.Begin();
+        if (status != c.expected) {
+            std::fprintf(stderr,
+                         "declared %u against capacity %llu: expected status "
+                         "%d, got %d\n",
+                         c.declared,
+                         static_cast<unsigned long long>(c.capacity),
+                         static_cast<int>(c.expected),
+                         static_cast<int>(status));
+            g_reject_side_divergences++;
+        }
+        if (status == CUDEC_OK && parser.declared != c.declared) {
+            std::fprintf(stderr,
+                         "declared %u read back as %llu\n", c.declared,
+                         static_cast<unsigned long long>(parser.declared));
+            g_reject_side_divergences++;
+        }
+        g_cases++;
+    }
+}
+
+}  // namespace
+
+int main() {
+    SweepLiteralLengths();
+    SweepTruncatedLengthFields();
+    SweepLiteralAgainstBothBounds();
+    SweepPreambleEncodings();
+    SweepDeclaredAgainstCapacity();
+
+    std::printf("snappy edge sweep: %zu streams, %zu accept-side divergences, "
+                "%zu reject-side divergences, %zu bounds violations\n",
+                g_cases, g_accept_side_divergences, g_reject_side_divergences,
+                g_bounds_violations);
+    REQUIRE(g_accept_side_divergences == 0);
+    REQUIRE(g_reject_side_divergences == 0);
+    REQUIRE(g_bounds_violations == 0);
+    /* A sweep that swept nothing prints the same line as one that swept
+     * everything and found nothing, so the count is asserted too. */
+    REQUIRE(g_cases >= 60);
+    std::printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #172.

Mutating a real stream damages bytes; it does not synthesise a shape the
compressor never emits. Both LZ4 fail-opens ever found in this tree needed a
length extension the mutation corpus could not build, and for Snappy the two
classes out of the corpus's reach are the literal length's extra bytes and the
varint preamble's edge encodings. `tests/snappy_edge_sweep.cpp` writes them by
hand and holds each one to the reference's own verdict.

102 streams, in five sweeps:

- The literal width-class transitions. The tag carries length-1 alone up to 60
  bytes and then selects how many bytes carry it instead, so 59, 60, 61, 254,
  255, 256, 257, 65535, 65536 and 65537 are swept, each in EVERY width class
  that can express it rather than only in the shortest one a compressor writes.
- The length field cut off inside itself, at every count of present bytes in
  every class, plus the tag byte with the whole field absent.
- A literal that fits the remaining source but not the remaining declared
  output, and the converse, plus the exact fit both are measured against. A
  parser checking only one of those bounds fails open on the other.
- Preambles: one to five groups, every non-minimal padding of a value that
  still fits, the fifth group at 15, 16 and 17, a sixth group, and the preamble
  truncated at every length.
- The declared length against a caller capacity it fits, misses by one, and
  dwarfs, including 2^32-1 against 2^32-1 and against 1024. Driven at the
  parser directly, because the format cannot express that axis and the
  reference therefore has no verdict on it.

Both reference calls are used, each in the direction where it is authoritative.
`SnappyOracleDecodes` carries the harness's own 256 MiB bound, so it decides
the verdicts; `IsValidCompressedBuffer` carries no bound at all, so it is asked
about every stream the twin ACCEPTED, where the declaration is inside the bound
by construction. A stream cudec accepts that snappy's validator calls invalid
is a fail-open however the decoding wrapper answered.

## Result

    snappy edge sweep: 102 streams, 0 accept-side divergences,
    0 reject-side divergences, 0 bounds violations
    PASS

Zero divergence in both directions, which is what the issue asked to be
established. No change to `src/snappy_block.h` was needed, and none is in this
change: the sweep found nothing to fix.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved. No decode path changes. The sweep is the check on
      it, and it counts a reject the twin turned into an accept separately from
      an accept it turned into a reject, so neither can hide in a single total.
- [x] Oracle coverage. Every stream is diffed against the pinned snappy 1.2.2,
      byte for byte where both sides accept.
- [x] Determinism. The streams are built from constants; there is no random
      input and no ordering dependence.
- [ ] CUDA API errors. No CUDA call is added. The sweep is host-side.
- [x] Adversarial review over the diff, recorded below.
- [x] Review record below.

### Review record

This section was produced by an automated re-run, not by a second person. This
board had no second reader for this change, so the mutants below carry the
evidence in place of one.

Robustness lens, verdict clean, CONFIRMED 0 / PLAUSIBLE 0 left standing. The
driver copies element by element only AFTER checking that both cursors and the
element lie inside their buffers, so a mutant that hands back an out-of-bounds
element is counted rather than executed.

Correctness lens, one finding, disposition FIX, applied before this PR was
opened. The sweep first read `REQUIRE` inside a `void` helper; that macro
expands to `return 1`, which does not compile there, and the capacity sweep now
counts a divergence the way every other sweep does. Caught by compiling with
the same `-Wall -Wextra -Werror` the test targets carry.

Integration lens, one finding, disposition FIX, applied. The new binary was
initially outside the sanitize job's pinned name set, so it would have run only
in the plain build. That matters here more than for most tests: a header field
read past the end of the source is caught by ASan and NOT by a status, since
the read happens before any verdict is formed. The regex and the per-name
identity grep both name it now.

## Guards proven by breaking what they guard

Three mutants of `src/snappy_block.h`, each built against the sweep and run.
None of them is committed; the header is unchanged in this branch.

    git diff --name-only origin/main...HEAD
    .github/workflows/ci.yml
    tests/CMakeLists.txt
    tests/snappy_edge_sweep.cpp

1. `kSnappyLiteralInlineMax` 59 -> 60, a one-character width-class off-by-one:

       snappy edge sweep: 102 streams, 65 accept-side divergences,
       0 reject-side divergences, 0 bounds violations
       exit=1

2. `kSnappyVarintGroups` 5 -> 4, which refuses a legal five-group preamble:

       snappy edge sweep: 102 streams, 7 accept-side divergences,
       3 reject-side divergences, 0 bounds violations
       exit=1

3. The literal payload-truncation rung deleted (`if (length > src_size -
   src_pos)` forced false), which is the fail-open direction:

       the parser left its bounds on a 19-byte stream
       snappy edge sweep: 102 streams, 0 accept-side divergences,
       0 reject-side divergences, 1 bounds violations
       exit=1

   Note what this one says: the verdicts still agreed. Only the bounds counter
   caught it, which is why the counter is in the driver and why the binary
   belongs in the sanitizer set.

The unmutated control, same build, same command:

    snappy edge sweep: 102 streams, 0 accept-side divergences,
    0 reject-side divergences, 0 bounds violations
    PASS
    exit=0

## Verification

The container with the CUDA toolchain was not reachable while this was written
(the Docker daemon does not answer), and the test net only configures with
`CUDEC_ENABLE_CUDA=ON`, so `cmake`/`ctest` over the tree were NOT run here. The
sweep itself was, against the real pinned oracle rather than a stand-in.

The oracle was built from the tarball this tree pins, and the pin was checked
rather than assumed:

    curl -sSL -o snappy-1.2.2.tar.gz \
      https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz
    sha256sum snappy-1.2.2.tar.gz
    90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc

which is the `URL_HASH` in `tests/CMakeLists.txt`, and the file is the 1108618
bytes the comment beside that pin records. `snappy-stubs-public.h` was generated
from the `.in` with the same four substitutions the build performs, and
`snappy.cc` plus `snappy-sinksource.cc` were compiled, which is the same
two-translation-unit oracle the build defines. The sweep was then compiled with
`-Wall -Wextra -Werror` against `src/snappy_block.h` and the two wrappers out of
`tests/fixtures.cpp`, and run. gcc 16.1.0.

The line citations in the file were read out of that same extracted tree rather
than carried over from another file.

- [ ] `cmake --build build` / `ctest` - not run here, see above. CI builds and
      runs this test in both the plain and the sanitized configuration.
- [x] Prettier clean over the tracked set.
- [ ] Docs synced - no behaviour, API or performance change to document.

## Notes

The 3-to-4 byte width-class transition sits at a 16 MiB literal, and the sweep
does not allocate one. It is exercised on the REJECT side instead, through a
four-byte class header declaring a length no source here carries, which both
sides refuse. That is a deliberate stop and it is stated rather than left to be
inferred from the case list.

The 32-bit literal-length wrap at 0xFFFFFFFF is the one deliberate divergence
between cudec and the reference, and it stays pinned where it already is, in
`tests/snappy_parser_twin.cpp`. The neighbouring value is swept here, which is
what says the refusal above the wrap is the source bound and not the four-byte
class itself.

The stream builders are local to this file, as they are in
`tests/snappy_probes.cpp`, whose header comment says a shared builder header is
the right home and is not that change. It is not this one either, and the
duplication is now three files wide, which is worth an issue of its own rather
than a refactor smuggled into a sweep.
