### PR TITLE
Derive the consumer-version gate's requests from the version's single source [#307]

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -21,7 +21,7 @@ body:
     attributes:
       label: cudec version or commit
       description: The output of `cudec_version()`, or the commit SHA you built.
-      placeholder: "0.0.1, or ab133e0"
+      placeholder: "0.1.0, or ab133e0"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/2-decode-divergence.yml
+++ b/.github/ISSUE_TEMPLATE/2-decode-divergence.yml
@@ -90,7 +90,7 @@ body:
     id: version
     attributes:
       label: cudec version or commit
-      placeholder: "0.0.1, or ab133e0"
+      placeholder: "0.1.0, or ab133e0"
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,45 @@ jobs:
           }
           cat "$out.log"
 
+      # The versions the consumer legs request are derived here, from
+      # include/cudec.h - the one place the version is written, and the same
+      # three macros the top-level CMakeLists reads to set the project version.
+      # A literal was wrong for the whole life of the 0.1.0 bump: the accept
+      # leg asked for 0.0.1, which SameMinorVersion refuses once the minor
+      # moves, and nothing caught it because the consumer steps arrived after
+      # that bump's own run (issue #307).
+      #
+      # Fail-closed on the parse rather than on the request. An empty capture
+      # would reach find_package as no version at all, and config mode then
+      # never opens cudec-config-version.cmake - so the legs would pass against
+      # a prefix carrying no version file, which is the hole they exist to
+      # close. A component that is absent, non-numeric, or matched twice reds
+      # here instead.
+      - name: Derive the requested versions from the version's single source
+        run: |
+          component() {
+            sed -n "s/^#define CUDEC_VERSION_$1 \([0-9][0-9]*\)$/\1/p" \
+              include/cudec.h
+          }
+          major="$(component MAJOR)"
+          minor="$(component MINOR)"
+          patch="$(component PATCH)"
+          for part in "$major" "$minor" "$patch"; do
+            case "$part" in
+              "" | *[!0-9]*)
+                echo "FAIL: include/cudec.h did not yield three integer" \
+                     "version components (major='$major' minor='$minor'" \
+                     "patch='$patch')"
+                exit 1
+                ;;
+            esac
+          done
+          echo "CUDEC_VERSION=$major.$minor.$patch" >> "$GITHUB_ENV"
+          echo "CUDEC_VERSION_ABOVE_MINOR=$major.$((minor + 1))" \
+            >> "$GITHUB_ENV"
+          echo "accept: $major.$minor.$patch"
+          echo "refuse: $major.$((minor + 1))"
+
       # The install surface is proven by consuming it, never by inspecting it
       # (issue #79). Install the host-only build into a prefix, then configure,
       # build AND RUN a project outside this tree that knows nothing but
@@ -188,17 +227,22 @@ jobs:
       # The consumer is driven TWICE, and both runs pass a version, because
       # config mode reads cudec-config-version.cmake only when the caller
       # requests one: a no-version consumer configures happily against a prefix
-      # whose version file was never installed. 0.0.1 must be accepted, 0.1
-      # must be refused, and the refusal leg reds if that configure SUCCEEDS.
+      # whose version file was never installed. The installed version must be
+      # accepted, the next minor above it must be refused, and the refusal leg
+      # reds if that configure SUCCEEDS. Both requests come from the step above
+      # rather than from a literal, so a bump carries them with it.
       #
       # What that pair does NOT prove, stated so the gate is not read as
-      # stronger than it is: at 0.0.1 no request separates SameMinorVersion
-      # from SameMajorVersion or AnyNewerVersion, because every one of them
-      # refuses a request above the installed version. Measured by swapping the
-      # mode to AnyNewerVersion and watching this step stay green. What the
-      # legs do prove is that the version file is installed and consulted -
-      # dropping it from the install reds the step - and the modes become
-      # distinguishable the first time the minor moves.
+      # stronger than it is: the refused request sits above the installed
+      # version, and SameMajorVersion and AnyNewerVersion refuse such a request
+      # as well, so the pair does not say which mode is configured. That
+      # follows from what the generated version file compares, not from a run
+      # here. The request that would separate the modes is the same major with
+      # a LOWER minor, which only SameMinorVersion refuses; it exists only
+      # while the minor is above zero, so it is not derivable for every version
+      # and is not added here. What the legs do prove is that the version file
+      # is installed and consulted - dropping it from the install reds the step
+      # - and that a minor mismatch is refused.
       - name: Install and consume out of tree (host-only)
         run: >-
           cmake --install build --prefix "$PWD/prefix-host" &&
@@ -209,15 +253,18 @@ jobs:
           -print -quit)" &&
           cmake -S tests/consumer -B build-consumer
           -DCMAKE_PREFIX_PATH="$PWD/prefix-host"
-          -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1 &&
+          -DCUDEC_CONSUMER_REQUEST_VERSION="$CUDEC_VERSION" &&
           cmake --build build-consumer &&
           ./build-consumer/consumer &&
           if cmake -S tests/consumer -B build-consumer-badver
           -DCMAKE_PREFIX_PATH="$PWD/prefix-host"
-          -DCUDEC_CONSUMER_REQUEST_VERSION=0.1 > badver.log 2>&1; then
-          echo "FAIL: find_package(cudec 0.1) was accepted against a 0.0.1
-          prefix - the version policy is not being applied"; exit 1; else
-          echo "PASS: find_package(cudec 0.1) refused against a 0.0.1 prefix";
+          -DCUDEC_CONSUMER_REQUEST_VERSION="$CUDEC_VERSION_ABOVE_MINOR"
+          > badver.log 2>&1; then
+          echo "FAIL: find_package(cudec $CUDEC_VERSION_ABOVE_MINOR) was
+          accepted against a $CUDEC_VERSION prefix - the version policy is not
+          being applied"; exit 1; else
+          echo "PASS: find_package(cudec $CUDEC_VERSION_ABOVE_MINOR) refused
+          against a $CUDEC_VERSION prefix";
           fi
 
       # Unconditional AND self-verifying: the GPU-test binaries exist only
@@ -270,7 +317,7 @@ jobs:
           "$(find "$PWD/prefix-cuda" -name cudec-config.cmake -print -quit)" &&
           cmake -S tests/consumer -B build-consumer-cuda
           -DCMAKE_PREFIX_PATH="$PWD/prefix-cuda"
-          -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1
+          -DCUDEC_CONSUMER_REQUEST_VERSION="$CUDEC_VERSION"
           -DCUDEC_CONSUMER_CALLS_DECODE=ON &&
           cmake --build build-consumer-cuda &&
           ./build-consumer-cuda/consumer
@@ -294,7 +341,7 @@ jobs:
           env -i PATH=/usr/bin:/bin HOME="$HOME"
           cmake -S tests/consumer -B build-consumer-nocuda
           -DCMAKE_PREFIX_PATH="$PWD/prefix-host"
-          -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1
+          -DCUDEC_CONSUMER_REQUEST_VERSION="$CUDEC_VERSION"
           -DCUDAToolkit_ROOT=/nonexistent
           -DCMAKE_IGNORE_PREFIX_PATH=/usr/local/cuda &&
           cmake --build build-consumer-nocuda &&

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ cmake --install build --prefix /some/prefix
 ```
 
 ```cmake
-find_package(cudec 0.0.1 REQUIRED)
+find_package(cudec 0.1.0 REQUIRED)
 target_link_libraries(your_target PRIVATE cudec::cudec)
 ```
 


### PR DESCRIPTION
# What & why

Closes #307.

The version bump to 0.1.0 landed against a consumer-version gate and a README
example that both spell 0.0.1 as a literal. The installed package is 0.1.0 and
the compatibility mode is `SameMinorVersion`, so both legs of the gate had
inverted: the accept leg asks for a minor that no longer matches and is
refused, and the refuse leg asks for 0.1, which is now compatible, so it would
have reached its own `FAIL:` line. The README handed a copyable
`find_package` line the package it documents refuses.

Nothing caught it because the consumer steps arrived after the bump's own run.

The fix removes the literals rather than correcting them. A new step reads
`CUDEC_VERSION_MAJOR`, `MINOR` and `PATCH` out of `include/cudec.h`, which the
top-level `CMakeLists.txt` already names as the one place the version is
written and reads for `project(... VERSION ...)`, and publishes two requests:
the installed version, which must be accepted, and the next minor above it,
which must be refused. The three consumer configures and both messages use
those. A bump moves them with it and the workflow needs no edit.

The parse fails closed. An empty capture would reach `find_package` as no
version at all, and config mode then never opens `cudec-config-version.cmake`,
so the legs would pass against a prefix carrying no version file, which is the
hole they exist to close. A component that is absent, non-numeric, or matched
twice reds the step instead. Both directions were run before the change was
committed:

```
$ rm -f /tmp/genv
$ GITHUB_ENV=/tmp/genv bash --noprofile --norc -eo pipefail step.sh ; echo "exit=$?"
accept: 0.1.0
refuse: 0.2
exit=0
$ cat /tmp/genv
CUDEC_VERSION=0.1.0
CUDEC_VERSION_ABOVE_MINOR=0.2

$ sed 's/^#define CUDEC_VERSION_PATCH 0$/#define CUDEC_VERSION_PATCH x/'     include/cudec.h > /tmp/neg/include/cudec.h
$ cd /tmp/neg && GITHUB_ENV=/tmp/genv2 bash --noprofile --norc -eo pipefail step.sh ; echo "exit=$?"
FAIL: include/cudec.h did not yield three integer version components (major='0' minor='1' patch='')
exit=1
$ cat /tmp/genv2
$ echo "(nothing written, which is the point)"
```

`step.sh` is the step's body copied out verbatim, run under the same shell
invocation the job's `defaults` give it. The negative writes nothing to
`GITHUB_ENV` and exits non-zero, so a header the parse cannot read reds the
step instead of handing the consumer legs an empty version.


What the pair still does not prove is stated at the step rather than left to be
assumed. The refused request sits above the installed version, and
`SameMajorVersion` and `AnyNewerVersion` refuse such a request as well, so it
does not say which mode is configured. The request that would separate them is
the same major with a lower minor; it exists only while the minor is above
zero, so it is not derivable for every version and is not added here. The
compatibility mode is out of scope for #307 by that issue's own last section.

`README.md` now shows a `find_package` line the installed package accepts, and
the two issue-template placeholders that illustrate a current version no longer
show one it refuses. The remaining `0.0.1` strings in `CMakeLists.txt` are
about the 0.x convention rather than about the current version and stay.

## Type of change

- [x] Build / CI / supply chain
- [x] Bug fix
- [x] Docs

## Engineering checklist

- [ ] Fail-closed preserved: no decode or parse path is touched. The one new
      parse is the workflow's own read of the version header, and it fails
      closed as shown above.
- [ ] Oracle coverage: not applicable, no format path is touched.
- [ ] Determinism preserved: not applicable, no device or decode code is
      touched.
- [ ] CUDA API calls: none added or changed.
- [ ] An adversarial review was not run as a separate reader. See Notes.
- [ ] Review record: no second reader. See Notes.

## Performance checklist

Not applicable. Nothing on the hot path is touched.

## Quality checklist

- [x] Minimal: one derivation step replaces four literals; nothing else added.
- [x] Self-documenting: the step says why the derivation exists and what its
      failure mode would have been.
- [x] Conformance tests: unchanged. The structural property this change
      establishes lives in the workflow itself, which is where the gate is.

## Verification

The version policy was exercised against a real installed prefix on this
machine rather than read out of the CMake documentation. Host-only build,
installed, then the consumer configured three times.

```
$ cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build
[3/3] Linking C static library libcudec.a
$ cmake --install build --prefix "$PWD/prefix-host"
-- Installing: .../prefix-host/lib/cmake/cudec/cudec-config-version.cmake

$ cmake -S tests/consumer -B b1 -G Ninja -DCMAKE_PREFIX_PATH="$PWD/prefix-host"     -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1 ; echo "exit=$?"
CMake Error at CMakeLists.txt:26 (find_package):
  Could not find a configuration file for package "cudec" that is compatible
  with requested version "0.0.1".

  The following configuration files were considered but not accepted:

    .../prefix-host/lib/cmake/cudec/cudec-config.cmake, version: 0.1.0
      The version found is not compatible with the version requested.
exit=1

$ cmake -S tests/consumer -B b2 -G Ninja -DCMAKE_PREFIX_PATH="$PWD/prefix-host"     -DCUDEC_CONSUMER_REQUEST_VERSION=0.1.0 ; echo "exit=$?"
-- Configuring done (3.1s)
-- Generating done (0.1s)
exit=0
$ cmake --build b2 && ./b2/consumer
cudec 0.1.0, consumed via find_package(cudec)

$ cmake -S tests/consumer -B b3 -G Ninja -DCMAKE_PREFIX_PATH="$PWD/prefix-host"     -DCUDEC_CONSUMER_REQUEST_VERSION=0.2 ; echo "exit=$?"
  Could not find a configuration file for package "cudec" that is compatible
  with requested version "0.2".
exit=1
```

That is the whole of #307 in three commands. 0.0.1 is the literal the gate
carried, and the installed package refuses it, so the accept leg reds at
mainline content. 0.1.0 is what the derivation produces for the accept leg and
it configures, builds and runs. 0.2 is what the derivation produces for the
refuse leg and it is refused, so that leg reaches its PASS branch rather than
its FAIL line.

- [x] Build: clean, host-only, GNU 16.1.0 with Ninja on this host.
- [ ] `ctest`: not run. The oracle targets fetch and build liblz4, snappy and
      libzstd, and the GPU-labelled tests need a device this route does not
      have. This branch touches no test and no source, so the suite is CI's to
      run.
- [x] Prettier over the changed files: clean.

```
$ npx --yes prettier@3 --check ".github/**/*.yml" "README.md"
Checking formatting...
All matched files use Prettier code style!
```

- [x] Docs synced: README carries the corrected example; no behaviour, API or
      performance claim moved.

## Notes

Three things about this change, stated plainly rather than left to be
inferred. The first two are things it does not carry; the third was owed when
this body was first written and is now supplied.

**No second reader.** No separate adversarial review pass was run on this diff,
so the review record above is empty rather than filled in. The evidence offered
in its place is the derivation's two negative cases run above, the fact that no
decode, kernel or ABI surface is touched, and the CI gate itself, which is the
thing this change edits and is also the thing that judges it.

**The first commit is empty, and the run it was written for never started.**
Its message says the run it triggers is a run at mainline content. No workflow
run was created for it:

```
$ gh api repos/iderex/cudec/commits/922e76074cfdfc6868c3b810edd6458118bd853a/check-runs --jq .total_count
0
```

That is stated here rather than corrected in the message, because the message
is already pushed and rewriting history on this branch is not on the table. The
second commit is the docs half alone, deliberately, so that the run it triggers
executes the consumer step with the workflow at mainline content and reds on
the accept leg. That run never started either, so the before evidence comes
from elsewhere and the paragraph below says where.

The before-and-after run links. #307 asks for a red run at mainline content
linked beside the green one. Both now exist.

Red, at unmodified mainline workflow content. This is not a run of this branch:
it is https://github.com/iderex/cudec/actions/runs/31125632738, whose branch
changes three documentation files and no workflow, so the `build` job executed
the consumer step exactly as mainline carries it. Step 8 of that job,
`Install and consume out of tree (host-only)`, is the only step that failed:

```
$ gh api repos/iderex/cudec/actions/jobs/92695551062/logs | tail
CMake Error at CMakeLists.txt:26 (find_package):
  Could not find a configuration file for package "cudec" that is compatible
  with requested version "0.0.1".
  The following configuration files were considered but not accepted:
    /__w/cudec/cudec/prefix-host/lib/cmake/cudec/cudec-config.cmake, version: 0.1.0
##[error]Process completed with exit code 1.
```

The second run at mainline content that reds the same way is
https://github.com/iderex/cudec/actions/runs/31124651473, on an unrelated
branch. Every pull request open against this repository was red on that step,
which is how large the literal had grown by the time it was found.

Green, with the derivation in place:
https://github.com/iderex/cudec/actions/runs/31141240357. Both required checks
pass. The three consumer configures are steps 8, 9 and 11 of the `build` job:

```
$ gh api repos/iderex/cudec/actions/jobs/92751404971/logs | grep -E 'accept:|refuse:|PASS:|consumed via'
accept: 0.1.0
refuse: 0.2
cudec 0.1.0, consumed via find_package(cudec)
PASS: find_package(cudec 0.2) refused against a 0.1.0 prefix
cudec 0.1.0, consumed via find_package(cudec)
cudec 0.1.0, consumed via find_package(cudec)
```

The accept leg configures, builds and runs the consumer; the refuse leg reaches
its PASS branch rather than its FAIL line; and the two CUDA-flavour consumers
carry the same derived version.

The empty first commit is still empty and the run it was written for still
never started. The run above was created by the merge commit at the head of
this branch, which brings the branch onto current mainline so the run judges
the derivation against what is there now rather than against the base the
branch was cut from.

The derivation was also reproduced outside CI before the push, on the host,
against a real installed prefix, including the two directions the parse must
fail closed in:

```
$ ./derive.sh include/cudec.h            # the step's body, verbatim
accept: 0.1.0
refuse: 0.2
$ ./derive.sh header-with-non-numeric-patch
FAIL: include/cudec.h did not yield three integer version components (major='0' minor='1' patch='')
exit=1, GITHUB_ENV holds: []
$ ./derive.sh header-with-MINOR-line-deleted
FAIL: include/cudec.h did not yield three integer version components (major='0' minor='' patch='0')
exit=1, GITHUB_ENV holds: []

$ cmake -S tests/consumer -B b-accept -G Ninja -DCMAKE_PREFIX_PATH=.../prefix-host -DCUDEC_CONSUMER_REQUEST_VERSION=0.1.0
-- Configuring done ; exit=0 ; ./b-accept/consumer.exe -> cudec 0.1.0, consumed via find_package(cudec)
$ ... -DCUDEC_CONSUMER_REQUEST_VERSION=0.2     -> refused, exit=1
$ ... -DCUDEC_CONSUMER_REQUEST_VERSION=0.0.1   -> refused, exit=1
```

That last line is the defect itself, reproduced off CI: the literal the gate
carried is refused by the package the gate installs. `derive.sh` is the step's
shell body copied out and is deliberately not checked in, since the workflow is
where it belongs.

The last Done-when bullet, that no remaining `0.0.1` in the tree is still meant
as the current version:

```
$ git grep -n '0\.0\.1'
.github/workflows/ci.yml:178:      # leg asked for 0.0.1, which SameMinorVersion refuses once the minor
CMakeLists.txt:395:  # at 0.x the minor bump is the breaking one, so 0.0.1 and 0.1.0 are not
CMakeLists.txt:398:  # it would refuse 0.0.2 to a consumer who wrote 0.0.1 and meant the patch
```

Three hits, all prose about the 0.x convention or about the defect being fixed.
None is a request, a documented example or a declared version.
