### PR TITLE
Refuse a Dependabot config the platform would reject [#232]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,20 @@ jobs:
       - name: Prettier check
         run: npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
 
+      # A Dependabot config the platform rejects is refused here rather than
+      # failing silently (issue #232). GitHub parses .github/dependabot.yml on
+      # its own schedule and reports a rejection nowhere this repository can
+      # read, so a misspelled key looks configured while the setting it names
+      # is not in force. The step above already reds an unparseable file - it
+      # is the YAML parser in this job - and passes a well-formed file whose
+      # keys the platform does not know.
+      #
+      # The route, the schema pin, the exact validator versions and the
+      # self-test that keeps the check from passing vacuously are argued in
+      # the script's own header, next to the constants they are about.
+      - name: Dependabot config validates against the published schema
+        run: scripts/check-dependabot-config.sh
+
       # Every Action pinned to a full commit SHA, enforced rather than swept
       # (issue #131). A tag or branch pin resolves to whatever the upstream
       # owner points it at later, which is the supply-chain hole the pinning

--- a/scripts/check-dependabot-config.sh
+++ b/scripts/check-dependabot-config.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# Refuses a .github/dependabot.yml the platform would reject.
+#
+# The failure this prevents is silent: GitHub parses the file on its own
+# schedule and reports a rejection nowhere this repository can read, so a
+# misspelled key sits in the tree looking configured while the setting it
+# names is not in force. Prettier already reds an unparseable file - it is
+# the YAML parser in the format job - and passes a well-formed file whose
+# keys the platform does not know, which is the whole gap this closes.
+#
+# Route: validate against the published JSON schema. The other route the
+# issue named, reading the platform's own parse status, has no public API -
+# GitHub's REST surface for Dependabot is alerts and secrets, and the
+# validation result appears only in the web UI. So the schema is the only
+# machine-readable statement of the config grammar available, and its known
+# limit is stated rather than glossed: Dependabot applies checks beyond the
+# schema, so a file this accepts can still be refused upstream. It is a floor.
+#
+# The schema is fetched under a SHA-256 pin rather than copied into the tree,
+# which is the pattern the masterplan's oracle-pinning policy already sets: a
+# copy restates bytes in a form that no longer carries its own verification.
+# When upstream edits the schema the pin mismatches and this reds - that is
+# the invariant working, and the repair is to read the new schema and move the
+# pin deliberately.
+#
+# Fail-closed at every step, because a config check that checked nothing reads
+# exactly like a clean one: an absent config file, a failed fetch, a hash
+# mismatch, an unparseable file, and a validator that cannot refuse a known
+# bad document are all hard errors here and never skips.
+set -eu
+
+cfg="${1:-.github/dependabot.yml}"
+
+# Pinned 2026-08-06 against https://www.schemastore.org/dependabot-2.0.json
+# (json.schemastore.org 301-redirects there). Recompute with:
+#   curl -fsSL "$schema_url" | sha256sum
+schema_url="https://www.schemastore.org/dependabot-2.0.json"
+schema_sha256="46255f692a8d661325e9d044b50f4b687aff68633b716420b64e460fb212b471"
+
+# Exact versions, so the gate's own dependencies cannot move underneath it.
+yaml_pkg="js-yaml@4.1.0"
+ajv_pkg="ajv-cli@5.0.0"
+
+die() {
+    echo "check-dependabot-config: $1" >&2
+    exit 1
+}
+
+command -v curl >/dev/null 2>&1 || die "curl is not on PATH"
+command -v sha256sum >/dev/null 2>&1 || die "sha256sum is not on PATH"
+command -v npx >/dev/null 2>&1 || die "npx is not on PATH"
+
+[ -f "$cfg" ] ||
+    die "$cfg does not exist. Deleting or renaming the config is the silent
+failure this check exists for, so an absent file is refused rather than
+skipped."
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+curl -fsSL "$schema_url" -o "$work/schema.json" ||
+    die "could not fetch $schema_url"
+echo "$schema_sha256  $work/schema.json" | sha256sum -c - >/dev/null ||
+    die "the schema at $schema_url does not match the recorded SHA-256.
+Read what changed upstream, then move the pin in this file deliberately."
+
+# ajv reads JSON, the config is YAML, and js-yaml is the conversion. A parse
+# failure here is the malformed-file case and stops the run.
+to_json() {
+    npx --yes --package="$yaml_pkg" -- js-yaml "$1" >"$2" ||
+        die "$1 is not parseable as YAML"
+}
+
+validate() {
+    npx --yes --package="$ajv_pkg" -- ajv validate \
+        --spec=draft7 --strict=false -s "$work/schema.json" -d "$1"
+}
+
+# The validator proves itself on every run before it is trusted with the real
+# file. A wrong flag, a wrong path, or a schema that lost its
+# additionalProperties clause would otherwise pass everything silently, which
+# is the vacuous run in another shape. The planted defect is the one the
+# platform actually rejects: an underscore where the key takes a hyphen.
+cat >"$work/self-test.yml" <<'EOF'
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default_days: 7
+EOF
+to_json "$work/self-test.yml" "$work/self-test.json"
+if validate "$work/self-test.json" >"$work/self-test.log" 2>&1; then
+    cat "$work/self-test.log" >&2
+    die "the self-test document was accepted. It carries default_days where
+the schema takes default-days, so a validator that accepts it is not
+refusing anything and its verdict on the real config means nothing."
+fi
+echo "PASS: self-test - the validator refuses a known-bad config"
+
+to_json "$cfg" "$work/config.json"
+validate "$work/config.json" ||
+    die "$cfg does not validate against the published Dependabot schema.
+The report above names the key. A config the schema refuses is one the
+platform is likely to reject, and a rejected config is not in force."
+
+echo "PASS: $cfg validates against $schema_url"


### PR DESCRIPTION
# What & why

Closes #232.

Nothing in this repository distinguished a valid Dependabot config from one
GitHub rejected. The rejection is reported only in the web UI, so a
misspelled key sits in the tree looking configured while the setting it names
is not in force. That is not hypothetical for this file: the `cooldown:` block
is the reason the issue was raised, and a hold that is not in force is a
supply-chain control that reads as present and is not.

## The gap, measured rather than assumed

Prettier is the YAML parser in the `format` job, so it already covers the
malformed case, and it covers nothing above it. Both legs run here against
prettier@3, the version the job pins:

    $ cat .github/dependabot.yml      # a sequence item mis-indented
    version: 2
    updates:
      - package-ecosystem: github-actions
       directory: "/"
    $ npx --yes prettier@3 --check ".github/dependabot.yml"; echo "exit=$?"
    Checking formatting...
    [error] .github/dependabot.yml: SyntaxError: Sequence item without - indicator (4:1)
    exit=2

    $ cat .github/dependabot.yml      # well formed, key the platform rejects
    version: 2
    updates:
      - package-ecosystem: github-actions
        directory: "/"
        schedule:
          interval: weekly
        cooldown:
          default_days: 7
    $ npx --yes prettier@3 --check ".github/dependabot.yml"; echo "exit=$?"
    Checking formatting...
    All matched files use Prettier code style!
    exit=0

And with the file removed entirely, against the job's own glob, with one
other matched file present so the pattern is not empty:

    $ ls
    README.md
    $ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"; echo "exit=$?"
    Checking formatting...
    All matched files use Prettier code style!
    exit=0

So the two failures the issue names, a rejected key and a deleted config, both
pass today.

## Route: the schema, because the other one has no API

The issue offered two, validate against the published schema or read the
platform's own parse status. The second does not exist to read. GitHub's REST
surface for Dependabot is alerts and secrets; the configuration validation
result appears in the web UI and in no documented endpoint. That leaves the
schema as the only machine-readable statement of the config grammar.

Its limit is stated in the script rather than glossed: Dependabot applies
checks beyond the schema, so a file this accepts can still be refused
upstream. This is a floor, not a proof of acceptance, and the header says so
in those words.

The schema is fetched under a SHA-256 pin rather than copied into the tree.
That follows the oracle-pinning policy in MASTERPLAN section 5 and the reason
recorded on #156: a copy restates bytes in a form that no longer carries its
own verification. When upstream edits the schema the pin mismatches and the
gate reds, which is the invariant working; the repair is to read what changed
and move the pin deliberately.

The two npm packages are pinned to exact versions for the same reason the
Actions are pinned to SHAs. They are the cost of this route and they are real:
`ajv-cli@5.0.0` pulls a transitive tree that npm itself warns about, and that
is a dependency inside the security net, which MASTERPLAN section 5 says to
keep near zero. The alternative on offer was no check at all.

## Proof that it bites, for the reason it names

All three legs, run at this commit on me machine. The check is
plain `sh`, `curl`, `sha256sum` and `npx`, so it runs anywhere the `format`
job runs.

Green on the unmodified tree:

    $ scripts/check-dependabot-config.sh; echo "exit=$?"
    PASS: self-test - the validator refuses a known-bad config
    /tmp/tmp.jPoQHfERxV/config.json valid
    PASS: .github/dependabot.yml validates against https://www.schemastore.org/dependabot-2.0.json
    exit=0

A key the platform rejects, the issue's own example, `default_days` for
`default-days`:

    $ sed -i 's/default-days/default_days/' .github/dependabot.yml
    $ scripts/check-dependabot-config.sh; echo "exit=$?"
    PASS: self-test - the validator refuses a known-bad config
    /tmp/tmp.z1g64HUrwn/config.json invalid
    [
      {
        instancePath: '/updates/0/cooldown',
        schemaPath: '#/properties/cooldown/additionalProperties',
        keyword: 'additionalProperties',
        params: { additionalProperty: 'default_days' },
        message: 'must NOT have additional properties'
      }
    ]
    check-dependabot-config: .github/dependabot.yml does not validate against the published Dependabot schema.
    exit=1

The config deleted, which is the fail-closed leg:

    $ rm .github/dependabot.yml
    $ scripts/check-dependabot-config.sh; echo "exit=$?"
    check-dependabot-config: .github/dependabot.yml does not exist. Deleting or renaming the config is the silent
    failure this check exists for, so an absent file is refused rather than
    skipped.
    exit=1

The tree was restored after each, and the diff is two files.

## The self-test, and why the throwaway commit is not what proves this

The issue asks for a throwaway commit that reds the check, with the run link,
then reverted. The stronger form is in the script: it validates a planted
`default_days` document on **every** run and refuses to continue if that
document is accepted. A wrong flag, a wrong path, or a schema that lost its
`additionalProperties` clause would otherwise let the check pass everything
silently, which is the vacuous run in another shape. The bite is therefore
proven by every future run and not only by one commit at one moment.

The throwaway-commit run link is **not** in this body. The legs above were
produced on this machine rather than in a workflow run, and that is the whole
disclosure rather than a softening of it: what is shown is the same script the
job invokes, on the same inputs, and what is not shown is that script failing
inside the runner.

## Type of change

- [x] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved. It is the subject: absent config, failed fetch,
      hash mismatch, unparseable YAML and a self-test that was accepted are
      all hard errors, never skips.
- [ ] Oracle coverage. Not applicable; no format path changed.
- [x] Determinism preserved. No decode path is touched.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      Unchanged, nothing here calls CUDA.
- [ ] An adversarial review (`/security-review`) was run. It was **not** run,
      and the box stays unticked rather than argued away. A workflow file is
      on the sensitive surface, so the gate is owed by the letter of the
      checklist. This change had no second reader; the commands above are the
      evidence in place of one.
- [ ] Review record. There is none, for the same reason.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

## Quality checklist

- [x] Minimal: one script and one step. The comment in `ci.yml` says what the
      step is for and sends the reader to the constants rather than restating
      them, so the two cannot drift apart.
- [x] Comments explain why: the route, the pin, the exact versions and the
      self-test each carry the failure they prevent.
- [ ] Conformance test. None, and the honest statement of the gap is that the
      check has no test above its own self-test. Nothing reds if the step is
      deleted from `ci.yml`, which is the same shape as every other step in
      that job.

## Verification

- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.

      $ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
      Checking formatting...
      All matched files use Prettier code style!

- [ ] `cmake --build build` / `ctest` - not run. No C, C++, CUDA or CMake file
      is in the diff, and the build gate runs on this pull request in CI.
- [x] Docs synced. The script's header is the document for this check; no
      other document describes it.

## Notes

The means is `sh` plus two exactly-pinned npm packages, and the reason it is
not the repository's usual shell-only shape is that JSON-schema validation is
not something a regex does. The neighbouring check in the same job, the
Action SHA pin, is one regex and stays one. This one could not be, and the
cost of the difference is written above rather than left for a reader to
discover.

The schema pin is dated in the script. It will red the day upstream edits the
file, and that is the pin working rather than a defect to route around.

## Merge state

The branch was rebuilt on the current mainline, because the head it was
opened from predates the repaired version gate and the `build` job red on it
for that reason and not for anything in this diff. All six checks on the
merged head are green:

    $ gh api repos/iderex/cudec/commits/aa6531efc4826e06cf406a46ad1880c5531496b7/check-runs \
        --jq '[.check_runs[]|"\(.name):\(.conclusion)"]|join(" ")'
    CodeQL:success format:success build:success sanitize:success dependency-review:success analyze:success

The sentence above that said "it should run there" is now a measurement. The
step ran inside the runner and the self-test bit there, which is what makes
the verdict on the real config mean anything:

    $ gh run view --job 92986078793 --log | grep "PASS:"
    PASS: self-test - the validator refuses a known-bad config
    PASS: .github/dependabot.yml validates against https://www.schemastore.org/dependabot-2.0.json

That does not convert the disclosure above it. The throwaway commit carrying
`default_days` was still not pushed, so what a runner has been seen to do
with a rejected config is nothing, and the refusal legs remain evidence from
this machine only.

There was no second reader for this change. The commands in this body stand
in place of one, and that is stated rather than implied.
