### PR TITLE
Add the differential libFuzzer target over the Snappy parser

### DIFF
--- a/cmake/CudecSnappyOracle.cmake
+++ b/cmake/CudecSnappyOracle.cmake
@@ -1,0 +1,103 @@
+# The google/snappy oracle, in one place because two directories need it: the
+# test net under tests/ and the fuzz targets under fuzz/ (issue #90). The same
+# reasoning as cmake/CudecLz4Oracle.cmake, and for the same hazard: a second
+# FetchContent_Declare under one name is not an error, the first declaration
+# wins in silence, so two copies of the pin could drift with nothing to report
+# which one the build used.
+include_guard(GLOBAL)
+
+# Supply chain: the hash-verified archive is the only acceptable oracle
+# source. Stated here as well as in tests/CMakeLists.txt because whichever
+# directory reaches this file first is the one that fetches.
+set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
+include(FetchContent)
+
+# The M3 oracle, pinned by the SHA-256 of the tag archive. snappy publishes no
+# maintainer-uploaded release asset, so this is the fallback the pinning
+# policy names (docs/MASTERPLAN.md section 5): the auto-generated archive,
+# pinned, with a future hash mismatch read as the invariant working rather
+# than as noise. Cross-checked at pin time against a second packaging
+# ecosystem each - the SHA-256 against the Homebrew formula, the SHA-512
+# 0c1e1019e1bec9281f9877996d896e59e1533456130143224acb9cbfc35c1b0dd9de0a76e4a36494844d9ec58c295eed8c50bdf6dbabe47cf679652eb24b1281
+# against vcpkg (conan-center only reaches 1.2.1). 1108618 bytes.
+set(CUDEC_SNAPPY_VERSION 1.2.2)
+FetchContent_Declare(
+  snappy
+  URL https://github.com/google/snappy/archive/refs/tags/${CUDEC_SNAPPY_VERSION}.tar.gz
+  URL_HASH
+    SHA256=90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc
+  # snappy, unlike lz4, DOES ship a top-level CMakeLists.txt, and pointing
+  # MakeAvailable at a directory that holds none is what keeps that build out
+  # of this tree: one oracle target over the sources the decode path needs,
+  # never the project's own build system, which would bring its tests, its
+  # install rules and its generated config.h with it.
+  SOURCE_SUBDIR cudec-uses-no-snappy-cmake
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+FetchContent_MakeAvailable(snappy)
+# And the same statement as a check rather than as a comment: snappy's build
+# system defines this target, so its presence means the line above stopped
+# working - a newer snappy layout, or a MakeAvailable that stopped honouring
+# SOURCE_SUBDIR.
+if(TARGET snappy)
+  message(
+    FATAL_ERROR
+      "snappy's own build system was added to this tree - the oracle rule is "
+      "one target over the translation units the decode path needs "
+      "(docs/MASTERPLAN.md section 5)")
+endif()
+
+# The source directory as a cache entry, because the guard above means only
+# the first directory to include this file evaluates it: a later includer sees
+# the targets, which are global, but not FetchContent's directory-scoped
+# variables. tests/ reads this for snappy's own testdata corpus.
+set(CUDEC_SNAPPY_SOURCE_DIR "${snappy_SOURCE_DIR}" CACHE INTERNAL
+                                                          "snappy source tree")
+
+# snappy.h includes snappy-stubs-public.h, which snappy generates from a .in
+# at configure time; generated here instead, with the four substitutions it
+# has and nothing else. config.h stays undefined: every reference to it in
+# these translation units sits behind `#if HAVE_CONFIG_H`, so the platform
+# detection falls back to the compiler's own macros rather than to a header
+# this project would have to keep true.
+#
+# A function, not inline code: the .in names ${PROJECT_VERSION_MAJOR} and its
+# siblings, which are CMake's own variables for the enclosing project, and
+# setting them for the rest of this directory to satisfy a third-party
+# template is a trap for whoever reads one later.
+function(cudec_generate_snappy_stubs version out_dir)
+  string(REPLACE "." ";" _parts "${version}")
+  list(LENGTH _parts _count)
+  if(NOT _count EQUAL 3)
+    message(FATAL_ERROR "the snappy pin '${version}' is not major.minor.patch "
+                        "- the version macros cannot be derived from it")
+  endif()
+  list(GET _parts 0 PROJECT_VERSION_MAJOR)
+  list(GET _parts 1 PROJECT_VERSION_MINOR)
+  list(GET _parts 2 PROJECT_VERSION_PATCH)
+  # 1 for the Linux container this builds in, which is where iovec lives. On a
+  # host without sys/uio.h the header defines its own, so the 0 case is real
+  # code and not a fallback that has to be added later.
+  set(HAVE_SYS_UIO_H_01 1)
+  # No @ONLY: the template's placeholders are ${...}, which is exactly what
+  # the default substitution reads.
+  configure_file(${snappy_SOURCE_DIR}/snappy-stubs-public.h.in
+                 ${out_dir}/snappy-stubs-public.h)
+endfunction()
+set(_snappy_generated_dir ${CMAKE_CURRENT_BINARY_DIR}/snappy-generated)
+cudec_generate_snappy_stubs(${CUDEC_SNAPPY_VERSION} ${_snappy_generated_dir})
+
+# Two translation units, which is the whole decode path: snappy.cc, and
+# snappy-sinksource.cc for the ByteArraySource the Source-taking calls read
+# through. snappy-stubs-internal.cc carries none of it. SYSTEM include and
+# none of the project's strict flags, the rule lz4_oracle follows for the
+# same reason - third-party code is audited by hash, not reformatted.
+add_library(snappy_oracle STATIC ${snappy_SOURCE_DIR}/snappy.cc
+                                 ${snappy_SOURCE_DIR}/snappy-sinksource.cc)
+target_include_directories(snappy_oracle SYSTEM PUBLIC ${snappy_SOURCE_DIR}
+                                                       ${_snappy_generated_dir})
+set_target_properties(snappy_oracle PROPERTIES CXX_STANDARD 11
+                                               CXX_STANDARD_REQUIRED ON)
+# -O2 for the same reason lz4_oracle carries it: the documented container
+# command sets no CMAKE_BUILD_TYPE, and the reference decoder runs over whole
+# corpora during fixture generation.
+target_compile_options(snappy_oracle PRIVATE -O2)

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -10,6 +10,7 @@
 # the timeout sweep has run, so a test added here would escape it entirely.
 
 include(${PROJECT_SOURCE_DIR}/cmake/CudecLz4Oracle.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/CudecSnappyOracle.cmake)
 
 function(cudec_add_fuzz_target name)
   cmake_parse_arguments(F "" "" "SOURCES;LIBS" ${ARGN})
@@ -49,4 +50,12 @@ cudec_add_fuzz_target(fuzz_lz4_block SOURCES fuzz_lz4_block.cpp LIBS
 cudec_add_fuzz_target(fuzz_lz4_block_selftest SOURCES fuzz_lz4_block.cpp LIBS
                       lz4_oracle)
 target_compile_definitions(fuzz_lz4_block_selftest
+                           PRIVATE CUDEC_FUZZ_SELFTEST_BREAK)
+
+# The Snappy pair (issue #90), the same two binaries for the same two reasons.
+cudec_add_fuzz_target(fuzz_snappy_block SOURCES fuzz_snappy_block.cpp LIBS
+                      snappy_oracle)
+cudec_add_fuzz_target(fuzz_snappy_block_selftest SOURCES fuzz_snappy_block.cpp
+                      LIBS snappy_oracle)
+target_compile_definitions(fuzz_snappy_block_selftest
                            PRIVATE CUDEC_FUZZ_SELFTEST_BREAK)

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,68 @@
+# The fuzz targets
+
+Differential libFuzzer targets over the format parsers. Each one drives
+arbitrary bytes into the single-sourced parser from `src/`, runs the same host
+driver the CPU twin test runs, and compares the result in process against the
+hash-pinned reference decoder.
+
+| target              | parser               | reference                                    |
+| ------------------- | -------------------- | -------------------------------------------- |
+| `fuzz_lz4_block`    | `src/lz4_block.h`    | `LZ4_decompress_safe`, liblz4 1.10.0         |
+| `fuzz_snappy_block` | `src/snappy_block.h` | `snappy::RawUncompress`, google/snappy 1.2.2 |
+
+The property each target asserts is the fail-open direction: where the parser
+accepts, the reference must accept the same bytes and produce the identical
+output and size. The opposite direction is not asserted, because a parser that
+is stricter than its reference is the fail-closed contract working. Where a
+deliberate strictness exists it is pinned in the twin test rather than here
+(`tests/parser_twin.cpp` holds the LZ4 `offset == 0` family).
+
+The Snappy target asserts one thing more, and it is the one a verdict cannot
+carry: the driver counts every element the parser handed back that a caller
+could not have executed without leaving its buffers, and that count must stay
+zero whatever the verdict is. A reject that arrived only after an over-read is
+still an over-read.
+
+## Building and running
+
+The build is opt-in, needs Clang, and refuses to build a fuzzer without
+sanitizers:
+
+```
+cmake -B build-fuzz -DCUDEC_FUZZ=ON -DCUDEC_SANITIZE=address,undefined \
+  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+cmake --build build-fuzz
+build-fuzz/fuzz/fuzz_lz4_block <corpus-dir> -max_total_time=60 -max_len=4096
+```
+
+No target is registered as a ctest entry. A fuzz run is unbounded and every
+ctest entry in this tree owes a finite timeout.
+
+## The selftest binaries
+
+Every target is built twice. The `_selftest` twin is the same source with
+`CUDEC_FUZZ_SELFTEST_BREAK` defined, which perturbs an accepted reference
+output so the comparison must fire. It is what shows the comparison is live
+without waiting for a real divergence to turn up, and it is never the binary
+whose findings are read. A `_selftest` binary that runs to its time limit
+instead of trapping means the harness has stopped comparing.
+
+## Regression seeds
+
+An input that ever crashed a target, tripped a sanitizer, or diverged from a
+reference is kept forever. It is not enough to fix the parser and move on: the
+input that found the defect is the only proof the fix holds, and a fuzzer
+reseeded from scratch may take a very long time to find it again.
+
+Two artifacts per finding, and one of them is not optional:
+
+- The input becomes a permanent seed in the committed corpus.
+- The same bytes become a negative in `tests/` pinning the exact status the
+  parser now returns, so the non-fuzz gate covers it too. A corpus entry alone
+  is covered only while the fuzz job runs; a pinned negative is covered on
+  every pull request.
+
+The committed corpus, its integrity check and the CI wiring that runs these
+targets are issue #142. Until that lands, a target is run from a corpus
+directory the runner supplies, and a finding is recorded on its issue with the
+input in it.

--- a/fuzz/fuzz_snappy_block.cpp
+++ b/fuzz/fuzz_snappy_block.cpp
@@ -1,0 +1,151 @@
+/* Differential fuzz target over the Snappy element parser (issue #90), the
+ * sibling of fuzz_lz4_block.cpp and built to the shape that one settled.
+ *
+ * Two properties, and the second is the one a parity comparison cannot see.
+ *
+ * Parity, in the fail-open direction: whenever the twin ACCEPTS, snappy must
+ * accept the same bytes and produce the identical output and size. The other
+ * direction is not asserted here. The twin is not knowingly stricter than
+ * snappy anywhere - tests/snappy_parser_twin.cpp requires its
+ * stricter-than-oracle count over the mutation corpus to be zero - but a
+ * fuzzer reaching bytes that corpus never produced is exactly where a
+ * legitimate strictness could first appear, and trapping on one would say
+ * "fail-open" about the opposite of a fail-open.
+ *
+ * Bounds, unconditionally: the driver counts every element the caller could
+ * not have executed without leaving its buffers, every cursor left outside
+ * its own bounds, and every parse that did not terminate. That count must
+ * stay zero whatever the verdict is, because a rejected stream whose reject
+ * arrived only after an over-read is still an over-read.
+ *
+ * The whole input is the stream. Unlike the LZ4 block format, a Snappy stream
+ * carries its own uncompressed length, so there is no capacity to fuzz
+ * alongside it: both sides size the destination from the declaration and
+ * refuse the same declarations above the same bound.
+ */
+#include "cudec.h"
+#include "snappy_twin.h"
+
+#include "snappy.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace {
+
+/* The shared refusal both sides apply. A stream may declare up to 4 GiB - 1
+ * of output and a mutated one will, so it is bounded here rather than
+ * allocated; the number is this harness's and not snappy's, and it is handed
+ * to the twin as its capacity so the two refuse the same declarations for the
+ * same reason. Well below tests/fixtures.h's 256 MiB, because a fuzzer that
+ * spends its time in a quarter-gigabyte memset explores nothing. */
+constexpr uint64_t kMaxDeclared = 1u << 22;
+
+/* Bounded so libFuzzer explores the parser rather than the allocator. */
+constexpr size_t kMaxStream = 1u << 14;
+
+struct Decoded {
+    bool ok;
+    std::vector<unsigned char> bytes;
+};
+
+/* snappy's exact-consume, exact-produce decode, under this harness's bound.
+ * The same shape as SnappyOracleDecodes in tests/fixtures.cpp, restated here
+ * for the same reason the LZ4 target calls LZ4_decompress_safe directly: the
+ * fuzz binary links the oracle, not the test-fixture library. */
+Decoded OracleDecode(const unsigned char* stream, size_t stream_size) {
+    Decoded decoded{false, {}};
+    if (stream_size == 0) {
+        return decoded; /* never hand snappy a null source pointer */
+    }
+    const char* src = reinterpret_cast<const char*>(stream);
+    size_t declared = 0;
+    if (!snappy::GetUncompressedLength(src, stream_size, &declared)) {
+        return decoded;
+    }
+    if (declared > kMaxDeclared) {
+        return decoded;
+    }
+    decoded.bytes.assign(declared, 0);
+    if (!snappy::RawUncompress(src, stream_size,
+                               reinterpret_cast<char*>(decoded.bytes.data()))) {
+        /* A rejected stream produces no output: a caller that reads the
+         * buffer after a false verdict must find nothing to mistake for one. */
+        decoded.bytes.clear();
+        return decoded;
+    }
+    decoded.ok = true;
+    return decoded;
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    size_t stream_size = size;
+    if (stream_size > kMaxStream) {
+        stream_size = kMaxStream;
+    }
+
+    /* libFuzzer hands out a slice of a buffer sized to -max_len, not to this
+     * input, so a read past `stream_size` would land in that slack and stay
+     * green. Both sides run over one exactly-sized copy instead. The twin
+     * driver tightens again internally, which is its own guarantee to its
+     * other caller. */
+    auto stream = std::make_unique<unsigned char[]>(stream_size);
+    if (stream_size != 0) {
+        std::memcpy(stream.get(), data, stream_size);
+    }
+
+    cudec_test::SnappyTwinObserver observer;
+    std::vector<unsigned char> twin_bytes;
+    const cudec_status twin = cudec_test::SnappyTwinDecode(
+        stream.get(), stream_size, kMaxDeclared, &twin_bytes, &observer);
+    Decoded oracle = OracleDecode(stream.get(), stream_size);
+
+#ifdef CUDEC_FUZZ_SELFTEST_BREAK
+    /* Off by default, and the only way to prove the comparisons below are
+     * live without waiting for a real divergence: a second binary built with
+     * this defined perturbs an accepted oracle output, so a harness that had
+     * silently stopped comparing would pass where this one traps. Never
+     * define it in a build whose findings are being believed. */
+    if (oracle.ok && !oracle.bytes.empty()) {
+        oracle.bytes[0] ^= 0xFFu;
+    }
+#endif
+
+    if (observer.bounds_violations != 0) {
+        std::fprintf(stderr,
+                     "BOUNDS VIOLATION: %zu on a %zu-byte stream (status %d)\n",
+                     observer.bounds_violations, stream_size,
+                     static_cast<int>(twin));
+        __builtin_trap();
+    }
+    if (twin != CUDEC_OK) {
+        return 0; /* the stricter direction is not asserted */
+    }
+    if (!oracle.ok) {
+        std::fprintf(stderr,
+                     "FAIL-OPEN: twin accepted (%zu bytes) a stream snappy "
+                     "rejected; stream=%zu\n",
+                     twin_bytes.size(), stream_size);
+        __builtin_trap();
+    }
+    if (twin_bytes.size() != oracle.bytes.size()) {
+        std::fprintf(stderr,
+                     "SIZE DIVERGENCE: twin=%zu oracle=%zu stream=%zu\n",
+                     twin_bytes.size(), oracle.bytes.size(), stream_size);
+        __builtin_trap();
+    }
+    if (!twin_bytes.empty() &&
+        std::memcmp(twin_bytes.data(), oracle.bytes.data(),
+                    twin_bytes.size()) != 0) {
+        std::fprintf(stderr, "BYTE DIVERGENCE: %zu bytes, stream=%zu\n",
+                     twin_bytes.size(), stream_size);
+        __builtin_trap();
+    }
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,89 +14,10 @@ set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
 include(FetchContent)
 include(${PROJECT_SOURCE_DIR}/cmake/CudecLz4Oracle.cmake)
 
-# google/snappy, the M3 oracle, pinned by the SHA-256 of the tag archive.
-# snappy publishes no maintainer-uploaded release asset, so this is the
-# fallback the pinning policy names (docs/MASTERPLAN.md section 5): the
-# auto-generated archive, pinned, with a future hash mismatch read as the
-# invariant working rather than as noise. Cross-checked at pin time against a
-# second packaging ecosystem each - the SHA-256 against the Homebrew formula,
-# the SHA-512
-# 0c1e1019e1bec9281f9877996d896e59e1533456130143224acb9cbfc35c1b0dd9de0a76e4a36494844d9ec58c295eed8c50bdf6dbabe47cf679652eb24b1281
-# against vcpkg (conan-center only reaches 1.2.1). 1108618 bytes.
-set(CUDEC_SNAPPY_VERSION 1.2.2)
-FetchContent_Declare(
-  snappy
-  URL https://github.com/google/snappy/archive/refs/tags/${CUDEC_SNAPPY_VERSION}.tar.gz
-  URL_HASH
-    SHA256=90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc
-  # snappy, unlike lz4, DOES ship a top-level CMakeLists.txt, and pointing
-  # MakeAvailable at a directory that holds none is what keeps that build out
-  # of this tree: one oracle target over the sources the decode path needs,
-  # never the project's own build system, which would bring its tests, its
-  # install rules and its generated config.h with it.
-  SOURCE_SUBDIR cudec-uses-no-snappy-cmake
-  DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
-FetchContent_MakeAvailable(snappy)
-# And the same statement as a check rather than as a comment: snappy's build
-# system defines this target, so its presence means the line above stopped
-# working - a newer snappy layout, or a MakeAvailable that stopped honouring
-# SOURCE_SUBDIR.
-if(TARGET snappy)
-  message(
-    FATAL_ERROR
-      "snappy's own build system was added to this tree - the oracle rule is "
-      "one target over the translation units the decode path needs "
-      "(docs/MASTERPLAN.md section 5)")
-endif()
-
-# snappy.h includes snappy-stubs-public.h, which snappy generates from a .in
-# at configure time; generated here instead, with the four substitutions it
-# has and nothing else. config.h stays undefined: every reference to it in
-# these translation units sits behind `#if HAVE_CONFIG_H`, so the platform
-# detection falls back to the compiler's own macros rather than to a header
-# this project would have to keep true.
-#
-# A function, not inline code: the .in names ${PROJECT_VERSION_MAJOR} and its
-# siblings, which are CMake's own variables for the enclosing project, and
-# setting them for the rest of this directory to satisfy a third-party
-# template is a trap for whoever reads one later.
-function(cudec_generate_snappy_stubs version out_dir)
-  string(REPLACE "." ";" _parts "${version}")
-  list(LENGTH _parts _count)
-  if(NOT _count EQUAL 3)
-    message(FATAL_ERROR "the snappy pin '${version}' is not major.minor.patch "
-                        "- the version macros cannot be derived from it")
-  endif()
-  list(GET _parts 0 PROJECT_VERSION_MAJOR)
-  list(GET _parts 1 PROJECT_VERSION_MINOR)
-  list(GET _parts 2 PROJECT_VERSION_PATCH)
-  # 1 for the Linux container this builds in, which is where iovec lives. On a
-  # host without sys/uio.h the header defines its own, so the 0 case is real
-  # code and not a fallback that has to be added later.
-  set(HAVE_SYS_UIO_H_01 1)
-  # No @ONLY: the template's placeholders are ${...}, which is exactly what
-  # the default substitution reads.
-  configure_file(${snappy_SOURCE_DIR}/snappy-stubs-public.h.in
-                 ${out_dir}/snappy-stubs-public.h)
-endfunction()
-set(_snappy_generated_dir ${CMAKE_CURRENT_BINARY_DIR}/snappy-generated)
-cudec_generate_snappy_stubs(${CUDEC_SNAPPY_VERSION} ${_snappy_generated_dir})
-
-# Two translation units, which is the whole decode path: snappy.cc, and
-# snappy-sinksource.cc for the ByteArraySource the Source-taking calls read
-# through. snappy-stubs-internal.cc carries none of it. SYSTEM include and
-# none of the project's strict flags, the rule lz4_oracle follows for the
-# same reason - third-party code is audited by hash, not reformatted.
-add_library(snappy_oracle STATIC ${snappy_SOURCE_DIR}/snappy.cc
-                                 ${snappy_SOURCE_DIR}/snappy-sinksource.cc)
-target_include_directories(snappy_oracle SYSTEM PUBLIC ${snappy_SOURCE_DIR}
-                                                       ${_snappy_generated_dir})
-set_target_properties(snappy_oracle PROPERTIES CXX_STANDARD 11
-                                               CXX_STANDARD_REQUIRED ON)
-# -O2 for the same reason lz4_oracle carries it: the documented container
-# command sets no CMAKE_BUILD_TYPE, and the reference decoder runs over whole
-# corpora during fixture generation.
-target_compile_options(snappy_oracle PRIVATE -O2)
+# google/snappy and its snappy_oracle target. The declaration moved to
+# cmake/CudecSnappyOracle.cmake when fuzz/ became a second consumer of the
+# same pin (issue #90), for the reason the liblz4 include above carries.
+include(${PROJECT_SOURCE_DIR}/cmake/CudecSnappyOracle.cmake)
 
 # facebook/zstd, the M5 oracle, pinned by the SHA-256 of the
 # MAINTAINER-UPLOADED release asset - the shape the pinning policy prefers and
@@ -343,7 +264,7 @@ target_include_directories(snappy_upstream_negatives
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_compile_definitions(
   snappy_upstream_negatives
-  PRIVATE CUDEC_SNAPPY_TESTDATA_DIR="${snappy_SOURCE_DIR}/testdata")
+  PRIVATE CUDEC_SNAPPY_TESTDATA_DIR="${CUDEC_SNAPPY_SOURCE_DIR}/testdata")
 # The other half of "single-source host AND device" (issue #171): the twin
 # above compiles src/snappy_block.h with the host compiler and this one hands
 # the same header to nvcc, then requires the two to produce an identical

--- a/tests/snappy_parser_twin.cpp
+++ b/tests/snappy_parser_twin.cpp
@@ -17,6 +17,7 @@
 #include "fixtures.h"
 #include "require.h"
 #include "snappy_block.h"
+#include "snappy_twin.h"
 
 #include <cstdio>
 #include <cstring>
@@ -28,25 +29,22 @@ namespace {
 
 using Bytes = std::vector<unsigned char>;
 
-/* Counts elements the parser handed back that the caller could not have
- * executed without leaving its buffers, and cursors left outside their own
- * bounds. main() requires it to be zero; the status Drive returns is left
- * alone, so a violation cannot be swallowed by a parity comparison that
- * only reads verdicts.
+/* The driver's own two counters, in the shared header that owns the driver
+ * (tests/snappy_twin.h). main() requires the bounds count to be zero; the
+ * status the driver returns is left alone, so a violation cannot be swallowed
+ * by a parity comparison that only reads verdicts. The references keep this
+ * file's call sites reading as they did before the driver moved out.
  *
- * It exists because a verdict alone cannot prove a bounds guard. Removing
- * the check that a long-form literal's length bytes are present, or that a
- * copy's offset bytes are, still rejects every crafted stream: the cursor
- * runs past the source end, the next subtraction wraps, and a later branch
- * catches it after the read has already happened. What the guard actually
- * prevents is that read, so that is what is counted. Measured - three of
- * those removals left a verdict-only suite green. */
-size_t g_bounds_violations = 0;
-
-/* Which ladder branch refused last, recorded wherever a driver sees a reject.
- * Diagnostic: it says which rung, where the returned status only says that
- * some rung refused, and eight of the crafted negatives share one status. */
-cudec_detail::SnappyReject g_last_reject = cudec_detail::kSnappyRejectNone;
+ * Why a count rather than a status: a verdict alone cannot prove a bounds
+ * guard. Removing the check that a long-form literal's length bytes are
+ * present, or that a copy's offset bytes are, still rejects every crafted
+ * stream - the cursor runs past the source end, the next subtraction wraps,
+ * and a later branch catches it after the read has already happened. What the
+ * guard actually prevents is that read, so that is what is counted. Measured,
+ * three of those removals left a verdict-only suite green. */
+cudec_test::SnappyTwinObserver g_twin;
+size_t& g_bounds_violations = g_twin.bounds_violations;
+cudec_detail::SnappyReject& g_last_reject = g_twin.last_reject;
 
 void ObserveReject(cudec_detail::SnappyReject branch) {
     g_last_reject = branch;
@@ -73,113 +71,20 @@ void CoverBranch(cudec_detail::SnappyReject branch) {
     }
 }
 
-/* Sequential reference execution of the parsed elements. A copy is the
- * chasing byte copy - reads may land on just-written bytes, which is the
- * pattern-repeating semantics an overlapping Snappy copy has. */
+/* The two vector-shaped entries this file uses, over the shared driver in
+ * tests/snappy_twin.h - one copy with the fuzz target (issue #90). The
+ * capacity bound handed to the whole-stream entry is the harness bound rather
+ * than the declaration itself: that is the same refusal SnappyOracleDecodes
+ * applies, so a mutant declaring 4 GiB is refused on both sides for the same
+ * reason instead of reading as a parity failure. */
 cudec_status Drive(const unsigned char* src, uint64_t src_size,
                    uint64_t capacity, Bytes* out) {
-    out->assign(static_cast<size_t>(capacity), 0);
-    cudec_detail::SnappyParser parser{src, src_size, capacity};
-    cudec_detail::SnappyElement element;
-    bool done = false;
-    /* Fuel, for the same reason every driver loop in this tree carries one:
-     * a parser that stops making progress must red the run rather than hang
-     * it. Every non-terminal call consumes at least one source byte, so one
-     * call per byte plus the terminal one is more than a live parser needs. */
-    uint64_t fuel = src_size + 2;
-    while (true) {
-        if (fuel-- == 0) {
-            std::fprintf(stderr, "the parser did not terminate on a %llu-byte "
-                                 "stream\n",
-                         static_cast<unsigned long long>(src_size));
-            g_bounds_violations++;
-            out->clear();
-            return CUDEC_ERR_CORRUPT_INPUT;
-        }
-        const cudec_status status = parser.Next(&element, &done);
-        if (status != CUDEC_OK) {
-            /* A rejected stream produces nothing, the same contract
-             * SnappyOracleDecodes holds its caller to. */
-            ObserveReject(parser.reject);
-            out->clear();
-            return status;
-        }
-        /* Both cursors stay inside their buffers, the produced length stays
-         * inside the declaration, and the element lies inside what the
-         * parser says it produced. A literal's source range is inside the
-         * stream; a copy reaches strictly backwards, which is what makes the
-         * chasing read below defined. */
-        const bool bounded =
-            parser.src_pos <= parser.src_size &&
-            parser.dst_pos <= parser.declared &&
-            parser.declared <= capacity &&
-            element.to + element.length <= parser.dst_pos &&
-            (element.is_copy ? element.from < element.to
-                             : element.from + element.length <=
-                                   parser.src_pos);
-        if (!bounded) {
-            std::fprintf(stderr,
-                         "the parser left its bounds: src_pos=%llu/%llu "
-                         "dst_pos=%llu/%llu element from=%llu to=%llu len=%llu "
-                         "copy=%d\n",
-                         static_cast<unsigned long long>(parser.src_pos),
-                         static_cast<unsigned long long>(parser.src_size),
-                         static_cast<unsigned long long>(parser.dst_pos),
-                         static_cast<unsigned long long>(parser.declared),
-                         static_cast<unsigned long long>(element.from),
-                         static_cast<unsigned long long>(element.to),
-                         static_cast<unsigned long long>(element.length),
-                         element.is_copy ? 1 : 0);
-            g_bounds_violations++;
-            out->clear();
-            return CUDEC_ERR_CORRUPT_INPUT;
-        }
-        if (element.is_copy) {
-            for (uint64_t i = 0; i < element.length; i++) {
-                (*out)[static_cast<size_t>(element.to + i)] =
-                    (*out)[static_cast<size_t>(element.from + i)];
-            }
-        } else {
-            for (uint64_t i = 0; i < element.length; i++) {
-                (*out)[static_cast<size_t>(element.to + i)] =
-                    src[element.from + i];
-            }
-        }
-        if (done) {
-            break;
-        }
-    }
-    out->resize(static_cast<size_t>(parser.dst_pos));
-    return CUDEC_OK;
+    return cudec_test::SnappyTwinDrive(src, src_size, capacity, out, &g_twin);
 }
 
-/* Parse from an EXACTLY-sized copy of the stream, as TwinDecode in
- * tests/parser_twin.cpp does: the mutation corpus truncates by
- * resize()-DOWN, which leaves the vector's rounded-up capacity readable, so
- * an over-read past src_size would land in that slack and leave ASan green.
- * A tight allocation puts a redzone right after the last stream byte. */
 cudec_status TwinDecode(const Bytes& stream, Bytes* out) {
-    out->clear();
-    const size_t stream_size = stream.size();
-    auto tight = std::make_unique<unsigned char[]>(stream_size);
-    if (stream_size != 0) {
-        std::memcpy(tight.get(), stream.data(), stream_size);
-    }
-    /* The declaration is read through the parser's own Begin, so the varint
-     * is parsed once and the destination is sized from a value that has
-     * already been compared against a capacity. The capacity here is the
-     * harness bound rather than the declaration itself: that is the same
-     * refusal SnappyOracleDecodes applies, so a mutant declaring 4 GiB is
-     * refused on both sides for the same reason instead of reading as a
-     * parity failure. */
-    cudec_detail::SnappyParser probe{tight.get(), stream_size,
-                                     kSnappyOracleMaxOutput};
-    const cudec_status header = probe.Begin();
-    if (header != CUDEC_OK) {
-        ObserveReject(probe.reject);
-        return header;
-    }
-    return Drive(tight.get(), stream_size, probe.declared, out);
+    return cudec_test::SnappyTwinDecode(stream.data(), stream.size(),
+                                        kSnappyOracleMaxOutput, out, &g_twin);
 }
 
 /* Drives the parser for its liveness contract alone, producing nothing.

--- a/tests/snappy_twin.h
+++ b/tests/snappy_twin.h
@@ -1,0 +1,165 @@
+/* The host reference driver for the Snappy element parser: one copy, shared
+ * by the CPU twin test (tests/snappy_parser_twin.cpp) and the differential
+ * fuzz target (fuzz/fuzz_snappy_block.cpp), issue #90. The LZ4 pair took the
+ * same shape first, in tests/lz4_twin.h (issue #140), and for the same
+ * reason: two similar drivers can drift until the fuzz target is green about
+ * a parser execution the test net never performs.
+ *
+ * What the driver carries with it, so neither caller has to remember it:
+ *
+ * The tight stream copy. A parse runs from an exactly-sized allocation, so an
+ * over-read past src_size lands in an ASan redzone instead of in a vector's
+ * rounded-up slack or in a fuzzer's input buffer.
+ *
+ * The fuel bound. A parser that stops making progress must red the run rather
+ * than hang it. Every non-terminal call consumes at least one source byte, so
+ * one call per byte plus the terminal one is more than a live parser needs.
+ *
+ * The bounds count. A verdict alone cannot prove a bounds guard: removing the
+ * check that a long-form literal's length bytes are present still rejects
+ * every crafted stream, because the cursor runs past the source end, the next
+ * subtraction wraps, and a later branch catches it after the read has already
+ * happened. What the guard prevents is that read, so that is what is counted,
+ * separately from the status. Measured - three such removals left a
+ * verdict-only suite green.
+ *
+ * The match copy is the chasing byte copy: reads may land on just-written
+ * bytes, which is the pattern-repeating semantics an overlapping Snappy copy
+ * has. */
+#ifndef CUDEC_TESTS_SNAPPY_TWIN_H
+#define CUDEC_TESTS_SNAPPY_TWIN_H
+
+#include "cudec.h"
+#include "snappy_block.h"
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace cudec_test {
+
+/* What a driver run reports beside its status. It is an out-parameter rather
+ * than a return value because both callers accumulate across many runs: the
+ * twin test requires the total to be zero at the end, and the fuzz target
+ * traps on the first one. */
+struct SnappyTwinObserver {
+    /* Elements the parser handed back that the caller could not have
+     * executed without leaving its buffers, cursors left outside their own
+     * bounds, and parses that did not terminate. */
+    size_t bounds_violations = 0;
+    /* Which ladder branch refused last. Diagnostic: the returned status only
+     * says that some rung refused, and several crafted negatives share one
+     * status. */
+    cudec_detail::SnappyReject last_reject = cudec_detail::kSnappyRejectNone;
+};
+
+/* Sequential reference execution of the parsed elements at a caller-chosen
+ * capacity. `src` must already be an exactly-sized allocation. */
+inline cudec_status SnappyTwinDrive(const unsigned char* src,
+                                    uint64_t src_size, uint64_t capacity,
+                                    std::vector<unsigned char>* out,
+                                    SnappyTwinObserver* observer) {
+    out->assign(static_cast<size_t>(capacity), 0);
+    cudec_detail::SnappyParser parser{src, src_size, capacity};
+    cudec_detail::SnappyElement element;
+    bool done = false;
+    uint64_t fuel = src_size + 2;
+    while (true) {
+        if (fuel-- == 0) {
+            std::fprintf(stderr,
+                         "the parser did not terminate on a %llu-byte "
+                         "stream\n",
+                         static_cast<unsigned long long>(src_size));
+            observer->bounds_violations++;
+            out->clear();
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        const cudec_status status = parser.Next(&element, &done);
+        if (status != CUDEC_OK) {
+            /* A rejected stream produces nothing, the same contract the
+             * snappy oracle wrapper holds its caller to. */
+            observer->last_reject = parser.reject;
+            out->clear();
+            return status;
+        }
+        /* Both cursors stay inside their buffers, the produced length stays
+         * inside the declaration, and the element lies inside what the
+         * parser says it produced. A literal's source range is inside the
+         * stream; a copy reaches strictly backwards, which is what makes the
+         * chasing read below defined. */
+        const bool bounded =
+            parser.src_pos <= parser.src_size &&
+            parser.dst_pos <= parser.declared &&
+            parser.declared <= capacity &&
+            element.to + element.length <= parser.dst_pos &&
+            (element.is_copy ? element.from < element.to
+                             : element.from + element.length <=
+                                   parser.src_pos);
+        if (!bounded) {
+            std::fprintf(stderr,
+                         "the parser left its bounds: src_pos=%llu/%llu "
+                         "dst_pos=%llu/%llu element from=%llu to=%llu len=%llu "
+                         "copy=%d\n",
+                         static_cast<unsigned long long>(parser.src_pos),
+                         static_cast<unsigned long long>(parser.src_size),
+                         static_cast<unsigned long long>(parser.dst_pos),
+                         static_cast<unsigned long long>(parser.declared),
+                         static_cast<unsigned long long>(element.from),
+                         static_cast<unsigned long long>(element.to),
+                         static_cast<unsigned long long>(element.length),
+                         element.is_copy ? 1 : 0);
+            observer->bounds_violations++;
+            out->clear();
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        if (element.is_copy) {
+            for (uint64_t i = 0; i < element.length; i++) {
+                (*out)[static_cast<size_t>(element.to + i)] =
+                    (*out)[static_cast<size_t>(element.from + i)];
+            }
+        } else {
+            for (uint64_t i = 0; i < element.length; i++) {
+                (*out)[static_cast<size_t>(element.to + i)] =
+                    src[element.from + i];
+            }
+        }
+        if (done) {
+            break;
+        }
+    }
+    out->resize(static_cast<size_t>(parser.dst_pos));
+    return CUDEC_OK;
+}
+
+/* The whole-stream entry: size the destination from the stream's own
+ * declaration, the way the snappy oracle wrapper does, so a mutant declaring
+ * 4 GiB is refused on both sides for the same reason instead of reading as a
+ * parity failure. `capacity_bound` is that shared refusal and belongs to the
+ * caller, because the two callers allocate under different limits. */
+inline cudec_status SnappyTwinDecode(const unsigned char* stream,
+                                     size_t stream_size,
+                                     uint64_t capacity_bound,
+                                     std::vector<unsigned char>* out,
+                                     SnappyTwinObserver* observer) {
+    out->clear();
+    auto tight = std::make_unique<unsigned char[]>(stream_size);
+    if (stream_size != 0) {
+        std::memcpy(tight.get(), stream, stream_size);
+    }
+    /* The declaration is read through the parser's own Begin, so the varint
+     * is parsed once and the destination is sized from a value that has
+     * already been compared against a capacity. */
+    cudec_detail::SnappyParser probe{tight.get(), stream_size, capacity_bound};
+    const cudec_status header = probe.Begin();
+    if (header != CUDEC_OK) {
+        observer->last_reject = probe.reject;
+        return header;
+    }
+    return SnappyTwinDrive(tight.get(), stream_size, probe.declared, out,
+                           observer);
+}
+
+}  // namespace cudec_test
+
+#endif /* CUDEC_TESTS_SNAPPY_TWIN_H */


### PR DESCRIPTION
# What & why

Closes #90.

The differential fuzz net reaches the second shipped format. A libFuzzer target
drives arbitrary bytes into `cudec_detail::SnappyParser` and compares the
result in process against `snappy::RawUncompress`: where the parser accepts,
snappy must accept the same bytes and report the same size.

The stricter direction is not asserted. The twin is not knowingly stricter than
snappy anywhere, `tests/snappy_parser_twin.cpp` requires its
stricter-than-oracle count over the mutation corpus to be zero, but a fuzzer
reaching bytes that corpus never produced is exactly where a legitimate
strictness would first appear, and trapping on one would report a fail-open
about the opposite of a fail-open.

It asserts one thing the LZ4 target has no equivalent of, because the Snappy
driver already counted it: elements the caller could not have executed without
leaving its buffers, cursors left outside their own bounds, and parses that did
not terminate. That count must stay zero whatever the verdict is. A reject that
arrived only after an over-read is still an over-read, and three guard removals
were measured to leave a verdict-only suite green.

The driver moved to `tests/snappy_twin.h` and is one copy shared with the twin
test, the shape `tests/lz4_twin.h` took in #140. Its two counters moved with
it, so a caller cannot forget them. `snappy_parser_twin.cpp` keeps its own
names as references onto the shared observer, which leaves every call site in
it reading as it did.

The snappy pin moved to `cmake/CudecSnappyOracle.cmake`, beside the liblz4 one
and for the same hazard: `fuzz/` is a second consumer, and a second
`FetchContent_Declare` under one name lets the first declaration win in
silence. The source directory is exported as a cache entry because the include
guard means only the first includer evaluates the file, and `tests/` reads that
path for snappy's own testdata corpus.

There is no capacity to fuzz alongside the bytes. A Snappy stream declares its
own uncompressed length, so both sides size the destination from the
declaration and refuse the same declarations above one shared bound.

`fuzz/README.md` carries the second acceptance criterion, the regression-seed
discipline, for both targets rather than for this one: a found input becomes a
permanent corpus seed and a pinned-status negative in `tests/`, because a
corpus entry is covered only while the fuzz job runs and a pinned negative is
covered on every pull request.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Build / CI / supply chain
- [x] Refactor / code quality

## Engineering checklist

- [x] Fail-closed preserved. No parse or decode path is added or changed. The
      change moves how `snappy_parser_twin` reaches the parser, not what the
      parser decides, and its status expectations, branch coverage set and
      bounds count are unchanged.
- [x] Oracle coverage. The target's whole content is the oracle comparison
      against `snappy::RawUncompress`, in the fail-open direction, plus the
      unconditional bounds count.
- [x] Determinism preserved. No decode path is touched.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      This change adds no CUDA call and no device code.
- [ ] An adversarial review (`/security-review`) was run.
- [ ] Review record.

No second reader stands behind this change and no review lens was run. The
evidence below is what stands in place of one, and it is stated as evidence
rather than as clearance.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

`src/snappy_block.h` is unmodified by this branch. The sanitizer route on this
machine is #258 in any case.

## Performance checklist

Not on the hot path. No decode code changes and no number is claimed.

## Quality checklist

- [x] Minimal. One driver replaced two, and the fuzz target restates only the
      oracle wrapper, for the reason the LZ4 target calls
      `LZ4_decompress_safe` directly: the fuzz binary links the oracle, not the
      test-fixture library.
- [x] Self-documenting.
- [ ] Conformance tests pass. Not run on this machine, for the reason under
      Verification.

## Verification

Run at `437dfd0`, in a Linux environment with Clang 18.1.3 and CMake 3.28.3
added from Kitware's release tarball after checking it against the SHA-256 that
release publishes. Both pinned archives were checked by hand before use and
handed to the configure directly, so this run exercises the pins but not the
downloads:

```
sha256sum -c
  537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
  lz4-1.10.0.tar.gz: OK
  90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc
  snappy-1.2.2.tar.gz: OK
```

The four targets configure and build:

```
cmake -S . -B build-fuzz2 -DCUDEC_FUZZ=ON -DCUDEC_SANITIZE=address,undefined \
  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
  -DFETCHCONTENT_SOURCE_DIR_LZ4=<extracted> -DFETCHCONTENT_SOURCE_DIR_SNAPPY=<extracted>
-- Configuring done (2.3s)
configure exit=0

cmake --build build-fuzz2 -j 6
[100%] Built target fuzz_snappy_block
[100%] Built target fuzz_snappy_block_selftest
[100%] Built target fuzz_lz4_block_selftest
[100%] Built target fuzz_lz4_block
build exit=0
```

The comparison is live, shown by the selftest twin. Its only difference is that
it perturbs an accepted reference output:

```
./fuzz_snappy_block_selftest ~/corpus-snappy -max_total_time=30 -max_len=4096
BYTE DIVERGENCE: 5 bytes, stream=7
SUMMARY: libFuzzer: deadly signal
stat::number_of_executed_units: 2
exit=77
```

The initial bounded run this issue asks for. Seeds are snappy's own three
bad-data vectors out of the pinned archive's `testdata`, plus two hand-built
valid streams, one a five-byte literal block and one a literal followed by a
two-byte-offset copy:

```
seeds: 5
./fuzz_snappy_block ~/corpus-snappy -max_total_time=300 -max_len=4096
Done 1978488 runs in 301 second(s)
stat::number_of_executed_units: 1978488
stat::average_exec_per_sec:     6573
stat::new_units_added:          895
stat::peak_rss_mb:              477
exit=0
```

Just under two million executions, zero fail-opens, zero bounds violations, no
sanitizer report. Read as what it is: 301 seconds is a smoke run, not a
campaign, and it says nothing about inputs the engine did not reach.

A configure that asks for none of it is unaffected:

```
cmake -S . -B h && cmake --build h
-- Configuring done (34.0s)
[ 66%] Built target cudec
[100%] Built target example_decode_frame
```

Prettier is clean:

```
npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
All matched files use Prettier code style!
```

- [x] Builds clean, in both configurations above.
- [ ] `ctest` green. Not run anywhere for this branch, and this is the gap in
      the local evidence. `tests/` is only configured under
      `CUDEC_ENABLE_CUDA=ON`, which needs a CUDA toolchain this machine has
      only inside the pinned container, and the container was not available for
      this work. So the `tests/CMakeLists.txt` and `tests/snappy_parser_twin.cpp`
      halves were compiled by nothing here. The `build` and `sanitize` jobs
      configure with `CUDEC_ENABLE_CUDA=ON` and run `snappy_parser_twin`, the
      second under ASan and UBSan, so that is where the driver move is judged.
      This is not merged before both are green.
- [x] Prettier clean.
- [x] Docs synced. `fuzz/README.md` is added by this change; no behaviour, API
      or performance change to record elsewhere.

## Notes

`fuzz_lz4_block` still reds on #315 within a minute, unchanged by this branch
and recorded in #317. Anyone running the LZ4 target before #316 lands meets
that trap first; the Snappy target is unaffected by it.

The committed seed corpus, its integrity check and the CI wiring for these
targets are #142, which is blocked behind #315 for the same reason: a fuzz job
added to the mainline today would red every pull request on a defect that is
already fixed in an open branch.
