### PR TITLE
The GPU sanitizer gate in the process, and the M5 Zstd v1 decode subset [#130, #102]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,32 @@
       reproduction was produced). Every finding of either kind carries a
       disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
 
+## GPU sanitizer gate
+
+Required from M1 onward for every change that touches device code. CI has no
+GPU, so the pasted output below is the evidence and there is nothing that
+reds without it. Produced by `scripts/sanitize-gpu.sh` inside the pinned
+container; the invocation is in [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+- [ ] Not applicable: this change touches no device code.
+
+```
+commit:    <sha the sweep ran against>
+gpu:       <name, driver version>
+cuda:      <nvcc release>
+sanitizer: <compute-sanitizer version>
+
+  <test>           memcheck   PASS/FAIL
+  <test>           racecheck  PASS/FAIL
+  <test>           initcheck  PASS/FAIL
+  <test>           synccheck  PASS/FAIL
+```
+
+racecheck reports shared-memory hazards only, so a clean sweep is not
+clearance for global memory. If no route to a device the sanitizer can attach
+to was available, say so here with the command that shows it, and leave the
+block empty rather than removing it.
+
 ## Performance checklist
 
 Fill in for any change on the hot path.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,41 @@ and need a CUDA 12.x toolchain plus a GPU for the tests - see the README's
 container command for the maintained path (build directory `build-cuda`,
 `ctest --test-dir build-cuda`).
 
+### The GPU sanitizer gate
+
+Any change that touches device code carries a Compute Sanitizer sweep, from M1
+onward. All four tools run over every `gpu`-labelled ctest target, and the
+output goes in the pull-request body: CI has no GPU, so nothing in the
+workflow can red for a missing sweep and the paste is the whole evidence.
+
+`scripts/sanitize-gpu.sh` is the runner. It discovers its targets with
+`ctest -L gpu -N` rather than from a list, and it refuses a sweep that covered
+nothing - an absent `compute-sanitizer`, an empty discovery, a missing binary
+or a known GPU test gone from the discovered set are errors there and never
+skips. The commit is passed in because the image ships no git:
+
+```sh
+docker run --rm --gpus all -v "$PWD:/w" -w /w \
+  nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8 \
+  sh -c "apt-get update -q >/dev/null && \
+         apt-get install -yq cmake >/dev/null 2>&1 && \
+         cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && \
+         cmake --build build-cuda -j && \
+         CUDEC_COMMIT=$(git rev-parse HEAD) scripts/sanitize-gpu.sh build-cuda"
+```
+
+racecheck checks shared-memory hazards only. A clean run says nothing about
+global-memory races, and reading it as clearance for them is the mistake this
+sentence exists to stop.
+
+The gate is written down here in full, and issue #258 records that no route to
+a device it can attach to is available today: under WSL2 the device is in WDDM
+mode, the debugger interface the sanitizer needs is absent, and all four tools
+report the same two initialization errors on a program with no fault in it. So
+the sweep is owed and currently cannot be produced on that route. Say that in
+the pull request, with the command that shows it, rather than leaving the block
+looking answered.
+
 `-DCUDEC_ENABLE_HIP=ON` exists and currently refuses on every machine: there
 are no HIP device sources yet, so the option fails the configure rather than
 handing back a host-only library that looks like a working port. The two

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ one, and this README will never claim otherwise.
 
 ## Status
 
-**M0 and M1 are complete; M2 is in progress.** cudec decodes real LZ4 on an
+**M0 through M2 are complete; M3 is next.** cudec decodes real LZ4 on an
 NVIDIA GPU today - batch block decode, the `.lz4` frame format
 (block-independent subset), and a pinned-host streaming path - all fail-closed
 and fuzz-diffed against liblz4. The design record is
@@ -52,15 +52,15 @@ baselines, each carrying its full methodology, are in
 port are planned, not yet implemented. Progress is tracked in the issues and
 milestones:
 
-| Milestone        | Deliverable                                         | Status      |
-| ---------------- | --------------------------------------------------- | ----------- |
-| M0 - Foundation  | Toolchain, CMake+CUDA skeleton, CI, test harness    | done        |
-| M1 - LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed      | done        |
-| M2 - LZ4 batch   | Frame format, batch API, streaming path, benchmarks | in progress |
-| M3 - Snappy      | Snappy decode on the same kernel family             | planned     |
-| M4 - GDeflate    | GDeflate decode as an auditable CUDA library        | planned     |
-| M5 - Zstd        | Zstd decode (FSE/Huffman sequences)                 | planned     |
-| M6 - Portability | HIP port                                            | planned     |
+| Milestone        | Deliverable                                         | Status  |
+| ---------------- | --------------------------------------------------- | ------- |
+| M0 - Foundation  | Toolchain, CMake+CUDA skeleton, CI, test harness    | done    |
+| M1 - LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed      | done    |
+| M2 - LZ4 batch   | Frame format, batch API, streaming path, benchmarks | done    |
+| M3 - Snappy      | Snappy decode on the same kernel family             | planned |
+| M4 - GDeflate    | GDeflate decode as an auditable CUDA library        | planned |
+| M5 - Zstd        | Zstd decode (FSE/Huffman sequences)                 | planned |
+| M6 - Portability | HIP port                                            | planned |
 
 ## Principles
 

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1061,3 +1061,146 @@ own terms, and it means the vendoring rung has nothing left to invent.
 **This subsection is about attribution only.** The patent position and the
 implementation-provenance posture are a separate, maintainer-gated
 decision, and nothing here pre-empts or softens it.
+
+## 12. M5 Zstd v1 decode subset (RFC 8878)
+
+Zstd is the one format on the ladder where "what cudec decodes" is a design
+decision rather than a reading. The spec's full envelope reaches windows the
+spec itself measures in terabytes, dictionaries, and frames that declare no
+content size, and none of those three is batch-GPU-shaped. The spec sanctions
+refusing part of that envelope in as many words, so the subset below is a
+decoder choice made inside the standard rather than a departure from it.
+
+Every fact quoted here was read out of RFC 8878 on 2026-08-06 at
+<https://www.rfc-editor.org/rfc/rfc8878.txt>, with the section number beside
+it, so a later reader can check the subset against the source instead of
+against this paragraph.
+
+### 12.1 The two facts that fix the batch unit
+
+Blocks inside one frame are **not** independent. Section 3.1.1.3 puts
+back-references at "previous decoded data, up to a distance of Window_Size,
+or the beginning of the Frame, whichever is smaller", and section 3.1.1.4
+adds that "all offsets leading to previously decoded data must be smaller
+than Window_Size". Entropy state carries across blocks in the same direction:
+Treeless literals reuse the previous block's Huffman table, and a sequence
+section in Repeat_Mode reuses the previous FSE tables. So decode inside a
+frame is inherently sequential, and no choice of kernel shape changes that.
+
+Frames **are** independent. Section 3.1: "Each frame is independent and can
+be decompressed independently of other frames. The decompressed content of
+multiple concatenated frames is the concatenation of each frame's
+decompressed content."
+
+Therefore **the batch unit is the frame**, which is the chunk model the batch
+ABI already has. The parallelism M5 sells is across frames; a single large
+frame is a sequential decode with intra-block parallelism only. That is the
+honest shape, and it is stated here so that no later section has to walk it
+back.
+
+### 12.2 The accepted envelope
+
+Inside the subset, everything the format offers is decoded: all three usable
+block types (Raw, RLE, Compressed), all four literals section types including
+Treeless, all four sequence table modes including Repeat, full repcode
+semantics, and the XXH64 content checksum verified whenever the frame carries
+one. Section 3.1.1 fixes what that checksum is: "the result of the XXH64()
+hash function digesting the original (decoded) data as input, and a seed of
+zero. The low 4 bytes of the checksum are stored in little-endian format."
+
+The gate sits at the frame header, and nowhere narrower:
+
+| Frame property              | Accepted                        | Refused with            |
+| --------------------------- | ------------------------------- | ----------------------- |
+| Magic number                | The Zstandard magic             | `CORRUPT_INPUT`         |
+| Skippable frame magic       | Never; 0x184D2A50 to 0x184D2A5F | `UNSUPPORTED`, see 12.4 |
+| `Dictionary_ID_flag`        | 0 only                          | `UNSUPPORTED`           |
+| `Frame_Content_Size`        | Present                         | `UNSUPPORTED`           |
+| `Single_Segment_flag` set   | Yes; window is the content size | -                       |
+| `Single_Segment_flag` clear | Window_Size up to 8 MB          | `UNSUPPORTED` above it  |
+| Reserved bits in the header | Zero                            | `CORRUPT_INPUT`         |
+| Block type                  | 0, 1 or 2                       | `CORRUPT_INPUT`         |
+| Block size                  | Up to min(Window_Size, 128 KB)  | `CORRUPT_INPUT`         |
+
+The two window rows come from section 3.1.1.1.2, which recommends "decoders
+to support values of Window_Size up to 8 MB" and, in the same section, allows
+"a decoder to reject a compressed frame that requests a memory size beyond
+the decoder's authorized range". Refusing above 8 MB is therefore inside the
+standard, and the number is the spec's own rather than one this project
+picked.
+
+`Single_Segment_flag` is the shape the GPU wants, and section 3.1.1.1.1.2
+says why it costs nothing to prefer: "If this flag is set, data must be
+regenerated within a single continuous memory segment. In this case,
+Window_Descriptor byte is skipped, but Frame_Content_Size is necessarily
+present." A declared content size is what lets output placement happen before
+the first byte is decoded, which is the property the LZ4 batch path already
+relies on.
+
+Block_Maximum_Size is section 3.1.1.2.4, "the smallest of: Window_Size [and]
+128 KB". Block type 3 is section 3.1.1.2.2: "Reserved: This is not a block.
+This value cannot be used with the current specification. If such a value is
+present, it is considered to be corrupt data." The spec assigns that rejection
+to the corrupt class itself, so cudec does not have to argue for it.
+
+### 12.3 Which rejection class, and why the line sits there
+
+`CUDEC_ERR_CORRUPT_INPUT` means no conforming encoder produced these bytes.
+`CUDEC_ERR_UNSUPPORTED` means a conforming encoder did, and cudec does not
+decode that part of the format. The distinction is a contract with the
+caller: a corrupt verdict is about the data and an unsupported verdict is
+about this library, and a caller that would fall back to a CPU decoder needs
+to tell them apart.
+
+So a dictionary id, an absent content size and a window above 8 MB are all
+`UNSUPPORTED`; each is a valid frame. Reserved bits, block type 3, an
+oversized block and a failed checksum are `CORRUPT_INPUT`. Nothing in the
+subset is refused silently, and no refusal may leave partial output that a
+caller could read as a short decode.
+
+### 12.4 Skippable frames are refused, not stepped over
+
+A skippable frame is refused with `UNSUPPORTED`.
+
+The spec makes stepping over one trivial. Section 3.1.2 gives the magic range
+0x184D2A50 to 0x184D2A5F and a `Frame_Size` field "represented using 4 bytes,
+little-endian format, unsigned 32 bits", so this is not a difficulty; it is a
+scope line. Stepping over one means a chunk holds a frame sequence rather
+than a frame, and the moment the unit is a sequence the per-chunk result has
+to describe several decodes with one status and one byte count. That is a
+batch-ABI question before it is a decode question, and it is what the
+extension ladder's first rung is for. Until that rung is taken, one chunk is
+one frame.
+
+### 12.5 The extension ladder, with its triggers
+
+Each rung carries the thing that would justify taking it, so that nobody
+proposes one without new evidence:
+
+1. **Multi-frame chunks, and skippable frames with them.** Taken when a real
+   corpus arrives whose chunks are frame sequences. Needs a per-chunk result
+   shape that can describe more than one decode.
+2. **Frames with no `Frame_Content_Size`.** Taken when a producer that
+   matters emits them. Needs either a sizing pre-pass or a growable output
+   contract, and both break the single-pass placement the batch model rests
+   on.
+3. **Windows above 8 MB.** Taken when a corpus measurably needs one. The cost
+   is device memory per in-flight frame, so the trigger is a measurement and
+   not a request.
+4. **Performance tiers.** Only once the subset decodes correctly. The
+   project's ordering, correctness before measured performance, applies here
+   with no exception.
+
+Permanently out until a design says otherwise: **dictionaries**, because they
+break the frame independence the batch unit rests on, and **legacy v0.x
+frames**, which are a different format wearing the same name.
+
+### 12.6 The recorded expectation
+
+Zstd is the slowest of the standard formats to decode on a GPU, and M5 wins
+at batch scale or it does not win. The entropy stages are serial by
+construction, each sequence's copy depends on the sequences before it, and
+12.1's block chain means one frame cannot be spread across the device. This
+is written down before the first number is measured, so that the number,
+whatever it turns out to be, is read against the expectation rather than
+against a hope.

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -207,6 +207,21 @@ is not an empty AMD field), and **hackability**.
   vacuously; `--no-tests=error` closes the zero-tests-selected route; CI
   prints the deferred `-L gpu -N` listing and pins the known GPU tests by
   name.
+- **The GPU sanitizer gate**, required from M1 onward for every PR that
+  touches device code: all four Compute Sanitizer tools - memcheck,
+  racecheck, initcheck, synccheck - over every `gpu`-labelled ctest target,
+  through `scripts/sanitize-gpu.sh`, which fails closed on a sweep that
+  covered nothing. CI cannot run it: the free plan has no GPU runners, so no
+  workflow reds for a missing sweep and the output pasted into the pull
+  request is the whole evidence, carrying the commit, the GPU, the driver and
+  the CUDA version it was produced against. **racecheck detects
+  shared-memory hazards only** - global-memory races are outside its scope,
+  and a clean sweep is never read as clearance for them. Today the gate is
+  owed and unproducible on the maintainer route: under WSL2 the device is in
+  WDDM mode, the debugger interface the tools need is absent, and all four
+  report the same two initialization errors against a program with no fault in
+  it, which #258 records with its commands. That is a gap in the evidence, not
+  a dispensation from the gate.
 - **Oracle pinning policy**: oracles are vendored via FetchContent from
   maintainer-uploaded release assets, pinned by a self-computed SHA-256
   cross-checked against a second packaging ecosystem; auto-generated


### PR DESCRIPTION
# What & why

Closes #130. Closes #102. Closes #146.

Three document-only changes on one branch. They share no paragraph, and the
only file two of them touch is `docs/MASTERPLAN.md`, in different sections.
They land together because each separate landing moves the mainline under
whatever else is open.

    $ git diff --name-only origin/main...HEAD
    .github/pull_request_template.md
    CONTRIBUTING.md
    README.md
    docs/MASTERPLAN.md

# Part one, #130: the GPU sanitizer gate

## The three surfaces

`.github/pull_request_template.md` gains a **GPU sanitizer gate** block above
the performance checklist. It carries the four tool results in the shape the
runner prints them, plus the commit, GPU, driver, CUDA and sanitizer versions
they were produced against, and a single opt-out line for a change that
touches no device code. The shape is the runner's own `report()` output rather
than an invention:

    $ sed -n '/=== Compute Sanitizer summary ===/,/cat "\$results"/p' \
        scripts/sanitize-gpu.sh
        echo "=== Compute Sanitizer summary ==="
        echo "commit:    $commit"
        echo "gpu:       $(nvidia-smi --query-gpu=name,driver_version \
            --format=csv,noheader)"
        echo "cuda:      $(nvcc --version | sed -n \
            's/^.*release \([0-9][0-9.]*\).*$/\1/p')"
        echo "sanitizer: $(compute-sanitizer --version |
            sed -n 's/^Version //p')"
        echo "build:     $build"
        echo
        cat "$results"

`CONTRIBUTING.md` gains the invocation in its build and test section: the
`docker run --gpus all` line against the digest-pinned image, the
`-DCUDEC_ENABLE_CUDA=ON` configure, and the `scripts/sanitize-gpu.sh` call
with `CUDEC_COMMIT` expanded on the host, because the image ships no git and
the script refuses a run that names no commit.

`docs/MASTERPLAN.md` section 5 gains the gate itself: required from M1 onward
for every change touching device code, run through the script that fails
closed on a sweep covering nothing, with CI unable to run it at all.

## The two things the gate is not

**CI cannot red for a missing sweep.** The free plan has no GPU runner, so the
paste in the body is the whole evidence and no workflow reads it. That is
written in all three places in those words rather than implied by the gate's
absence from `ci.yml`.

**racecheck is shared memory only.** A clean racecheck is not clearance for
global-memory races. The tool's own help is where that comes from, and the
runner's header already records it beside the flags it settled:

    $ sed -n '/initcheck has no --initcheck-address-space/,/left off\./p' \
        scripts/sanitize-gpu.sh
    #   - initcheck has no --initcheck-address-space. Its own help calls it
    #     "Global memory initialization checking", so in this version the tool
    #     has no shared-memory address space to switch on; shared memory is
    #     racecheck's subject ("Shared memory hazard checking") and racecheck
    #     runs below. initcheck's remaining knob, --track-unused-memory,
    #     reports unused allocations rather than uninitialised reads and is
    #     left off.

## What all three places say cannot be done today

#258 measured that no route to a device the sanitizer can attach to exists on
my machine: under WSL2 the device is in WDDM mode, the debugger
interface is absent, and all four tools report the same two initialization
errors against a program with no fault in it. So the gate is owed and
currently unproducible on that route.

Written into the documents rather than left to the issue, and written as a
gap in the evidence rather than as a dispensation. The template's block says
to state the unavailability with its command and leave the block empty, never
to remove it. If #258 is resolved by moving the gate elsewhere, that sentence
is what moves; the requirement above it does not.

# Part two, #102: the M5 Zstd v1 decode subset

`docs/MASTERPLAN.md` gains section 12. Zstd is the one format on the ladder
where what cudec decodes is a decision rather than a reading, and without it
written down every M5 implementation issue re-derives the same line from
RFC 8878, with two of them drawing it differently.

The section records the accepted envelope, every rejection mapped to
`UNSUPPORTED` or `CORRUPT_INPUT` with the reason the line sits there,
skippable frames refused rather than stepped over with the ABI reason,
the extension ladder with a trigger per rung, and the recorded expectation
that Zstd is the slowest standard format on a GPU.

## Every spec fact was read out of the RFC, not inherited

The issue body carried these facts with a 2026-07-25 date. They were read
again for this change, on 2026-08-06, at
<https://www.rfc-editor.org/rfc/rfc8878.txt>, and each one is quoted in the
section with its own section number so a later reader checks the subset
against the source rather than against the paragraph asserting it. The
load-bearing ones:

- 3.1: "Each frame is independent and can be decompressed independently of
  other frames."
- 3.1.1.3 and 3.1.1.4: back-references reach "previous decoded data, up to a
  distance of Window_Size, or the beginning of the Frame, whichever is
  smaller", and "all offsets leading to previously decoded data must be
  smaller than Window_Size".
- 3.1.1.1.2: "it's recommended for decoders to support values of Window_Size
  up to 8 MB", and a decoder "is allowed to reject a compressed frame that
  requests a memory size beyond the decoder's authorized range".
- 3.1.1.1.1.2: with `Single_Segment_flag` set, "Window_Descriptor byte is
  skipped, but Frame_Content_Size is necessarily present".
- 3.1.1.2.4: Block_Maximum_Size is "the smallest of: Window_Size [and]
  128 KB".
- 3.1.1.2.2: block type 3 "is considered to be corrupt data".
- 3.1.2: skippable magic is 0x184D2A50 to 0x184D2A5F with a `Frame_Size`
  field of "4 bytes, little-endian format, unsigned 32 bits".
- 3.1.1: the checksum is XXH64 with "a seed of zero", and "the low 4 bytes of
  the checksum are stored in little-endian format".

Those two spec facts together are what fix the batch unit at the frame, which
is the chunk model the batch ABI already has, and the section says so plainly
rather than letting a reader infer that a large single frame parallelises.

## The two places the section makes a decision rather than a reading

**Skippable frames are refused with `UNSUPPORTED`, not stepped over.** Section
3.1.2 makes stepping over one trivial, so this is a scope line and not a
difficulty: stepping over one means a chunk holds a frame sequence, and a
sequence cannot be described by one status and one byte count in
`cudec_chunk_result`. It is an ABI question, and it is the ladder's first
rung.

**The class of each rejection.** A dictionary id, an absent content size and
a window above 8 MB are `UNSUPPORTED`, because each is a frame a conforming
encoder produced. Reserved bits, block type 3, an oversized block and a
failed checksum are `CORRUPT_INPUT`. The line matters to a caller that would
fall back to a CPU decoder, and it is the #23 distinction the header already
carries.

# Part three, #146: M2 published as done

The status table said M2 was in progress. Every deliverable that row names is
in the tree. Three of the four are entry points in the public header:

    $ grep -n "cudec_lz4f_decompress\|cudec_lz4_decompress_batch\|cudec_lz4_decompress_stream_ctx" include/cudec.h
    102:cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
    130:cudec_status cudec_lz4f_decompress(const void* frame, size_t frame_size,
    193:cudec_status cudec_lz4_decompress_stream_ctx(
    204: * cudec_stream_ctx_create, one cudec_lz4_decompress_stream_ctx, and

The fourth is the published benchmark, which is two recorded sections each
carrying its methodology:

    $ grep -n "^## M1: \|^## M2: " docs/BENCHMARKS.md
    20:## M1: first GPU decode (Silesia)
    451:## M2: reusable streaming context, end-to-end (Silesia)

After the edit nothing in either document calls M2 in progress:

    $ grep -rn "in progress" README.md docs/MASTERPLAN.md; echo "exit=$?"
    exit=1

`docs/MASTERPLAN.md` is untouched by this half. Its milestone table carries
deliverables and no status column, so there is no second row to flip, and
adding one would put the same status in two files for the next reader to find
out of step.

What the flipped row does not say is the part worth reading. The M2 milestone
still holds fourteen open issues:

    $ gh issue list --milestone "M2 - LZ4 batch" --state open --json number --jq length
    14

    $ gh issue list --milestone "M2 - LZ4 batch" --state open --json number,labels         --jq '.[] | select(.labels[].name=="priority:p2") | .number'
    146
    142
    141
    140
    139
    82

Six are p2 and eight are p3. The p2 set is this issue, the three libFuzzer
issues split out of #69 (#140, #141, #142), the asset-like corpus (#139) and
the release itself (#82). The p3 set is the perf backlog that #82 already
recorded as not blocking the tag. So the row states the four deliverables it
names and not the milestone's issue count, and a reader who opens the
milestone finds those fourteen. The fuzz gap in particular is written into
#82, where the tag decision is.

## Type of change

- [x] Docs

## Engineering checklist

Not applicable, every line. No source, script, test or workflow file is in
the diff, and the three names above are the whole of it.

- [ ] An adversarial review (`/security-review`) was run. It was **not** run,
      and the box stays unticked. The sensitive surface is kernels, format
      parsing, the C-ABI boundary, the build files and the workflows; this
      diff reaches none of them. A reviewer who holds that a document stating
      a security gate, or one fixing a format's accepted envelope, is itself
      on that surface has a fair reading and this should go back.
- [ ] Review record. There is none. This change had no second reader, and the
      commands and quotations in this body are the evidence in place of one.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

## Quality checklist

- [x] Minimal: one block per surface for #130; one section for #102, placed
      after the M4 dossier in the numbering the document already uses.
- [x] Comments explain why. The racecheck sentence, the #258 sentence, the
      skippable-frame reason and the rejection-class reason are each there
      because a reader would otherwise get that specific thing wrong.
- [ ] Conformance test. None for either half, and the gap is the same in both
      shapes: nothing reds when the template block is deleted, when the
      invocation drifts from the runner's real usage, or when an M5 change
      contradicts section 12. The gate for the first is a paste CI cannot
      read, and the gate for the second is the M5 negative ladder, which
      #200 owes and which does not exist yet.

## Verification

- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.

      $ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
      Checking formatting...
      All matched files use Prettier code style!

- [ ] `cmake --build build` / `ctest` - not run. No C, C++, CUDA or CMake
      file is in the diff, and the build gate runs on this pull request in CI.
- [x] Docs synced: the documents are the change.

## Notes

The means for both halves is Markdown in the documents each issue names,
because both facts are process or design facts with exactly one place a
reader already looks. Neither refuses anything, and each says so in its own
text.

Section 12 is written to be falsifiable rather than agreeable: every spec
claim carries the section it came from, and the extension ladder carries the
trigger that would justify taking each rung, so a later proposal has to bring
evidence rather than a preference.

## Merge state

The head this was opened from predated the repaired version gate, so the
`build` job red on it for a reason outside this diff. The branch was rebuilt
on the current mainline and every check on the new head is green:

    $ gh api repos/iderex/cudec/commits/8b304bed9aa2dda0f61f50f5a294fa08c0feb099/check-runs         --jq '[.check_runs[]|"\(.name):\(.conclusion)"]|join(" ")'
    CodeQL:success dependency-review:success build:success format:success sanitize:success analyze:success

That covers the build in both configurations, the host-side test subset, the
sanitize job and Prettier over the whole glob. No GPU ran, which for a
documents-only diff is the whole of what is owed.

This change had no second reader. The commands in this body are the evidence
in place of one, and the sanitizer gate the first half writes down is a gate
this machine cannot execute today, which the documents state in their own
text rather than leaving to be inferred.

