### PR TITLE
Generate the M5 Zstd corpus and prove it reached each mode [#185]

### DIFF
--- a/docs/ZSTD-CORPUS.md
+++ b/docs/ZSTD-CORPUS.md
@@ -1,0 +1,93 @@
+# The Zstd corpus
+
+What `tests/zstd_corpus.cpp` generates, which decode surface each family
+reaches, and how the corpus proves it reached it. The generator and its
+self-proof are `tests/zstd_corpus.cpp` and
+`tests/zstd_corpus_selfproof.cpp`; issue #185 is where the shape was argued.
+
+Run it:
+
+    ctest --test-dir build-cuda -R zstd_corpus_selfproof --output-on-failure
+
+## Why the source bytes are built and not fetched
+
+The self-proof has to be green on the CI runner, and that runner fetches no
+corpus:
+
+    grep -c -i "silesia\|get-corpora" .github/workflows/ci.yml
+    0
+
+So the two things cannot be one artifact. Every family below constructs its
+own bytes, in the shape the existing bench self-checks already use, and none
+of them reads a file.
+
+The multi-level Silesia rung lives with the fetch instead. `MakeZstdBatchFrames`
+takes the source bytes as an argument for exactly that reason: pointing it at
+`bench/get-corpora.sh`'s Silesia needs no change here, and the batch geometry
+it emits is the same one the self-proof checks on constructed bytes. What the
+CI-gated proof therefore does NOT cover is Silesia's own level sweep at
+Silesia's own scale. That is not covered anywhere yet, and no number or
+property in this document should be read as covering it.
+
+## What each family asks for, and what proves it got it
+
+Each fixture carries a demand: the modes that must be present in the frame it
+produced. The self-proof walks the emitted headers and fails the fixture when
+a demanded mode is absent, so a compressor that declines a forced parameter
+reds the suite instead of quietly costing coverage. The walker reads headers
+only, and never entropy-decodes anything.
+
+| Family   | Fixture                              | Surface reached                                |
+| -------- | ------------------------------------ | ---------------------------------------------- |
+| envelope | envelope-content-size-and-checksum   | content size present, XXH64 checksum present   |
+| envelope | envelope-no-content-size-no-checksum | content size absent, checksum absent           |
+| envelope | envelope-single-segment              | Single_Segment frame, no window descriptor     |
+| envelope | envelope-windowed                    | windowed frame, many blocks                    |
+| block    | block-raw                            | Raw block                                      |
+| block    | block-rle                            | RLE block, not the frame's first               |
+| block    | block-compressed                     | Compressed block                               |
+| literals | literals-raw                         | Raw literals inside a compressed block         |
+| literals | literals-rle-handbuilt               | RLE literals, no sequences                     |
+| literals | literals-compressed-one-stream       | Huffman literals, 1 stream                     |
+| literals | literals-compressed-four-stream      | Huffman literals, 4 streams and the jump table |
+| literals | literals-treeless                    | Treeless literals reusing the previous tree    |
+| tables   | tables-basic                         | Set_Basic for all three sequence fields        |
+| tables   | tables-rle                           | Set_RLE for offsets and match lengths          |
+| tables   | tables-compressed                    | Set_Compressed for all three fields            |
+| tables   | tables-repeat                        | Repeat for all three fields                    |
+| level    | level-18, level-19                   | the high-search family                         |
+| level    | level-22-long-window                 | the high-search family with a 128 MiB window   |
+| batch    | MakeZstdBatchFrames                  | independent frames over one source, rejoined   |
+
+The self-proof also pins the list of cells above as a set. Removing a family
+or weakening its demand reds the coverage check, so this table cannot drift
+away from the corpus without the suite saying so.
+
+## Two cells the compressor would not produce
+
+**RLE literals.** A block needs a one-symbol literal alphabet AND enough
+literals for a Huffman attempt to be made at all. Both together were not
+reachable through the advanced API: the sources that make every literal
+identical also make the run matchable, the match finder absorbs the literals
+into an offset-1 match, and what comes back is Raw literals. Every variant
+tried came back Raw, so the fixture is a hand-built frame instead, and the
+oracle round-trip is what establishes it is legal rather than plausible. That
+is the shape `tests/zstd_probes.cpp` already uses for behaviours no
+compressor emits.
+
+**Set_RLE for literal lengths.** On the one-symbol-per-field source the
+compressor emitted Set_RLE for offsets and match lengths and a compressed
+table for literal lengths. That is the measurement; no cause is claimed for
+it. The cell itself is already covered in the tree, by the hand-built frames
+in `tests/zstd_probes.cpp`, which set Symbol_Compression_Mode 1 for all three
+fields:
+
+    grep -n "RLE sequence tables" tests/zstd_probes.cpp
+
+## The digest pin
+
+The self-proof pins an FNV-1a digest over every fixture's name and frame
+bytes, the instrument `tests/oracle_lz4.cpp` and `tests/snappy_corpus.cpp`
+both carry. A zstd bump that moves the compressor's output moves every
+fixture with it, and the bump then has to update the pin on purpose instead of
+watching a changed corpus pass. FNV-1a is a drift tripwire, not a defence.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -403,6 +403,15 @@ target_compile_definitions(zstd_probes PRIVATE ZSTD_STATIC_LINKING_ONLY)
 # Huffman code exists to run over it (issue #215). Every serial core in M5
 # reads through this one unit, so it is proven alone: hand-written bit strings
 # for expectations, one negative per reject rung. No oracle and no device.
+# The M5 corpus proving itself before any Zstd decoder exists (issue #185),
+# the counterpart of oracle_lz4 and snappy_corpus. It drives the compressor
+# through its advanced API for the forced-mode families, so it links zstd_full
+# alone for the reason zstd_oracle_smoke gives above. Host-side and GPU-less;
+# the source bytes are constructed rather than fetched, because the runner
+# this has to be green on fetches no corpus - docs/ZSTD-CORPUS.md carries that
+# decision and the coverage matrix.
+cudec_add_test(zstd_corpus_selfproof SOURCES zstd_corpus_selfproof.cpp
+               zstd_corpus.cpp LIBS zstd_full)
 cudec_add_test(zstd_bitstream_twin SOURCES zstd_bitstream_twin.cpp)
 target_include_directories(zstd_bitstream_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)

--- a/tests/zstd_corpus.cpp
+++ b/tests/zstd_corpus.cpp
@@ -1,0 +1,647 @@
+/* Implementation of the M5 Zstd corpus and its frame walker. See
+ * zstd_corpus.h for what this is for and why the source bytes are built
+ * rather than fetched. */
+#include "zstd_corpus.h"
+
+#define ZSTD_STATIC_LINKING_ONLY
+#include <zstd.h>
+
+#include <cstddef>
+#include <cstring>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* ---- Source constructions ---------------------------------------------
+ *
+ * Every source is a pure function of its length, so two generation passes
+ * agree byte for byte without a seeded RNG anywhere. The shapes are chosen
+ * for what the compressor does with them, not for realism: a decode surface
+ * the compressor never emits cannot be covered by a corpus of realistic
+ * data, which is the whole reason the forced-mode families exist. */
+
+/* Splitmix64, inlined so the corpus does not depend on a library RNG whose
+ * output could move under us. Used only where incompressible bytes are
+ * wanted. */
+uint64_t Mix(uint64_t* state) {
+    *state += 0x9e3779b97f4a7c15ull;
+    uint64_t z = *state;
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ull;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111ebull;
+    return z ^ (z >> 31);
+}
+
+/* High entropy: no match longer than chance, so the compressor cannot beat
+ * the input and emits a Raw block. */
+Bytes IncompressibleSource(size_t size) {
+    Bytes out(size);
+    uint64_t state = 0x5eed1234ull;
+    for (size_t i = 0; i < size; i++) {
+        out[i] = static_cast<unsigned char>(Mix(&state) & 0xff);
+    }
+    return out;
+}
+
+/* Text-like: a small word list joined by a walk that revisits words, so the
+ * match distribution is wide enough for FSE-compressed tables and the
+ * literal distribution is skewed enough for a Huffman tree. */
+Bytes TextSource(size_t size) {
+    static const char* const kWords[] = {
+        "the ",     "decoder ", "rejects ", "a ",        "malformed ",
+        "stream ",  "and ",     "never ",   "guesses ",  "at ",
+        "the ",     "output ",  "bytes ",   "it ",       "cannot ",
+        "produce ", "from ",    "hostile ", "input ",    "safely "};
+    const size_t word_count = sizeof(kWords) / sizeof(kWords[0]);
+    Bytes out;
+    out.reserve(size + 16);
+    uint64_t state = 0xc0ffeeull;
+    while (out.size() < size) {
+        const char* word = kWords[Mix(&state) % word_count];
+        out.insert(out.end(), word, word + std::strlen(word));
+    }
+    out.resize(size);
+    return out;
+}
+
+/* A fixed-period pattern: every match the compressor finds has the same
+ * offset and the same length, which is the one-distinct-symbol case
+ * Symbol_Compression_Mode RLE exists for. */
+Bytes PeriodicSource(size_t size, size_t period) {
+    Bytes out(size);
+    for (size_t i = 0; i < size; i++) {
+        out[i] = static_cast<unsigned char>('a' + (i % period));
+    }
+    return out;
+}
+
+/* Runs of 64 identical bytes, each run a different byte. Every sequence is
+ * then literals_length 1, match_length 63 and offset 1 - and offset 1 is the
+ * initial repcode, so even the first sequence encodes as rep1 and the offset
+ * alphabet holds exactly one symbol. One distinct symbol per field is what
+ * Symbol_Compression_Mode RLE is selected on. */
+Bytes RleSequenceSource(size_t size) {
+    Bytes out;
+    out.reserve(size + 64);
+    /* 7 is odd, so i*7 walks all 256 values before repeating: every run holds
+     * a byte no other run holds. A repeated run byte would give the match
+     * finder a second, longer candidate at a different offset, and the field
+     * that stops being one symbol is the one this fixture is for. */
+    for (unsigned i = 0; out.size() < size && i < 256; i++) {
+        out.insert(out.end(), 64, static_cast<unsigned char>((i * 7u + 1u) & 0xffu));
+    }
+    out.resize(size);
+    return out;
+}
+
+/* Compressible bytes first, then a pure run. With the block size cut down by
+ * a small window the run lands in blocks of its own, and a block that is not
+ * the frame's first can be emitted as RLE - zstd refuses to make the first
+ * one RLE whatever it holds. */
+Bytes TextThenRunSource(size_t size) {
+    const size_t head = size / 4;
+    Bytes out = TextSource(head);
+    out.insert(out.end(), size - head, 'q');
+    return out;
+}
+
+/* ---- The frame walker -------------------------------------------------- */
+
+struct Reader {
+    const unsigned char* data;
+    size_t size;
+    size_t pos = 0;
+
+    bool Take(size_t count, const unsigned char** at) {
+        if (count > size - pos) {
+            return false;
+        }
+        *at = data + pos;
+        pos += count;
+        return true;
+    }
+    bool Skip(size_t count) {
+        if (count > size - pos) {
+            return false;
+        }
+        pos += count;
+        return true;
+    }
+};
+
+/* Number_Of_Sequences, RFC 8878 section 3.1.1.3.2.1: one byte below 128, two
+ * bytes up to 254, three bytes at 255. */
+bool ReadSequenceCount(Reader* r, unsigned* out) {
+    const unsigned char* first = nullptr;
+    if (!r->Take(1, &first)) {
+        return false;
+    }
+    if (*first < 128) {
+        *out = *first;
+        return true;
+    }
+    const unsigned char* more = nullptr;
+    if (*first < 255) {
+        if (!r->Take(1, &more)) {
+            return false;
+        }
+        *out = ((static_cast<unsigned>(*first) - 128u) << 8) + *more;
+        return true;
+    }
+    if (!r->Take(2, &more)) {
+        return false;
+    }
+    *out = more[0] + (static_cast<unsigned>(more[1]) << 8) + 0x7f00u;
+    return true;
+}
+
+/* Literals_Section_Header, RFC 8878 section 3.1.1.3.1.1. Reports the type,
+ * the stream count and how many bytes of the block the section occupies in
+ * total, which is what lets the walk reach the sequences section without
+ * decoding anything. */
+bool ReadLiteralsSection(Reader* r, ZstdBlockShape* shape) {
+    const unsigned char* head = nullptr;
+    if (!r->Take(1, &head)) {
+        return false;
+    }
+    const unsigned type = *head & 0x3u;
+    const unsigned size_format = (*head >> 2) & 0x3u;
+    shape->literals_type = type;
+    shape->literals_streams = 0;
+
+    if (type == kZstdLiteralsRaw || type == kZstdLiteralsRle) {
+        size_t regenerated = 0;
+        if (size_format == 0 || size_format == 2) {
+            regenerated = *head >> 3;
+        } else if (size_format == 1) {
+            const unsigned char* rest = nullptr;
+            if (!r->Take(1, &rest)) {
+                return false;
+            }
+            regenerated = (*head >> 4) | (static_cast<size_t>(rest[0]) << 4);
+        } else {
+            const unsigned char* rest = nullptr;
+            if (!r->Take(2, &rest)) {
+                return false;
+            }
+            regenerated = (*head >> 4) | (static_cast<size_t>(rest[0]) << 4) |
+                          (static_cast<size_t>(rest[1]) << 12);
+        }
+        /* An RLE literals section stores exactly one byte whatever it
+         * regenerates; a Raw one stores every byte it regenerates. */
+        return r->Skip(type == kZstdLiteralsRle ? 1u : regenerated);
+    }
+
+    /* Compressed and Treeless carry a compressed size as well, and the
+     * stream count is the Size_Format: 00 is the only single-stream form. */
+    size_t compressed = 0;
+    if (size_format == 0 || size_format == 1) {
+        const unsigned char* rest = nullptr;
+        if (!r->Take(2, &rest)) {
+            return false;
+        }
+        const uint32_t packed = (static_cast<uint32_t>(*head) >> 4) |
+                                (static_cast<uint32_t>(rest[0]) << 4) |
+                                (static_cast<uint32_t>(rest[1]) << 12);
+        compressed = (packed >> 10) & 0x3ffu;
+    } else if (size_format == 2) {
+        const unsigned char* rest = nullptr;
+        if (!r->Take(3, &rest)) {
+            return false;
+        }
+        const uint32_t packed = (static_cast<uint32_t>(*head) >> 4) |
+                                (static_cast<uint32_t>(rest[0]) << 4) |
+                                (static_cast<uint32_t>(rest[1]) << 12) |
+                                (static_cast<uint32_t>(rest[2]) << 20);
+        compressed = (packed >> 14) & 0x3fffu;
+    } else {
+        const unsigned char* rest = nullptr;
+        if (!r->Take(4, &rest)) {
+            return false;
+        }
+        const uint64_t packed = (static_cast<uint64_t>(*head) >> 4) |
+                                (static_cast<uint64_t>(rest[0]) << 4) |
+                                (static_cast<uint64_t>(rest[1]) << 12) |
+                                (static_cast<uint64_t>(rest[2]) << 20) |
+                                (static_cast<uint64_t>(rest[3]) << 28);
+        compressed = static_cast<size_t>((packed >> 18) & 0x3ffffu);
+    }
+    shape->literals_streams = size_format == 0 ? 1u : 4u;
+    return r->Skip(compressed);
+}
+
+}  // namespace
+
+bool ParseZstdFrameShape(const Bytes& frame, ZstdFrameShape* out,
+                         std::string* why) {
+    *out = ZstdFrameShape();
+    Reader r{frame.data(), frame.size(), 0};
+    const unsigned char* magic = nullptr;
+    if (!r.Take(4, &magic) || magic[0] != 0x28 || magic[1] != 0xb5 ||
+        magic[2] != 0x2f || magic[3] != 0xfd) {
+        *why = "not a zstd frame magic";
+        return false;
+    }
+    const unsigned char* descriptor = nullptr;
+    if (!r.Take(1, &descriptor)) {
+        *why = "frame header descriptor truncated";
+        return false;
+    }
+    const unsigned fcs_flag = (*descriptor >> 6) & 0x3u;
+    out->single_segment = ((*descriptor >> 5) & 1u) != 0;
+    out->checksum_present = ((*descriptor >> 2) & 1u) != 0;
+    const unsigned did_flag = *descriptor & 0x3u;
+
+    if (!out->single_segment && !r.Skip(1)) {
+        *why = "window descriptor truncated";
+        return false;
+    }
+    static const size_t kDidBytes[4] = {0, 1, 2, 4};
+    if (!r.Skip(kDidBytes[did_flag])) {
+        *why = "dictionary id truncated";
+        return false;
+    }
+    size_t fcs_bytes = 0;
+    if (fcs_flag == 0) {
+        fcs_bytes = out->single_segment ? 1u : 0u;
+    } else if (fcs_flag == 1) {
+        fcs_bytes = 2;
+    } else if (fcs_flag == 2) {
+        fcs_bytes = 4;
+    } else {
+        fcs_bytes = 8;
+    }
+    out->content_size_present = fcs_bytes != 0;
+    if (!r.Skip(fcs_bytes)) {
+        *why = "frame content size truncated";
+        return false;
+    }
+
+    for (;;) {
+        const unsigned char* header = nullptr;
+        if (!r.Take(3, &header)) {
+            *why = "block header truncated";
+            return false;
+        }
+        const uint32_t value = static_cast<uint32_t>(header[0]) |
+                               (static_cast<uint32_t>(header[1]) << 8) |
+                               (static_cast<uint32_t>(header[2]) << 16);
+        ZstdBlockShape block;
+        block.last = (value & 1u) != 0;
+        block.block_type = (value >> 1) & 0x3u;
+        const size_t block_size = (value >> 3);
+        if (block.block_type == 3) {
+            *why = "reserved block type";
+            return false;
+        }
+        if (block.block_type == kZstdBlockCompressed) {
+            const size_t block_start = r.pos;
+            if (!ReadLiteralsSection(&r, &block)) {
+                *why = "literals section truncated";
+                return false;
+            }
+            if (!ReadSequenceCount(&r, &block.sequence_count)) {
+                *why = "sequence count truncated";
+                return false;
+            }
+            if (block.sequence_count > 0) {
+                const unsigned char* modes = nullptr;
+                if (!r.Take(1, &modes)) {
+                    *why = "symbol compression modes truncated";
+                    return false;
+                }
+                block.ll_mode = (*modes >> 6) & 0x3u;
+                block.of_mode = (*modes >> 4) & 0x3u;
+                block.ml_mode = (*modes >> 2) & 0x3u;
+                if ((*modes & 0x3u) != 0) {
+                    *why = "reserved bits set in symbol compression modes";
+                    return false;
+                }
+            }
+            /* The walk stops at the mode byte, so it resumes from the block
+             * size the header declared rather than from where it stopped. */
+            if (block_start + block_size > frame.size()) {
+                *why = "compressed block runs past the frame";
+                return false;
+            }
+            r.pos = block_start + block_size;
+        } else if (!r.Skip(block.block_type == kZstdBlockRle ? 1u
+                                                             : block_size)) {
+            *why = "block payload truncated";
+            return false;
+        }
+        out->blocks.push_back(block);
+        if (block.last) {
+            break;
+        }
+        if (out->blocks.size() > 4096) {
+            *why = "more blocks than this corpus ever generates";
+            return false;
+        }
+    }
+    if (out->checksum_present && !r.Skip(4)) {
+        *why = "content checksum truncated";
+        return false;
+    }
+    if (r.pos != frame.size()) {
+        *why = "trailing bytes after the frame";
+        return false;
+    }
+    return true;
+}
+
+bool ZstdShapeSatisfies(const ZstdFrameShape& shape, const ZstdDemand& demand,
+                        std::string* why) {
+    if (demand.single_segment >= 0 &&
+        shape.single_segment != (demand.single_segment != 0)) {
+        *why = "single-segment flag";
+        return false;
+    }
+    if (demand.content_size >= 0 &&
+        shape.content_size_present != (demand.content_size != 0)) {
+        *why = "content size presence";
+        return false;
+    }
+    if (demand.checksum >= 0 &&
+        shape.checksum_present != (demand.checksum != 0)) {
+        *why = "checksum presence";
+        return false;
+    }
+    if (demand.min_blocks >= 0 &&
+        shape.blocks.size() < static_cast<size_t>(demand.min_blocks)) {
+        *why = "block count";
+        return false;
+    }
+    const bool wants_block =
+        demand.block_type >= 0 || demand.literals_type >= 0 ||
+        demand.literals_streams >= 0 || demand.ll_mode >= 0 ||
+        demand.of_mode >= 0 || demand.ml_mode >= 0;
+    if (!wants_block) {
+        return true;
+    }
+    for (const auto& block : shape.blocks) {
+        if (demand.block_type >= 0 &&
+            block.block_type != static_cast<unsigned>(demand.block_type)) {
+            continue;
+        }
+        if (demand.literals_type >= 0 &&
+            (block.block_type != kZstdBlockCompressed ||
+             block.literals_type !=
+                 static_cast<unsigned>(demand.literals_type))) {
+            continue;
+        }
+        if (demand.literals_streams >= 0 &&
+            block.literals_streams !=
+                static_cast<unsigned>(demand.literals_streams)) {
+            continue;
+        }
+        if (demand.ll_mode >= 0 &&
+            (block.sequence_count == 0 ||
+             block.ll_mode != static_cast<unsigned>(demand.ll_mode))) {
+            continue;
+        }
+        if (demand.of_mode >= 0 &&
+            (block.sequence_count == 0 ||
+             block.of_mode != static_cast<unsigned>(demand.of_mode))) {
+            continue;
+        }
+        if (demand.ml_mode >= 0 &&
+            (block.sequence_count == 0 ||
+             block.ml_mode != static_cast<unsigned>(demand.ml_mode))) {
+            continue;
+        }
+        return true;
+    }
+    *why = "no block carries the demanded mode combination";
+    return false;
+}
+
+namespace {
+
+/* One knob setting. Kept as data so a family reads as what it asked the
+ * compressor for. */
+struct Param {
+    ZSTD_cParameter id;
+    int value;
+};
+
+struct FamilySpec {
+    const char* name;
+    const char* family;
+    Bytes (*source)(size_t);
+    size_t source_size;
+    int level;
+    std::vector<Param> params;
+    ZstdDemand demand;
+};
+
+Bytes SourceText(size_t n) { return TextSource(n); }
+Bytes SourceIncompressible(size_t n) { return IncompressibleSource(n); }
+Bytes SourcePeriodic(size_t n) { return PeriodicSource(n, 8); }
+Bytes SourceRleSequences(size_t n) { return RleSequenceSource(n); }
+Bytes SourceTextThenRun(size_t n) { return TextThenRunSource(n); }
+
+bool Compress(const Bytes& source, int level, const std::vector<Param>& params,
+              Bytes* out) {
+    ZSTD_CCtx* cctx = ZSTD_createCCtx();
+    if (cctx == nullptr) {
+        return false;
+    }
+    bool ok = !ZSTD_isError(
+        ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, level));
+    for (const auto& p : params) {
+        if (!ok) {
+            break;
+        }
+        ok = !ZSTD_isError(ZSTD_CCtx_setParameter(cctx, p.id, p.value));
+    }
+    if (ok) {
+        out->assign(ZSTD_compressBound(source.size()), 0);
+        const size_t written = ZSTD_compress2(cctx, out->data(), out->size(),
+                                              source.data(), source.size());
+        ok = !ZSTD_isError(written);
+        if (ok) {
+            out->resize(written);
+        }
+    }
+    ZSTD_freeCCtx(cctx);
+    return ok;
+}
+
+}  // namespace
+
+bool ZstdOracleDecodes(const Bytes& frame, Bytes* out) {
+    const unsigned long long declared =
+        ZSTD_getFrameContentSize(frame.data(), frame.size());
+    /* A frame without a content size still has to be decodable here, so the
+     * bound comes from the corpus rather than from the frame: nothing this
+     * generator emits exceeds it, and a hostile frame is not this function's
+     * job. */
+    const size_t bound =
+        (declared == ZSTD_CONTENTSIZE_UNKNOWN ||
+         declared == ZSTD_CONTENTSIZE_ERROR)
+            ? size_t{1} << 22
+            : static_cast<size_t>(declared);
+    out->assign(bound, 0);
+    const size_t written =
+        ZSTD_decompress(out->data(), out->size(), frame.data(), frame.size());
+    if (ZSTD_isError(written)) {
+        out->clear();
+        return false;
+    }
+    out->resize(written);
+    return true;
+}
+
+std::vector<std::vector<unsigned char>> MakeZstdBatchFrames(
+    const Bytes& source, size_t chunk_size, int level) {
+    std::vector<Bytes> frames;
+    if (chunk_size == 0) {
+        return frames;
+    }
+    for (size_t at = 0; at < source.size(); at += chunk_size) {
+        const size_t take =
+            at + chunk_size <= source.size() ? chunk_size : source.size() - at;
+        /* ptrdiff_t rather than long: long is 32-bit on LLP64 hosts, and this
+         * function is meant to take a fetched corpus of any size. */
+        const Bytes chunk(
+            source.begin() + static_cast<std::ptrdiff_t>(at),
+            source.begin() + static_cast<std::ptrdiff_t>(at + take));
+        Bytes frame;
+        if (!Compress(chunk, level, {}, &frame)) {
+            return std::vector<Bytes>();
+        }
+        frames.push_back(frame);
+    }
+    return frames;
+}
+
+std::vector<ZstdFixture> MakeZstdFixtures() {
+    /* Every row states what it asks the compressor for and what must come
+     * back. docs/ZSTD-CORPUS.md is the same table in prose. */
+    static const FamilySpec kSpecs[] = {
+        /* Frame envelope. */
+        {"envelope-content-size-and-checksum", "envelope", SourceText, 8192, 3,
+         {{ZSTD_c_contentSizeFlag, 1}, {ZSTD_c_checksumFlag, 1}},
+         [] { ZstdDemand d; d.content_size = 1; d.checksum = 1; return d; }()},
+        {"envelope-no-content-size-no-checksum", "envelope", SourceText, 8192,
+         3, {{ZSTD_c_contentSizeFlag, 0}, {ZSTD_c_checksumFlag, 0}},
+         [] { ZstdDemand d; d.content_size = 0; d.checksum = 0; return d; }()},
+        {"envelope-single-segment", "envelope", SourceText, 1024, 3,
+         {{ZSTD_c_contentSizeFlag, 1}},
+         [] { ZstdDemand d; d.single_segment = 1; return d; }()},
+        {"envelope-windowed", "envelope", SourceText, 262144, 3,
+         {{ZSTD_c_windowLog, 10}, {ZSTD_c_contentSizeFlag, 1}},
+         [] { ZstdDemand d; d.single_segment = 0; d.min_blocks = 2; return d; }()},
+
+        /* Block types. */
+        {"block-raw", "block", SourceIncompressible, 4096, 3, {},
+         [] { ZstdDemand d; d.block_type = kZstdBlockRaw; return d; }()},
+        {"block-rle", "block", SourceTextThenRun, 8192, 3,
+         {{ZSTD_c_windowLog, 10}},
+         [] { ZstdDemand d; d.block_type = kZstdBlockRle; return d; }()},
+        {"block-compressed", "block", SourceText, 8192, 3, {},
+         [] { ZstdDemand d; d.block_type = kZstdBlockCompressed; return d; }()},
+
+        /* Literals section. */
+        {"literals-raw", "literals", SourcePeriodic, 8192, 3,
+         {{ZSTD_c_literalCompressionMode, ZSTD_ps_disable}},
+         [] { ZstdDemand d; d.literals_type = kZstdLiteralsRaw; return d; }()},
+        {"literals-compressed-four-stream", "literals", SourceText, 65536, 3,
+         {},
+         [] { ZstdDemand d; d.literals_type = kZstdLiteralsCompressed;
+              d.literals_streams = 4; return d; }()},
+        {"literals-compressed-one-stream", "literals", SourceText, 2048, 3,
+         {{ZSTD_c_targetCBlockSize, 340}},
+         [] { ZstdDemand d; d.literals_type = kZstdLiteralsCompressed;
+              d.literals_streams = 1; return d; }()},
+        {"literals-treeless", "literals", SourceText, 262144, 3,
+         {{ZSTD_c_targetCBlockSize, 1300}},
+         [] { ZstdDemand d; d.literals_type = kZstdLiteralsTreeless; return d; }()},
+
+        /* Sequence table modes, one family per mode per field position. */
+        {"tables-basic", "tables", SourcePeriodic, 32768, 3, {},
+         [] { ZstdDemand d; d.ll_mode = kZstdTableBasic;
+              d.of_mode = kZstdTableBasic; d.ml_mode = kZstdTableBasic;
+              return d; }()},
+        /* Offsets and match lengths only. On this source the compressor
+         * emitted a compressed literal-lengths table beside the two RLE
+         * ones; that is the measurement, and no cause is claimed for it.
+         * The literal-lengths RLE cell is covered by the hand-built frames
+         * in tests/zstd_probes.cpp, which set Symbol_Compression_Mode 1 for
+         * all three fields. docs/ZSTD-CORPUS.md carries the pointer. */
+        {"tables-rle", "tables", SourceRleSequences, 16384, 3, {},
+         [] { ZstdDemand d; d.of_mode = kZstdTableRle;
+              d.ml_mode = kZstdTableRle; return d; }()},
+        {"tables-compressed", "tables", SourceText, 262144, 9, {},
+         [] { ZstdDemand d; d.ll_mode = kZstdTableCompressed;
+              d.of_mode = kZstdTableCompressed;
+              d.ml_mode = kZstdTableCompressed; return d; }()},
+        {"tables-repeat", "tables", SourceText, 262144, 9,
+         {{ZSTD_c_targetCBlockSize, 2600}},
+         [] { ZstdDemand d; d.ll_mode = kZstdTableRepeat;
+              d.of_mode = kZstdTableRepeat; d.ml_mode = kZstdTableRepeat;
+              return d; }()},
+
+        /* The high-search family: the class where interop bugs have shipped
+         * upstream, so it is carried whatever the block modes turn out to
+         * be. */
+        {"level-18", "level", SourceText, 131072, 18, {},
+         [] { ZstdDemand d; d.block_type = kZstdBlockCompressed; return d; }()},
+        {"level-19", "level", SourceText, 131072, 19, {},
+         [] { ZstdDemand d; d.block_type = kZstdBlockCompressed; return d; }()},
+        {"level-22-long-window", "level", SourceText, 131072, 22,
+         {{ZSTD_c_windowLog, 27}},
+         [] { ZstdDemand d; d.block_type = kZstdBlockCompressed; return d; }()},
+    };
+
+    std::vector<ZstdFixture> fixtures;
+    const size_t count = sizeof(kSpecs) / sizeof(kSpecs[0]);
+    for (size_t i = 0; i < count; i++) {
+        const FamilySpec& spec = kSpecs[i];
+        ZstdFixture fixture;
+        fixture.name = spec.name;
+        fixture.family = spec.family;
+        fixture.original = spec.source(spec.source_size);
+        fixture.demand = spec.demand;
+        if (!Compress(fixture.original, spec.level, spec.params,
+                      &fixture.compressed)) {
+            return std::vector<ZstdFixture>();
+        }
+        fixtures.push_back(fixture);
+    }
+
+    /* One surface the pinned compressor will not emit, so it is written by
+     * hand instead - the shape tests/zstd_probes.cpp already uses for
+     * behaviours no compressor produces.
+     *
+     * An RLE literals section needs a block whose literal alphabet is one
+     * symbol AND enough literals for a Huffman attempt to be made at all
+     * (zstd_compress_literals.c:158). Both together are unreachable from the
+     * advanced API: the sources that make every literal identical also make
+     * the run matchable, and the match finder then absorbs the literals into
+     * an offset-1 match, leaving too few to reach the floor. Every variant
+     * tried came back Raw. So this fixture carries a hand-built block with
+     * RLE literals and no sequences at all, and the oracle round-trip below
+     * is what says it is a legal frame rather than a plausible one.
+     *
+     * Frame: magic, descriptor 0x00 (no content size, not single segment, no
+     * checksum), Window_Descriptor 0x00 (windowLog 10). One last compressed
+     * block of three bytes: the Literals_Section_Header for RLE with
+     * Size_Format 00 and Regenerated_Size 20, the repeated byte, then
+     * Number_Of_Sequences 0. */
+    {
+        ZstdFixture fixture;
+        fixture.name = "literals-rle-handbuilt";
+        fixture.family = "literals";
+        fixture.original = Bytes(20, 'z');
+        fixture.compressed =
+            Bytes{0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x00, 0x1d, 0x00, 0x00,
+                  static_cast<unsigned char>(kZstdLiteralsRle | (20u << 3)),
+                  'z', 0x00};
+        fixture.demand.literals_type = kZstdLiteralsRle;
+        fixture.demand.block_type = kZstdBlockCompressed;
+        fixtures.push_back(fixture);
+    }
+    return fixtures;
+}

--- a/tests/zstd_corpus.h
+++ b/tests/zstd_corpus.h
@@ -1,0 +1,121 @@
+/* The M5 Zstd corpus: fixtures that reach every decode surface the kernel
+ * must handle, plus the frame walker that proves each one got the mode it
+ * asked for (issue #185).
+ *
+ * Two halves, deliberately separate. MakeZstdFixtures() drives the pinned
+ * compressor through its advanced API; ParseZstdFrameShape() reads the
+ * emitted bytes back and reports which modes are actually in them. A forced
+ * parameter the compressor declines is then a test failure rather than
+ * coverage silently lost, which is the rule this corpus exists to carry.
+ *
+ * The walker reads headers only. Block sizes, literals-section sizes and the
+ * sequence count are all in the clear, so every mode byte is reachable
+ * without entropy decoding, and no second decoder enters the tree.
+ *
+ * Source bytes are constructed here, never fetched: the self-proof runs on
+ * the GPU-less CI runner, which fetches no corpus. docs/ZSTD-CORPUS.md
+ * records that decision and where the Silesia rung lives instead. */
+#ifndef CUDEC_TESTS_ZSTD_CORPUS_H
+#define CUDEC_TESTS_ZSTD_CORPUS_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/* Literals_Block_Type, RFC 8878 section 3.1.1.3.1.1. */
+enum ZstdLiteralsType {
+    kZstdLiteralsRaw = 0,
+    kZstdLiteralsRle = 1,
+    kZstdLiteralsCompressed = 2,
+    kZstdLiteralsTreeless = 3
+};
+
+/* Block_Type, RFC 8878 section 3.1.1.2. */
+enum ZstdBlockType {
+    kZstdBlockRaw = 0,
+    kZstdBlockRle = 1,
+    kZstdBlockCompressed = 2
+};
+
+/* Symbol_Compression_Mode, RFC 8878 section 3.1.1.3.2.1.1. */
+enum ZstdTableMode {
+    kZstdTableBasic = 0,
+    kZstdTableRle = 1,
+    kZstdTableCompressed = 2,
+    kZstdTableRepeat = 3
+};
+
+/* What one block of an emitted frame turned out to be. Per-block rather than
+ * per-frame because a single frame legitimately mixes modes - a Treeless
+ * literals block only exists next to the Compressed one whose table it
+ * reuses, and that pairing is the surface, not an accident. */
+struct ZstdBlockShape {
+    unsigned block_type = 0;
+    bool last = false;
+    /* Set only for a compressed block. */
+    unsigned literals_type = 0;
+    unsigned literals_streams = 0; /* 1 or 4 */
+    unsigned sequence_count = 0;
+    /* Set only where sequence_count > 0. */
+    unsigned ll_mode = 0;
+    unsigned of_mode = 0;
+    unsigned ml_mode = 0;
+};
+
+struct ZstdFrameShape {
+    bool single_segment = false;
+    bool content_size_present = false;
+    bool checksum_present = false;
+    std::vector<ZstdBlockShape> blocks;
+};
+
+/* An expectation, one field per decode surface. Negative means unconstrained.
+ * Frame-level fields must hold for the frame; block-level fields must hold
+ * for at least one block in it. */
+struct ZstdDemand {
+    int single_segment = -1;
+    int content_size = -1;
+    int checksum = -1;
+    int block_type = -1;
+    int literals_type = -1;
+    int literals_streams = -1;
+    int ll_mode = -1;
+    int of_mode = -1;
+    int ml_mode = -1;
+    int min_blocks = -1;
+};
+
+struct ZstdFixture {
+    std::string name;
+    std::string family;
+    std::vector<unsigned char> original;
+    std::vector<unsigned char> compressed;
+    ZstdDemand demand;
+};
+
+/* Walks a frame's headers. Returns false on anything it cannot account for,
+ * so a shape is never reported from a frame the walker only partly
+ * understood. */
+bool ParseZstdFrameShape(const std::vector<unsigned char>& frame,
+                         ZstdFrameShape* out, std::string* why);
+
+/* True when every field the demand constrains is present in the shape. */
+bool ZstdShapeSatisfies(const ZstdFrameShape& shape, const ZstdDemand& demand,
+                        std::string* why);
+
+/* Deterministic: two calls return byte-identical fixtures in the same order.
+ * Empty on a compressor failure, which the self-proof treats as a failure. */
+std::vector<ZstdFixture> MakeZstdFixtures();
+
+/* The batch rung: one source cut at a fixed chunk size, every chunk its own
+ * independent frame, which is the geometry cudec_zstd_decompress_batch
+ * consumes. Source-agnostic on purpose - pointing it at fetched Silesia
+ * bytes is a caller's choice and needs no change here. */
+std::vector<std::vector<unsigned char>> MakeZstdBatchFrames(
+    const std::vector<unsigned char>& source, size_t chunk_size, int level);
+
+/* Round-trips one frame through the pinned decoder. */
+bool ZstdOracleDecodes(const std::vector<unsigned char>& frame,
+                       std::vector<unsigned char>* out);
+
+#endif /* CUDEC_TESTS_ZSTD_CORPUS_H */

--- a/tests/zstd_corpus_selfproof.cpp
+++ b/tests/zstd_corpus_selfproof.cpp
@@ -1,0 +1,217 @@
+/* The Zstd corpus proving itself before any Zstd decoder exists, the
+ * counterpart of oracle_lz4.cpp and snappy_corpus.cpp (issue #185).
+ *
+ * Four properties, and the third is the one this corpus was built for:
+ *
+ *  - the pairs are real: the pinned oracle decodes every frame back to the
+ *    bytes it was made from;
+ *  - generation is deterministic: two passes agree byte for byte, and a
+ *    pinned digest catches a drift that both passes share;
+ *  - every fixture GOT the mode it asked for, read out of the emitted
+ *    headers. A compressor that quietly declines a forced parameter fails
+ *    here instead of costing coverage in silence;
+ *  - the coverage set is fixed in place, so deleting a fixture reds this
+ *    test rather than shrinking the corpus unnoticed.
+ *
+ * The machinery that judges the third property is itself checked against
+ * cases it must refuse - a walker that accepted anything, or a demand check
+ * that passed everything, would make the whole file vacuous.
+ *
+ * docs/ZSTD-CORPUS.md is the coverage matrix in prose and records why the
+ * Silesia rung is not here. */
+#include "require.h"
+#include "zstd_corpus.h"
+
+#include <cstdio>
+#include <set>
+#include <string>
+
+namespace {
+
+/* Corpus drift tripwire, the instrument oracle_lz4.cpp and
+ * snappy_corpus.cpp both carry: a zstd bump that moves the compressor's
+ * output moves every fixture, and the bump should have to update this number
+ * on purpose instead of watching a changed corpus pass. FNV-1a, not crypto:
+ * a tripwire against drift, not a defence. */
+constexpr uint64_t kExpectedZstdCorpusDigest = 0xd104a6f6fef0e98bull;
+
+uint64_t Fnv1a64(uint64_t hash, const void* data, size_t size) {
+    const unsigned char* bytes = static_cast<const unsigned char*>(data);
+    for (size_t i = 0; i < size; i++) {
+        hash ^= bytes[i];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+/* The cells this corpus claims, one string per (dimension, value). Written
+ * out rather than derived from the fixtures, because a set derived from the
+ * fixtures would shrink with them and prove nothing. Cells covered
+ * elsewhere in the tree are named in docs/ZSTD-CORPUS.md, not here. */
+const char* const kExpectedCoverage[] = {
+    "block:compressed",   "block:raw",           "block:rle",
+    "checksum:0",         "checksum:1",          "content-size:0",
+    "content-size:1",     "literals:compressed", "literals:raw",
+    "literals:rle",       "literals:treeless",   "ll-mode:basic",
+    "ll-mode:compressed", "ll-mode:repeat",      "ml-mode:basic",
+    "ml-mode:compressed", "ml-mode:repeat",      "ml-mode:rle",
+    "of-mode:basic",      "of-mode:compressed",  "of-mode:repeat",
+    "of-mode:rle",        "single-segment:0",    "single-segment:1",
+    "streams:1",          "streams:4",
+};
+
+const char* const kBlockNames[] = {"raw", "rle", "compressed"};
+const char* const kLiteralsNames[] = {"raw", "rle", "compressed", "treeless"};
+const char* const kModeNames[] = {"basic", "rle", "compressed", "repeat"};
+
+void CollectCoverage(const ZstdDemand& d, std::set<std::string>* into) {
+    if (d.single_segment >= 0) {
+        into->insert("single-segment:" + std::to_string(d.single_segment));
+    }
+    if (d.content_size >= 0) {
+        into->insert("content-size:" + std::to_string(d.content_size));
+    }
+    if (d.checksum >= 0) {
+        into->insert("checksum:" + std::to_string(d.checksum));
+    }
+    if (d.block_type >= 0) {
+        into->insert(std::string("block:") + kBlockNames[d.block_type]);
+    }
+    if (d.literals_type >= 0) {
+        into->insert(std::string("literals:") + kLiteralsNames[d.literals_type]);
+    }
+    if (d.literals_streams >= 0) {
+        into->insert("streams:" + std::to_string(d.literals_streams));
+    }
+    if (d.ll_mode >= 0) {
+        into->insert(std::string("ll-mode:") + kModeNames[d.ll_mode]);
+    }
+    if (d.of_mode >= 0) {
+        into->insert(std::string("of-mode:") + kModeNames[d.of_mode]);
+    }
+    if (d.ml_mode >= 0) {
+        into->insert(std::string("ml-mode:") + kModeNames[d.ml_mode]);
+    }
+}
+
+}  // namespace
+
+int main() {
+    const auto fixtures = MakeZstdFixtures();
+    REQUIRE(!fixtures.empty());
+    const auto again = MakeZstdFixtures();
+    REQUIRE(again.size() == fixtures.size());
+
+    uint64_t digest = 14695981039346656037ull;
+    std::set<std::string> covered;
+    size_t block_total = 0;
+
+    for (size_t i = 0; i < fixtures.size(); i++) {
+        const ZstdFixture& f = fixtures[i];
+        const char* name = f.name.c_str();
+
+        /* Determinism first: everything below is a statement about one of two
+         * runs, and it is only worth making if the two runs agree. */
+        REQUIRE_CTX(again[i].name == f.name, "fixture %zu order moved", i);
+        REQUIRE_CTX(again[i].original == f.original, "fixture %s source", name);
+        REQUIRE_CTX(again[i].compressed == f.compressed, "fixture %s frame",
+                    name);
+
+        digest = Fnv1a64(digest, f.name.data(), f.name.size());
+        digest = Fnv1a64(digest, f.compressed.data(), f.compressed.size());
+
+        std::vector<unsigned char> decoded;
+        REQUIRE_CTX(ZstdOracleDecodes(f.compressed, &decoded),
+                    "fixture %s: the oracle refused a frame the corpus made",
+                    name);
+        REQUIRE_CTX(decoded.size() == f.original.size(),
+                    "fixture %s: %zu bytes back, %zu expected", name,
+                    decoded.size(), f.original.size());
+        REQUIRE_CTX(
+            equal_bytes(decoded.data(), f.original.data(), decoded.size()),
+            "fixture %s", name);
+
+        ZstdFrameShape shape;
+        std::string why;
+        REQUIRE_CTX(ParseZstdFrameShape(f.compressed, &shape, &why),
+                    "fixture %s: the walker could not read the frame it "
+                    "generated: %s",
+                    name, why.c_str());
+        REQUIRE_CTX(!shape.blocks.empty(), "fixture %s has no blocks", name);
+        REQUIRE_CTX(ZstdShapeSatisfies(shape, f.demand, &why),
+                    "fixture %s asked the compressor for a mode it did not "
+                    "emit (%s) - coverage lost, not a tolerable outcome",
+                    name, why.c_str());
+        block_total += shape.blocks.size();
+        CollectCoverage(f.demand, &covered);
+    }
+
+    REQUIRE_CTX(digest == kExpectedZstdCorpusDigest,
+                "corpus digest is 0x%016llx - an oracle or generator change "
+                "moved the fixtures; verify deliberately, then update the pin",
+                static_cast<unsigned long long>(digest));
+
+    /* Every claimed cell present, and no cell claimed that nothing covers:
+     * both directions, so the list cannot drift away from the corpus in
+     * either one. */
+    const size_t expected_cells =
+        sizeof(kExpectedCoverage) / sizeof(kExpectedCoverage[0]);
+    for (size_t i = 0; i < expected_cells; i++) {
+        REQUIRE_CTX(covered.count(kExpectedCoverage[i]) == 1,
+                    "no fixture demands %s - a corpus family was removed or "
+                    "its demand weakened",
+                    kExpectedCoverage[i]);
+    }
+    REQUIRE_CTX(covered.size() == expected_cells,
+                "%zu cells demanded, %zu listed - a new family arrived "
+                "without joining the recorded matrix",
+                covered.size(), expected_cells);
+
+    /* The batch rung: the geometry cudec_zstd_decompress_batch consumes is
+     * independent frames over one source, so the proof is that the frames
+     * decode independently and reassemble to the source exactly. */
+    const std::vector<unsigned char>& source = fixtures[0].original;
+    const size_t chunk = 1024;
+    const auto frames = MakeZstdBatchFrames(source, chunk, 3);
+    REQUIRE(!frames.empty());
+    REQUIRE(frames.size() == (source.size() + chunk - 1) / chunk);
+    std::vector<unsigned char> rejoined;
+    for (size_t i = 0; i < frames.size(); i++) {
+        std::vector<unsigned char> out;
+        REQUIRE_CTX(ZstdOracleDecodes(frames[i], &out), "batch frame %zu", i);
+        rejoined.insert(rejoined.end(), out.begin(), out.end());
+    }
+    REQUIRE(rejoined.size() == source.size());
+    REQUIRE(equal_bytes(rejoined.data(), source.data(), rejoined.size()));
+
+    /* The judging machinery against cases it must refuse. Without these three
+     * every claim above could be produced by a walker that returned true and
+     * a demand check that agreed with everything. */
+    {
+        ZstdFrameShape shape;
+        std::string why;
+        std::vector<unsigned char> truncated = fixtures[0].compressed;
+        truncated.resize(truncated.size() - 1);
+        REQUIRE(!ParseZstdFrameShape(truncated, &shape, &why));
+
+        /* A frame that is well formed in every other respect, with one magic
+         * byte changed. Short junk would be refused for being short, which
+         * proves nothing about the magic check; this input is refused only
+         * because the magic is read. */
+        std::vector<unsigned char> wrong_magic = fixtures[0].compressed;
+        wrong_magic[0] = 0x27;
+        REQUIRE(!ParseZstdFrameShape(wrong_magic, &shape, &why));
+
+        REQUIRE(ParseZstdFrameShape(fixtures[0].compressed, &shape, &why));
+        ZstdDemand impossible;
+        impossible.block_type = kZstdBlockRaw;
+        impossible.literals_type = kZstdLiteralsTreeless;
+        REQUIRE(!ZstdShapeSatisfies(shape, impossible, &why));
+    }
+
+    std::printf("PASS: %zu zstd fixtures round-trip over %zu blocks; %zu "
+                "coverage cells demanded and met; %zu batch frames rejoin; "
+                "generation deterministic\n",
+                fixtures.size(), block_total, covered.size(), frames.size());
+    return 0;
+}


### PR DESCRIPTION
Closes #185.

## What this adds

`tests/zstd_corpus.cpp` drives the pinned libzstd 1.5.7 compressor through its
advanced API for 18 forced-mode families, plus one hand-built frame. The same
file carries a walker that reads the emitted frames back and reports which
modes are actually in them: block types, the literals section type and stream
count, and the three sequence-table modes. It reads headers only, so no second
decoder enters the tree. `tests/zstd_corpus_selfproof.cpp` ties them together
and `docs/ZSTD-CORPUS.md` is the coverage matrix in prose.

## The decision this issue owed

The issue's Surfaces list names `bench/get-corpora.sh` for Silesia while the
Done-when asks for the self-proof to be green on the GPU-less runner. Those
cannot be one artifact, because that runner fetches nothing:

    grep -c -i "silesia\|get-corpora" .github/workflows/ci.yml
    0

So the CI-gated proof runs entirely on bytes the harness constructs, in the
shape the existing bench self-checks already use, and the Silesia level sweep
stays with the fetch. `MakeZstdBatchFrames` takes its source bytes as an
argument for that reason: pointing it at a fetched corpus needs no change to
this code.

What is therefore NOT covered: Silesia's own level sweep at Silesia's scale. It
is covered nowhere yet, and nothing in this change or in `docs/ZSTD-CORPUS.md`
should be read as covering it.

## Means

C++17 in `tests/`, driving the already-vendored `zstd_full` target. The corpus
has to be generated by the same reference the decoder is diffed against, and
that reference is a C library the tree already fetches by SHA-256, so any other
means would add a runtime to reach bytes that are already reachable. No new
language, dependency or fetch.

## Evidence

The tarball the local verification built against is the one the tree pins:

    curl -sSL -o zstd.tar.gz https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz
    sha256sum zstd.tar.gz
    eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3

    grep -A2 URL_HASH tests/CMakeLists.txt | grep SHA256
        SHA256=eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3

The self-proof, built with the same warning set the harness applies and the
same compile definitions the in-tree `zstd_full` target uses:

    g++ -std=c++17 -O2 -Wall -Wextra -Werror -I zstd-1.5.7/lib -I tests \
        -o selfproof zstd_corpus_selfproof.cpp zstd_corpus.cpp libzstd_full.a
    ./selfproof
    PASS: 19 zstd fixtures round-trip over 340 blocks; 26 coverage cells demanded and met; 8 batch frames rejoin; generation deterministic
    exit=0

Format gate:

    npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

Host-only configuration still builds:

    cmake -B build-host -G "MinGW Makefiles" && cmake --build build-host
    [ 66%] Built target cudec
    [100%] Built target example_decode_frame

## Each guard deleted, and the suite watched

Four guards ship here. Each was removed in a scratch copy of the two files and
the suite re-run.

The demand check. `block-rle`'s forced window removed, so the mode is no longer
emitted:

    FAIL zstd_corpus_selfproof.cpp:141: ZstdShapeSatisfies(shape, f.demand, &why) | fixture block-rle asked the compressor for a mode it did not emit (no block carries the demanded mode combination) - coverage lost, not a tolerable outcome
    exit=1

The digest pin. A family deleted:

    FAIL zstd_corpus_selfproof.cpp:149: digest == kExpectedZstdCorpusDigest | corpus digest is 0xe264d5a3fb449949 - an oracle or generator change moved the fixtures; verify deliberately, then update the pin
    exit=1

The coverage-cell list. The same family deleted and the digest updated, so the
digest guard does not fire first and this one is isolated:

    FAIL zstd_corpus_selfproof.cpp:160: covered.count(kExpectedCoverage[i]) == 1 | no fixture demands block:rle - a corpus family was removed or its demand weakened
    exit=1

The walker's magic check. This one is worth reading, because the first attempt
at it did not bite. With the magic comparison removed the suite still passed:
the negative was five junk bytes, and the walker refused those for being short
rather than for the magic, so the probe proved nothing about the guard it was
aimed at. The negative was replaced with a valid frame carrying one changed
magic byte, which is refused only if the magic is read. Re-run with the guard
removed:

    FAIL zstd_corpus_selfproof.cpp:203: !ParseZstdFrameShape(wrong_magic, &shape, &why)
    exit=1

## Two cells the compressor would not produce

RLE literals. A block needs a one-symbol literal alphabet and enough literals
for a Huffman attempt to be made at all. Both together were not reachable
through the advanced API: the sources that make every literal identical also
make the run matchable, the match finder absorbs the literals into an offset-1
match, and Raw literals come back. So that fixture is a hand-built frame, which
is the shape `tests/zstd_probes.cpp` already uses for behaviours no compressor
emits, and the oracle round-trip in the self-proof is what says it is legal
rather than plausible.

Set_RLE for literal lengths. On the one-symbol-per-field source the compressor
emitted Set_RLE for offsets and match lengths and a compressed table for
literal lengths. That is the measurement and no cause is claimed for it. The
cell is already covered in the tree by the hand-built frames in
`tests/zstd_probes.cpp`, which set Symbol_Compression_Mode 1 for all three
fields; `docs/ZSTD-CORPUS.md` carries the pointer rather than a second copy.

## What was not run here, and what stands in for it

No ctest run. `tests/` is added only inside the `CUDEC_ENABLE_CUDA` block of the
top-level `CMakeLists.txt`, so a host-only test cannot be configured without a
CUDA toolchain, and this host has none:

    (Get-Command nvcc -ErrorAction SilentlyContinue) -ne $null
    False
    docker version --format "{{.Server.Version}}"
    failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine

The two files were therefore compiled and run directly, as quoted above. The
CMake registration itself is unverified locally and this PR's build check is its
first run.

No GPU anywhere. Nothing here reaches a device and nothing here needs one.
Starting the container engine means starting a stopped Windows service, which
raises a consent prompt on this machine; it was not attempted.

The pinned digest was computed by the local build above, not by CI. If the check
reds on the digest, the number CI reports is the number, and moving the pin is
then a deliberate act rather than a fix.

`.github/workflows/ci.yml` is untouched. The new test carries no `gpu` label, so
`ctest -LE gpu` selects it without a workflow change. The explicit `grep`
presence list in that step would lock its selection in place, and that is worth
adding, but the file is being edited by other work in flight and two changes to
one file is the collision worth avoiding more than the lock is worth having.

Size. 1087 lines added, above the 400-line guideline. One property holds across
all of it: every family states the modes it demands and the self-proof refuses
the family that did not get them, so the reader checks that property rather
than the diff. 647 of the lines are the family table and the header walker. The
nearest precedent in this tree is `tests/zstd_probes.cpp` at 574 lines in one
landing.

No second reader. This change had one author and no reviewer. The evidence above
stands in place of one and is not a substitute for one.

The new document is not linked from `README.md` or `CONTRIBUTING.md`. Both are
being edited by other work in flight, and the same collision reasoning applies
as for the workflow file. It is reachable from the four files that own it:
`tests/zstd_corpus.h`, `tests/zstd_corpus.cpp`, `tests/zstd_corpus_selfproof.cpp`
and the registration comment in `tests/CMakeLists.txt`. No mechanical check
refuses an unlinked document, so nothing reds either way and this is a
disclosure rather than a deferral with a gate behind it.

One thing the digest was checked against, since the number came from a local
build: the oracle was rebuilt at `-O3` instead of `-O1`, same pinned sources
and same defines, and the suite passed unchanged, so the pin does not track the
oracle's optimisation level. That is not a proof of platform independence and
is not offered as one; it removes the likeliest cause of a divergence on the
CI toolchain and no more.

## What the checks then reported

The registration and the digest both held on the CI toolchain. From the build
job log:

    [100%] Built target zstd_corpus_selfproof
    Start 12: zstd_corpus_selfproof
    11/20 Test #12: zstd_corpus_selfproof ............   Passed    0.49 sec
    100% tests passed, 0 tests failed out of 20

So the digest computed locally is the digest CI computes, and the two
disclosures above about the registration being locally unverified stay as
written: they describe what was and was not done before the push, and this
paragraph is the outcome rather than a correction to them.
