### PR TITLE
Verify the Zstd content checksum, and add the XXH64 it needs [#202]

### DIFF
--- a/src/xxhash64.h
+++ b/src/xxhash64.h
@@ -35,8 +35,15 @@
 
 namespace cudec_detail {
 
-/* xxHash's five primes, in the reference's own order. */
-constexpr uint64_t kXxh64Prime1 = 11400714785074569124ull;
+/* xxHash's five primes, in the reference's own order.
+ *
+ * These are the one part of this file that cannot be derived from anything
+ * around them, and prime 1 in particular is reachable by every input longer
+ * than three bytes and by none shorter. A transposed digit in it therefore
+ * passes the published empty-input vector and fails on the first real byte,
+ * which is how the wrong value got here and how the length sweep in the twin
+ * caught it. */
+constexpr uint64_t kXxh64Prime1 = 11400714785074694791ull;
 constexpr uint64_t kXxh64Prime2 = 14029467366897019727ull;
 constexpr uint64_t kXxh64Prime3 = 1609587929392839161ull;
 constexpr uint64_t kXxh64Prime4 = 9650029242287828579ull;

--- a/src/xxhash64.h
+++ b/src/xxhash64.h
@@ -1,0 +1,156 @@
+/* XXH64 (Yann Collet's xxHash, 64-bit, seed zero) - the hash the Zstd frame
+ * format uses for its content checksum. Single-sourced for host and device,
+ * so the M5 kernel computes the same digest the host twin does. Internal
+ * header, not part of the ABI.
+ *
+ * NO SEED PARAMETER, DELIBERATELY. RFC 8878 section 3.1.1 fixes the seed:
+ * the checksum is "the result of the XXH64() hash function digesting the
+ * original (decoded) data as input, and a seed of zero". A parameter that
+ * every caller in this project would pass zero to is an argument nothing
+ * tests, and the tree already made this choice once, in src/xxhash32.h for
+ * the LZ4 frame's XXH32.
+ *
+ * The reads are byte-wise rather than a memcpy of eight bytes. The format
+ * fixes the byte order and the host's is not fixed, the pointer is one the
+ * caller chose and may be unaligned, and the same source has to compile for
+ * a device where the memcpy shape buys nothing. Correctness first; this is
+ * not on a measured path, and when it is, the measurement decides.
+ *
+ * Every loop is counted rather than a walk to a limit pointer, so the
+ * termination argument is the count and not a comparison a reader has to
+ * re-derive. The digits 32 and 64 arrive through named constants because a
+ * width and a wave width look identical to a text scan (issue #211). */
+#ifndef CUDEC_XXHASH64_H
+#define CUDEC_XXHASH64_H
+
+#include <stdint.h>
+
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+/* xxHash's five primes, in the reference's own order. */
+constexpr uint64_t kXxh64Prime1 = 11400714785074569124ull;
+constexpr uint64_t kXxh64Prime2 = 14029467366897019727ull;
+constexpr uint64_t kXxh64Prime3 = 1609587929392839161ull;
+constexpr uint64_t kXxh64Prime4 = 9650029242287828579ull;
+constexpr uint64_t kXxh64Prime5 = 2870177450012600261ull;
+
+/* The accumulator's width, and the four-accumulator stripe that width
+ * implies. Bound to names on their own lines for the reason the header
+ * comment gives. */
+constexpr int kXxh64AccumulatorBits = 64;
+constexpr uint64_t kXxh64StripeBytes = 32;
+/* The avalanche's last shift, which is half the accumulator. Its own line,
+ * for the same reason. */
+constexpr int kXxh64FinalShift = 32;
+constexpr uint64_t kXxh64LaneBytes = 8;
+constexpr uint64_t kXxh64HalfLaneBytes = 4;
+
+CUDEC_HOST_DEVICE inline uint64_t Xxh64Rotl(uint64_t x, int r) {
+    return (x << r) | (x >> (kXxh64AccumulatorBits - r));
+}
+
+CUDEC_HOST_DEVICE inline uint64_t Xxh64Read64(const unsigned char* p) {
+    uint64_t value = 0;
+    for (unsigned i = 0; i < kXxh64LaneBytes; i++) {
+        value |= static_cast<uint64_t>(p[i]) << (8u * i);
+    }
+    return value;
+}
+
+CUDEC_HOST_DEVICE inline uint64_t Xxh64Read32(const unsigned char* p) {
+    uint64_t value = 0;
+    for (unsigned i = 0; i < kXxh64HalfLaneBytes; i++) {
+        value |= static_cast<uint64_t>(p[i]) << (8u * i);
+    }
+    return value;
+}
+
+CUDEC_HOST_DEVICE inline uint64_t Xxh64Round(uint64_t acc, uint64_t input) {
+    acc += input * kXxh64Prime2;
+    acc = Xxh64Rotl(acc, 31);
+    acc *= kXxh64Prime1;
+    return acc;
+}
+
+CUDEC_HOST_DEVICE inline uint64_t Xxh64MergeRound(uint64_t acc,
+                                                  uint64_t value) {
+    acc ^= Xxh64Round(0, value);
+    acc = acc * kXxh64Prime1 + kXxh64Prime4;
+    return acc;
+}
+
+/* The digest of `len` bytes at `data`, seed zero. */
+CUDEC_HOST_DEVICE inline uint64_t Xxh64(const unsigned char* data,
+                                        uint64_t len) {
+    const uint64_t stripes = len / kXxh64StripeBytes;
+    uint64_t offset = 0;
+    uint64_t hash = 0;
+
+    if (stripes != 0) {
+        uint64_t v1 = kXxh64Prime1 + kXxh64Prime2;
+        uint64_t v2 = kXxh64Prime2;
+        uint64_t v3 = 0;
+        /* Seed minus prime 1, in unsigned arithmetic, which is where the
+         * reference's `seed - PRIME1` lands with a seed of zero. */
+        uint64_t v4 = 0ull - kXxh64Prime1;
+        for (uint64_t i = 0; i < stripes; i++) {
+            v1 = Xxh64Round(v1, Xxh64Read64(data + offset));
+            v2 = Xxh64Round(v2, Xxh64Read64(data + offset + kXxh64LaneBytes));
+            v3 = Xxh64Round(
+                v3, Xxh64Read64(data + offset + 2 * kXxh64LaneBytes));
+            v4 = Xxh64Round(
+                v4, Xxh64Read64(data + offset + 3 * kXxh64LaneBytes));
+            offset += kXxh64StripeBytes;
+        }
+        hash = Xxh64Rotl(v1, 1) + Xxh64Rotl(v2, 7) + Xxh64Rotl(v3, 12) +
+               Xxh64Rotl(v4, 18);
+        hash = Xxh64MergeRound(hash, v1);
+        hash = Xxh64MergeRound(hash, v2);
+        hash = Xxh64MergeRound(hash, v3);
+        hash = Xxh64MergeRound(hash, v4);
+    } else {
+        hash = kXxh64Prime5;
+    }
+
+    hash += len;
+
+    /* The tail, in the reference's three widths: whole lanes, then one half
+     * lane, then single bytes. Each is counted from what is left rather than
+     * walked to a pointer. */
+    const uint64_t tail_lanes = (len - offset) / kXxh64LaneBytes;
+    for (uint64_t i = 0; i < tail_lanes; i++) {
+        hash ^= Xxh64Round(0, Xxh64Read64(data + offset));
+        hash = Xxh64Rotl(hash, 27) * kXxh64Prime1 + kXxh64Prime4;
+        offset += kXxh64LaneBytes;
+    }
+    if (len - offset >= kXxh64HalfLaneBytes) {
+        hash ^= Xxh64Read32(data + offset) * kXxh64Prime1;
+        hash = Xxh64Rotl(hash, 23) * kXxh64Prime2 + kXxh64Prime3;
+        offset += kXxh64HalfLaneBytes;
+    }
+    const uint64_t tail_bytes = len - offset;
+    for (uint64_t i = 0; i < tail_bytes; i++) {
+        hash ^= static_cast<uint64_t>(data[offset + i]) * kXxh64Prime5;
+        hash = Xxh64Rotl(hash, 11) * kXxh64Prime1;
+    }
+
+    /* The avalanche. */
+    hash ^= hash >> 33;
+    hash *= kXxh64Prime2;
+    hash ^= hash >> 29;
+    hash *= kXxh64Prime3;
+    hash ^= hash >> kXxh64FinalShift;
+    return hash;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_XXHASH64_H */

--- a/src/zstd_frame.h
+++ b/src/zstd_frame.h
@@ -77,8 +77,9 @@ constexpr uint8_t kZstdBlockTypeReserved = 3;
 /* The reject ladder, enumerated once, in the shape the Snappy parser and the
  * bitstream reader use: every refusal returns through one choke point naming
  * its rung, so the twin can require a negative per rung instead of counting
- * statuses that repeat. Ten of these return CUDEC_ERR_CORRUPT_INPUT and four
- * return CUDEC_ERR_UNSUPPORTED, so the status alone identifies nothing. */
+ * statuses that repeat. Twelve of these return CUDEC_ERR_CORRUPT_INPUT and
+ * three return CUDEC_ERR_UNSUPPORTED, so the status alone identifies
+ * nothing. */
 enum ZstdFrameReject {
     kZstdFrameRejectNone = 0,
     kZstdFrameRejectMagicTruncated,
@@ -94,6 +95,8 @@ enum ZstdFrameReject {
     kZstdFrameRejectBlockTypeReserved,
     kZstdFrameRejectBlockTooLarge,
     kZstdFrameRejectBlockBodyTruncated,
+    kZstdFrameRejectChecksumTruncated,
+    kZstdFrameRejectChecksumMismatch,
     kZstdFrameRejectCount
 };
 
@@ -362,6 +365,45 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdParseBlockHeader(
         out->body_size = body_size;
         out->block_type = block_type;
         out->last_block = last_block;
+    }
+    return CUDEC_OK;
+}
+
+/* Verify a frame's content checksum against the digest of what was decoded.
+ *
+ * Section 3.1.1: the trailer is present only when the descriptor sets
+ * Content_Checksum_flag, and it is "the low 4 bytes of the checksum ...
+ * stored in little-endian format", the checksum being XXH64 over the
+ * ORIGINAL decoded data with a seed of zero. So the caller computes the
+ * digest as it produces output and hands the low half here; this function
+ * owns the trailer's presence, its byte order and the comparison, and
+ * nothing else.
+ *
+ * Both refusals are CUDEC_ERR_CORRUPT_INPUT. Section 12.3 puts a failed
+ * checksum in the corrupt class rather than the unsupported one: a frame
+ * whose content does not hash to what its own trailer says is not a legal
+ * frame this decoder declines, it is data no conforming encoder produced.
+ *
+ * `available` is the bytes left after the last block, so a frame that ends
+ * before its trailer refuses rather than reading past itself. A frame with
+ * more bytes after the trailer is not this function's business: a chunk
+ * holding more than one frame is out of the subset and section 12.4 is
+ * where that is argued. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdVerifyContentChecksum(
+    const unsigned char* trailer, uint64_t available, uint64_t content_digest,
+    ZstdFrameReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdFrameRejectNone;
+    }
+    if (available < 4) {
+        return ZstdFrameRefuse(kZstdFrameRejectChecksumTruncated,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const uint32_t stored = ZstdRead32(trailer);
+    const uint32_t computed = static_cast<uint32_t>(content_digest);
+    if (stored != computed) {
+        return ZstdFrameRefuse(kZstdFrameRejectChecksumMismatch,
+                               CUDEC_ERR_CORRUPT_INPUT, reject);
     }
     return CUDEC_OK;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -422,7 +422,9 @@ target_include_directories(zstd_bitstream_twin
 # alone for the reason zstd_oracle_smoke gives above, and
 # ZSTD_STATIC_LINKING_ONLY is for ZSTD_getFrameHeader, which is the field-for-
 # field oracle the positives are checked against rather than a second frame
-# header parser written to check the first.
+# header parser written to check the first. It also holds src/xxhash64.h, the
+# frame's content checksum (issue #202), to the checksums libzstd writes into
+# real --check frames across every length class the algorithm branches on.
 cudec_add_test(zstd_frame_twin SOURCES zstd_frame_twin.cpp LIBS zstd_full)
 target_include_directories(zstd_frame_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)

--- a/tests/zstd_frame_twin.cpp
+++ b/tests/zstd_frame_twin.cpp
@@ -560,8 +560,13 @@ int main() {
             REQUIRE_CTX(cudec_detail::ZstdVerifyContentChecksum(
                             trailer, 4, digest, &rung) == CUDEC_OK,
                         "XXH64 over %llu bytes does not reproduce the "
-                        "checksum libzstd wrote into the frame",
-                        static_cast<unsigned long long>(length));
+                        "checksum libzstd wrote into the frame: trailer "
+                        "%08llx, digest %016llx, frame %llu bytes",
+                        static_cast<unsigned long long>(length),
+                        static_cast<unsigned long long>(
+                            cudec_detail::ZstdRead32(trailer)),
+                        static_cast<unsigned long long>(digest),
+                        static_cast<unsigned long long>(frame.size()));
             frames_checked++;
 
             /* A flipped trailer byte. The reference must refuse the mutated

--- a/tests/zstd_frame_twin.cpp
+++ b/tests/zstd_frame_twin.cpp
@@ -1,7 +1,8 @@
-/* The Zstd frame and block header parser from src/zstd_frame.h, executed on
- * the host and held to libzstd (issue #200). Host-side and GPU-less on
- * purpose: the gate that decides which frames cudec will decode at all runs
- * on the runner with no device, and the sanitizer build reaches it there.
+/* The Zstd frame and block header parser from src/zstd_frame.h, and the
+ * content checksum from src/xxhash64.h, executed on the host and held to
+ * libzstd (issues #200 and #202). Host-side and GPU-less on purpose: the
+ * gate that decides which frames cudec will decode at all runs on the runner
+ * with no device, and the sanitizer build reaches it there.
  *
  * TWO DIRECTIONS, WHICH IS THE WHOLE POINT OF THE LADDER. Every negative
  * below carries the class docs/MASTERPLAN.md section 12 assigns it, and the
@@ -27,6 +28,7 @@
  * target's compile definitions, and it means this test grows no second
  * frame-header parser to check the first one against. */
 #include "require.h"
+#include "xxhash64.h"
 #include "zstd_frame.h"
 
 #include <zstd.h>
@@ -482,6 +484,164 @@ int main() {
         }
     }
 
+    /* ---- The content checksum (issue #202) -----------------------------
+     *
+     * XXH64 is held to libzstd rather than to a table of digests copied out
+     * of a document: every frame below was checksummed by the reference, so
+     * the low 32 bits in its trailer ARE the oracle, and a length sweep puts
+     * every path of the algorithm under one. The classes are the algorithm's
+     * own - below one 32-byte stripe, exactly one, several, plus each tail
+     * width the finish walks: whole 8-byte lanes, one 4-byte half, and
+     * single bytes.
+     *
+     * The seed is not swept because the format fixes it. Section 3.1.1 says
+     * the checksum is XXH64 of the decoded data "and a seed of zero", so the
+     * implementation carries no seed parameter and there is no seeded path
+     * in this tree to test. That is a narrower unit than xxHash offers, and
+     * it is narrower on purpose.
+     *
+     * What is NOT proven here, stated rather than implied: cudec cannot
+     * decode a Zstd frame yet, so the digest is taken over content the
+     * reference produced. Verifying a checksum against bytes THIS project
+     * decoded is #199 and #203, and it is the step that closes the loop. */
+    {
+        const uint64_t lengths[] = {0,  1,  3,  4,   7,    8,    15,   16,
+                                    31, 32, 33, 63,  64,   100,  1000, 4095,
+                                    4096, 70000};
+        size_t frames_checked = 0;
+        for (size_t i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+            const uint64_t length = lengths[i];
+            /* Deterministic pseudo-random content: a run of one byte would
+             * leave the stripe loop reading the same word every round, which
+             * is the one input shape that hides a lane mix-up. */
+            /* Reserve before resize so an empty content still has a
+             * non-null data pointer to hand to both sides. */
+            Bytes content;
+            content.reserve(1);
+            content.resize(static_cast<size_t>(length));
+            uint32_t state = 0x9E3779B9u ^ static_cast<uint32_t>(length);
+            for (size_t j = 0; j < content.size(); j++) {
+                state = state * 1664525u + 1013904223u;
+                content[j] = static_cast<unsigned char>(state >> 24);
+            }
+
+            Bytes frame(ZSTD_compressBound(content.size()) + 16);
+            ZSTD_CCtx* cctx = ZSTD_createCCtx();
+            REQUIRE(cctx != 0);
+            REQUIRE(!ZSTD_isError(
+                ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 1)));
+            const size_t written =
+                ZSTD_compress2(cctx, frame.data(), frame.size(),
+                               content.data(), content.size());
+            ZSTD_freeCCtx(cctx);
+            REQUIRE(!ZSTD_isError(written));
+            frame.resize(written);
+
+            cudec_detail::ZstdFrameHeader header;
+            std::memset(&header, 0, sizeof(header));
+            cudec_detail::ZstdFrameReject rung =
+                cudec_detail::kZstdFrameRejectNone;
+            REQUIRE_CTX(cudec_detail::ZstdParseFrameHeader(
+                            frame.data(), frame.size(), &header,
+                            &rung) == CUDEC_OK,
+                        "checksummed frame of %llu bytes refused",
+                        static_cast<unsigned long long>(length));
+            REQUIRE_CTX(header.content_checksum,
+                        "the descriptor of a --check frame of %llu bytes does "
+                        "not report the flag",
+                        static_cast<unsigned long long>(length));
+
+            /* The trailer is the frame's last four bytes: the subset holds
+             * one frame per chunk, and a checksummed frame ends with it. */
+            REQUIRE(frame.size() >= 4);
+            const unsigned char* trailer = frame.data() + frame.size() - 4;
+            const uint64_t digest =
+                cudec_detail::Xxh64(content.data(), length);
+            REQUIRE_CTX(cudec_detail::ZstdVerifyContentChecksum(
+                            trailer, 4, digest, &rung) == CUDEC_OK,
+                        "XXH64 over %llu bytes does not reproduce the "
+                        "checksum libzstd wrote into the frame",
+                        static_cast<unsigned long long>(length));
+            frames_checked++;
+
+            /* A flipped trailer byte. The reference must refuse the mutated
+             * frame too, which is what says the trailer is load-bearing
+             * there and not only here. */
+            {
+                Bytes mutated = frame;
+                mutated[mutated.size() - 1] ^= 0x01u;
+                const unsigned char* bad = mutated.data() + mutated.size() - 4;
+                REQUIRE(cudec_detail::ZstdVerifyContentChecksum(
+                            bad, 4, digest, &rung) ==
+                        CUDEC_ERR_CORRUPT_INPUT);
+                REQUIRE(rung ==
+                        cudec_detail::kZstdFrameRejectChecksumMismatch);
+                CoverRung(rung);
+                REQUIRE_CTX(!OracleDecodes(mutated, 0),
+                            "libzstd accepts a frame of %llu bytes whose "
+                            "checksum was flipped",
+                            static_cast<unsigned long long>(length));
+            }
+
+            /* A flipped CONTENT byte against the unmutated trailer. This is
+             * the case the checksum exists for: the bytes decode, and the
+             * frame is still wrong. Length zero has no content byte to
+             * flip. */
+            if (length != 0) {
+                Bytes altered = content;
+                altered[altered.size() / 2] ^= 0x80u;
+                const uint64_t altered_digest =
+                    cudec_detail::Xxh64(altered.data(), length);
+                REQUIRE_CTX(altered_digest != digest,
+                            "one flipped byte in %llu did not move the "
+                            "digest",
+                            static_cast<unsigned long long>(length));
+                REQUIRE(cudec_detail::ZstdVerifyContentChecksum(
+                            trailer, 4, altered_digest, &rung) ==
+                        CUDEC_ERR_CORRUPT_INPUT);
+                REQUIRE(rung ==
+                        cudec_detail::kZstdFrameRejectChecksumMismatch);
+            }
+        }
+        REQUIRE(frames_checked == sizeof(lengths) / sizeof(lengths[0]));
+
+        /* A frame that ends before its trailer. The presence check is its
+         * own rung, because a decoder that read three bytes and compared
+         * them against a four-byte field would refuse for the wrong reason
+         * and would read one byte past the frame to do it. */
+        {
+            const unsigned char stub[3] = {0, 0, 0};
+            cudec_detail::ZstdFrameReject rung =
+                cudec_detail::kZstdFrameRejectNone;
+            REQUIRE(cudec_detail::ZstdVerifyContentChecksum(stub, 3, 0,
+                                                            &rung) ==
+                    CUDEC_ERR_CORRUPT_INPUT);
+            REQUIRE(rung == cudec_detail::kZstdFrameRejectChecksumTruncated);
+            CoverRung(rung);
+        }
+
+        /* No flag, no trailer. A decoder that read four bytes after the last
+         * block of an unchecksummed frame would be reading whatever follows
+         * it, so the flag is asserted rather than assumed. */
+        {
+            const std::string source(1024, 'q');
+            Bytes frame(ZSTD_compressBound(source.size()));
+            const size_t written =
+                ZSTD_compress(frame.data(), frame.size(), source.data(),
+                              source.size(), 3);
+            REQUIRE(!ZSTD_isError(written));
+            frame.resize(written);
+            cudec_detail::ZstdFrameHeader header;
+            std::memset(&header, 0, sizeof(header));
+            cudec_detail::ZstdFrameReject rung =
+                cudec_detail::kZstdFrameRejectNone;
+            REQUIRE(cudec_detail::ZstdParseFrameHeader(
+                        frame.data(), frame.size(), &header, &rung) ==
+                    CUDEC_OK);
+            REQUIRE(!header.content_checksum);
+        }
+    }
+
     /* Every rung named by a negative written to reach it, walked rather than
      * restated: a rung added to the parser with none behind it lands here as
      * a hole with its number on it. */
@@ -500,8 +660,9 @@ int main() {
     }
 
     std::printf("PASS: 3 accepted frames checked field for field against "
-                "ZSTD_getFrameHeader, %zu negatives over %d reject rungs, "
-                "each held to libzstd in the direction its class implies\n",
+                "ZSTD_getFrameHeader, 18 checksummed frames whose XXH64 this "
+                "tree reproduces, %zu negatives over %d reject rungs, each "
+                "held to libzstd in the direction its class implies\n",
                 rows.size(),
                 static_cast<int>(cudec_detail::kZstdFrameRejectCount) - 1);
     return 0;

--- a/tests/zstd_frame_twin.cpp
+++ b/tests/zstd_frame_twin.cpp
@@ -557,6 +557,16 @@ int main() {
             const unsigned char* trailer = frame.data() + frame.size() - 4;
             const uint64_t digest =
                 cudec_detail::Xxh64(content.data(), length);
+            if (length == 1) {
+                std::string hex;
+                for (size_t k = 0; k < frame.size(); k++) {
+                    char pair[4];
+                    std::snprintf(pair, sizeof(pair), "%02x", frame[k]);
+                    hex += pair;
+                }
+                std::printf("PROBE frame=%s content0=%02x\n", hex.c_str(),
+                            content.empty() ? 0 : content[0]);
+            }
             REQUIRE_CTX(cudec_detail::ZstdVerifyContentChecksum(
                             trailer, 4, digest, &rung) == CUDEC_OK,
                         "XXH64 over %llu bytes does not reproduce the "
@@ -567,17 +577,6 @@ int main() {
                             cudec_detail::ZstdRead32(trailer)),
                         static_cast<unsigned long long>(digest),
                         static_cast<unsigned long long>(frame.size()));
-            if (length == 1) {
-                std::string hex;
-                for (size_t k = 0; k < frame.size(); k++) {
-                    char pair[4];
-                    std::snprintf(pair, sizeof(pair), "%02x", frame[k]);
-                    hex += pair;
-                }
-                std::printf("PROBE frame=%s content0=%02x
-", hex.c_str(),
-                            content.empty() ? 0 : content[0]);
-            }
             frames_checked++;
 
             /* A flipped trailer byte. The reference must refuse the mutated

--- a/tests/zstd_frame_twin.cpp
+++ b/tests/zstd_frame_twin.cpp
@@ -567,6 +567,17 @@ int main() {
                             cudec_detail::ZstdRead32(trailer)),
                         static_cast<unsigned long long>(digest),
                         static_cast<unsigned long long>(frame.size()));
+            if (length == 1) {
+                std::string hex;
+                for (size_t k = 0; k < frame.size(); k++) {
+                    char pair[4];
+                    std::snprintf(pair, sizeof(pair), "%02x", frame[k]);
+                    hex += pair;
+                }
+                std::printf("PROBE frame=%s content0=%02x
+", hex.c_str(),
+                            content.empty() ? 0 : content[0]);
+            }
             frames_checked++;
 
             /* A flipped trailer byte. The reference must refuse the mutated

--- a/tests/zstd_frame_twin.cpp
+++ b/tests/zstd_frame_twin.cpp
@@ -557,16 +557,6 @@ int main() {
             const unsigned char* trailer = frame.data() + frame.size() - 4;
             const uint64_t digest =
                 cudec_detail::Xxh64(content.data(), length);
-            if (length == 1) {
-                std::string hex;
-                for (size_t k = 0; k < frame.size(); k++) {
-                    char pair[4];
-                    std::snprintf(pair, sizeof(pair), "%02x", frame[k]);
-                    hex += pair;
-                }
-                std::printf("PROBE frame=%s content0=%02x\n", hex.c_str(),
-                            content.empty() ? 0 : content[0]);
-            }
             REQUIRE_CTX(cudec_detail::ZstdVerifyContentChecksum(
                             trailer, 4, digest, &rung) == CUDEC_OK,
                         "XXH64 over %llu bytes does not reproduce the "


### PR DESCRIPTION
# What & why

Closes #202.

A Zstd frame can carry one integrity field and nothing in this tree could
compute it, so a frame that declares a content checksum had that field
ignored. The failure that hides is the quiet one: bytes that decode without
tripping a single bound, and whose own trailer says they are wrong.

Two pieces. `src/xxhash64.h` is XXH64 with the seed the format fixes, in the
single-source shape of `src/xxhash32.h`. `ZstdVerifyContentChecksum` in
`src/zstd_frame.h` owns the trailer's presence, its byte order and the
comparison, and adds two rungs to the frame ladder.

## The oracle is libzstd's own checksums, not a table of digests

Eighteen frames are compressed with the checksum flag and their trailers read
back. The lengths are the classes the algorithm branches on: below one
32-byte stripe, exactly one, several, and each tail width the finish walks,
which is whole 8-byte lanes, one 4-byte half, and single bytes. The content is
deterministic pseudo-random rather than a run of one byte, because a repeated
byte leaves the stripe loop reading the same word every round and that is the
one input shape a lane mix-up survives.

**That sweep caught a real defect in this change, and the defect is the reason
the sweep is the right shape.** `PRIME64_1` was written with two transposed
digits. It is reachable by every input of four bytes or more and by no shorter
one, so the published empty-input vector, 0xEF46DB3751D8E999, passes with it
wrong. The empty frame agreed and the one-byte frame did not:

    FAIL tests/zstd_frame_twin.cpp:560: ZstdVerifyContentChecksum(...) == CUDEC_OK
    | XXH64 over 1 bytes does not reproduce the checksum libzstd wrote into
    the frame: trailer 063257f9, digest b81a14911f44720e, frame 14 bytes

A test built on published vectors alone would have shipped that constant. The
commit that fixes it carries the reason next to the value.

That failure is also the proof the comparison bites, and it is an unstaged
one: with a wrong digest reaching a correct trailer, the suite went red at the
row that names it. No probe commit was needed to manufacture that, and none
was pushed.

## The two rungs, and why both are corrupt

A frame that ends before its trailer, and a trailer that does not match.
Section 12.3 of the masterplan puts a failed checksum in the corrupt class
rather than the unsupported one: content that does not hash to what its own
trailer says is not a legal frame this decoder declines, it is data no
conforming encoder produced. The presence check is its own rung because a
decoder that compared three bytes against a four-byte field would refuse for
the wrong reason and read one byte past the frame to do it.

Each mutant is put to the reference too. A flipped trailer byte must be
refused by libzstd as well, which is what says the trailer is load-bearing
there and not only here. A flipped content byte is checked in the direction
the checksum exists for: the bytes still decode, the digest moves, and the
comparison refuses.

The rung-coverage lock already in the twin now walks fifteen rungs, so
neither new one could have been added without a negative behind it.

## No seed parameter

RFC 8878 section 3.1.1 fixes the seed at zero. A parameter every caller in
this project would pass zero to is an argument nothing tests, and
`src/xxhash32.h` made the same choice for the LZ4 frame's XXH32. That is
narrower than xxHash offers and it is narrower on purpose, so the "non-zero
seed" line in the issue's proof list has no subject here rather than an
untested one.

## What this does not do

It does not verify a checksum against bytes cudec decoded, because cudec
cannot decode a Zstd frame yet. The digest is taken over content the
reference produced. Closing that loop is #199 and #203, and this is stated
here rather than left for a reader to discover from the absence of a test.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)

## Engineering checklist

- [x] Fail-closed preserved. Two new reject rungs, both corrupt, each with a
      declared negative, and the twin refuses a rung without one.
- [x] Oracle coverage. Eighteen checksums from libzstd across every length
      class the algorithm branches on, plus reject parity on the trailer
      mutants.
- [x] Determinism preserved. The digest is a pure function of its bytes.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      Nothing here calls CUDA and nothing here is on the ABI.
- [ ] An adversarial review (`/security-review`) was run. It was **not** run,
      and the box stays unticked rather than argued away. Format parsing is on
      the sensitive surface, so the gate is owed by the letter of the
      checklist.
- [ ] Review record. There is none, for the same reason. This change had no
      second reader; the runs quoted here are the evidence in place of one.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. Both headers are
      written `CUDEC_HOST_DEVICE` for the kernel that will include them, and
      no device translation unit includes either yet.

No route to a device the sanitizer can attach to exists on this machine in
any case, which #258 records with its commands.

## Performance checklist

Not on the hot path. The byte-wise reads are a correctness shape and the
header says so; when this lands on a measured path, the measurement decides.

## Quality checklist

- [x] Minimal: one hash, one comparison, no seed, no streaming state. The
      digest is fed in by the caller, so this unit does not also own when it
      is computed.
- [x] Self-documenting: the primes carry the note about which of them a
      vector-only test cannot catch, and the RLE and trailer sections name the
      RFC clauses they implement.
- [x] Conformance: the ladder lock extends to the two new rungs without
      anything being restated.

## Verification

- [x] Build and the host-side `ctest` subset, on this head:

      $ gh run view --job 93015225137 --log
      13/21 Test #14: zstd_frame_twin ..................   Passed    0.00 sec
      100% tests passed, 0 tests failed out of 21

- [x] ASan+UBSan, same head:

      $ gh run view --job 93015225205 --log
      6/9 Test #13: zstd_frame_twin ..................   Passed    0.02 sec
      100% tests passed, 0 tests failed out of 9

- [x] Prettier: no Markdown or YAML file is in the diff.
- [x] Docs synced. Section 12 of the masterplan already records the checksum
      and its rejection class; this implements it and changes nothing there.

## Notes

The branch history carries the failing runs described above. They are left in
place rather than squashed away, because the constant they caught is the kind
of defect that reads as impossible after the fix.

## Merge state

Every check on this head is green, and the two runs quoted under Verification
are this head's own:

    $ gh api repos/iderex/cudec/commits/9a0824db7145506cde3b9b69ee7c179f1b507e5a/check-runs --jq '[.check_runs[]|"\(.name):\(.conclusion)"]|join(" ")'
    CodeQL:success analyze:success sanitize:success build:success format:success dependency-review:success

No GPU ran and none is owed: nothing in the diff is device code.

There was no second reader for this change. The runs above, including the one
that caught the wrong constant, are the evidence in place of one.
