### PR TITLE
Reject every non-zero token at a zero destination capacity

### DIFF
--- a/src/lz4_block.h
+++ b/src/lz4_block.h
@@ -171,6 +171,21 @@ struct Lz4Parser {
             if (src_pos + literals_len != src_size) {
                 return CUDEC_ERR_CORRUPT_INPUT;
             }
+            /* liblz4's empty-output-buffer early-out, mirrored (issue #315).
+             * With dstCapacity == 0 the reference accepts exactly one stream,
+             * the single byte 0x00, and rejects every other input before it
+             * looks at the token. Reaching this line with dst_capacity == 0
+             * means literals_len == 0 (the capacity check above admits no
+             * other length) and exact consumption of a one-byte stream, so
+             * `token` IS that byte: without this, every token whose literal
+             * nibble is zero satisfies the terminal rule vacuously and
+             * fifteen streams the reference rejects are accepted here. Only
+             * capacity zero is affected - at every other capacity liblz4
+             * ignores a terminal token's match nibble exactly as this parser
+             * does, so no other acceptance moves. */
+            if (dst_capacity == 0 && token != 0) {
+                return CUDEC_ERR_CORRUPT_INPUT;
+            }
             sequence->literals_src = src_pos;
             sequence->literals_dst = dst_pos;
             sequence->literals_len = literals_len;

--- a/tests/fixtures.cpp
+++ b/tests/fixtures.cpp
@@ -160,6 +160,16 @@ bool OracleDecodes(const std::vector<unsigned char>& stream,
     return true;
 }
 
+bool OracleDecodesAtZeroCapacity(const std::vector<unsigned char>& stream) {
+    if (stream.empty()) {
+        return false; /* never hand liblz4 a null source pointer */
+    }
+    unsigned char scratch = 0;
+    return LZ4_decompress_safe(reinterpret_cast<const char*>(stream.data()),
+                               reinterpret_cast<char*>(&scratch),
+                               static_cast<int>(stream.size()), 0) >= 0;
+}
+
 bool SnappyOracleDecodes(const std::vector<unsigned char>& stream,
                          std::vector<unsigned char>* decoded) {
     decoded->clear();

--- a/tests/fixtures.h
+++ b/tests/fixtures.h
@@ -40,6 +40,16 @@ std::vector<Mutant> MutateStream(const std::vector<unsigned char>& stream,
 bool OracleDecodes(const std::vector<unsigned char>& stream,
                    size_t original_size, std::vector<unsigned char>* decoded);
 
+/* The same verdict at a destination capacity of zero, which liblz4 treats as
+ * its own case: it accepts exactly one stream there, the single byte 0x00.
+ * Separate from OracleDecodes because that one would hand the reference the
+ * data() of an empty vector, which is allowed to be null - the reference
+ * returns before touching the destination, but a real one-byte buffer with a
+ * declared capacity of zero states the same case without asking a sanitizer
+ * build to reason about the null. No output parameter: an accept here
+ * produces no bytes by construction. */
+bool OracleDecodesAtZeroCapacity(const std::vector<unsigned char>& stream);
+
 /* CPU-reference block compression. Fixture generation and the bench
  * harness share it so every compressed stream in the project has a single
  * provenance; aborts on compressor failure (infrastructure, not a test). */

--- a/tests/parser_twin.cpp
+++ b/tests/parser_twin.cpp
@@ -233,6 +233,62 @@ int SweepExtensionReadBound(size_t* accepts, size_t* rejects) {
     return 0;
 }
 
+/* The zero-capacity family (issue #315, found by the differential fuzz target
+ * of #140). liblz4 handles an empty output buffer in its own early-out and
+ * accepts exactly one stream there, the single byte 0x00; the parser's
+ * terminal rule is satisfied vacuously by every token whose literal nibble is
+ * zero, so before the guard in src/lz4_block.h it accepted 0x01 through 0x0F
+ * as well - fifteen streams the reference rejects.
+ *
+ * All 256 one-byte streams, both directions, and the direction that matters is
+ * exact here rather than a subset: no match can be reached at capacity zero
+ * (any literal length above zero is refused by the capacity check, so the run
+ * is always terminal), which is why the offset==0 strictness cannot appear in
+ * this family and equality of the two verdicts is the right assertion.
+ * Deleting the guard reds this sweep. */
+int SweepZeroCapacity(size_t* accepts, size_t* rejects) {
+    for (int token = 0; token < 256; token++) {
+        const std::vector<unsigned char> s = {
+            static_cast<unsigned char>(token)};
+        std::vector<unsigned char> twin_out;
+        const cudec_status twin = TwinDecode(s, 0, &twin_out);
+        const bool oracle_ok = OracleDecodesAtZeroCapacity(s);
+        REQUIRE_CTX((twin == CUDEC_OK) == oracle_ok,
+                    "zero-capacity parity: token 0x%02X (twin %d, oracle %d)",
+                    token, static_cast<int>(twin),
+                    static_cast<int>(oracle_ok));
+        if (twin == CUDEC_OK) {
+            REQUIRE_CTX(token == 0x00, "zero-capacity accept: token 0x%02X",
+                        token);
+            REQUIRE_CTX(twin_out.empty(),
+                        "zero-capacity output: token 0x%02X", token);
+            (*accepts)++;
+        } else {
+            REQUIRE_CTX(twin == CUDEC_ERR_CORRUPT_INPUT ||
+                            twin == CUDEC_ERR_OUTPUT_TOO_SMALL,
+                        "zero-capacity reject status %d: token 0x%02X",
+                        static_cast<int>(twin), token);
+            (*rejects)++;
+        }
+    }
+    /* A longer stream at capacity zero stays refused on both sides whatever
+     * its first byte is: the reference's early-out takes only a one-byte
+     * input, and the parser's exact-consumption check takes only a one-byte
+     * terminal run. */
+    for (int token = 0; token < 256; token++) {
+        const std::vector<unsigned char> s = {
+            static_cast<unsigned char>(token), 0x00};
+        std::vector<unsigned char> twin_out;
+        REQUIRE_CTX(TwinDecode(s, 0, &twin_out) != CUDEC_OK,
+                    "zero-capacity two-byte accept: token 0x%02X", token);
+        REQUIRE_CTX(!OracleDecodesAtZeroCapacity(s),
+                    "zero-capacity two-byte oracle accept: token 0x%02X",
+                    token);
+        (*rejects)++;
+    }
+    return 0;
+}
+
 }  // namespace
 
 int main() {
@@ -326,6 +382,14 @@ int main() {
     REQUIRE(ext_accepts > 0);
     REQUIRE(ext_rejects > 0);
 
+    /* The empty-output-buffer family, swept exhaustively over the token
+     * (issue #315). Exactly one of the 256 one-byte streams may be accepted. */
+    size_t zerocap_accepts = 0;
+    size_t zerocap_rejects = 0;
+    REQUIRE(SweepZeroCapacity(&zerocap_accepts, &zerocap_rejects) == 0);
+    REQUIRE(zerocap_accepts == 1);
+    REQUIRE(zerocap_rejects == 511);
+
     /* One crafted negative per ladder branch that liblz4 also rejects:
      * pins the twin's specific status AND that the stream is malformed. */
     const auto crafted = MakeCraftedNegatives();
@@ -405,9 +469,11 @@ int main() {
                 "spec-invalid input); %zu crafted negatives; last-5 sweep "
                 "%zu accept / %zu reject; empty block, offset==0 "
                 "divergence, SIZE_MAX and beyond-convention capacity "
-                "pinned; ext-read sweep %zu accept / %zu reject\n",
+                "pinned; ext-read sweep %zu accept / %zu reject; "
+                "zero-capacity sweep %zu accept / %zu reject\n",
                 fixtures.size(), mutant_total, rejected_total,
                 stricter_than_oracle, crafted.size(), last5_accepts,
-                last5_rejects, ext_accepts, ext_rejects);
+                last5_rejects, ext_accepts, ext_rejects, zerocap_accepts,
+                zerocap_rejects);
     return 0;
 }


### PR DESCRIPTION
# What & why

Closes #315.

At a destination capacity of zero the LZ4 block parser accepted any one-byte
stream whose token had a zero literal nibble, that is `0x00` through `0x0F`,
and reported `CUDEC_OK`. liblz4 accepts exactly one of them, `0x00`. Fifteen
acceptances the fail-closed contract forbids, in the direction the project
forbids: whenever the reference rejects, cudec must reject.

liblz4 handles an empty output buffer in its own early-out, before it looks at
the token. `Lz4Parser::Next` had no such case, and its terminal rule is
satisfied vacuously there: `literals_len` is 0, both length checks pass on 0,
`dst_slack` is 0 and therefore below `kLz4MinTrailingSlackDst`, and
`src_pos + 0 == src_size` holds for a one-byte stream.

The guard sits inside the terminal branch rather than at the top of `Next`, so
it can only remove acceptances. Reaching it with `dst_capacity == 0` means
`literals_len == 0` and exact consumption of a one-byte stream, so `token` is
that byte; no reject status anywhere else in the ladder moves, and no
acceptance at any other capacity moves.

Found by the differential fuzz target being built for #140, then bounded by
exhaustive enumeration rather than left at the fuzzer's word.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Bug fix

## Engineering checklist

- [x] Fail-closed preserved: the change is a new reject, and it carries the
      negative test below.
- [x] Oracle coverage: the new sweep compares against `LZ4_decompress_safe` in
      both directions for all 256 tokens.
- [x] Determinism preserved: the accept set shrinks by fifteen streams and no
      accepted stream's output changes.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      This change adds no CUDA call.
- [ ] An adversarial review (`/security-review`) was run.
- [ ] Review record.

No second reader stands behind this change and no review lens was run. The
evidence below is what stands in place of one, and it is stated as evidence
rather than as clearance.

## GPU sanitizer gate

`src/lz4_block.h` is compiled into device code, so this section applies and is
not being waived.

No route to a device the sanitizer can attach to was available for this change,
so the block stays empty. Two things stand in the way, both readable rather
than asserted.

The sanitizer itself cannot attach on this machine at all. That is #258, which
carries the four-tool measurement and the two initialization errors behind it,
and it is open.

The container the gate runs in was also not reachable, because the engine was
not running:

    docker images --format "{{.Repository}}:{{.Tag}}"
    failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine;
    check if the path is correct and if the daemon is running

Starting it is a decision for the machine's owner rather than something to be
done from a session, so it was left alone.

```
commit:    (no sweep ran)
gpu:       (no sweep ran)
cuda:      (no sweep ran)
sanitizer: (no sweep ran)
```

## Performance checklist

Not on the hot path in any measurable sense: one comparison of a value already
in a register, on the terminal-sequence exit that runs at most once per chunk.
No measurement is offered and none is claimed.

## Quality checklist

- [x] Minimal: two lines of code, and the reason is written where the branch is.
- [x] Self-documenting.
- [x] Conformance tests unchanged; the new structural property is locked by the
      sweep below.

## Verification

`ctest` did not run and no CUDA build was produced. The test tree only
configures under `CUDEC_ENABLE_CUDA=ON`, which needs a CUDA toolchain, and this
host has none reachable tonight (see the sanitizer section). What did run is
below, on a Linux toolchain with the same oracle source the test tree pins:
liblz4 1.10.0 from the release tarball named in `tests/CMakeLists.txt`,
hash-verified before use.

    sha256sum lz4-1.10.0.tar.gz
    537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
    clang++ --version | head -1
    Ubuntu clang version 18.1.3 (1ubuntu1)

1. The test file compiles under the project's strict flags.

       clang++ -std=c++17 -Wall -Wextra -Werror -fsyntax-only \
         -I include -I src -I tests tests/parser_twin.cpp
       OK

   The one function added to `tests/fixtures.cpp` was compiled the same way
   against the declaration added to `tests/fixtures.h`.

2. The new sweep's assertions, executed against the patched parser through the
   real `src/lz4_block.h` and the real liblz4, under
   `-fsanitize=address,undefined -fno-sanitize-recover=all`:

       sweep OK: 1 accept / 511 reject

3. The guard bites. With `if (dst_capacity == 0 && token != 0)` replaced by
   `if (false)` and nothing else changed, the same sweep goes red on the first
   token it reaches:

       FAIL: zero-capacity parity: token 0x01 (twin 0, oracle 0)
       exit=1

4. The enumeration that bounded the finding, re-run on the patched parser.
   Every 1-byte and 2-byte stream at every capacity from 0 to 32, and every
   3-byte stream at capacity 0 to 4, twin verdict against oracle verdict:

       ### 1-byte streams, capacity 0..32
         checked=8448 divergences=0
       ### 2-byte streams, capacity 0..32
         checked=2162688 divergences=0
       ### 3-byte streams, capacity 0..4
         checked=83886080 divergences=0
       ### total checked=86057216 divergences=0

   The same run before the change reported 15 divergences, all of them the
   fifteen tokens named above. It is on #315.

5. The libFuzzer target that found it, re-run on the patched parser for 300
   seconds across 4 workers over the grown corpus, ASan and UBSan on:

       stat::number_of_executed_units: 26230443
       stat::number_of_executed_units: 19895454
       stat::number_of_executed_units: 19642170
       stat::number_of_executed_units: 18860722
       exit=0
       artifacts: 0

   84628789 executions, no crash, no sanitizer report, no artifact written.

6. The local gate legs that do run on this host.

       cmake -B build && cmake --build build
       [100%] Built target example_decode_frame

       npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
       All matched files use Prettier code style!

   The host-only configuration compiles `src/version.c` and the examples and
   reaches neither changed file, so that leg is reported for what it is rather
   than as coverage of this change. CI builds both configurations and runs the
   GPU-less test subset, `parser_twin` among them, so the new sweep is gated
   there.

- [x] `cmake --build build` builds clean.
- [ ] `ctest --test-dir build` green.
- [x] Prettier clean.
- [x] Docs synced: no behaviour this change touches is described in
      MASTERPLAN, README or BENCHMARKS. The parity rule it restores is already
      stated in `src/lz4_block.h` and in masterplan section 5.

## Notes

The fuzz harness that found this is not in this change. It is #140, and it is
not landable from this host: its build seam is a CMake option over a Clang
toolchain, and no machine here has CMake and Clang together. That is written
into #140 with the commands.

The public ABI does not refuse a zero capacity for a chunk, so the class was
reachable through `cudec_lz4_decompress_batch`. Whether zero-capacity chunks
should be refused earlier, at the batch argument check, is a separate question
and is not decided here.
