### PR TITLE
Execute the four M5 Zstd decode behaviours the ladder had only read [#189]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -390,6 +390,15 @@ endif()
 # reaching for both would be refused by the linker. Host-side and GPU-less;
 # nothing here is about cudec's own Zstd path, which does not exist yet.
 cudec_add_test(zstd_oracle_smoke SOURCES zstd_oracle_smoke.cpp LIBS zstd_full)
+# The M5 decode behaviours the research read out of RFC 8878 and the zstd
+# source, executed instead of argued (issue #189). Same standalone shape and
+# the same reason as zstd_oracle_smoke above: it drives the compressor for the
+# one probe that needs a real Huffman-coded literals section, so it links
+# zstd_full alone. ZSTD_STATIC_LINKING_ONLY is for ZSTD_frameHeaderSize, which
+# is how that probe locates the first block without this test growing a second
+# frame-header parser.
+cudec_add_test(zstd_probes SOURCES zstd_probes.cpp LIBS zstd_full)
+target_compile_definitions(zstd_probes PRIVATE ZSTD_STATIC_LINKING_ONLY)
 # The Zstd backward bitstream reader, executed on the host before any FSE or
 # Huffman code exists to run over it (issue #215). Every serial core in M5
 # reads through this one unit, so it is proven alone: hand-written bit strings

--- a/tests/zstd_probes.cpp
+++ b/tests/zstd_probes.cpp
@@ -1,0 +1,568 @@
+/* The Zstd decode behaviours the M5 ladder took from a reading of RFC 8878
+ * and the zstd source, executed against the pinned oracle instead of argued
+ * from the text (issue #189). It is the Snappy probes' rule applied to M5:
+ * the research established these by reading, so each one becomes a permanent
+ * test that RUNS, and each assertion names the section or the reference line
+ * it was read from.
+ *
+ * Line citations are into the pinned tree, facebook/zstd 1.5.7, as fetched by
+ * the URL_HASH in tests/CMakeLists.txt. They move only when that pin moves.
+ *
+ * Most of the streams here are hand-built byte by byte rather than compressor
+ * output, for the reason the Snappy probes give: a behaviour the compressor
+ * never emits is exactly the one a hostile stream will carry. The repcode
+ * shift and the rep1-1 corruption below cannot be reached from ZSTD_compress
+ * at all - it never emits a repcode sequence whose resolution would be zero.
+ *
+ * The hand-built frames use RLE sequence tables (Symbol_Compression_Mode 1,
+ * RFC 8878 section 3.1.1.3.2.1.1) for all three fields. An RLE table is one
+ * cell, so its state costs zero bits to initialise and zero to update
+ * (ZSTD_buildSeqTable_rle, zstd_decompress_block.c:657-663), which leaves a
+ * sequence bitstream carrying nothing but the extra bits under test. That is
+ * what makes a frame with an exactly-known bit layout writable by hand.
+ *
+ * No cudec code is under test here. This is the reference's behaviour, which
+ * the M5 fail-closed matrix is then allowed to lock against. */
+#include "require.h"
+
+#include <zstd.h>
+#include <zstd_errors.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+void Append(Bytes* out, const Bytes& more) {
+    out->insert(out->end(), more.begin(), more.end());
+}
+
+/* ---- Frame construction ------------------------------------------------
+ *
+ * Frame_Header_Descriptor 0x00 (RFC 8878 section 3.1.1.1.1): no content
+ * size, not single-segment, no checksum, no dictionary. The frame therefore
+ * carries a Window_Descriptor, and 0x00 is the smallest legal window -
+ * exponent 0, mantissa 0, so windowLog 10 and a 1 KiB window (section
+ * 3.1.1.1.2). Every offset probed below stays inside it, and leaving the
+ * content size out keeps the header at two bytes whatever the frame
+ * produces. */
+Bytes FrameHeader() {
+    return Bytes{0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x00};
+}
+
+/* Block_Header, 3 bytes little-endian: bit 0 Last_Block, bits 1-2
+ * Block_Type, bits 3-23 Block_Size (RFC 8878 section 3.1.1.2). */
+Bytes BlockHeader(bool last, unsigned type, size_t size) {
+    const uint32_t value = (last ? 1u : 0u) | (type << 1) |
+                           (static_cast<uint32_t>(size) << 3);
+    return Bytes{static_cast<unsigned char>(value & 0xff),
+                 static_cast<unsigned char>((value >> 8) & 0xff),
+                 static_cast<unsigned char>((value >> 16) & 0xff)};
+}
+
+Bytes RawBlock(const Bytes& payload, bool last) {
+    Bytes out = BlockHeader(last, 0, payload.size());
+    Append(&out, payload);
+    return out;
+}
+
+/* Bits in the order the DECODER reads them. The sequence bitstream is read
+ * backward from its last byte, so the writer below is where that reversal
+ * lives: callers think forward and never touch a byte order. */
+struct BitWriter {
+    std::string bits;
+
+    void Add(uint32_t value, unsigned count) {
+        for (unsigned i = count; i > 0; i--) {
+            bits.push_back(((value >> (i - 1)) & 1u) ? '1' : '0');
+        }
+    }
+};
+
+/* Seal a bitstream: append the end marker and pad to a byte boundary.
+ *
+ * BIT_initDStream reads the LAST byte, takes its highest set bit as the end
+ * marker and starts reading below it (bitstream.h:292-294). So the marker is
+ * the first bit written after the payload, the padding above it is zero, and
+ * the byte the decoder starts at is the byte this function emits last. */
+Bytes SealBitstream(const std::string& read_order) {
+    std::string all = "1" + read_order;
+    while (all.size() % 8 != 0) {
+        all.insert(all.begin(), '0');
+    }
+    const size_t byte_count = all.size() / 8;
+    Bytes out(byte_count, 0);
+    for (size_t chunk = 0; chunk < byte_count; chunk++) {
+        unsigned char byte = 0;
+        for (size_t bit = 0; bit < 8; bit++) {
+            byte = static_cast<unsigned char>(
+                (byte << 1) | (all[chunk * 8 + bit] == '1' ? 1 : 0));
+        }
+        out[byte_count - 1 - chunk] = byte;
+    }
+    return out;
+}
+
+/* A compressed block whose three sequence tables are all RLE.
+ *
+ * Layout, in order (RFC 8878 sections 3.1.1.3.1 and 3.1.1.3.2): the
+ * Literals_Section_Header for a Raw_Literals_Block with Size_Format 00 (one
+ * byte: type in bits 0-1, one size-format bit, then a 5-bit
+ * Regenerated_Size), the literal bytes, Number_Of_Sequences,
+ * Symbol_Compression_Modes, then one symbol byte per field in the order
+ * Literals_Lengths, Offsets, Match_Lengths, then the bitstream. */
+Bytes RleSequenceBlock(const Bytes& literals, unsigned nb_seq, unsigned ll_sym,
+                       unsigned of_sym, unsigned ml_sym,
+                       const std::string& read_order, bool last) {
+    Bytes content;
+    content.push_back(static_cast<unsigned char>(literals.size() << 3));
+    Append(&content, literals);
+    content.push_back(static_cast<unsigned char>(nb_seq));
+    /* Literals_Lengths_Mode in bits 6-7, Offsets_Mode in 4-5,
+     * Match_Lengths_Mode in 2-3, bits 0-1 reserved and zero. Mode 1 is RLE
+     * for each of the three. */
+    content.push_back(0x54);
+    content.push_back(static_cast<unsigned char>(ll_sym));
+    content.push_back(static_cast<unsigned char>(of_sym));
+    content.push_back(static_cast<unsigned char>(ml_sym));
+    Append(&content, SealBitstream(read_order));
+
+    Bytes out = BlockHeader(last, 2, content.size());
+    Append(&out, content);
+    return out;
+}
+
+/* History for the frames that need earlier output to match into: a raw block
+ * of distinct-enough bytes, so a wrong offset produces wrong bytes rather
+ * than accidentally-right ones. */
+Bytes HistoryBytes(size_t size) {
+    Bytes out;
+    out.reserve(size);
+    for (size_t i = 0; i < size; i++) {
+        out.push_back(static_cast<unsigned char>('A' + (i % 26)));
+    }
+    return out;
+}
+
+/* One capacity for every call, larger than anything any frame here
+ * regenerates. It is a named constant rather than a per-call number because
+ * the refusal helper below has to be able to say that a refusal was NOT
+ * dstSize_tooSmall - and it could not say that if the capacity were ever the
+ * binding constraint. An earlier draft sized this buffer per frame, and the
+ * one probe whose frame outgrew it saw every mutant "rejected" for running
+ * out of room; the mutation run that caught it is in the pull request. */
+const size_t kDecodeCapacity = 256 * 1024;
+
+bool OracleDecodes(const Bytes& frame, Bytes* out) {
+    Bytes decoded(kDecodeCapacity, 0);
+    const size_t produced = ZSTD_decompress(decoded.data(), decoded.size(),
+                                            frame.data(), frame.size());
+    if (ZSTD_isError(produced)) {
+        out->clear();
+        return false;
+    }
+    decoded.resize(produced);
+    *out = decoded;
+    return true;
+}
+
+/* A refusal, with the reason it was refused for. `expected` is the error code
+ * the pinned oracle actually returns, measured rather than predicted; the
+ * assertion is what keeps a probe from passing on a rejection that has
+ * nothing to do with the rule under test. dstSize_tooSmall is the one this
+ * suite has already been bitten by, and it can no longer occur silently
+ * because the capacity above is fixed and generous. */
+bool OracleRefuses(const Bytes& frame, ZSTD_ErrorCode expected) {
+    Bytes decoded(kDecodeCapacity, 0);
+    const size_t produced = ZSTD_decompress(decoded.data(), decoded.size(),
+                                            frame.data(), frame.size());
+    if (!ZSTD_isError(produced)) {
+        std::fprintf(stderr, "a frame expected to be refused decoded to "
+                             "%zu bytes\n",
+                     produced);
+        return false;
+    }
+    const ZSTD_ErrorCode code = ZSTD_getErrorCode(produced);
+    if (code != expected) {
+        std::fprintf(stderr, "refused with error code %d, expected %d\n",
+                     static_cast<int>(code), static_cast<int>(expected));
+        return false;
+    }
+    return true;
+}
+
+/* The decoded frame's bytes, compared against history plus an expected match
+ * resolved at `offset` for `length` bytes. Writing the expectation this way
+ * rather than as a literal is what makes the assertion about the OFFSET: the
+ * bytes come out of the history the frame itself carried. */
+bool MatchesHistoryAt(const Bytes& decoded, const Bytes& history,
+                      size_t offset, size_t length) {
+    /* The expectation is built by reaching backwards, so an offset larger
+     * than what has been produced would index before the buffer. It cannot
+     * happen from the callers below, and it is refused rather than trusted
+     * because this file is built under the host sanitizer gate (issue #42)
+     * and a test that reads out of bounds reds it for its own defect. */
+    if (offset == 0 || offset > history.size()) {
+        std::fprintf(stderr, "offset %zu is outside %zu bytes of history\n",
+                     offset, history.size());
+        return false;
+    }
+    if (decoded.size() != history.size() + length) {
+        std::fprintf(stderr, "decoded %zu bytes, expected %zu\n",
+                     decoded.size(), history.size() + length);
+        return false;
+    }
+    Bytes expected = history;
+    for (size_t i = 0; i < length; i++) {
+        expected.push_back(expected[expected.size() - offset]);
+    }
+    return equal_bytes(decoded.data(), expected.data(), decoded.size());
+}
+
+}  // namespace
+
+int main() {
+    REQUIRE(std::string(ZSTD_versionString()) == "1.5.7");
+
+    /* Every refusal below comes back under this one code, which is a
+     * measurement and not a prediction: the frames here are refused for four
+     * different reasons - a repeat offset that resolved to zero, a jump table
+     * that leaves no fourth stream, an empty stream, and a missing end marker
+     * - and zstd reports the same corruption_detected for all of them. So the
+     * error code is not a surface the M5 matrix can read a REASON out of, only
+     * a refusal, which is worth knowing before a row is written that assumes
+     * otherwise. zstd_oracle_smoke.cpp records the same shape one level up,
+     * where three different malformed frames all come back srcSize_wrong. */
+    const ZSTD_ErrorCode kCorrupt = ZSTD_error_corruption_detected;
+
+    /* ---- Probe 1: the repeat-offset list is indexed differently when
+     * Literals_Length is zero.
+     *
+     * RFC 8878 section 3.1.1.5 "Repeat Offsets": with a non-zero
+     * literals length, Offset_Value 1 means the most recent offset; with a
+     * literals length of zero the meaning shifts by one, so Offset_Value 1
+     * means the SECOND most recent. In the reference this is the `ll0` term
+     * at zstd_decompress_block.c:1300-1303, where the index into
+     * prevOffset[] is the flag itself.
+     *
+     * The two frames below differ in one field - the Literals_Lengths RLE
+     * symbol, 0 against 1 - and in the one literal byte that a length of 1
+     * needs. Same Offset_Value, from the same repeat-offset history
+     * {1, 4, 8} at frame start (section 3.1.1.5). If the shift were not
+     * there, both would resolve to offset 1. */
+    {
+        const Bytes history = HistoryBytes(8);
+
+        /* Offsets_Mode RLE symbol 0: Offset_Code 0 carries no extra bits, so
+         * Offset_Value is 1 and the sequence bitstream is empty - one byte
+         * holding nothing but the end marker. Match_Lengths symbol 0 is
+         * Match_Length 3 (section 3.1.1.3.2.1.1, Match_Length baselines). */
+        Bytes ll_zero = FrameHeader();
+        Append(&ll_zero, RawBlock(history, false));
+        Append(&ll_zero, RleSequenceBlock(Bytes(), 1, 0, 0, 0, "", true));
+
+        Bytes decoded;
+        REQUIRE(OracleDecodes(ll_zero, &decoded));
+        /* Offset_Value 1 with Literals_Length 0 resolves to the second entry
+         * of the history, 4 - not the first, 1. */
+        REQUIRE(MatchesHistoryAt(decoded, history, 4, 3));
+
+        const Bytes one_literal = {'x'};
+        Bytes ll_one = FrameHeader();
+        Append(&ll_one, RawBlock(history, false));
+        Append(&ll_one, RleSequenceBlock(one_literal, 1, 1, 0, 0, "", true));
+
+        REQUIRE(OracleDecodes(ll_one, &decoded));
+        /* Same Offset_Value, non-zero literals length: the first entry, 1.
+         * The literal is emitted before the match, so the history the match
+         * reads from is the frame's output including that byte. */
+        Bytes with_literal = history;
+        with_literal.push_back('x');
+        REQUIRE(MatchesHistoryAt(decoded, with_literal, 1, 3));
+    }
+
+    /* ---- Probe 2: Offset_Value 3 with Literals_Length 0 resolves to
+     * rep1 - 1, and a resulting zero is a corrupt frame.
+     *
+     * RFC 8878 section 3.1.1.5 again: in the zero-literals case
+     * Offset_Value 3 means "the most recent offset, minus one", and the
+     * result may not be zero. The reference forces the failure rather than
+     * testing for it - `temp -= !temp` at zstd_decompress_block.c:1309 turns
+     * a zero into an offset no output can satisfy, and the refusal lands in
+     * execSequence.
+     *
+     * Offset_Code 1 is the code that can express Offset_Value 3: it carries
+     * one extra bit, and the decoder adds the ll0 flag to the code's
+     * baseline (zstd_decompress_block.c:1306), so with a zero literals
+     * length the extra bit 1 selects the rep1-1 rule. */
+    {
+        const Bytes history = HistoryBytes(16);
+
+        /* At frame start rep1 is 1, so rep1 - 1 is 0: refused. */
+        BitWriter one_bit;
+        one_bit.Add(1, 1);
+        Bytes zero_offset = FrameHeader();
+        Append(&zero_offset, RawBlock(history, false));
+        Append(&zero_offset,
+               RleSequenceBlock(Bytes(), 1, 0, 1, 0, one_bit.bits, true));
+        REQUIRE(OracleRefuses(zero_offset, kCorrupt));
+
+        /* The same frame with a NON-zero literals length: the shift is gone,
+         * Offset_Value 3 means the third repeat offset, 8, and the frame
+         * decodes. One byte of the block differs between this frame and the
+         * refused one - the Literals_Lengths RLE symbol - so the refusal
+         * above is attributable to the rule and not to the construction. */
+        const Bytes one_literal = {'x'};
+        Bytes third_rep = FrameHeader();
+        Append(&third_rep, RawBlock(history, false));
+        Append(&third_rep,
+               RleSequenceBlock(one_literal, 1, 1, 1, 0, one_bit.bits, true));
+        Bytes decoded;
+        REQUIRE(OracleDecodes(third_rep, &decoded));
+        Bytes with_literal = history;
+        with_literal.push_back('x');
+        REQUIRE(MatchesHistoryAt(decoded, with_literal, 8, 3));
+
+        /* And rep1 - 1 where it is legal: a first block whose sequence uses
+         * an explicit offset moves rep1 to 5 (Offset_Code 3 carries a
+         * baseline of 5 - Offset_Value 8 less the 3 the repeat slots
+         * occupy), so the second block's rep1-1 sequence resolves to 4. The
+         * repeat-offset history survives the block boundary, which is the
+         * other half of what this probe pins. */
+        BitWriter three_zero_bits;
+        three_zero_bits.Add(0, 3);
+        Bytes rep_minus_one = FrameHeader();
+        Append(&rep_minus_one, RawBlock(history, false));
+        Append(&rep_minus_one, RleSequenceBlock(Bytes(), 1, 0, 3, 0,
+                                                three_zero_bits.bits, false));
+        Append(&rep_minus_one,
+               RleSequenceBlock(Bytes(), 1, 0, 1, 0, one_bit.bits, true));
+
+        REQUIRE(OracleDecodes(rep_minus_one, &decoded));
+        Bytes expected = history;
+        for (int i = 0; i < 3; i++) {
+            expected.push_back(expected[expected.size() - 5]);
+        }
+        for (int i = 0; i < 3; i++) {
+            expected.push_back(expected[expected.size() - 4]);
+        }
+        REQUIRE(decoded.size() == expected.size());
+        REQUIRE(equal_bytes(decoded.data(), expected.data(), decoded.size()));
+    }
+
+    /* ---- Probe 3: the jump table of a 4-stream literals section is bounded
+     * by the section, and the fourth stream's size is what the bound is
+     * about.
+     *
+     * RFC 8878 section 3.1.1.3.1.2: the jump table is three 16-bit sizes and
+     * the fourth stream's size is DERIVED - total, less the three, less the
+     * six bytes of the table itself. A derived length is a subtraction on
+     * attacker-controlled numbers, which is why it gets a probe of its own:
+     * huf_decompress.c:626 computes it, and huf_decompress.c:642 is the
+     * check that catches the underflow.
+     *
+     * Compressor output here rather than a hand-built section: this probe is
+     * about the arithmetic over a real Huffman-coded section, and the
+     * mutations below are what the hand-building would have been for. */
+    {
+        Bytes original;
+        original.reserve(64 * 1024);
+        uint64_t state = 0x9e3779b97f4a7c15ull;
+        while (original.size() < 64 * 1024) {
+            state = state * 6364136223846793005ull + 1442695040888963407ull;
+            /* A byte distribution wide enough to be Huffman-coded and narrow
+             * enough not to be sent raw. */
+            original.push_back(static_cast<unsigned char>((state >> 40) % 12));
+        }
+        Bytes frame(ZSTD_compressBound(original.size()));
+        const size_t written = ZSTD_compress(frame.data(), frame.size(),
+                                             original.data(), original.size(),
+                                             3);
+        REQUIRE(!ZSTD_isError(written));
+        frame.resize(written);
+
+        const size_t header = ZSTD_frameHeaderSize(frame.data(), frame.size());
+        REQUIRE(!ZSTD_isError(header));
+        const size_t block_header = header;
+        REQUIRE(frame.size() > block_header + 3);
+        const uint32_t bh = static_cast<uint32_t>(frame[block_header]) |
+                            (static_cast<uint32_t>(frame[block_header + 1])
+                             << 8) |
+                            (static_cast<uint32_t>(frame[block_header + 2])
+                             << 16);
+        /* Block_Type 2 is Compressed_Block; anything else and the literals
+         * section this probe needs is not there. */
+        REQUIRE(((bh >> 1) & 3u) == 2u);
+
+        const size_t lit = block_header + 3;
+        const unsigned lit_type = frame[lit] & 3u;
+        const unsigned size_format = (frame[lit] >> 2) & 3u;
+        /* Literals_Block_Type 2 is Compressed_Literals_Block. Size_Format 1,
+         * 2 and 3 are the 4-stream forms; 0 is the single-stream one, which
+         * has no jump table at all and would make this probe vacuous. */
+        REQUIRE(lit_type == 2u);
+        REQUIRE(size_format != 0u);
+
+        size_t lh_size = 0;
+        size_t compressed_size = 0;
+        /* Five bytes are read below - the four the widest header packs its
+         * fields into, plus the fifth byte the Size_Format 3 form carries.
+         * Bounded here rather than after the fact. */
+        REQUIRE(frame.size() > lit + 5);
+        const uint32_t lh = static_cast<uint32_t>(frame[lit]) |
+                            (static_cast<uint32_t>(frame[lit + 1]) << 8) |
+                            (static_cast<uint32_t>(frame[lit + 2]) << 16) |
+                            (static_cast<uint32_t>(frame[lit + 3]) << 24);
+        if (size_format == 1u) {
+            lh_size = 3;
+            compressed_size = (lh >> 14) & 0x3ffu;
+        } else if (size_format == 2u) {
+            lh_size = 4;
+            compressed_size = (lh >> 18) & 0x3fffu;
+        } else {
+            lh_size = 5;
+            compressed_size = ((lh >> 22) & 0x3ffu) |
+                              (static_cast<size_t>(frame[lit + 4]) << 10);
+        }
+
+        /* The Huffman tree description sits between the literals header and
+         * the jump table, and its own first byte says how long it is (RFC
+         * 8878 section 3.1.1.3.1.2, "Huffman Tree Description"): below 128 it
+         * is an FSE-compressed description of that many bytes, at or above
+         * 128 it is 4-bit weights, two per byte, for headerByte - 127
+         * symbols. */
+        const size_t tree = lit + lh_size;
+        REQUIRE(frame.size() > tree);
+        const unsigned tree_header = frame[tree];
+        const size_t tree_size = tree_header >= 128
+                                     ? 1 + (tree_header - 127 + 1) / 2
+                                     : 1 + tree_header;
+        const size_t jump = tree + tree_size;
+        REQUIRE(compressed_size > tree_size + 6);
+        const size_t streams = compressed_size - tree_size;
+        REQUIRE(frame.size() > jump + 6);
+
+        const size_t l1 = static_cast<size_t>(frame[jump]) |
+                          (static_cast<size_t>(frame[jump + 1]) << 8);
+        const size_t l2 = static_cast<size_t>(frame[jump + 2]) |
+                          (static_cast<size_t>(frame[jump + 3]) << 8);
+        const size_t l3 = static_cast<size_t>(frame[jump + 4]) |
+                          (static_cast<size_t>(frame[jump + 5]) << 8);
+        /* The location is confirmed before anything is mutated: the three
+         * sizes plus the table itself must leave a fourth stream inside the
+         * section. A probe that mutated the wrong six bytes would still see
+         * rejections, and they would mean nothing. */
+        REQUIRE(l1 + l2 + l3 + 6 < streams);
+
+        Bytes decoded(original.size(), 0);
+        const size_t produced = ZSTD_decompress(decoded.data(), decoded.size(),
+                                                frame.data(), frame.size());
+        REQUIRE(!ZSTD_isError(produced));
+        REQUIRE(produced == original.size());
+        REQUIRE(std::memcmp(decoded.data(), original.data(), produced) == 0);
+
+        struct JumpMutant {
+            const char* name;
+            size_t first_stream;
+        };
+        /* Three ways the first size can put the fourth stream outside the
+         * section, each one a different arithmetic edge: the sum exactly
+         * consuming the section so the fourth stream is empty, the sum one
+         * past it so the subtraction underflows, and a size larger than the
+         * whole section. */
+        const JumpMutant mutants[] = {
+            {"fourth stream empty", streams - 6 - l2 - l3},
+            {"sum one past the section", streams - 5 - l2 - l3},
+            {"first size past the section", streams + 1},
+        };
+        size_t refused = 0;
+        for (const JumpMutant& mutant : mutants) {
+            Bytes mutated = frame;
+            REQUIRE(mutant.first_stream <= 0xffffu);
+            mutated[jump] = static_cast<unsigned char>(mutant.first_stream &
+                                                       0xffu);
+            mutated[jump + 1] =
+                static_cast<unsigned char>((mutant.first_stream >> 8) & 0xffu);
+            REQUIRE_CTX(OracleRefuses(mutated, kCorrupt), "%s",
+                        mutant.name);
+            refused++;
+        }
+        REQUIRE(refused == 3);
+
+        /* A zero-length stream is refused for a different reason than the
+         * three above: BIT_initDStream refuses an empty bitstream outright
+         * (bitstream.h:255), before any bound on the section is consulted. */
+        Bytes empty_stream = frame;
+        empty_stream[jump] = 0;
+        empty_stream[jump + 1] = 0;
+        REQUIRE(OracleRefuses(empty_stream, kCorrupt));
+    }
+
+    /* ---- Probe 4: the end marker of a backward bitstream, at every
+     * position a byte has, and the zero byte that has none.
+     *
+     * RFC 8878 section 3.1.1.3.2.2: a bitstream's last byte carries a set
+     * bit marking where the payload ends, everything above it is padding,
+     * and a final byte of zero is corrupt. The reference reads the marker as
+     * the highest set bit and refuses the zero byte in the same two lines
+     * (bitstream.h:292-294).
+     *
+     * The eight frames below place the marker at every bit position a byte
+     * has. Each carries one sequence whose Offset_Code is the loop variable,
+     * and an Offset_Code of N reads exactly N extra bits (section
+     * 3.1.1.3.2.1.1) - so the payload is N bits, the marker lands at N mod 8,
+     * and N = 8 is the case where the marker byte holds nothing else. */
+    {
+        const Bytes history = HistoryBytes(256);
+        /* Offset_Code N with all-zero extra bits resolves to the code's
+         * baseline. Codes 2 and up are explicit offsets, (1 << N) - 3, the
+         * three subtracted being the repeat slots. Code 1 is not an explicit
+         * offset at all: with a zero literals length its extra bit 0 selects
+         * the third repeat offset, 8, which is the value at frame start. */
+        const size_t resolved[9] = {0, 8, 1, 5, 13, 29, 61, 125, 253};
+        size_t widths = 0;
+        for (unsigned code = 1; code <= 8; code++) {
+            BitWriter zeros;
+            zeros.Add(0, code);
+            const Bytes sealed = SealBitstream(zeros.bits);
+            /* The layout the probe is about, asserted rather than assumed:
+             * the marker sits at bit code % 8 of the last byte, and code 8
+             * is the width that needs a second byte to hold it. */
+            REQUIRE_CTX(sealed.size() == (code == 8 ? 2u : 1u), "code %u",
+                        code);
+            REQUIRE_CTX(sealed.back() == (1u << (code % 8)), "code %u", code);
+
+            Bytes frame = FrameHeader();
+            Append(&frame, RawBlock(history, false));
+            Append(&frame, RleSequenceBlock(Bytes(), 1, 0, code, 0,
+                                            zeros.bits, true));
+            Bytes decoded;
+            REQUIRE_CTX(OracleDecodes(frame, &decoded), "code %u", code);
+            REQUIRE_CTX(MatchesHistoryAt(decoded, history, resolved[code], 3),
+                        "code %u", code);
+            widths++;
+
+            /* The same frame with the marker byte zeroed. Nothing else
+             * changes - same block size, same field bytes - so the refusal
+             * is the missing end marker and not a length that stopped
+             * agreeing. */
+            Bytes no_marker = frame;
+            no_marker.back() = 0;
+            REQUIRE_CTX(OracleRefuses(no_marker, kCorrupt), "code %u",
+                        code);
+        }
+        REQUIRE(widths == 8);
+    }
+
+    std::printf("PASS: 4 zstd %s decode behaviours confirmed by execution - "
+                "the literals-length-zero repcode shift, rep1-1 and its zero "
+                "refusal, the 4-stream jump table's derived fourth size, and "
+                "the end marker at all 8 bit positions\n",
+                ZSTD_versionString());
+    return 0;
+}

--- a/tests/zstd_probes.cpp
+++ b/tests/zstd_probes.cpp
@@ -292,7 +292,7 @@ int main() {
      * RFC 8878 section 3.1.1.5 again: in the zero-literals case
      * Offset_Value 3 means "the most recent offset, minus one", and the
      * result may not be zero. The reference forces the failure rather than
-     * testing for it - `temp -= !temp` at zstd_decompress_block.c:1309 turns
+     * testing for it - `temp -= !temp` at zstd_decompress_block.c:1308 turns
      * a zero into an offset no output can satisfy, and the refusal lands in
      * execSequence.
      *
@@ -363,8 +363,10 @@ int main() {
      * the fourth stream's size is DERIVED - total, less the three, less the
      * six bytes of the table itself. A derived length is a subtraction on
      * attacker-controlled numbers, which is why it gets a probe of its own:
-     * huf_decompress.c:626 computes it, and huf_decompress.c:642 is the
-     * check that catches the underflow.
+     * huf_decompress.c:626 computes it, and huf_decompress.c:643 is the
+     * check that catches the underflow. Both lines are in the X1 decoder,
+     * the one these literals go through; the X2 variant carries its own copy
+     * of the same arithmetic at 1407 and 1424.
      *
      * Compressor output here rather than a hand-built section: this probe is
      * about the arithmetic over a real Huffman-coded section, and the
@@ -496,7 +498,11 @@ int main() {
 
         /* A zero-length stream is refused for a different reason than the
          * three above: BIT_initDStream refuses an empty bitstream outright
-         * (bitstream.h:255), before any bound on the section is consulted. */
+         * (bitstream.h:256), before any bound on the section is consulted.
+         * It refuses it as srcSize_wrong, and what reaches the caller is
+         * still corruption_detected - the literals path remaps every HUF
+         * error to that one code (zstd_decompress_block.c:241), which is a
+         * second reason the code cannot be read as a reason. */
         Bytes empty_stream = frame;
         empty_stream[jump] = 0;
         empty_stream[jump + 1] = 0;


### PR DESCRIPTION
# What & why

Closes #189.

The M5 ladder took four Zstd decode behaviours out of RFC 8878 and the zstd
source by reading them. This executes all four against the pinned oracle and
turns each into a permanent test, so the fail-closed matrix locks against
measured behaviour rather than against a reading of it. A misread behaviour
that gets locked in fails closed on legal input or fails open on hostile
input, and reads correct either way.

`tests/zstd_probes.cpp` builds its frames byte by byte rather than compressing
them, which is the point: `ZSTD_compress` cannot emit a repcode sequence whose
resolution would be zero, and that is the case the matrix most needs pinned.
The frames use RLE sequence tables for all three fields, which cost no state
bits, so the bitstream carries nothing but the extra bits under test and the
layout is exact enough to write by hand. Each assertion cites the RFC section
or the zstd 1.5.7 line it came from.

The four:

- The repeat-offset list shifts by one when `Literals_Length` is zero. Two
  frames differing in one field byte resolve the same `Offset_Value` to 4 and
  to 1.
- `Offset_Value` 3 with a zero literals length means rep1 - 1, and a result of
  zero is refused. The same frame with a non-zero literals length decodes,
  which is what attributes the refusal to the rule rather than to the
  construction. A legal rep1-1 is decoded too, across a block boundary, so the
  repeat history's survival is pinned beside it.
- The 4-stream literals jump table carries three sizes and derives the fourth
  by subtraction. Three ways to put that fourth stream outside the section are
  each refused, plus a zero-length stream.
- The backward bitstream's end marker, at all eight bit positions a byte has,
  and the zeroed marker byte refused at each one.

One thing the probes measured that the ladder had not asked: all of these
refusals come back as `corruption_detected`, whatever the reason. That is now
asserted, so no later matrix row can assume the error code tells the reasons
apart. `zstd_oracle_smoke.cpp` records the same shape one level up.

The means: a C++ ctest binary next to the tests it belongs with, driving the
oracle the tree already pins and builds. Anything else would need its own
runner and would not sit in the suite whose green is the gate.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd) - tests only, no
      decoder code
- [ ] Decode kernel / device code
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: no cudec parse or decode path is touched. What
      the new test asserts is the ORACLE's refusals, four of them, each with
      the error code it actually returns.
- [x] Oracle coverage: the whole file is oracle-driven; there is no cudec
      output to diff yet on this path.
- [x] Determinism preserved: the test is deterministic - fixed frames, one
      fixed-seed generated buffer, a pinned compressor.
- [x] No CUDA call and no exception crosses anything: host-only, GPU-less.
- [ ] An adversarial review (`/security-review`) was run. NOT RUN. No second
      reader read this change. The evidence below stands in place of one, and
      this line stays negative.
- [ ] Review record: none, for the same reason.

## Performance checklist

Not on the hot path; no claim made.

## Quality checklist

- [x] Minimal: one new test file and its registration. No production code.
- [x] Self-documenting: the frame builders are named for the format's own
      fields, and every comment says why the bytes are what they are.
- [x] Conformance: the new ctest entry inherits the timeout property through
      `cudec_add_test`, so the timeout sweep stays satisfied.

## Verification

The in-tree gate could not be run on this machine and that is disclosed
rather than worked around: `tests/` is configured only under
`CUDEC_ENABLE_CUDA`, this host has no CUDA toolchain, and the container that
has one is not reachable (see #258 and #127 - bringing it up needs a consent
prompt, which is refused here). So `cmake --build` and `ctest` were NOT run,
and the CI build and sanitize jobs are what will run them.

What WAS run, on the same sources CI will use. The oracle was rebuilt from
the tarball this tree pins, hash-checked against the pin in
`tests/CMakeLists.txt` before anything was compiled:

```
$ sha256sum zstd-1.5.7.tar.gz
eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3 *zstd-1.5.7.tar.gz
```

which is the URL_HASH in `tests/CMakeLists.txt`, and 2434947 bytes as the pin
comment records. Then, at the branch head, with the same three defines the
`zstd_full` target uses:

```
$ g++ -std=c++17 -Wall -Wextra -Werror -O1 -DZSTD_STATIC_LINKING_ONLY \
    -Itests -I<zstd>/lib tests/zstd_probes.cpp -o zstd_probes \
    -L<oracle> -lzstd_full
$ ./zstd_probes
PASS: 4 zstd 1.5.7 decode behaviours confirmed by execution - the
literals-length-zero repcode shift, rep1-1 and its zero refusal, the 4-stream
jump table's derived fourth size, and the end marker at all 8 bit positions
$ echo $?
0
```

A suite that passes first try proves nothing until it has been made to fail,
so every probe was mutated and the suite re-run. Eight mutations, eight reds:

| mutation | result |
| --- | --- |
| probe 1: expect offset 1 instead of the shifted 4 | red, byte mismatch at offset 8 |
| probe 2 control: expect offset 1 where rep3 (8) is used | red, byte mismatch at offset 17 |
| probe 2: expect the rep1-1 == 0 frame to be accepted | red |
| probe 3: first jump-table mutant writes the original size back | red, "a frame expected to be refused decoded to 65536 bytes" |
| probe 3: empty-stream mutant left unmutated | red, same shape |
| probe 4: wrong resolved offset for code 8 | red, byte mismatch at offset 256 |
| probe 4: marker byte not zeroed | red, "decoded to 259 bytes" |
| probe 4: marker asserted at the wrong bit position | red |

The fourth and fifth rows are the reason this table exists rather than being a
formality. In the first draft they came back GREEN: the decode helper
allocated a 4 KiB output buffer, probe 3's frame regenerates 64 KiB, and every
mutant was therefore "refused" for `dstSize_tooSmall` before the jump table
was ever read. Three of that probe's four assertions were vacuous and looked
exactly like working ones. The fix is a fixed generous capacity plus a refusal
helper that asserts WHICH error came back, which is also what pinned the
`corruption_detected` finding above.

The half of the build that does not need CUDA was run, at the branch head, and
it is only that half: `tests/` and `bench/` sit inside the `CUDEC_ENABLE_CUDA`
block, so this configuration compiles the library and the examples and reaches
neither the new test nor the registration this change adds to
`tests/CMakeLists.txt`. It proves the tree still configures and builds, and
nothing more.

```
$ cmake -S . -B build-host -G Ninja -DCMAKE_C_COMPILER=gcc
-- Build files have been written to: .../build-host
$ cmake --build build-host
[1/3] Building C object CMakeFiles/cudec.dir/src/version.c.obj
[2/3] Building C object examples/CMakeFiles/example_decode_frame.dir/decode_frame.c.obj
[3/3] Linking C static library libcudec.a
```

- [ ] `cmake --build build` - the CUDA configuration was not built here, see
      above; the host-only one is above and does not cover this change.
- [ ] `ctest --test-dir build` - not run here, see above.
- [x] Prettier: no `.md`, `.yml` or `.yaml` file is touched by this change.
- [x] Docs synced: no behaviour, API or performance change to record.

## Notes

`tests/CMakeLists.txt` gains an additive block; nothing existing in it moves.

The one new build knob is `ZSTD_STATIC_LINKING_ONLY`, PRIVATE to this test
target. It is there for `ZSTD_frameHeaderSize`, which is how the jump-table
probe finds the first block without this file growing a second frame-header
parser.

CI has now run and is green. The head this was judged on is
`39ae2e231d5941c57b38bc53c41f819e6258ad14`, which is the two probe commits
plus a merge that brings the branch onto current mainline. The run is
https://github.com/iderex/cudec/actions/runs/31141655665.

The part that matters for this issue is that the probe binary was built and
executed on the GPU-less runner, in the `Host-side tests` step:

```
$ gh api repos/iderex/cudec/actions/jobs/92753221733/logs | grep -E 'zstd_probes|tests passed'
[ 98%] Building CXX object tests/CMakeFiles/zstd_probes.dir/zstd_probes.cpp.o
[100%] Linking CXX executable zstd_probes
[100%] Built target zstd_probes
      Start 11: zstd_probes
10/19 Test #11: zstd_probes ......................   Passed    0.01 sec
100% tests passed, 0 tests failed out of 19
```

The first attempt on this head red, and not on anything in this change. The
pinned zstd tarball failed to download:

```
error: downloading 'https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz' failed
      status_code: 22
      status_string: "HTTP response code said error"
      The requested URL returned error: 500
```

That is the CDN answering 500 for the pinned artefact, not a hash mismatch and
not a change in what is pinned. Re-running the failed jobs on the same head
fetched it and the build went green, which is what the run above is.

Two earlier reds on this branch were the version gate, not this change: the
consumer step in the `build` job was refusing `0.0.1` against a `0.1.0` prefix
on every pull request in the repository. That is #307, now on mainline, and
this branch carries it through the merge commit.

The citations were checked against the upstream tag rather than taken on
trust. Every line this file cites into facebook/zstd v1.5.7 was read at
`raw.githubusercontent.com/facebook/zstd/v1.5.7`:

```
zstd_decompress_block.c:657-663  the set_rle case, ending in ZSTD_buildSeqTable_rle
zstd_decompress_block.c:1300-1303 the ofBits==0 shift, prevOffset[ll0] and prevOffset[!ll0]
zstd_decompress_block.c:1306     (offset==3) ? prevOffset[0] - 1 : prevOffset[offset]
zstd_decompress_block.c:1308     temp -= !temp;
zstd_decompress_block.c:241      RETURN_ERROR_IF(HUF_isError(hufSuccess), corruption_detected, "")
huf_decompress.c:626             length4 = cSrcSize - (length1 + length2 + length3 + 6)
huf_decompress.c:643             if (length4 > cSrcSize) return ERROR(corruption_detected)
```

All seven resolve to the lines the comments say they do. That is a check on
the citations and not a second reading of the change; the review lines above
stay negative.
The second commit on this branch changes no assertion. It corrects three
reference line numbers that were one off (`zstd_decompress_block.c:1308`,
`huf_decompress.c:643`, `bitstream.h:256`), names the X2 copy of the
jump-table arithmetic beside the X1 lines this path uses, and records why the
empty-stream case asserts `corruption_detected` while the line it cites
returns `srcSize_wrong`: the literals path remaps every HUF error to that one
code at `zstd_decompress_block.c:241`. In a file whose whole claim is that
each assertion carries the line it came from, an off-by-one citation is the
defect the file exists against, so they were checked against the pinned tree
rather than against the draft.

