### PR TITLE
Add the differential libFuzzer target over the LZ4 block parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,47 @@ if(CUDEC_ENABLE_HIP)
       "build.")
 endif()
 
+# ---- The fuzz gate (issue #140). Opt-in, default OFF, and fail-closed twice
+# over: asking for it without a Clang host toolchain is a configure error, and
+# so is asking for it without sanitizers. The second refusal is the one worth
+# stating - a fuzz run whose memory errors nobody is watching finds only the
+# divergences the harness happens to assert, while reading exactly like a run
+# that also proved the parser touched nothing it should not.
+#
+# The sanitizer set is CUDEC_SANITIZE's rather than a second string of its
+# own, so there is one spelling of "which sanitizers" in this build system and
+# the fuzz build cannot be instrumented differently from the sanitizer gate
+# without somebody meaning it.
+#
+# Host-only by construction: fuzz/ has no CUDA sources and does not link the
+# cudec archive, so this configures and builds on a machine with no CUDA
+# toolchain at all - which is the point, since the parser under it is the
+# single-sourced host/device header.
+option(CUDEC_FUZZ "Build the libFuzzer targets (requires Clang + CUDEC_SANITIZE)"
+       OFF)
+if(CUDEC_FUZZ AND PROJECT_IS_TOP_LEVEL)
+  if(NOT CUDEC_SANITIZE)
+    message(
+      FATAL_ERROR
+        "CUDEC_FUZZ needs CUDEC_SANITIZE set (e.g. "
+        "-DCUDEC_SANITIZE=address,undefined): -fsanitize=fuzzer alone builds "
+        "a fuzzer that cannot see an out-of-bounds access, which is most of "
+        "what fuzzing this parser is for.")
+  endif()
+  enable_language(CXX)
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(
+      FATAL_ERROR
+        "CUDEC_FUZZ requires a Clang host toolchain (libFuzzer ships with "
+        "Clang; got '${CMAKE_CXX_COMPILER_ID}'). Configure with "
+        "-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++.")
+  endif()
+  # After the CUDA block, so in a combined configure the timeout sweep has
+  # already run over every directory that registers tests - fuzz/ registers
+  # none, and says why.
+  add_subdirectory(fuzz)
+endif()
+
 # ---- The examples (issue #158). Built in BOTH configurations, which is the
 # point: they include nothing but the public header, so they compile wherever
 # the header is usable and link wherever the decoder is built. Top-level only,

--- a/cmake/CudecLz4Oracle.cmake
+++ b/cmake/CudecLz4Oracle.cmake
@@ -1,0 +1,53 @@
+# The liblz4 oracle, in one place because two directories now need it: the
+# test net under tests/ and the fuzz targets under fuzz/ (issue #140). A
+# second FetchContent_Declare for the same name would not be an error - the
+# first declaration silently wins - so two copies of the pin could drift and
+# the losing copy would never say so. One file, one pin, one pair of targets.
+include_guard(GLOBAL)
+
+# Supply chain: the hash-verified tarball is the only acceptable oracle
+# source - a system copy must never silently substitute for it. Stated here
+# as well as in tests/CMakeLists.txt because whichever directory reaches this
+# file first is the one that fetches, and the other may never process the
+# line at all.
+set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
+
+# liblz4, pinned by the SHA-256 of the maintainer-uploaded release asset
+# (self-computed at pin time and cross-checked against conan-center; the
+# auto-generated /archive/ tarballs are avoided - GitHub regenerated them
+# in 2023 and their hashes moved). Test-only dependency: the link
+# allowlist in tests/CMakeLists.txt keeps it out of the library.
+include(FetchContent)
+FetchContent_Declare(
+  lz4
+  URL https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz
+  URL_HASH
+    SHA256=537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+FetchContent_MakeAvailable(lz4)
+
+# The uploaded tarball has no top-level CMakeLists (lz4's lives in
+# build/cmake), so MakeAvailable only populates the source tree; we compile
+# the one translation unit the block-format oracle needs and depend on
+# nothing of lz4's build system. SYSTEM include + none of our strict flags:
+# third-party code is audited by hash, not reformatted.
+add_library(lz4_oracle STATIC ${lz4_SOURCE_DIR}/lib/lz4.c)
+target_include_directories(lz4_oracle SYSTEM PUBLIC ${lz4_SOURCE_DIR}/lib)
+
+# The frame oracle adds liblz4's frame API and xxHash (the checksum the
+# frame format uses) - the reference the cudec frame decoder is held to.
+add_library(
+  lz4_frame_oracle STATIC
+  ${lz4_SOURCE_DIR}/lib/lz4.c ${lz4_SOURCE_DIR}/lib/lz4hc.c
+  ${lz4_SOURCE_DIR}/lib/lz4frame.c ${lz4_SOURCE_DIR}/lib/xxhash.c)
+target_include_directories(lz4_frame_oracle SYSTEM PUBLIC
+                           ${lz4_SOURCE_DIR}/lib)
+# -O2 unconditionally: the oracle is also the bench harness's timed
+# decoder, and an empty CMAKE_BUILD_TYPE (the documented container
+# command) would otherwise time -O0 reference code. Correctness is
+# optimization-independent; honest numbers are not.
+target_compile_options(lz4_oracle PRIVATE -O2)
+
+# Never instrumented, in either the sanitizer gate or the fuzz gate: the
+# reference is third-party code audited by hash, and a sanitizer finding
+# inside it would red a gate that exists to judge this project's parser.

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,52 @@
+# The fuzz targets (issue #140). Built only under -DCUDEC_FUZZ=ON; the
+# top-level guard is what decides that, and it has already refused a
+# non-Clang toolchain and a fuzz build with no sanitizers by the time this
+# file is read.
+#
+# No ctest entry is registered here, deliberately. A fuzz target's natural run
+# is unbounded, and every ctest entry in this tree must carry a finite TIMEOUT
+# (issue #72) - a bounded -runs=N smoke entry is CI's shape and belongs to the
+# CI wiring issue, not to the harness. This directory is also processed after
+# the timeout sweep has run, so a test added here would escape it entirely.
+
+include(${PROJECT_SOURCE_DIR}/cmake/CudecLz4Oracle.cmake)
+
+function(cudec_add_fuzz_target name)
+  cmake_parse_arguments(F "" "" "SOURCES;LIBS" ${ARGN})
+  add_executable(${name} ${F_SOURCES})
+  target_link_libraries(${name} PRIVATE ${F_LIBS})
+  # src/ for the single-sourced parser, tests/ for the shared host driver the
+  # CPU twin test runs. Nothing here links the cudec archive: the parser is a
+  # header and the target must not drag the CUDA runtime into a host-only
+  # fuzz build.
+  target_include_directories(
+    ${name} PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src
+                    ${PROJECT_SOURCE_DIR}/tests)
+  set_target_properties(${name} PROPERTIES CXX_STANDARD 17
+                                           CXX_STANDARD_REQUIRED ON)
+  # -fsanitize=fuzzer on top of the requested sanitizers, on both the compile
+  # and the link: the compile flag is what instruments the coverage the engine
+  # steers on, the link flag is what supplies its main(). C/C++ only, the same
+  # generator-expression guard the sanitizer flags carry, so no CUDA
+  # translation unit could ever see them.
+  target_compile_options(
+    ${name}
+    PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:-Wall;-Wextra;-Werror;-fsanitize=fuzzer>
+            $<$<COMPILE_LANGUAGE:C,CXX>:${CUDEC_SANITIZE_COMPILE_FLAGS}>)
+  target_link_options(${name} PRIVATE -fsanitize=fuzzer
+                      ${CUDEC_SANITIZE_LINK_FLAGS})
+endfunction()
+
+cudec_add_fuzz_target(fuzz_lz4_block SOURCES fuzz_lz4_block.cpp LIBS
+                      lz4_oracle)
+
+# The second binary of the pair, and the reason the first one's verdict can be
+# believed: identical sources with CUDEC_FUZZ_SELFTEST_BREAK defined, which
+# perturbs an accepted oracle output so the parity comparison MUST fire. A
+# harness that had silently stopped comparing passes as this one, so building
+# it is how the guard is shown to bite. It is never the binary whose findings
+# are read.
+cudec_add_fuzz_target(fuzz_lz4_block_selftest SOURCES fuzz_lz4_block.cpp LIBS
+                      lz4_oracle)
+target_compile_definitions(fuzz_lz4_block_selftest
+                           PRIVATE CUDEC_FUZZ_SELFTEST_BREAK)

--- a/fuzz/fuzz_lz4_block.cpp
+++ b/fuzz/fuzz_lz4_block.cpp
@@ -7,12 +7,13 @@
  * (tests/parser_twin.cpp pins that divergence); asserting it would red on
  * legitimate strictness.
  *
- * Both sides get a tight allocation for the stream and for the output, so an
- * over-read past the last stream byte or an over-write past the capacity lands
- * in an ASan redzone rather than in vector slack.
- */
+ * The twin side is tests/lz4_twin.h - the same driver tests/parser_twin.cpp
+ * runs, not a second copy of it, so this target cannot go green about a
+ * parser execution the test net never performs. Both sides get tight
+ * allocations, so an over-read past the last stream byte or a write past the
+ * declared capacity lands in an ASan redzone rather than in slack. */
 #include "cudec.h"
-#include "lz4_block.h"
+#include "lz4_twin.h"
 
 #include "lz4.h"
 
@@ -24,8 +25,10 @@
 
 namespace {
 
-/* Ceilings, so the fuzzer explores the parser instead of the allocator. */
-constexpr size_t kMaxCapacity = 1u << 16;
+/* Ceilings, so the fuzzer explores the parser instead of the allocator. The
+ * capacity ceiling is what two header bytes can express; the stream ceiling
+ * is set below libFuzzer's own -max_len so a length-prefix blow-up cannot
+ * turn a corpus entry into an allocation. */
 constexpr size_t kMaxStream = 1u << 14;
 
 struct Decoded {
@@ -34,55 +37,25 @@ struct Decoded {
     std::unique_ptr<unsigned char[]> bytes; /* tight: exactly `capacity` */
 };
 
-/* Sequential reference execution of the parsed sequences - the same driver
- * shape as TwinDecode in tests/parser_twin.cpp. */
-Decoded TwinDecode(const unsigned char* stream, size_t stream_size,
-                   size_t capacity) {
-    Decoded d{false, 0, nullptr};
-    d.bytes = std::make_unique<unsigned char[]>(capacity);
-    std::memset(d.bytes.get(), 0, capacity);
-
-    cudec_detail::Lz4Parser parser{stream, stream_size, capacity};
-    cudec_detail::Lz4Sequence seq;
-    bool done = false;
-    while (true) {
-        const cudec_status status = parser.Next(&seq, &done);
-        if (status != CUDEC_OK) {
-            return d;
-        }
-        for (uint64_t i = 0; i < seq.literals_len; i++) {
-            d.bytes[seq.literals_dst + i] = stream[seq.literals_src + i];
-        }
-        for (uint64_t i = 0; i < seq.match_len; i++) {
-            d.bytes[seq.match_dst + i] = d.bytes[seq.match_src + i];
-        }
-        if (done) {
-            break;
-        }
-    }
-    d.ok = true;
-    d.size = static_cast<size_t>(parser.dst_pos);
-    return d;
-}
-
 Decoded OracleDecode(const unsigned char* stream, size_t stream_size,
                      size_t capacity) {
-    Decoded d{false, 0, nullptr};
-    d.bytes = std::make_unique<unsigned char[]>(capacity);
-    std::memset(d.bytes.get(), 0, capacity);
+    Decoded decoded{false, 0, std::make_unique<unsigned char[]>(capacity)};
+    if (capacity != 0) {
+        std::memset(decoded.bytes.get(), 0, capacity);
+    }
     if (stream_size == 0) {
-        return d; /* never hand liblz4 a null source pointer */
+        return decoded; /* never hand liblz4 a null source pointer */
     }
     const int written = LZ4_decompress_safe(
         reinterpret_cast<const char*>(stream),
-        reinterpret_cast<char*>(d.bytes.get()), static_cast<int>(stream_size),
-        static_cast<int>(capacity));
+        reinterpret_cast<char*>(decoded.bytes.get()),
+        static_cast<int>(stream_size), static_cast<int>(capacity));
     if (written < 0) {
-        return d;
+        return decoded;
     }
-    d.ok = true;
-    d.size = static_cast<size_t>(written);
-    return d;
+    decoded.ok = true;
+    decoded.size = static_cast<size_t>(written);
+    return decoded;
 }
 
 }  // namespace
@@ -90,41 +63,46 @@ Decoded OracleDecode(const unsigned char* stream, size_t stream_size,
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     /* The fuzzer controls the output capacity as well as the stream: with a
      * fixed capacity, CUDEC_ERR_OUTPUT_TOO_SMALL swamps the corpus and the
-     * deeper reject branches stay unreached. Two header bytes, then the
-     * stream. Both sides are handed the identical capacity. */
+     * deeper reject branches stay unreached. Two big-endian header bytes,
+     * then the stream. Both sides are handed the identical capacity, so a
+     * divergence is never an artefact of comparing two different contracts. */
     if (size < 2) {
         return 0;
     }
     const size_t capacity =
-        (static_cast<size_t>(data[0]) << 8 | static_cast<size_t>(data[1])) %
-        (kMaxCapacity + 1);
+        static_cast<size_t>(data[0]) << 8 | static_cast<size_t>(data[1]);
     const uint8_t* body = data + 2;
     size_t body_size = size - 2;
     if (body_size > kMaxStream) {
         body_size = kMaxStream;
     }
 
-    /* Tight copy of the stream: an over-read past the last byte must land in
-     * an ASan redzone, not in slack the allocator happened to round up. */
-    auto tight = std::make_unique<unsigned char[]>(body_size);
+    /* libFuzzer hands out a slice of a buffer sized to -max_len, not to this
+     * input, so a read past `body_size` would land in that slack and stay
+     * green. Both sides are run over one exactly-sized copy instead. The twin
+     * driver tightens again internally - that is its own guarantee to its
+     * other caller, and it costs one copy of at most 16 KiB here. */
+    auto stream = std::make_unique<unsigned char[]>(body_size);
     if (body_size != 0) {
-        std::memcpy(tight.get(), body, body_size);
+        std::memcpy(stream.get(), body, body_size);
     }
 
-    const Decoded twin = TwinDecode(tight.get(), body_size, capacity);
-    const Decoded oracle = OracleDecode(tight.get(), body_size, capacity);
+    const cudec_test::Lz4TwinResult twin =
+        cudec_test::Lz4TwinDecode(stream.get(), body_size, capacity);
+    Decoded oracle = OracleDecode(stream.get(), body_size, capacity);
 
 #ifdef CUDEC_FUZZ_SELFTEST_BREAK
-    /* Off by default, and the only way to prove the comparison below is live:
-     * a second binary built with this defined perturbs an accepted output, so
-     * a harness that had silently stopped comparing would pass where this one
-     * traps. Never define it in a build whose findings are being believed. */
-    if (twin.ok && twin.size != 0) {
-        const_cast<Decoded&>(twin).bytes[0] ^= 0xFFu;
+    /* Off by default, and the only way to prove the comparison below is live
+     * without waiting for a real divergence: a second binary built with this
+     * defined perturbs an accepted output, so a harness that had silently
+     * stopped comparing would pass where this one traps. Never define it in a
+     * build whose findings are being believed. */
+    if (oracle.ok && oracle.size != 0) {
+        oracle.bytes[0] ^= 0xFFu;
     }
 #endif
 
-    if (!twin.ok) {
+    if (twin.status != CUDEC_OK) {
         return 0; /* the twin may be stricter; that direction is not asserted */
     }
     if (!oracle.ok) {
@@ -150,20 +128,3 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     }
     return 0;
 }
-
-/* Built and run so far without a CMake seam, because no machine available to
- * this work has CMake and Clang together. The exact invocation that produced
- * the findings recorded on issue #140, against the liblz4 release tarball
- * pinned in tests/CMakeLists.txt and hash-verified before use:
- *
- *   clang -std=c11 -O2 -g -fsanitize=address,undefined \
- *     -fno-sanitize-recover=all -isystem lz4-1.10.0/lib \
- *     -c lz4-1.10.0/lib/lz4.c -o lz4_oracle.o
- *   clang++ -std=c++17 -g -O1 -fsanitize=fuzzer,address,undefined \
- *     -fno-sanitize-recover=all -I include -I src \
- *     -isystem lz4-1.10.0/lib -o fuzz_lz4_block \
- *     fuzz/fuzz_lz4_block.cpp lz4_oracle.o
- *
- * The CMake option that replaces it, and the committed seed corpus, are what
- * issue #140 still owes.
- */

--- a/fuzz/fuzz_lz4_block.cpp
+++ b/fuzz/fuzz_lz4_block.cpp
@@ -1,0 +1,169 @@
+/* Differential fuzz target over the LZ4 block parser (issue #140).
+ *
+ * Property, the fail-open direction: whenever the twin ACCEPTS, liblz4 must
+ * accept the same bytes at the same capacity and produce the identical output
+ * and size. The other direction is not asserted, because the twin is
+ * deliberately stricter than liblz4 in at least the offset==0 family
+ * (tests/parser_twin.cpp pins that divergence); asserting it would red on
+ * legitimate strictness.
+ *
+ * Both sides get a tight allocation for the stream and for the output, so an
+ * over-read past the last stream byte or an over-write past the capacity lands
+ * in an ASan redzone rather than in vector slack.
+ */
+#include "cudec.h"
+#include "lz4_block.h"
+
+#include "lz4.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+
+namespace {
+
+/* Ceilings, so the fuzzer explores the parser instead of the allocator. */
+constexpr size_t kMaxCapacity = 1u << 16;
+constexpr size_t kMaxStream = 1u << 14;
+
+struct Decoded {
+    bool ok;
+    size_t size;
+    std::unique_ptr<unsigned char[]> bytes; /* tight: exactly `capacity` */
+};
+
+/* Sequential reference execution of the parsed sequences - the same driver
+ * shape as TwinDecode in tests/parser_twin.cpp. */
+Decoded TwinDecode(const unsigned char* stream, size_t stream_size,
+                   size_t capacity) {
+    Decoded d{false, 0, nullptr};
+    d.bytes = std::make_unique<unsigned char[]>(capacity);
+    std::memset(d.bytes.get(), 0, capacity);
+
+    cudec_detail::Lz4Parser parser{stream, stream_size, capacity};
+    cudec_detail::Lz4Sequence seq;
+    bool done = false;
+    while (true) {
+        const cudec_status status = parser.Next(&seq, &done);
+        if (status != CUDEC_OK) {
+            return d;
+        }
+        for (uint64_t i = 0; i < seq.literals_len; i++) {
+            d.bytes[seq.literals_dst + i] = stream[seq.literals_src + i];
+        }
+        for (uint64_t i = 0; i < seq.match_len; i++) {
+            d.bytes[seq.match_dst + i] = d.bytes[seq.match_src + i];
+        }
+        if (done) {
+            break;
+        }
+    }
+    d.ok = true;
+    d.size = static_cast<size_t>(parser.dst_pos);
+    return d;
+}
+
+Decoded OracleDecode(const unsigned char* stream, size_t stream_size,
+                     size_t capacity) {
+    Decoded d{false, 0, nullptr};
+    d.bytes = std::make_unique<unsigned char[]>(capacity);
+    std::memset(d.bytes.get(), 0, capacity);
+    if (stream_size == 0) {
+        return d; /* never hand liblz4 a null source pointer */
+    }
+    const int written = LZ4_decompress_safe(
+        reinterpret_cast<const char*>(stream),
+        reinterpret_cast<char*>(d.bytes.get()), static_cast<int>(stream_size),
+        static_cast<int>(capacity));
+    if (written < 0) {
+        return d;
+    }
+    d.ok = true;
+    d.size = static_cast<size_t>(written);
+    return d;
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    /* The fuzzer controls the output capacity as well as the stream: with a
+     * fixed capacity, CUDEC_ERR_OUTPUT_TOO_SMALL swamps the corpus and the
+     * deeper reject branches stay unreached. Two header bytes, then the
+     * stream. Both sides are handed the identical capacity. */
+    if (size < 2) {
+        return 0;
+    }
+    const size_t capacity =
+        (static_cast<size_t>(data[0]) << 8 | static_cast<size_t>(data[1])) %
+        (kMaxCapacity + 1);
+    const uint8_t* body = data + 2;
+    size_t body_size = size - 2;
+    if (body_size > kMaxStream) {
+        body_size = kMaxStream;
+    }
+
+    /* Tight copy of the stream: an over-read past the last byte must land in
+     * an ASan redzone, not in slack the allocator happened to round up. */
+    auto tight = std::make_unique<unsigned char[]>(body_size);
+    if (body_size != 0) {
+        std::memcpy(tight.get(), body, body_size);
+    }
+
+    const Decoded twin = TwinDecode(tight.get(), body_size, capacity);
+    const Decoded oracle = OracleDecode(tight.get(), body_size, capacity);
+
+#ifdef CUDEC_FUZZ_SELFTEST_BREAK
+    /* Off by default, and the only way to prove the comparison below is live:
+     * a second binary built with this defined perturbs an accepted output, so
+     * a harness that had silently stopped comparing would pass where this one
+     * traps. Never define it in a build whose findings are being believed. */
+    if (twin.ok && twin.size != 0) {
+        const_cast<Decoded&>(twin).bytes[0] ^= 0xFFu;
+    }
+#endif
+
+    if (!twin.ok) {
+        return 0; /* the twin may be stricter; that direction is not asserted */
+    }
+    if (!oracle.ok) {
+        std::fprintf(stderr,
+                     "FAIL-OPEN: twin accepted (%zu bytes) a stream liblz4 "
+                     "rejected; capacity=%zu stream=%zu\n",
+                     twin.size, capacity, body_size);
+        __builtin_trap();
+    }
+    if (twin.size != oracle.size) {
+        std::fprintf(stderr,
+                     "SIZE DIVERGENCE: twin=%zu oracle=%zu capacity=%zu "
+                     "stream=%zu\n",
+                     twin.size, oracle.size, capacity, body_size);
+        __builtin_trap();
+    }
+    if (twin.size != 0 &&
+        std::memcmp(twin.bytes.get(), oracle.bytes.get(), twin.size) != 0) {
+        std::fprintf(stderr,
+                     "BYTE DIVERGENCE: %zu bytes, capacity=%zu stream=%zu\n",
+                     twin.size, capacity, body_size);
+        __builtin_trap();
+    }
+    return 0;
+}
+
+/* Built and run so far without a CMake seam, because no machine available to
+ * this work has CMake and Clang together. The exact invocation that produced
+ * the findings recorded on issue #140, against the liblz4 release tarball
+ * pinned in tests/CMakeLists.txt and hash-verified before use:
+ *
+ *   clang -std=c11 -O2 -g -fsanitize=address,undefined \
+ *     -fno-sanitize-recover=all -isystem lz4-1.10.0/lib \
+ *     -c lz4-1.10.0/lib/lz4.c -o lz4_oracle.o
+ *   clang++ -std=c++17 -g -O1 -fsanitize=fuzzer,address,undefined \
+ *     -fno-sanitize-recover=all -I include -I src \
+ *     -isystem lz4-1.10.0/lib -o fuzz_lz4_block \
+ *     fuzz/fuzz_lz4_block.cpp lz4_oracle.o
+ *
+ * The CMake option that replaces it, and the committed seed corpus, are what
+ * issue #140 still owes.
+ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,41 +6,13 @@
 # source - a system copy must never silently substitute for it.
 set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
 
-# liblz4, pinned by the SHA-256 of the maintainer-uploaded release asset
-# (self-computed at pin time and cross-checked against conan-center; the
-# auto-generated /archive/ tarballs are avoided - GitHub regenerated them
-# in 2023 and their hashes moved). Test-only dependency: the link
-# allowlist below keeps it out of the library.
+# liblz4 and its two oracle targets, lz4_oracle and lz4_frame_oracle. The
+# declaration moved to cmake/CudecLz4Oracle.cmake when fuzz/ became a second
+# consumer of the same pin (issue #140): FetchContent lets the first
+# declaration win in silence, so two copies of the URL and hash could drift
+# with nothing to say which one the build used.
 include(FetchContent)
-FetchContent_Declare(
-  lz4
-  URL https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz
-  URL_HASH
-    SHA256=537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
-  DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
-FetchContent_MakeAvailable(lz4)
-
-# The uploaded tarball has no top-level CMakeLists (lz4's lives in
-# build/cmake), so MakeAvailable only populates the source tree; we compile
-# the one translation unit the block-format oracle needs and depend on
-# nothing of lz4's build system. SYSTEM include + none of our strict flags:
-# third-party code is audited by hash, not reformatted.
-add_library(lz4_oracle STATIC ${lz4_SOURCE_DIR}/lib/lz4.c)
-target_include_directories(lz4_oracle SYSTEM PUBLIC ${lz4_SOURCE_DIR}/lib)
-
-# The frame oracle adds liblz4's frame API and xxHash (the checksum the
-# frame format uses) - the reference the cudec frame decoder is held to.
-add_library(
-  lz4_frame_oracle STATIC
-  ${lz4_SOURCE_DIR}/lib/lz4.c ${lz4_SOURCE_DIR}/lib/lz4hc.c
-  ${lz4_SOURCE_DIR}/lib/lz4frame.c ${lz4_SOURCE_DIR}/lib/xxhash.c)
-target_include_directories(lz4_frame_oracle SYSTEM PUBLIC
-                           ${lz4_SOURCE_DIR}/lib)
-# -O2 unconditionally: the oracle is also the bench harness's timed
-# decoder, and an empty CMAKE_BUILD_TYPE (the documented container
-# command) would otherwise time -O0 reference code. Correctness is
-# optimization-independent; honest numbers are not.
-target_compile_options(lz4_oracle PRIVATE -O2)
+include(${PROJECT_SOURCE_DIR}/cmake/CudecLz4Oracle.cmake)
 
 # google/snappy, the M3 oracle, pinned by the SHA-256 of the tag archive.
 # snappy publishes no maintainer-uploaded release asset, so this is the

--- a/tests/lz4_twin.h
+++ b/tests/lz4_twin.h
@@ -1,0 +1,81 @@
+/* The host reference driver for the LZ4 block parser: one copy, shared by
+ * the CPU twin test (tests/parser_twin.cpp) and the differential fuzz target
+ * (fuzz/fuzz_lz4_block.cpp), issue #140.
+ *
+ * It has to be one copy rather than two similar ones. The fuzz target and the
+ * twin test assert the same property against the same parser, so a second
+ * implementation could drift into asserting the property against a driver the
+ * test net never runs - a fuzzer that goes green about code nobody ships.
+ *
+ * Both buffers are allocated tight, which is the load-bearing part on a
+ * sanitized build: the stream copy puts an ASan redzone immediately after the
+ * last stream byte, so a parser over-read past src_size reds instead of
+ * landing in a vector's rounded-up slack, and the output buffer is exactly
+ * `capacity` bytes so a write past the declared capacity reds the same way.
+ *
+ * The match copy is the chasing byte copy - reads may land on just-written
+ * bytes, which is exactly LZ4's replication semantics for overlapping matches
+ * (and equivalent to the kernel's closed-form modular gather). */
+#ifndef CUDEC_TESTS_LZ4_TWIN_H
+#define CUDEC_TESTS_LZ4_TWIN_H
+
+#include "cudec.h"
+#include "lz4_block.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+
+namespace cudec_test {
+
+struct Lz4TwinResult {
+    cudec_status status;
+    /* Decoded byte count, meaningful only when status == CUDEC_OK. */
+    size_t size;
+    /* Exactly `capacity` bytes, always allocated: on a reject the caller may
+     * still want the partial writes the parser had already authorised. */
+    std::unique_ptr<unsigned char[]> bytes;
+};
+
+inline Lz4TwinResult Lz4TwinDecode(const unsigned char* stream,
+                                   size_t stream_size, size_t capacity) {
+    Lz4TwinResult result{CUDEC_OK, 0,
+                         std::make_unique<unsigned char[]>(capacity)};
+    if (capacity != 0) {
+        std::memset(result.bytes.get(), 0, capacity);
+    }
+
+    auto tight = std::make_unique<unsigned char[]>(stream_size);
+    if (stream_size != 0) {
+        std::memcpy(tight.get(), stream, stream_size);
+    }
+
+    cudec_detail::Lz4Parser parser{tight.get(), stream_size, capacity};
+    cudec_detail::Lz4Sequence sequence;
+    bool done = false;
+    while (true) {
+        const cudec_status status = parser.Next(&sequence, &done);
+        if (status != CUDEC_OK) {
+            result.status = status;
+            return result;
+        }
+        for (uint64_t i = 0; i < sequence.literals_len; i++) {
+            result.bytes[sequence.literals_dst + i] =
+                tight[sequence.literals_src + i];
+        }
+        for (uint64_t i = 0; i < sequence.match_len; i++) {
+            result.bytes[sequence.match_dst + i] =
+                result.bytes[sequence.match_src + i];
+        }
+        if (done) {
+            break;
+        }
+    }
+    result.size = static_cast<size_t>(parser.dst_pos);
+    return result;
+}
+
+}  // namespace cudec_test
+
+#endif /* CUDEC_TESTS_LZ4_TWIN_H */

--- a/tests/parser_twin.cpp
+++ b/tests/parser_twin.cpp
@@ -8,6 +8,7 @@
 #include "cudec.h"
 #include "fixtures.h"
 #include "lz4_block.h"
+#include "lz4_twin.h"
 #include "require.h"
 
 #include <cstdio>
@@ -18,45 +19,19 @@
 
 namespace {
 
-/* Sequential reference execution of the parsed sequences. The match copy
- * is the chasing byte copy - reads may land on just-written bytes, which
- * is exactly LZ4's replication semantics for overlapping matches (and
- * equivalent to the kernel's closed-form modular gather). */
+/* The vector-shaped call sites of this file over the shared driver in
+ * tests/lz4_twin.h, which is where the tight allocations and the sequential
+ * execution now live - one copy with the fuzz target (issue #140). On a
+ * reject `out` keeps the capacity-sized buffer with whatever the parser had
+ * already authorised, which is what the assertions below expect. */
 cudec_status TwinDecode(const std::vector<unsigned char>& stream,
                         size_t capacity, std::vector<unsigned char>* out) {
-    out->assign(capacity, 0);
-    /* Parse from an EXACTLY-sized copy of the stream: the mutation corpus
-     * truncates by resize()-DOWN, which leaves the vector's rounded-up
-     * capacity readable, so a src/lz4_block.h over-read past src_size would
-     * land in that slack and leave ASan green. A tight allocation puts an ASan
-     * redzone right after the last stream byte so the over-read reds instead.
-     * Literals are still executed from `stream` below, but only over the
-     * ranges the parser has already bound to <= src_size. */
-    const size_t stream_size = stream.size();
-    auto tight = std::make_unique<unsigned char[]>(stream_size);
-    if (stream_size != 0) {
-        std::memcpy(tight.get(), stream.data(), stream_size);
-    }
-    cudec_detail::Lz4Parser parser{tight.get(), stream_size, capacity};
-    cudec_detail::Lz4Sequence seq;
-    bool done = false;
-    while (true) {
-        const cudec_status status = parser.Next(&seq, &done);
-        if (status != CUDEC_OK) {
-            return status;
-        }
-        for (uint64_t i = 0; i < seq.literals_len; i++) {
-            (*out)[seq.literals_dst + i] = stream[seq.literals_src + i];
-        }
-        for (uint64_t i = 0; i < seq.match_len; i++) {
-            (*out)[seq.match_dst + i] = (*out)[seq.match_src + i];
-        }
-        if (done) {
-            break;
-        }
-    }
-    out->resize(parser.dst_pos);
-    return CUDEC_OK;
+    cudec_test::Lz4TwinResult decoded =
+        cudec_test::Lz4TwinDecode(stream.data(), stream.size(), capacity);
+    const size_t kept =
+        decoded.status == CUDEC_OK ? decoded.size : capacity;
+    out->assign(decoded.bytes.get(), decoded.bytes.get() + kept);
+    return decoded.status;
 }
 
 struct CraftedNegative {


### PR DESCRIPTION
# What & why

Closes #140.

A libFuzzer target that drives arbitrary bytes into `cudec_detail::Lz4Parser`
and compares the result in process against `LZ4_decompress_safe` at the
identical output capacity. Where the parser accepts, the reference must accept
the same bytes and report the same size. The opposite direction is not
asserted, because the parser is deliberately stricter than liblz4 in the
`offset == 0` family and `tests/parser_twin.cpp` pins that divergence;
asserting it would red on legitimate strictness.

The twin side is `tests/lz4_twin.h`, shared with `tests/parser_twin.cpp` rather
than copied. Two similar drivers could drift until the fuzz target is green
about a parser execution the test net never performs. The shared header also
owns the tight allocations, so the ASan redzone sits immediately after the last
stream byte and at the declared capacity for both callers instead of for
whichever one remembered to do it.

`CUDEC_FUZZ` is the build seam and it refuses twice. Without `CUDEC_SANITIZE`,
because `-fsanitize=fuzzer` alone builds a fuzzer that cannot see an
out-of-bounds access while reading exactly like one that can. Without a Clang
host toolchain, because libFuzzer ships with Clang and a GCC configure would
otherwise fail at the link with nothing saying why. It reuses `CUDEC_SANITIZE`'s
sanitizer set rather than declaring a second spelling of the same question,
adds `-fsanitize=fuzzer` only under the `C,CXX` generator expression the
sanitizer flags already carry, and registers no ctest entry: a fuzz run is
unbounded, every ctest entry in this tree owes a finite TIMEOUT (#72), and
`fuzz/` is processed after the sweep that enforces that.

The liblz4 pin moved to `cmake/CudecLz4Oracle.cmake` because `fuzz/` is now a
second consumer of it. A second `FetchContent_Declare` for one name is not an
error, the first declaration wins in silence, so two copies of the URL and hash
could drift with nothing to report which one the build used.

The engine and structure decision #140 inherits from #69 is recorded here
rather than as a comment on #69, because #69 was closed on 2026-08-06 and a
plan posted under a closed issue is a plan nobody reads. It is the stated
default: libFuzzer, in process, one target per parser, the fuzzer choosing the
output capacity out of the first two input bytes so `CUDEC_ERR_OUTPUT_TOO_SMALL`
does not swamp the corpus, the stream bounded to 16 KiB, and the differential
oracle linked into the same binary. Nothing was deviated from, so nothing else
is owed here.

The seed corpus, the CI wiring and the regression-seed policy are not in this
change. They are #142.

## Type of change

- [x] Build / CI / supply chain
- [x] Refactor / code quality

## Engineering checklist

- [x] Fail-closed preserved. This change adds no parse or decode path. It
      changes how `tests/parser_twin.cpp` reaches the parser and not what the
      parser decides, and the twin's own status expectations are unchanged.
- [x] Oracle coverage. The target's whole content is the oracle comparison
      against `LZ4_decompress_safe` at a matched capacity, in the fail-open
      direction.
- [x] Determinism preserved. No decode path is touched.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      This change adds no CUDA call and no device code.
- [ ] An adversarial review (`/security-review`) was run.
- [ ] Review record.

No second reader stands behind this change and no review lens was run. The
evidence below is what stands in place of one, and it is stated as evidence
rather than as clearance.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

`fuzz/`, `cmake/`, `tests/lz4_twin.h` and the two CMakeLists are host-only.
`src/lz4_block.h` is unmodified by this branch, and the sanitizer route on this
machine is #258 in any case.

## Performance checklist

Not on the hot path. No decode code changes and no number is claimed.

## Quality checklist

- [x] Minimal. The harness lost its manual build instructions and its dead
      capacity modulo when the seam replaced them, and one driver replaced two.
- [x] Self-documenting.
- [ ] Conformance tests pass. Not run on this machine, for the reason under
      Verification.

## Verification

Run at `88aa5ac`. The Linux environment used below has Clang 18.1.3 and no
CMake; CMake 3.28.3 was added to it from Kitware's release tarball after
checking it against the SHA-256 the same release publishes:

```
sha256sum -c
  804d231460ab3c8b556a42d2660af4ac7a0e21c98a7f8ee3318a74b4a9a187a6
  cmake-3.28.3-linux-x86_64.tar.gz: OK
cmake version 3.28.3
Ubuntu clang version 18.1.3 (1ubuntu1)
```

The pinned liblz4 tarball already present in this checkout was checked against
the pin in `cmake/CudecLz4Oracle.cmake` before use, and handed to the configure
directly, so this run exercises the pin but not the download:

```
sha256sum -c
  537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
  lz4-1.10.0.tar.gz: OK
```

The seam configures and builds:

```
cmake -S . -B build-fuzz -DCUDEC_FUZZ=ON -DCUDEC_SANITIZE=address,undefined \
  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
  -DFETCHCONTENT_SOURCE_DIR_LZ4=<the extracted tarball above>
-- Configuring done (2.2s)
-- Generating done (0.0s)
configure exit=0

cmake --build build-fuzz -j 6
[100%] Built target fuzz_lz4_block
[100%] Built target fuzz_lz4_block_selftest
build exit=0
```

The sanitizer runtime is in the binary rather than assumed to be, the same
check the `sanitize` job makes:

```
nm build-fuzz/fuzz/fuzz_lz4_block | grep -c __asan_report
48
```

The parity comparison is live, shown by the second binary the seam builds. Its
only difference is that it perturbs an accepted oracle output, so a harness
that had silently stopped comparing would run to the time limit instead:

```
./fuzz_lz4_block_selftest ~/corpus -max_total_time=30 -max_len=4096
BYTE DIVERGENCE: 1 bytes, capacity=2577 stream=2
SUMMARY: libFuzzer: deadly signal
stat::number_of_executed_units: 9
exit=77
```

The real binary, run against this branch's parser, stops on #315 within a
minute. That is the same defect the harness found before it had a build seam,
and it is not fixed here:

```
./fuzz_lz4_block ~/corpus -max_total_time=90 -max_len=4096
FAIL-OPEN: twin accepted (0 bytes) a stream liblz4 rejected; capacity=0 stream=1
SUMMARY: libFuzzer: deadly signal
stat::number_of_executed_units: 305
exit=77
```

So that the run is not left at "it reds on a known open defect", the same
sources were rebuilt with the `src/lz4_block.h` from #316 shadowing the
mainline header on the include path only. Nothing of #316 is in this branch and
nothing was written into the tree:

```
clang++ -std=c++17 -g -O1 -fsanitize=fuzzer,address,undefined \
  -fno-sanitize-recover=all -fno-omit-frame-pointer -Wall -Wextra -Werror \
  -I <the #316 header> -I include -I src -I tests -isystem <lz4>/lib \
  -o fuzz_lz4_block_pr316 fuzz/fuzz_lz4_block.cpp build-fuzz/fuzz/liblz4_oracle.a

./fuzz_lz4_block_pr316 ~/corpus -max_total_time=300 -max_len=4096
Done 12103613 runs in 301 second(s)
stat::number_of_executed_units: 12103613
stat::average_exec_per_sec:     40211
stat::peak_rss_mb:              458
exit=0
```

Twelve million executions, no divergence and no sanitizer report. Read as what
it is: 301 seconds is a smoke run, not a campaign, and it says nothing about
inputs the engine did not reach.

Both refusals were exercised on a GCC host, which is also what shows the
messages are the ones a reader would get:

```
cmake -S . -B a -DCUDEC_FUZZ=ON
CMake Error at CMakeLists.txt:360 (message):
  CUDEC_FUZZ needs CUDEC_SANITIZE set (e.g.
  -DCUDEC_SANITIZE=address,undefined): -fsanitize=fuzzer alone builds a
  fuzzer that cannot see an out-of-bounds access, which is most of what
  fuzzing this parser is for.

cmake -S . -B b -DCUDEC_FUZZ=ON -DCUDEC_SANITIZE=address,undefined
CMake Error at CMakeLists.txt:369 (message):
  CUDEC_FUZZ requires a Clang host toolchain (libFuzzer ships with Clang; got
  'GNU').  Configure with -DCMAKE_C_COMPILER=clang
  -DCMAKE_CXX_COMPILER=clang++.
```

A configure that asks for none of it is unaffected:

```
cmake -S . -B c && cmake --build c
-- Configuring done (43.8s)
[ 66%] Built target cudec
[100%] Built target example_decode_frame
```

Prettier is clean:

```
npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
All matched files use Prettier code style!
```

- [x] Builds clean, in the two configurations above.
- [ ] `ctest` green. Not run anywhere for this branch, and this is the gap in
      the local evidence. `tests/` is only configured under
      `CUDEC_ENABLE_CUDA=ON`, which needs a CUDA toolchain; this machine has
      none outside the pinned container, and the container was not running for
      this work. So the `tests/CMakeLists.txt` and `tests/parser_twin.cpp`
      halves of this change were compiled by nothing here. The `build` and
      `sanitize` jobs configure with `CUDEC_ENABLE_CUDA=ON` and run
      `parser_twin`, the second of them under ASan and UBSan, so that is where
      the refactor is judged. This is not merged before both are green.
- [x] Prettier clean.
- [x] Docs synced. No behaviour, API or performance change to record.

## Notes

The 300-second clean run is against a header this branch does not contain. On
this branch alone the target reds, on #315, which is open with a fix in #316.
That is the harness working, not the harness failing, but it does mean anyone
running `fuzz_lz4_block` before #316 lands will meet that trap first.

`fuzz_lz4_block_selftest` is built by every fuzz configure and is never the
binary whose findings are read. It exists so the comparison can be shown to
bite without waiting for a real divergence to turn up.
