### PR TITLE
Parse and gate the Zstd frame and block headers [#200]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,7 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|zstd_frame_twin|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
@@ -462,6 +462,7 @@ jobs:
           grep -E ': snappy_edge_sweep$' san-selected.txt &&
           grep -E ': snappy_upstream_negatives$' san-selected.txt &&
           grep -E ': frame_host_negative$' san-selected.txt &&
+          grep -E ': zstd_frame_twin$' san-selected.txt &&
           grep -E ': termination$' san-selected.txt
 
   format:

--- a/src/zstd_frame.h
+++ b/src/zstd_frame.h
@@ -257,8 +257,9 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdParseFrameHeader(
      * fixed at zero bytes + the content size. Every term is a small constant,
      * so the sum cannot overflow the 32 bits it is kept in. */
     const unsigned window_size_bytes = single_segment ? 0u : 1u;
-    const uint32_t header_size = 5u + window_size_bytes +
-                                 ZstdDidFieldSize(did_flag) + fcs_size;
+    const unsigned did_bytes = ZstdDidFieldSize(did_flag);
+    const uint32_t header_size =
+        5u + window_size_bytes + did_bytes + fcs_size;
     if (size < header_size) {
         return ZstdFrameRefuse(kZstdFrameRejectHeaderTruncated,
                                CUDEC_ERR_CORRUPT_INPUT, reject);
@@ -267,8 +268,8 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdParseFrameHeader(
     /* Section 3.1.1.1.1.1: the two-byte encoding carries the value minus
      * 256, so the whole 16-bit range maps to 256..65791 rather than wasting
      * the sizes a one-byte field already covers. */
-    uint64_t content_size =
-        ZstdReadLe(src + 5u + window_size_bytes, fcs_size);
+    uint64_t content_size = ZstdReadLe(
+        src + 5u + window_size_bytes + did_bytes, fcs_size);
     if (fcs_size == 2) {
         content_size += 256;
     }

--- a/src/zstd_frame.h
+++ b/src/zstd_frame.h
@@ -342,6 +342,10 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdParseBlockHeader(
     const uint64_t block_max = window_size < kZstdBlockSizeCeiling
                                    ? window_size
                                    : kZstdBlockSizeCeiling;
+    if (static_cast<uint64_t>(block_size) > block_max) {
+        return ZstdFrameRefuse(kZstdFrameRejectBlockTooLarge,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
     const uint32_t body_size =
         block_type == kZstdBlockTypeRle ? 1u : block_size;
     /* 3 + body_size in 64-bit, against the bytes actually present. body_size

--- a/src/zstd_frame.h
+++ b/src/zstd_frame.h
@@ -1,0 +1,370 @@
+/* The Zstd frame and block header parser, and the v1 subset gate that sits
+ * on top of it - the first thing any Zstd decode path in this project reads,
+ * and the only place a frame is judged admissible. Single-sourced for host
+ * and device, the sibling of src/lz4_block.h, src/snappy_block.h and
+ * src/zstd_bitstream.h. Internal header, not part of the ABI.
+ *
+ * Every field layout, every derivation and every refusal below carries the
+ * RFC 8878 section it was read from; the subset itself is
+ * docs/MASTERPLAN.md section 12, which is where the decision to accept less
+ * than the format offers is argued rather than restated here.
+ *
+ * TWO REJECT CLASSES, AND THE LINE BETWEEN THEM IS THE CONTRACT.
+ * CUDEC_ERR_CORRUPT_INPUT means no conforming encoder produced these bytes.
+ * CUDEC_ERR_UNSUPPORTED means one did and cudec does not decode that part of
+ * the format. A caller that would fall back to a CPU decoder needs to tell
+ * them apart, so a legal frame outside the subset must never be reported as
+ * corrupt and a corrupt one must never be reported as merely unsupported.
+ * Section 12.3 sets the line; this header is where it is executed.
+ *
+ * NOTHING IS EVER SIZED FROM THE STREAM BEFORE IT IS BOUNDED. The frame
+ * header's own length depends on flag bits inside it, so the length is
+ * derived first and checked against the available bytes before any field is
+ * read; a block's declared size is checked against both the block maximum
+ * and the bytes actually present before it is used as a step. The declared
+ * content size is attacker-controlled and is never used to size anything
+ * here at all - it is reported, and the caller's capacity remains the truth.
+ *
+ * Widths: sizes and offsets are uint64_t because the caller's are, and
+ * because Frame_Content_Size is a 64-bit field a hostile stream can set to
+ * anything. Mixing a 32-bit intermediate into a bound comparison is where an
+ * overflow would hide, so there are none. */
+#ifndef CUDEC_ZSTD_FRAME_H
+#define CUDEC_ZSTD_FRAME_H
+
+#include "cudec.h"
+
+#include <stdint.h>
+
+/* Guarded: src/lz4_block.h, src/snappy_block.h and src/zstd_bitstream.h
+ * define the same macro for the same reason, and a device translation unit
+ * that decodes more than one format includes more than one header. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+/* RFC 8878 section 3.1.1: the frame's own magic, little-endian. */
+constexpr uint32_t kZstdMagic = 0xFD2FB528u;
+
+/* Section 3.1.2: the skippable range. These frames are legal and trivially
+ * steppable; refusing them is a scope line rather than a difficulty, and
+ * section 12.4 is where that line is argued. */
+constexpr uint32_t kZstdSkippableMagicMin = 0x184D2A50u;
+constexpr uint32_t kZstdSkippableMagicMax = 0x184D2A5Fu;
+
+/* Section 3.1.1.1.2 recommends decoders support windows up to 8 MB and, in
+ * the same section, allows a decoder to refuse a frame demanding more than
+ * its authorized range. The number is the spec's, not this project's. */
+constexpr uint64_t kZstdMaxWindowSize = 8ull * 1024ull * 1024ull;
+
+/* Section 3.1.1.2.4: Block_Maximum_Size is the smaller of Window_Size and
+ * 128 KB. */
+constexpr uint64_t kZstdBlockSizeCeiling = 128ull * 1024ull;
+
+/* Section 3.1.1.2.2: block types. 3 is "not a block ... considered to be
+ * corrupt data", which is the spec assigning the rejection class itself. */
+constexpr uint8_t kZstdBlockTypeRaw = 0;
+constexpr uint8_t kZstdBlockTypeRle = 1;
+constexpr uint8_t kZstdBlockTypeCompressed = 2;
+constexpr uint8_t kZstdBlockTypeReserved = 3;
+
+/* The reject ladder, enumerated once, in the shape the Snappy parser and the
+ * bitstream reader use: every refusal returns through one choke point naming
+ * its rung, so the twin can require a negative per rung instead of counting
+ * statuses that repeat. Ten of these return CUDEC_ERR_CORRUPT_INPUT and four
+ * return CUDEC_ERR_UNSUPPORTED, so the status alone identifies nothing. */
+enum ZstdFrameReject {
+    kZstdFrameRejectNone = 0,
+    kZstdFrameRejectMagicTruncated,
+    kZstdFrameRejectMagicWrong,
+    kZstdFrameRejectSkippableFrame,
+    kZstdFrameRejectDescriptorTruncated,
+    kZstdFrameRejectReservedBitSet,
+    kZstdFrameRejectDictionaryId,
+    kZstdFrameRejectContentSizeAbsent,
+    kZstdFrameRejectHeaderTruncated,
+    kZstdFrameRejectWindowTooLarge,
+    kZstdFrameRejectBlockHeaderTruncated,
+    kZstdFrameRejectBlockTypeReserved,
+    kZstdFrameRejectBlockTooLarge,
+    kZstdFrameRejectBlockBodyTruncated,
+    kZstdFrameRejectCount
+};
+
+/* The one choke point. It records which rung refused and returns that rung's
+ * status; `out` is null only where a caller has no interest in the reason,
+ * and the ladder itself always supplies one. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdFrameRefuse(ZstdFrameReject rung,
+                                                      cudec_status status,
+                                                      ZstdFrameReject* out) {
+    if (out != 0) {
+        *out = rung;
+    }
+    return status;
+}
+
+/* What a parsed frame header says, in the terms the decode path needs.
+ *
+ * `header_size` counts from the magic through the last header byte, so a
+ * caller steps by it to reach the first block header and never re-derives
+ * the layout. `frame_content_size` is reported and never used as a size
+ * here; `window_size` is the bound back-references are held to and, with the
+ * 128 KB ceiling, fixes the block maximum. */
+struct ZstdFrameHeader {
+    uint64_t frame_content_size;
+    uint64_t window_size;
+    uint32_t header_size;
+    bool single_segment;
+    bool content_checksum;
+};
+
+/* Little-endian reads, byte by byte. The stream's byte order is fixed by the
+ * format and the host's is not, and a cast to a wider type would also be an
+ * unaligned access on a pointer the caller chose. */
+CUDEC_HOST_DEVICE inline uint32_t ZstdRead32(const unsigned char* p) {
+    return static_cast<uint32_t>(p[0]) |
+           (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) |
+           (static_cast<uint32_t>(p[3]) << 24);
+}
+
+CUDEC_HOST_DEVICE inline uint64_t ZstdReadLe(const unsigned char* p,
+                                             unsigned bytes) {
+    uint64_t value = 0;
+    for (unsigned i = 0; i < bytes; i++) {
+        value |= static_cast<uint64_t>(p[i]) << (8u * i);
+    }
+    return value;
+}
+
+/* Section 3.1.1.1.2. Window_Size is a base of 2^(10 + Exponent) plus
+ * Mantissa eighths of that base. The exponent is five bits, so windowLog
+ * reaches 41 and the whole value fits in 64 bits with room left; that is why
+ * this returns a uint64_t rather than clamping, and why the caller compares
+ * against the 8 MB line afterwards rather than this function deciding. */
+CUDEC_HOST_DEVICE inline uint64_t ZstdWindowSize(unsigned char descriptor) {
+    const uint64_t exponent = static_cast<uint64_t>(descriptor >> 3);
+    const uint64_t mantissa = static_cast<uint64_t>(descriptor & 0x07u);
+    const uint64_t base = static_cast<uint64_t>(1) << (10 + exponent);
+    return base + (base / 8) * mantissa;
+}
+
+/* Section 3.1.1.1.1, the Frame_Header_Descriptor's bit assignment:
+ *
+ *   7-6  Frame_Content_Size_flag
+ *   5    Single_Segment_flag
+ *   4    Unused_bit
+ *   3    Reserved_bit
+ *   2    Content_Checksum_flag
+ *   1-0  Dictionary_ID_flag
+ *
+ * The Reserved_bit "must be zero" (3.1.1.1.1.3) and a set one is corrupt.
+ * The Unused_bit is a different thing wearing a similar name: 3.1.1.1.1.4
+ * says a decoder compliant with this version "shall not interpret" it, so
+ * refusing on it would refuse frames a future encoder may legally emit.
+ * These two are one bit apart and swapping them is the mistake this comment
+ * exists to stop. */
+CUDEC_HOST_DEVICE inline unsigned ZstdFcsFieldSize(unsigned flag,
+                                                   bool single_segment) {
+    /* Section 3.1.1.1.1.1's table. Flag 0 is the only entry that depends on
+     * Single_Segment_flag, and it is the one that decides whether the frame
+     * declares its content size at all. */
+    if (flag == 0) {
+        return single_segment ? 1u : 0u;
+    }
+    return 1u << flag; /* 1 -> 2, 2 -> 4, 3 -> 8 */
+}
+
+/* Section 3.1.1.1.3's table: 0, 1, 2 or 4 bytes. Only flag 0 survives the
+ * subset gate, so the other three sizes are never read; the function exists
+ * so the header-length arithmetic is written once and stays honest if the
+ * dictionary rung is ever taken (section 12.5 keeps it permanently out). */
+CUDEC_HOST_DEVICE inline unsigned ZstdDidFieldSize(unsigned flag) {
+    return flag == 0 ? 0u : (1u << (flag - 1u));
+}
+
+/* Parse and gate a frame header.
+ *
+ * `size` is the bytes available from `src`, not the frame's declared length:
+ * a frame is bounded by the chunk it arrives in, and a header that reaches
+ * past that is truncated whatever it claims. The refusals are ordered so
+ * that each field is bounded before it is read, which is why the header
+ * length is derived from the descriptor before the descriptor's dependents
+ * are touched. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdParseFrameHeader(
+    const unsigned char* src, uint64_t size, ZstdFrameHeader* out,
+    ZstdFrameReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdFrameRejectNone;
+    }
+    if (size < 4) {
+        return ZstdFrameRefuse(kZstdFrameRejectMagicTruncated,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const uint32_t magic = ZstdRead32(src);
+    if (magic != kZstdMagic) {
+        /* The skippable range is separated from every other wrong magic
+         * BEFORE the corrupt verdict, because those frames are legal. A
+         * caller told "corrupt" about a valid skippable frame would have no
+         * reason to try a CPU decoder, which is the confusion 12.3 exists to
+         * prevent. */
+        if (magic >= kZstdSkippableMagicMin && magic <= kZstdSkippableMagicMax) {
+            return ZstdFrameRefuse(kZstdFrameRejectSkippableFrame,
+                                   CUDEC_ERR_UNSUPPORTED, reject);
+        }
+        return ZstdFrameRefuse(kZstdFrameRejectMagicWrong,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    if (size < 5) {
+        return ZstdFrameRefuse(kZstdFrameRejectDescriptorTruncated,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    const unsigned descriptor = src[4];
+    const unsigned fcs_flag = descriptor >> 6;
+    const bool single_segment = (descriptor & 0x20u) != 0;
+    const bool reserved_bit = (descriptor & 0x08u) != 0;
+    const bool content_checksum = (descriptor & 0x04u) != 0;
+    const unsigned did_flag = descriptor & 0x03u;
+
+    if (reserved_bit) {
+        return ZstdFrameRefuse(kZstdFrameRejectReservedBitSet,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    /* Both of the next two are legal frames outside the subset, so both are
+     * UNSUPPORTED and both are decided before the header length is used to
+     * read anything: a dictionary id changes the layout, and a frame with no
+     * declared content size cannot be placed in a caller's buffer before it
+     * is decoded, which is the property the batch model rests on. */
+    if (did_flag != 0) {
+        return ZstdFrameRefuse(kZstdFrameRejectDictionaryId,
+                               CUDEC_ERR_UNSUPPORTED, reject);
+    }
+    const unsigned fcs_size = ZstdFcsFieldSize(fcs_flag, single_segment);
+    if (fcs_size == 0) {
+        return ZstdFrameRefuse(kZstdFrameRejectContentSizeAbsent,
+                               CUDEC_ERR_UNSUPPORTED, reject);
+    }
+
+    /* 4 magic + 1 descriptor + the window descriptor when Single_Segment is
+     * clear (3.1.1.1.2) + the dictionary id, which the gate above has just
+     * fixed at zero bytes + the content size. Every term is a small constant,
+     * so the sum cannot overflow the 32 bits it is kept in. */
+    const unsigned window_size_bytes = single_segment ? 0u : 1u;
+    const uint32_t header_size = 5u + window_size_bytes +
+                                 ZstdDidFieldSize(did_flag) + fcs_size;
+    if (size < header_size) {
+        return ZstdFrameRefuse(kZstdFrameRejectHeaderTruncated,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    /* Section 3.1.1.1.1.1: the two-byte encoding carries the value minus
+     * 256, so the whole 16-bit range maps to 256..65791 rather than wasting
+     * the sizes a one-byte field already covers. */
+    uint64_t content_size =
+        ZstdReadLe(src + 5u + window_size_bytes, fcs_size);
+    if (fcs_size == 2) {
+        content_size += 256;
+    }
+
+    /* Section 3.1.1.1.1.2: with Single_Segment set the content must be
+     * regenerated in one segment, so the window IS the content size and the
+     * Window_Descriptor byte is absent. Section 12.2 records that this shape
+     * is accepted without a window bound: the memory the caller must supply
+     * is its own capacity check, and refusing here would refuse frames the
+     * subset table says are in. */
+    const uint64_t window_size =
+        single_segment ? content_size : ZstdWindowSize(src[5]);
+    if (!single_segment && window_size > kZstdMaxWindowSize) {
+        return ZstdFrameRefuse(kZstdFrameRejectWindowTooLarge,
+                               CUDEC_ERR_UNSUPPORTED, reject);
+    }
+
+    if (out != 0) {
+        out->frame_content_size = content_size;
+        out->window_size = window_size;
+        out->header_size = header_size;
+        out->single_segment = single_segment;
+        out->content_checksum = content_checksum;
+    }
+    return CUDEC_OK;
+}
+
+/* What a parsed block header says. `body_size` is what the block occupies in
+ * the stream and `block_size` is what the field declared: they differ for an
+ * RLE block, where the declaration is the REGENERATED length and the body is
+ * the single byte to repeat (3.1.1.2.3). Stepping by the declared size
+ * across an RLE block is an over-read of up to 128 KB, which is why the two
+ * are separate fields rather than one that means different things. */
+struct ZstdBlockHeader {
+    uint32_t block_size;
+    uint32_t body_size;
+    uint8_t block_type;
+    bool last_block;
+};
+
+/* Parse and gate one block header plus the presence of its body.
+ *
+ * `src` points at the block header and `available` is the bytes left in the
+ * frame from there, so the caller does no arithmetic this function then has
+ * to trust. `window_size` comes from the frame header and, with the 128 KB
+ * ceiling, is the block maximum of 3.1.1.2.4. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdParseBlockHeader(
+    const unsigned char* src, uint64_t available, uint64_t window_size,
+    ZstdBlockHeader* out, ZstdFrameReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdFrameRejectNone;
+    }
+    if (available < 3) {
+        return ZstdFrameRefuse(kZstdFrameRejectBlockHeaderTruncated,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    /* Section 3.1.1.2: three bytes, little-endian, holding Last_Block in bit
+     * 0, Block_Type in bits 1-2 and Block_Size in the remaining 21. */
+    const uint32_t raw = static_cast<uint32_t>(src[0]) |
+                         (static_cast<uint32_t>(src[1]) << 8) |
+                         (static_cast<uint32_t>(src[2]) << 16);
+    const bool last_block = (raw & 0x01u) != 0;
+    const uint8_t block_type = static_cast<uint8_t>((raw >> 1) & 0x03u);
+    const uint32_t block_size = raw >> 3;
+
+    if (block_type == kZstdBlockTypeReserved) {
+        return ZstdFrameRefuse(kZstdFrameRejectBlockTypeReserved,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const uint64_t block_max = window_size < kZstdBlockSizeCeiling
+                                   ? window_size
+                                   : kZstdBlockSizeCeiling;
+    if (static_cast<uint64_t>(block_size) > block_max) {
+        return ZstdFrameRefuse(kZstdFrameRejectBlockTooLarge,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const uint32_t body_size =
+        block_type == kZstdBlockTypeRle ? 1u : block_size;
+    /* 3 + body_size in 64-bit, against the bytes actually present. body_size
+     * is bounded by block_max above, so the sum cannot wrap; the width is
+     * 64-bit anyway because `available` is, and a narrower comparison is
+     * where the wrap would have hidden. */
+    if (available < static_cast<uint64_t>(3) + body_size) {
+        return ZstdFrameRefuse(kZstdFrameRejectBlockBodyTruncated,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    if (out != 0) {
+        out->block_size = block_size;
+        out->body_size = body_size;
+        out->block_type = block_type;
+        out->last_block = last_block;
+    }
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_ZSTD_FRAME_H */

--- a/src/zstd_frame.h
+++ b/src/zstd_frame.h
@@ -342,7 +342,7 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdParseBlockHeader(
     const uint64_t block_max = window_size < kZstdBlockSizeCeiling
                                    ? window_size
                                    : kZstdBlockSizeCeiling;
-    if (static_cast<uint64_t>(block_size) > block_max + 1024) {
+    if (static_cast<uint64_t>(block_size) > block_max) {
         return ZstdFrameRefuse(kZstdFrameRejectBlockTooLarge,
                                CUDEC_ERR_CORRUPT_INPUT, reject);
     }

--- a/src/zstd_frame.h
+++ b/src/zstd_frame.h
@@ -342,7 +342,7 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdParseBlockHeader(
     const uint64_t block_max = window_size < kZstdBlockSizeCeiling
                                    ? window_size
                                    : kZstdBlockSizeCeiling;
-    if (static_cast<uint64_t>(block_size) > block_max) {
+    if (static_cast<uint64_t>(block_size) > block_max + 1024) {
         return ZstdFrameRefuse(kZstdFrameRejectBlockTooLarge,
                                CUDEC_ERR_CORRUPT_INPUT, reject);
     }

--- a/src/zstd_frame.h
+++ b/src/zstd_frame.h
@@ -342,10 +342,6 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdParseBlockHeader(
     const uint64_t block_max = window_size < kZstdBlockSizeCeiling
                                    ? window_size
                                    : kZstdBlockSizeCeiling;
-    if (static_cast<uint64_t>(block_size) > block_max) {
-        return ZstdFrameRefuse(kZstdFrameRejectBlockTooLarge,
-                               CUDEC_ERR_CORRUPT_INPUT, reject);
-    }
     const uint32_t body_size =
         block_type == kZstdBlockTypeRle ? 1u : block_size;
     /* 3 + body_size in 64-bit, against the bytes actually present. body_size

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -415,6 +415,18 @@ cudec_add_test(zstd_corpus_selfproof SOURCES zstd_corpus_selfproof.cpp
 cudec_add_test(zstd_bitstream_twin SOURCES zstd_bitstream_twin.cpp)
 target_include_directories(zstd_bitstream_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The Zstd frame and block header parser and the v1 subset gate (issue #200):
+# the first thing any Zstd decode path reads, and the only place a frame is
+# judged admissible. Host-side and GPU-less, so the runner with no device
+# reaches the gate and the sanitizer build instruments it. It links zstd_full
+# alone for the reason zstd_oracle_smoke gives above, and
+# ZSTD_STATIC_LINKING_ONLY is for ZSTD_getFrameHeader, which is the field-for-
+# field oracle the positives are checked against rather than a second frame
+# header parser written to check the first.
+cudec_add_test(zstd_frame_twin SOURCES zstd_frame_twin.cpp LIBS zstd_full)
+target_include_directories(zstd_frame_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_compile_definitions(zstd_frame_twin PRIVATE ZSTD_STATIC_LINKING_ONLY)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/zstd_frame_twin.cpp
+++ b/tests/zstd_frame_twin.cpp
@@ -1,0 +1,508 @@
+/* The Zstd frame and block header parser from src/zstd_frame.h, executed on
+ * the host and held to libzstd (issue #200). Host-side and GPU-less on
+ * purpose: the gate that decides which frames cudec will decode at all runs
+ * on the runner with no device, and the sanitizer build reaches it there.
+ *
+ * TWO DIRECTIONS, WHICH IS THE WHOLE POINT OF THE LADDER. Every negative
+ * below carries the class docs/MASTERPLAN.md section 12 assigns it, and the
+ * oracle is asked about each one:
+ *
+ *   CORRUPT_INPUT rows: libzstd must also refuse the bytes. A row where the
+ *   reference decodes and cudec calls the data corrupt is a fail-closed
+ *   error in the other direction, and it would be invisible to a test that
+ *   only checked cudec's own verdict.
+ *
+ *   UNSUPPORTED rows: libzstd must ACCEPT the header. That is what makes the
+ *   refusal a scope decision rather than a rejection - the frame is legal,
+ *   cudec declines it, and section 12.3 says a caller must be able to tell
+ *   those apart because one of them is worth a CPU fallback.
+ *
+ * The frames are hand-built byte by byte, for the reason the Snappy and Zstd
+ * probes give: a shape the compressor never emits is exactly the one a
+ * hostile stream will carry. The compressor is driven once, for a real frame
+ * the hand-built ones are checked against.
+ *
+ * ZSTD_getFrameHeader is the field-for-field oracle for the positive cases.
+ * It is in libzstd's static API, hence ZSTD_STATIC_LINKING_ONLY in the
+ * target's compile definitions, and it means this test grows no second
+ * frame-header parser to check the first one against. */
+#include "require.h"
+#include "zstd_frame.h"
+
+#include <zstd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* Which reject rungs a declared negative reached. Same discipline as the
+ * bitstream twin: the enumeration lives once, in the header, and main()
+ * requires every rung to have been reached by a negative written for it. */
+bool g_reject_covered[cudec_detail::kZstdFrameRejectCount] = {false};
+
+void CoverRung(cudec_detail::ZstdFrameReject rung) {
+    if (rung != cudec_detail::kZstdFrameRejectNone) {
+        g_reject_covered[rung] = true;
+    }
+}
+
+void AppendLe(Bytes* out, uint64_t value, unsigned bytes) {
+    for (unsigned i = 0; i < bytes; i++) {
+        out->push_back(static_cast<unsigned char>((value >> (8u * i)) & 0xFFu));
+    }
+}
+
+/* The frame magic, then whatever the caller wants after it. */
+Bytes Magic(uint32_t magic) {
+    Bytes out;
+    AppendLe(&out, magic, 4);
+    return out;
+}
+
+/* One block header in the 3-byte little-endian shape of RFC 8878 section
+ * 3.1.1.2: Last_Block in bit 0, Block_Type in bits 1-2, Block_Size above. */
+void AppendBlockHeader(Bytes* out, uint32_t size, uint8_t type, bool last) {
+    const uint32_t raw = (size << 3) | (static_cast<uint32_t>(type) << 1) |
+                         (last ? 1u : 0u);
+    AppendLe(out, raw, 3);
+}
+
+/* Does the reference decode these bytes at all? The frames here are small,
+ * so one fixed output buffer covers every row; a row that would need more is
+ * one this test should not be building. */
+bool OracleDecodes(const Bytes& frame, std::string* decoded) {
+    std::vector<char> out(1 << 16);
+    const size_t rc =
+        ZSTD_decompress(out.data(), out.size(), frame.data(), frame.size());
+    if (ZSTD_isError(rc)) {
+        return false;
+    }
+    if (decoded != 0) {
+        decoded->assign(out.data(), out.data() + rc);
+    }
+    return true;
+}
+
+/* Does the reference read the header as a legal one? Zero means it parsed
+ * the whole header; a positive return means it wanted more bytes, which for
+ * these fixtures is a defect in the fixture rather than a verdict. */
+bool OracleHeaderIsLegal(const Bytes& frame, ZSTD_frameHeader* header) {
+    return ZSTD_getFrameHeader(header, frame.data(), frame.size()) == 0;
+}
+
+struct Negative {
+    const char* name;
+    Bytes bytes;
+    cudec_status expect_status;
+    cudec_detail::ZstdFrameReject expect_rung;
+    /* True where the bytes are a legal frame cudec declines, false where no
+     * conforming encoder produced them. Drives which way the oracle is
+     * asked. */
+    bool legal_frame;
+    /* Block-level rows carry a frame header the parser must accept first,
+     * so they are driven through both calls rather than the first alone. */
+    bool block_level;
+};
+
+int RunNegative(const Negative& row) {
+    cudec_detail::ZstdFrameReject rung = cudec_detail::kZstdFrameRejectNone;
+    cudec_detail::ZstdFrameHeader header;
+    std::memset(&header, 0, sizeof(header));
+    cudec_status status = cudec_detail::ZstdParseFrameHeader(
+        row.bytes.data(), row.bytes.size(), &header, &rung);
+
+    if (row.block_level) {
+        /* The header of a block-level negative is in the subset, so a
+         * refusal here means the fixture broke something it did not mean
+         * to. */
+        REQUIRE_CTX(status == CUDEC_OK, "%s: frame header refused with %d",
+                    row.name, static_cast<int>(status));
+        const uint64_t offset = header.header_size;
+        REQUIRE_CTX(offset <= row.bytes.size(), "%s: header past the end",
+                    row.name);
+        cudec_detail::ZstdBlockHeader block;
+        std::memset(&block, 0, sizeof(block));
+        status = cudec_detail::ZstdParseBlockHeader(
+            row.bytes.data() + offset, row.bytes.size() - offset,
+            header.window_size, &block, &rung);
+    }
+
+    REQUIRE_CTX(status == row.expect_status, "%s: status %d, wanted %d",
+                row.name, static_cast<int>(status),
+                static_cast<int>(row.expect_status));
+    REQUIRE_CTX(rung == row.expect_rung, "%s: rung %d, wanted %d", row.name,
+                static_cast<int>(rung), static_cast<int>(row.expect_rung));
+    CoverRung(rung);
+
+    if (row.legal_frame) {
+        ZSTD_frameHeader oracle;
+        std::memset(&oracle, 0, sizeof(oracle));
+        REQUIRE_CTX(OracleHeaderIsLegal(row.bytes, &oracle),
+                    "%s: cudec calls this unsupported but libzstd does not "
+                    "read it as a legal header - the refusal would be a "
+                    "corrupt verdict wearing the wrong class",
+                    row.name);
+        REQUIRE_CTX(row.expect_status == CUDEC_ERR_UNSUPPORTED,
+                    "%s: a legal frame must be refused as unsupported",
+                    row.name);
+    } else {
+        REQUIRE_CTX(!OracleDecodes(row.bytes, 0),
+                    "%s: libzstd decodes these bytes and cudec calls them "
+                    "corrupt - reject parity runs in both directions",
+                    row.name);
+        REQUIRE_CTX(row.expect_status == CUDEC_ERR_CORRUPT_INPUT,
+                    "%s: bytes no encoder produced must be refused as "
+                    "corrupt",
+                    row.name);
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    /* ---- Positives, held to the reference field for field ---------------
+     *
+     * A single-segment frame with a one-byte content size and one raw
+     * block, the smallest thing the subset accepts. Section 3.1.1.1.1.1:
+     * Frame_Content_Size_flag 0 with Single_Segment set is a one-byte
+     * field. */
+    {
+        Bytes frame = Magic(cudec_detail::kZstdMagic);
+        frame.push_back(0x20); /* Single_Segment, FCS flag 0, no dict, no
+                                  checksum, reserved clear */
+        frame.push_back(0x03); /* Frame_Content_Size = 3 */
+        AppendBlockHeader(&frame, 3, cudec_detail::kZstdBlockTypeRaw, true);
+        frame.push_back('a');
+        frame.push_back('b');
+        frame.push_back('c');
+
+        cudec_detail::ZstdFrameHeader header;
+        std::memset(&header, 0, sizeof(header));
+        cudec_detail::ZstdFrameReject rung =
+            cudec_detail::kZstdFrameRejectNone;
+        REQUIRE(cudec_detail::ZstdParseFrameHeader(
+                    frame.data(), frame.size(), &header, &rung) == CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdFrameRejectNone);
+
+        ZSTD_frameHeader oracle;
+        std::memset(&oracle, 0, sizeof(oracle));
+        REQUIRE(OracleHeaderIsLegal(frame, &oracle));
+        REQUIRE(header.header_size == oracle.headerSize);
+        REQUIRE(header.frame_content_size == oracle.frameContentSize);
+        REQUIRE(header.window_size == oracle.windowSize);
+        REQUIRE(header.content_checksum == (oracle.checksumFlag != 0));
+        REQUIRE(header.single_segment);
+
+        cudec_detail::ZstdBlockHeader block;
+        std::memset(&block, 0, sizeof(block));
+        REQUIRE(cudec_detail::ZstdParseBlockHeader(
+                    frame.data() + header.header_size,
+                    frame.size() - header.header_size, header.window_size,
+                    &block, &rung) == CUDEC_OK);
+        REQUIRE(block.block_type == cudec_detail::kZstdBlockTypeRaw);
+        REQUIRE(block.block_size == 3);
+        REQUIRE(block.body_size == 3);
+        REQUIRE(block.last_block);
+
+        std::string decoded;
+        REQUIRE(OracleDecodes(frame, &decoded));
+        REQUIRE(decoded == "abc");
+    }
+
+    /* An RLE block, which is the one place the declared size and the bytes
+     * on the wire differ: section 3.1.1.2.3 makes Block_Size the REGENERATED
+     * length and the body a single byte. A walker that stepped by the
+     * declared size here would step 1000 bytes past a 1-byte body, so the
+     * distinction is asserted against a frame the reference agrees decodes
+     * to 1000 bytes. */
+    {
+        const uint32_t regenerated = 1000;
+        Bytes frame = Magic(cudec_detail::kZstdMagic);
+        frame.push_back(0x60); /* Single_Segment, FCS flag 1 -> 2 bytes */
+        AppendLe(&frame, regenerated - 256, 2);
+        AppendBlockHeader(&frame, regenerated,
+                          cudec_detail::kZstdBlockTypeRle, true);
+        frame.push_back('A');
+
+        cudec_detail::ZstdFrameHeader header;
+        std::memset(&header, 0, sizeof(header));
+        cudec_detail::ZstdFrameReject rung =
+            cudec_detail::kZstdFrameRejectNone;
+        REQUIRE(cudec_detail::ZstdParseFrameHeader(
+                    frame.data(), frame.size(), &header, &rung) == CUDEC_OK);
+        REQUIRE(header.frame_content_size == regenerated);
+        REQUIRE(header.window_size == regenerated);
+
+        ZSTD_frameHeader oracle;
+        std::memset(&oracle, 0, sizeof(oracle));
+        REQUIRE(OracleHeaderIsLegal(frame, &oracle));
+        REQUIRE(header.frame_content_size == oracle.frameContentSize);
+        REQUIRE(header.window_size == oracle.windowSize);
+        REQUIRE(header.header_size == oracle.headerSize);
+
+        cudec_detail::ZstdBlockHeader block;
+        std::memset(&block, 0, sizeof(block));
+        REQUIRE(cudec_detail::ZstdParseBlockHeader(
+                    frame.data() + header.header_size,
+                    frame.size() - header.header_size, header.window_size,
+                    &block, &rung) == CUDEC_OK);
+        REQUIRE(block.block_size == regenerated);
+        REQUIRE(block.body_size == 1);
+
+        std::string decoded;
+        REQUIRE(OracleDecodes(frame, &decoded));
+        REQUIRE(decoded.size() == regenerated);
+        REQUIRE(decoded[0] == 'A');
+        REQUIRE(decoded[regenerated - 1] == 'A');
+    }
+
+    /* A frame the compressor actually produced, so the hand-built shapes
+     * above are not the only ones the parser has ever seen. Default
+     * settings: content size present, no dictionary, no checksum. */
+    {
+        const std::string source(4096, 'z');
+        Bytes frame(ZSTD_compressBound(source.size()));
+        const size_t written = ZSTD_compress(frame.data(), frame.size(),
+                                             source.data(), source.size(), 3);
+        REQUIRE(!ZSTD_isError(written));
+        frame.resize(written);
+
+        cudec_detail::ZstdFrameHeader header;
+        std::memset(&header, 0, sizeof(header));
+        cudec_detail::ZstdFrameReject rung =
+            cudec_detail::kZstdFrameRejectNone;
+        REQUIRE(cudec_detail::ZstdParseFrameHeader(
+                    frame.data(), frame.size(), &header, &rung) == CUDEC_OK);
+
+        ZSTD_frameHeader oracle;
+        std::memset(&oracle, 0, sizeof(oracle));
+        REQUIRE(OracleHeaderIsLegal(frame, &oracle));
+        REQUIRE(header.header_size == oracle.headerSize);
+        REQUIRE(header.frame_content_size == oracle.frameContentSize);
+        REQUIRE(header.window_size == oracle.windowSize);
+        REQUIRE(header.content_checksum == (oracle.checksumFlag != 0));
+        REQUIRE(header.frame_content_size == source.size());
+
+        /* Block_Maximum_Size, section 3.1.1.2.4, is what the parser holds a
+         * declared block size to; the reference computes the same number and
+         * publishes it, so the bound is checked rather than assumed. */
+        const uint64_t block_max =
+            header.window_size < cudec_detail::kZstdBlockSizeCeiling
+                ? header.window_size
+                : cudec_detail::kZstdBlockSizeCeiling;
+        REQUIRE(block_max == oracle.blockSizeMax);
+
+        /* Walk the block chain to the end of the frame. Nothing here decodes
+         * anything; it is the stepping arithmetic that has to be right, and
+         * a wrong body_size for any block would land the last step somewhere
+         * other than the frame's end. */
+        uint64_t offset = header.header_size;
+        unsigned blocks = 0;
+        bool reached_last = false;
+        /* Bounded by the frame's own length: a block costs at least its
+         * three header bytes, so no frame can hold more blocks than it has
+         * bytes. The walk terminates on the count even if the last-block
+         * flag never arrives. */
+        for (uint64_t step = 0; step < frame.size() && !reached_last; step++) {
+            cudec_detail::ZstdBlockHeader block;
+            std::memset(&block, 0, sizeof(block));
+            REQUIRE(cudec_detail::ZstdParseBlockHeader(
+                        frame.data() + offset, frame.size() - offset,
+                        header.window_size, &block, &rung) == CUDEC_OK);
+            offset += 3u + block.body_size;
+            blocks++;
+            reached_last = block.last_block;
+        }
+        REQUIRE(reached_last);
+        REQUIRE(blocks >= 1);
+        REQUIRE(offset == frame.size());
+    }
+
+    /* ---- The negative ladder, one row per rung -------------------------
+     *
+     * The rows are the table in docs/MASTERPLAN.md section 12.2 turned into
+     * bytes: every property that table names, in the class it assigns. */
+    std::vector<Negative> rows;
+
+    /* Magic number, refused as corrupt. Three bytes cannot even carry it. */
+    {
+        Bytes bytes = {0x28, 0xB5, 0x2F};
+        rows.push_back({"magic truncated", bytes, CUDEC_ERR_CORRUPT_INPUT,
+                        cudec_detail::kZstdFrameRejectMagicTruncated, false,
+                        false});
+    }
+    {
+        Bytes bytes = {0xDE, 0xAD, 0xBE, 0xEF, 0x20, 0x03};
+        rows.push_back({"magic wrong", bytes, CUDEC_ERR_CORRUPT_INPUT,
+                        cudec_detail::kZstdFrameRejectMagicWrong, false,
+                        false});
+    }
+    /* Skippable frames are legal and refused as a scope line, section 12.4.
+     * The frame is complete: the magic and a four-byte Frame_Size of zero. */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdSkippableMagicMin);
+        AppendLe(&bytes, 0, 4);
+        rows.push_back({"skippable frame", bytes, CUDEC_ERR_UNSUPPORTED,
+                        cudec_detail::kZstdFrameRejectSkippableFrame, true,
+                        false});
+    }
+    /* The magic alone: the descriptor byte the layout needs next is not
+     * there. */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        rows.push_back({"descriptor truncated", bytes,
+                        CUDEC_ERR_CORRUPT_INPUT,
+                        cudec_detail::kZstdFrameRejectDescriptorTruncated,
+                        false, false});
+    }
+    /* Section 3.1.1.1.1.3: the reserved bit must be zero. Bit 3, one below
+     * the Unused_bit a decoder of this version must NOT interpret. */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        bytes.push_back(0x28); /* Single_Segment + Reserved_bit */
+        bytes.push_back(0x03);
+        rows.push_back({"reserved bit set", bytes, CUDEC_ERR_CORRUPT_INPUT,
+                        cudec_detail::kZstdFrameRejectReservedBitSet, false,
+                        false});
+    }
+    /* A dictionary id is a legal frame outside the subset: dictionaries
+     * break the frame independence the batch unit rests on (section 12.5). */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        bytes.push_back(0x21); /* Single_Segment, Dictionary_ID_flag 1 */
+        bytes.push_back(0x07); /* the one-byte dictionary id */
+        bytes.push_back(0x03); /* Frame_Content_Size */
+        rows.push_back({"dictionary id", bytes, CUDEC_ERR_UNSUPPORTED,
+                        cudec_detail::kZstdFrameRejectDictionaryId, true,
+                        false});
+    }
+    /* No declared content size, which is legal and which the batch model
+     * cannot place output for (section 12.5, rung 2). */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        bytes.push_back(0x00); /* FCS flag 0, Single_Segment clear */
+        bytes.push_back(0x00); /* Window_Descriptor: the smallest window */
+        rows.push_back({"content size absent", bytes, CUDEC_ERR_UNSUPPORTED,
+                        cudec_detail::kZstdFrameRejectContentSizeAbsent, true,
+                        false});
+    }
+    /* A header that declares an eight-byte content size and stops short of
+     * it. The length is derived from the descriptor and checked before any
+     * dependent field is read, which is the rung this reaches. */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        bytes.push_back(0xE0); /* FCS flag 3 -> 8 bytes, Single_Segment */
+        AppendLe(&bytes, 0, 3);
+        rows.push_back({"header truncated", bytes, CUDEC_ERR_CORRUPT_INPUT,
+                        cudec_detail::kZstdFrameRejectHeaderTruncated, false,
+                        false});
+    }
+    /* Section 3.1.1.1.2 allows refusing a window beyond the decoder's
+     * authorized range, and section 12.2 puts that line at 8 MB. Exponent 13
+     * with mantissa 1 is 8 MB plus an eighth, the smallest step over it that
+     * the encoding can express at that exponent. */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        bytes.push_back(0x40); /* FCS flag 1 -> 2 bytes, Single_Segment
+                                  clear */
+        bytes.push_back(static_cast<unsigned char>((13u << 3) | 1u));
+        AppendLe(&bytes, 0, 2); /* content size 256 */
+        rows.push_back({"window too large", bytes, CUDEC_ERR_UNSUPPORTED,
+                        cudec_detail::kZstdFrameRejectWindowTooLarge, true,
+                        false});
+    }
+    /* Block-level rows. Each carries a header the subset accepts, so the
+     * refusal is the block's and the frame header's acceptance is proven on
+     * the way past it. */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        bytes.push_back(0x20);
+        bytes.push_back(0x03);
+        bytes.push_back(0x19); /* two bytes of a three-byte block header */
+        bytes.push_back(0x00);
+        rows.push_back({"block header truncated", bytes,
+                        CUDEC_ERR_CORRUPT_INPUT,
+                        cudec_detail::kZstdFrameRejectBlockHeaderTruncated,
+                        false, true});
+    }
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        bytes.push_back(0x20);
+        bytes.push_back(0x03);
+        AppendBlockHeader(&bytes, 3, cudec_detail::kZstdBlockTypeReserved,
+                          true);
+        AppendLe(&bytes, 0, 3);
+        rows.push_back({"block type reserved", bytes,
+                        CUDEC_ERR_CORRUPT_INPUT,
+                        cudec_detail::kZstdFrameRejectBlockTypeReserved,
+                        false, true});
+    }
+    /* Block_Maximum_Size is min(Window_Size, 128 KB), and here the window is
+     * the 1024-byte smallest one, so 2000 is over the line without needing a
+     * 128 KB fixture to prove it. */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        bytes.push_back(0x40); /* Single_Segment clear, FCS 2 bytes */
+        bytes.push_back(0x00); /* Window_Descriptor 0 -> 1024 */
+        AppendLe(&bytes, 0, 2);
+        AppendBlockHeader(&bytes, 2000, cudec_detail::kZstdBlockTypeRaw,
+                          true);
+        bytes.resize(bytes.size() + 2000, 0);
+        rows.push_back({"block over the maximum", bytes,
+                        CUDEC_ERR_CORRUPT_INPUT,
+                        cudec_detail::kZstdFrameRejectBlockTooLarge, false,
+                        true});
+    }
+    /* A block that declares more bytes than the frame holds. The declared
+     * size is inside the maximum, so this is the presence check rather than
+     * the bound check, and the two are separate rungs for that reason. */
+    {
+        Bytes bytes = Magic(cudec_detail::kZstdMagic);
+        bytes.push_back(0x20);
+        bytes.push_back(0x64); /* content size 100 */
+        AppendBlockHeader(&bytes, 100, cudec_detail::kZstdBlockTypeRaw, true);
+        bytes.resize(bytes.size() + 10, 0);
+        rows.push_back({"block body truncated", bytes,
+                        CUDEC_ERR_CORRUPT_INPUT,
+                        cudec_detail::kZstdFrameRejectBlockBodyTruncated,
+                        false, true});
+    }
+
+    for (size_t i = 0; i < rows.size(); i++) {
+        const int rc = RunNegative(rows[i]);
+        if (rc != 0) {
+            return rc;
+        }
+    }
+
+    /* Every rung named by a negative written to reach it, walked rather than
+     * restated: a rung added to the parser with none behind it lands here as
+     * a hole with its number on it. */
+    {
+        size_t rungs_covered = 0;
+        for (int rung = cudec_detail::kZstdFrameRejectNone + 1;
+             rung < cudec_detail::kZstdFrameRejectCount; rung++) {
+            REQUIRE_CTX(g_reject_covered[rung],
+                        "reject rung %d has no declared negative that reaches "
+                        "it - add one, or the rung is untested",
+                        rung);
+            rungs_covered++;
+        }
+        REQUIRE(rungs_covered ==
+                static_cast<size_t>(cudec_detail::kZstdFrameRejectCount) - 1);
+    }
+
+    std::printf("PASS: 3 accepted frames checked field for field against "
+                "ZSTD_getFrameHeader, %zu negatives over %d reject rungs, "
+                "each held to libzstd in the direction its class implies\n",
+                rows.size(),
+                static_cast<int>(cudec_detail::kZstdFrameRejectCount) - 1);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #200.

The M5 subset was recorded in `docs/MASTERPLAN.md` section 12 and nothing
executed it. This adds the unit that does: `src/zstd_frame.h`, the frame and
block header parser with the subset gate on top of it, and
`tests/zstd_frame_twin.cpp`, which holds it to libzstd in both directions.

Two failures this prevents. A decoder that starts work on a frame it cannot
finish is an out-of-bounds walk waiting for a hostile stream, and the frame
header is where every length that walk depends on is decided. A decoder that
reports a legal frame outside the subset as corrupt is a contract error: a
caller that would fall back to a CPU decoder cannot tell the two verdicts
apart if they arrive as one, which is exactly what section 12.3 separates.

## What the parser owns

The frame header: magic, the `Frame_Header_Descriptor` bits, the
`Window_Descriptor` and the window size it derives, `Frame_Content_Size`, and
the header-length arithmetic each flag combination implies. The block header:
last-block flag, type, size, the block maximum of `min(Window_Size, 128 KB)`,
and whether the body it declares is actually present.

The layout is derived before any dependent field is read, which is the order
the truncation rungs exist to enforce. The declared content size is reported
and never used to size anything.

**The RLE block is the one place the declared size and the bytes on the wire
differ.** Section 3.1.1.2.3 makes `Block_Size` the regenerated length for that
type, while the body is a single byte. A walker stepping by the declared size
across an RLE block steps up to 128 KB past a one-byte body, so `block_size`
and `body_size` are separate fields and a real frame proves the distinction
rather than a comment claiming it.

## The ladder, and both directions of the oracle

Every refusal returns through one choke point naming its rung, the shape
`src/snappy_block.h` and `src/zstd_bitstream.h` already use. The twin walks
the enumeration and refuses a rung no declared negative reaches, so a branch
added without a negative reds the suite and a deleted negative reds it too.

Each negative is also put to libzstd, in the direction its class implies:

- The `CORRUPT_INPUT` rows must be refused by the reference too. A row where
  libzstd decodes and cudec calls the bytes corrupt is a fail-closed error in
  the other direction, and it is invisible to a test that only reads cudec's
  own verdict.
- The `UNSUPPORTED` rows must be read by libzstd as legal headers. That is
  what makes the refusal a scope line rather than a rejection, and it is the
  half that would rot silently if only the status were asserted.

The three accepted frames are checked field for field against
`ZSTD_getFrameHeader`, so no second frame-header parser was written to check
the first. `blockSizeMax` is compared too, because the bound the parser holds
declared block sizes to is a number the reference also publishes.

## Proof that the guard bites, for the reason it names

Two probe commits on this branch, both reverted, both with their run.

The first deleted the block-maximum refusal outright. It red, and it red for
the wrong reason, which is stated rather than counted as the proof:

    /__w/cudec/cudec/tests/../src/zstd_frame.h:342:20: error: unused variable 'block_max' [-Werror=unused-variable]

That says the strict-flag set works. It says nothing about the negative.

The second left the refusal in place and weakened its bound by 1024 bytes, so
the fixture that declares a 2000-byte block against a 1024-byte window slips
under it. That reached the assertion:

    $ gh run view --job 93004685248 --log
    6/9 Test #13: zstd_frame_twin ..................***Failed    0.01 sec
    FAIL /__w/cudec/cudec/tests/zstd_frame_twin.cpp:136: status == row.expect_status | block over the maximum: status 0, wanted 2

Status 0 is `CUDEC_OK` and status 2 is `CUDEC_ERR_CORRUPT_INPUT`: with the
bound moved, the parser accepts an over-sized block and the negative names
the row that caught it. Both probes are in this branch's history and both are
reverted; the head below carries neither.

The workflow change adds `zstd_frame_twin` to the ASan+UBSan selection and to
the per-name greps beside it, which is where a host-side ladder over hostile
input belongs. The greps are the reason a test cannot quietly leave that set.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved. It is the subject: thirteen reject rungs, one
      declared negative each, and the twin refuses a rung without one.
- [x] Oracle coverage. Every negative is put to libzstd in the direction its
      class implies, and every accepted frame is compared field for field
      against `ZSTD_getFrameHeader`.
- [x] Determinism preserved. The parser is a pure function of its bytes; no
      decode path is touched and nothing here writes output.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      Nothing here calls CUDA and nothing here is on the ABI: the header is
      internal, in the mold of `src/lz4_block.h`.
- [ ] An adversarial review (`/security-review`) was run. It was **not** run,
      and the box stays unticked rather than argued away. Format parsing is on
      the sensitive surface, so the gate is owed by the letter of the
      checklist.
- [ ] Review record. There is none, for the same reason. This change had no
      second reader; the runs quoted here are the evidence in place of one.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. The header is
      written `CUDEC_HOST_DEVICE` so a later kernel can include it, but no
      device translation unit includes it yet and no `.cu` file is in the
      diff.

Separately, and stated because the block above would otherwise read as a
clean sweep: no route to a device the sanitizer can attach to exists on this
machine at all, which #258 records with its commands.

## Performance checklist

Not on the hot path, and no number is claimed anywhere in this change.

## Quality checklist

- [x] Minimal: one internal header and one test. The parser is two functions
      and the derivations they need; the walker, the block loop and the
      integrity check are #199, #201 and #202 and are not started here.
- [x] Self-documenting: every field layout and every derivation carries the
      RFC section it was read from, and the two bits that are one apart and
      easy to swap, `Reserved_bit` and `Unused_bit`, carry the sentence that
      says which is which and why refusing on the wrong one would refuse
      legal frames.
- [x] Conformance: the rung-coverage lock is the new structural property and
      it is enforced by the twin itself rather than by a comment.

## Verification

- [x] `cmake --build build-cuda` and the host-side `ctest` subset, in CI on
      this branch:

      $ gh run view --job 93005791963 --log
      13/21 Test #14: zstd_frame_twin ..................   Passed    0.00 sec
      100% tests passed, 0 tests failed out of 21

- [x] ASan+UBSan, same commit, the sanitize job:

      $ gh run view --job 93005791958 --log
      6/9 Test #13: zstd_frame_twin ..................   Passed    0.02 sec
      100% tests passed, 0 tests failed out of 9

- [x] Prettier (`**/*.{md,yml,yaml}`) - clean on the changed workflow, run on
      this machine against the glob the `format` job uses.
- [x] Docs synced. `docs/MASTERPLAN.md` section 12 is the specification this
      implements and it is unchanged: the parser was written to it, not the
      other way round.

## Notes

The means is a C++ header in `src/`, host and device compilable, because that
is what the other three format cores in this tree are and because the M5
kernel will include this one rather than restate it. No new dependency: the
test links the zstd oracle the tree already pins.

`ZSTD_getFrameHeader` is in libzstd's static API, hence
`ZSTD_STATIC_LINKING_ONLY` on the test target, the same seam `zstd_probes`
already uses.

Out of scope and named so nobody reads their absence as coverage: the block
loop with entropy state carried across blocks (#201), the frame walker and
the integrity check (#199, #202), and the XXH64 content checksum (#202). This
change parses headers and refuses; it decodes nothing.

## Merge state

Every check on this head is green, and the two runs quoted under Verification
are this head's own rather than an earlier commit's:

    $ gh api repos/iderex/cudec/commits/95a01855fc355d4a4b278f0fe3f2aa574533c47f/check-runs --jq '[.check_runs[]|"\(.name):\(.conclusion)"]|join(" ")'
    CodeQL:success analyze:success format:success build:success sanitize:success dependency-review:success

No GPU ran and none is owed: nothing in the diff is device code.

There was no second reader for this change. The runs above, and the two
reverted probes that watched the guard go red, are the evidence in place of
one.
