### PR TITLE
Hold snappy own three negative vectors against the ladder [#156]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|frame_host_negative|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
@@ -412,6 +412,7 @@ jobs:
           grep -E ': parser_twin$' san-selected.txt &&
           grep -E ': snappy_parser_twin$' san-selected.txt &&
           grep -E ': snappy_edge_sweep$' san-selected.txt &&
+          grep -E ': snappy_upstream_negatives$' san-selected.txt &&
           grep -E ': frame_host_negative$' san-selected.txt &&
           grep -E ': termination$' san-selected.txt
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -351,6 +351,18 @@ cudec_add_test(snappy_parser_twin SOURCES snappy_parser_twin.cpp LIBS
                cudec_test_fixtures)
 target_include_directories(snappy_parser_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# snappy's own three negative vectors (issue #156), read out of the pinned
+# archive rather than copied into this tree: the URL_HASH above already proves
+# the bytes, and a copy would be three binary blobs restating it. The path is
+# handed in here so the test names none of its own; provenance and the licence
+# posture for everything under that directory are recorded in the test's header.
+cudec_add_test(snappy_upstream_negatives SOURCES snappy_upstream_negatives.cpp
+               LIBS cudec_test_fixtures)
+target_include_directories(snappy_upstream_negatives
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_compile_definitions(
+  snappy_upstream_negatives
+  PRIVATE CUDEC_SNAPPY_TESTDATA_DIR="${snappy_SOURCE_DIR}/testdata")
 # The other half of "single-source host AND device" (issue #171): the twin
 # above compiles src/snappy_block.h with the host compiler and this one hands
 # the same header to nvcc, then requires the two to produce an identical

--- a/tests/snappy_upstream_negatives.cpp
+++ b/tests/snappy_upstream_negatives.cpp
@@ -1,0 +1,165 @@
+/* snappy's own negative vectors, held against both sides (issue #156).
+ *
+ * baddata1, baddata2 and baddata3 are the three malformed streams google/snappy
+ * carries in its `testdata/` and feeds to its own decoder in
+ * snappy_unittest.cc. They are not mutations of anything in this tree, and that
+ * is their whole value: they were written by the format's authors to break the
+ * format's own decoder, so they reach the ladder from outside every generator
+ * this project owns.
+ *
+ * PROVENANCE. The files come out of the archive this tree already pins,
+ * google/snappy 1.2.2, fetched by the URL_HASH in tests/CMakeLists.txt and used
+ * from where FetchContent put it. They are NOT copied into this repository. The
+ * pin is the provenance: the whole archive is verified by SHA-256 before
+ * anything is read out of it, so a copy in the tree would restate under review
+ * what a hash already proves, and would put three binary blobs in a tree whose
+ * supply-chain rule keeps binaries out of it. Measured, at the pinned archive,
+ * for a reader who wants the per-file identity rather than the archive's:
+ *
+ *   sha256sum testdata/baddata1.snappy
+ *   ca84adbcd5b4b784c3405fcdd4fa88f88a6614f2d5e5d4a527838785f1806623
+ *   sha256sum testdata/baddata2.snappy
+ *   06f0ca34f0de885d6a849e1c8df95391d4494bf430d3784ea2167113d6ca8947
+ *   sha256sum testdata/baddata3.snappy
+ *   2f60f8c9b5f3b9b0e3b4ff9aef983946552cdd1fdecdfad122292882894163bd
+ *
+ * LICENCE. snappy is BSD-3-Clause and its COPYING covers the repository,
+ * including these three files; nothing in that file carves them out. The rest
+ * of `testdata/` is where the licence question actually lives: `fireworks.jpeg`
+ * is CC-BY-3.0, `kppkn.gtb` is MIT and `paper-100k.pdf` is CC-BY, each with its
+ * own attribution obligation. None of them is read here, and none is needed:
+ * they are compression CORPORA, and this project generates its own from the
+ * Silesia path. Only the three negatives are used, and only through the pinned
+ * archive, so no attribution obligation is created and none is discharged in
+ * silence.
+ *
+ * What is asserted, per file: snappy's own no-write validator refuses it, the
+ * decoding wrapper refuses it, and the cudec ladder refuses it with a defined
+ * status and produces nothing. Reject parity on an outside corpus, which is the
+ * property the fail-closed contract is made of. */
+#include "cudec.h"
+#include "fixtures.h"
+#include "require.h"
+#include "snappy_block.h"
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* Where FetchContent put the pinned archive, handed in by the build so this
+ * file names no path of its own. */
+#ifndef CUDEC_SNAPPY_TESTDATA_DIR
+#error "CUDEC_SNAPPY_TESTDATA_DIR must name the pinned archive's testdata/"
+#endif
+
+bool ReadFile(const std::string& path, Bytes* out) {
+    out->clear();
+    FILE* file = std::fopen(path.c_str(), "rb");
+    if (file == nullptr) {
+        return false;
+    }
+    unsigned char buffer[4096];
+    size_t got = 0;
+    while ((got = std::fread(buffer, 1, sizeof buffer, file)) > 0) {
+        out->insert(out->end(), buffer, buffer + got);
+    }
+    const bool ok = std::ferror(file) == 0;
+    std::fclose(file);
+    return ok;
+}
+
+/* Drives the ladder to a verdict and reports whether anything was produced. A
+ * reject that wrote bytes first is a different failure from a reject that
+ * wrote none, and only the second one is fail-closed. */
+cudec_status TwinVerdict(const Bytes& stream, uint64_t* produced,
+                         cudec_detail::SnappyReject* rung) {
+    *produced = 0;
+    *rung = cudec_detail::kSnappyRejectNone;
+    const size_t size = stream.size();
+    auto tight = std::make_unique<unsigned char[]>(size);
+    if (size != 0) {
+        std::memcpy(tight.get(), stream.data(), size);
+    }
+    cudec_detail::SnappyParser parser{tight.get(), size, kSnappyOracleMaxOutput};
+    cudec_status status = parser.Begin();
+    if (status != CUDEC_OK) {
+        *rung = parser.reject;
+        return status;
+    }
+    cudec_detail::SnappyElement element;
+    bool done = false;
+    uint64_t fuel = static_cast<uint64_t>(size) + 2;
+    while (true) {
+        if (fuel-- == 0) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        status = parser.Next(&element, &done);
+        if (status != CUDEC_OK) {
+            /* What a caller executing the elements would have written before
+             * the refusal arrived. The contract is that this never becomes
+             * output: a rejected stream produces nothing. */
+            *produced = parser.dst_pos;
+            *rung = parser.reject;
+            return status;
+        }
+        if (done) {
+            *produced = parser.dst_pos;
+            return CUDEC_OK;
+        }
+    }
+}
+
+}  // namespace
+
+int main() {
+    const char* names[] = {"baddata1.snappy", "baddata2.snappy",
+                           "baddata3.snappy"};
+    for (const char* name : names) {
+        const std::string path =
+            std::string(CUDEC_SNAPPY_TESTDATA_DIR) + "/" + name;
+        Bytes stream;
+        REQUIRE_CTX(ReadFile(path, &stream), "%s", path.c_str());
+        /* A vector that failed to arrive would otherwise be an empty stream,
+         * which every decoder refuses - a green run proving nothing. */
+        REQUIRE_CTX(stream.size() > 1024, "%s is %zu bytes", name,
+                    stream.size());
+
+        REQUIRE_CTX(!SnappyOracleAccepts(stream), "%s", name);
+        Bytes oracle_out;
+        REQUIRE_CTX(!SnappyOracleDecodes(stream, &oracle_out), "%s", name);
+        REQUIRE_CTX(oracle_out.empty(), "%s", name);
+
+        uint64_t produced = 0;
+        cudec_detail::SnappyReject rung = cudec_detail::kSnappyRejectNone;
+        const cudec_status status = TwinVerdict(stream, &produced, &rung);
+        REQUIRE_CTX(status != CUDEC_OK, "%s was accepted by the ladder", name);
+        REQUIRE_CTX(status == CUDEC_ERR_CORRUPT_INPUT ||
+                        status == CUDEC_ERR_OUTPUT_TOO_SMALL,
+                    "%s refused with status %d", name,
+                    static_cast<int>(status));
+        /* The RUNG, not only the verdict, and the difference was measured
+         * rather than assumed: with the copy-before-start check deleted, all
+         * three files are still refused - a later rung catches each one - so a
+         * verdict-only assertion here passes over a decoder that lost the
+         * check these vectors exist to exercise. All three of them refuse for
+         * the same reason, a copy reaching before the start of the output,
+         * which is the defect snappy planted in them. A refactor that moves
+         * the refusal to another rung reds this and should. */
+        REQUIRE_CTX(rung == cudec_detail::kSnappyRejectCopyOffsetBeforeStart,
+                    "%s refused at rung %d, not the copy-before-start rung",
+                    name, static_cast<int>(rung));
+        std::printf("%s: %zu bytes, refused by both, status %d, rung %d, %llu "
+                    "bytes produced before the refusal\n",
+                    name, stream.size(), static_cast<int>(status),
+                    static_cast<int>(rung),
+                    static_cast<unsigned long long>(produced));
+    }
+    std::printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
# What & why

Refs #156. This does NOT close it: one of the three things that issue asks for
is deliberately not done, and the reason is written into the issue rather than
left here. What is done is the coverage and the record.

`baddata1.snappy`, `baddata2.snappy` and `baddata3.snappy` are the malformed
streams google/snappy carries in its `testdata/` and feeds to its own decoder.
They are not mutations of anything in this tree, and that is their value: they
were written by the format's authors to break the format's decoder, so they
reach the ladder from outside every generator this project owns. Nothing here
had ever read them.

`tests/snappy_upstream_negatives.cpp` asserts, per file: snappy's own no-write
validator refuses it, the decoding wrapper refuses it and writes nothing, and
the cudec ladder refuses it at the rung the planted defect belongs to.

## What the vectors turned out to be

All three are refused by both sides, and all three for the same reason: a copy
whose offset reaches before the start of the output.

    baddata1.snappy: 27512 bytes, refused by both, status 2, rung 12,
      19791 bytes produced before the refusal
    baddata2.snappy: 27483 bytes, refused by both, status 2, rung 12,
      82393 bytes produced before the refusal
    baddata3.snappy: 28384 bytes, refused by both, status 2, rung 12,
      35399 bytes produced before the refusal
    PASS

Rung 12 is `kSnappyRejectCopyOffsetBeforeStart`. No divergence, and no change
to `src/snappy_block.h` was needed.

## The rung, not only the verdict, and why

The first version of this test asserted the verdict alone. Deleting the
copy-before-start check from the ladder left it GREEN: all three files are
still refused, because a later rung catches each one once the earlier one is
gone.

    # if (offset > dst_pos)  ->  if (false)
    baddata1.snappy: refused by both, status 2, 128004 bytes produced
    baddata2.snappy: refused by both, status 2, 127553 bytes produced
    baddata3.snappy: refused by both, status 2, 35423 bytes produced
    PASS
    exit=0

So a verdict-only test here would have passed over a decoder that had lost the
very check these vectors exist to exercise, and would have looked exactly like
one that had not. With the rung asserted, the same mutant reds:

    FAIL snappy_upstream_negatives.cpp:154:
      rung == cudec_detail::kSnappyRejectCopyOffsetBeforeStart |
      baddata1.snappy refused at rung 6, not the copy-before-start rung
    exit=1

The cost of pinning the rung is that a refactor moving the refusal elsewhere
reds this test. That is the intended reading: which rung catches an outside
vector is a fact about the ladder worth noticing when it changes.

## Provenance and licence, recorded in the tree

Both are in the test's header, where the next reader of these vectors will be,
rather than only here.

The files are read from the pinned archive where FetchContent puts it. The
whole archive is verified by SHA-256 before anything is read out of it, so the
pin IS the provenance. The per-file identities are recorded beside it, measured
at that archive:

    ca84adbcd5b4b784c3405fcdd4fa88f88a6614f2d5e5d4a527838785f1806623  baddata1
    06f0ca34f0de885d6a849e1c8df95391d4494bf430d3784ea2167113d6ca8947  baddata2
    2f60f8c9b5f3b9b0e3b4ff9aef983946552cdd1fdecdfad122292882894163bd  baddata3

snappy is BSD-3-Clause and its `COPYING` covers the repository, these three
files included; nothing in it carves them out. The licence question in that
directory is about the CORPUS files beside them - `fireworks.jpeg` CC-BY-3.0,
`kppkn.gtb` MIT, `paper-100k.pdf` CC-BY, each with an attribution obligation of
its own. None of them is read, and none is needed: this project generates its
own corpora from the Silesia path. So no attribution obligation is created here
and none is discharged in silence.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved. No decode path changes; this is a check on one.
- [x] Oracle coverage. Every vector is put to both reference calls.
- [x] Determinism. Three fixed files from a hash-pinned archive.
- [ ] CUDA API errors. Not applicable, host-side.
- [x] Adversarial review over the diff, recorded below.
- [x] Review record below.

### Review record

This section was produced by an automated re-run, not by a second person. This
board had no second reader for this change, so the mutant above stands in place
of one.

Correctness lens, one finding, disposition FIX, applied before this PR was
opened: the verdict-only assertion described above, which the mutant showed to
be inert. That is the whole reason the rung is asserted.

Robustness lens, verdict clean, CONFIRMED 0 / PLAUSIBLE 0. The size floor on
each file is there so a vector that failed to arrive cannot pass as a refused
stream: an empty file is refused by everything, and would otherwise be a green
run proving nothing.

Integration lens, verdict clean, CONFIRMED 0 / PLAUSIBLE 0. The test names no
path of its own; the build hands it the directory FetchContent populated, so
the path cannot drift from the pin. Three files change:

    git diff --name-only origin/main...HEAD
    .github/workflows/ci.yml
    tests/CMakeLists.txt
    tests/snappy_upstream_negatives.cpp

## Verification

The container with a CUDA toolchain was not reachable while this was written
(the Docker daemon does not answer) and the test net only configures with
`CUDEC_ENABLE_CUDA=ON`, so `cmake`/`ctest` over the tree were NOT run here.
The test itself was, against the real pinned oracle.

The archive was fetched and its hash checked against the `URL_HASH` in
`tests/CMakeLists.txt` before anything was read out of it:

    sha256sum snappy-1.2.2.tar.gz
    90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc

`snappy-stubs-public.h` was generated from the `.in` with the same four
substitutions the build performs, `snappy.cc` and `snappy-sinksource.cc` were
compiled - the same two translation units the oracle target defines - and the
test was built against `src/snappy_block.h` and the two wrappers out of
`tests/fixtures.cpp` with `-Wall -Wextra -Werror`, then run. gcc 16.1.0.

- [ ] `cmake --build build` / `ctest` - not run here, see above.
- [x] Prettier clean over the tracked set, which `ci.yml` is in:

      npx prettier@3 --check $(git ls-files '*.yml')
      All matched files use Prettier code style!
- [ ] Docs synced - no behaviour, API or performance change.

## Notes

This branch carries a merge of `main` rather than a rebase: the sweep from #172
landed in the same place in `tests/CMakeLists.txt` while this was being written,
and both registrations belong there. Rebasing would have needed a force-push
over a branch that was already pushed.

The test is in the sanitize job's pinned name set, regex and per-name grep
both, because it drives the ladder over real malformed streams and a read past
the end of a source is caught by ASan rather than by a verdict.
