### PR TITLE
Parse and validate the GDeflate TileStream envelope on the host [#174]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,7 @@ jobs:
           grep -E ': oracle_lz4$' host-selected.txt &&
           grep -E ': parser_twin$' host-selected.txt &&
           grep -E ': snappy_parser_twin$' host-selected.txt &&
+          grep -E ': tilestream_host_negative$' host-selected.txt &&
           grep -E ': termination$' host-selected.txt &&
           grep -E ': launch_fail$' host-selected.txt &&
           grep -E ': bench_selfcheck$' host-selected.txt &&
@@ -431,6 +432,7 @@ jobs:
           test -x build-san/tests/parser_twin &&
           test -x build-san/tests/snappy_parser_twin &&
           test -x build-san/tests/frame_host_negative &&
+          test -x build-san/tests/tilestream_host_negative &&
           test -x build-san/tests/termination
 
       # Prove the sanitizer runtimes are actually linked: a dropped or renamed
@@ -452,7 +454,7 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|zstd_frame_twin|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|zstd_frame_twin|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
@@ -462,6 +464,7 @@ jobs:
           grep -E ': snappy_edge_sweep$' san-selected.txt &&
           grep -E ': snappy_upstream_negatives$' san-selected.txt &&
           grep -E ': frame_host_negative$' san-selected.txt &&
+          grep -E ': tilestream_host_negative$' san-selected.txt &&
           grep -E ': zstd_frame_twin$' san-selected.txt &&
           grep -E ': termination$' san-selected.txt
 

--- a/src/tilestream.h
+++ b/src/tilestream.h
@@ -1,0 +1,265 @@
+/* The GDeflate TileStream envelope parser (issue #174): a candidate byte
+ * range becomes a validated tile table - one offset and compressed size per
+ * tile, plus the total uncompressed size - or it is refused with a defined
+ * status. It decodes nothing, reads no tile payload, and touches no device.
+ * Internal header, not part of the ABI, the sibling of src/lz4_block.h,
+ * src/snappy_block.h and src/zstd_frame.h.
+ *
+ * WHY THE ENVELOPE IS A SEPARATE THING AT ALL. The page bitstream carries no
+ * uncompressed size and no checksum of any kind (MASTERPLAN section 11.4), so
+ * every bound a decoder has for a GDeflate tile comes from outside the bits.
+ * This container is where those bounds come from, which makes it the whole
+ * structural defence: a tile size this parser gets wrong is a bound the kernel
+ * then enforces against the wrong number. Nothing downstream can re-derive it.
+ *
+ * NOTHING IS SIZED FROM THE STREAM BEFORE IT IS BOUNDED. The table of contents
+ * length is derived from a declared tile count, so the count is bounded and
+ * the declared table is checked against the bytes actually present before a
+ * single table entry is read. Every derived size is computed in uint64_t: the
+ * largest total this container can describe is 65535 * 65536 bytes, which is
+ * inside a uint32_t by 65536 bytes and would be one careless addition away
+ * from wrapping there.
+ *
+ * A SINGLE-SOURCED HEADER RATHER THAN THE .h/.cpp PAIR THE ISSUE NAMED. Every
+ * format parser in this tree is a header (lz4_block, snappy_block,
+ * zstd_frame); the .cpp files under src/ are host orchestration that the CUDA
+ * build adds to the library. A tilestream.cpp would have to join that list to
+ * be compiled at all, which is the one build where this parser is not wanted -
+ * it is host-only by design so the GPU-less runner and the sanitizer gate both
+ * reach it. Header-only keeps it in every translation unit that asks for it
+ * and adds no library membership question. The ABI entry that will link it is
+ * issue #177.
+ *
+ * FIELD LAYOUT PROVENANCE, STATED RATHER THAN IMPLIED. The header and table
+ * layout below is issue #174's statement of the DirectStorage TileStream
+ * container, not a quotation from a specification this repository holds - the
+ * dossier records that enveloping is external and does not pin this container
+ * (MASTERPLAN section 11.4). Pinning these facts against the oracle and the
+ * real DirectStorage vectors is issues #170 and #169; until those land, this
+ * parser is self-consistent and unconfirmed, and a divergence they find is a
+ * defect here rather than in them. */
+#ifndef CUDEC_TILESTREAM_H
+#define CUDEC_TILESTREAM_H
+
+#include "cudec.h"
+
+#include <stdint.h>
+
+namespace cudec_detail {
+
+/* The one tile size this container may declare. tileSizeIdx is a 2-bit field
+ * with four spellings and exactly one of them is decodable here; the other
+ * three are refused rather than mapped onto a default. */
+constexpr uint64_t kTileStreamTileSize = 65536;
+constexpr uint32_t kTileStreamTileSizeIdx64K = 1;
+
+/* 8 bytes: id, magic, a 16-bit tile count, and one packed 32-bit word. */
+constexpr uint64_t kTileStreamHeaderBytes = 8;
+constexpr uint64_t kTileStreamTocEntryBytes = 4;
+
+/* The declared tile count is a uint16, so this is the field's own ceiling and
+ * not a policy this parser applies. It is asserted rather than re-checked at
+ * run time: a runtime branch on it could never be reached, and a guard no
+ * input can reach is a guard nothing proves. What the total-size arithmetic
+ * actually rests on is this equality, so this is where it is pinned. */
+constexpr uint64_t kTileStreamMaxTiles = 65535;
+static_assert(kTileStreamMaxTiles == UINT16_MAX,
+              "the tile-count ceiling is the declared field's width; the "
+              "total-size arithmetic below is overflow-free only because of "
+              "it");
+
+/* One validated tile: where its compressed bytes start in the stream, how
+ * many there are, and how many bytes it must produce. Every field is derived
+ * and checked; none is copied out of the stream unexamined. */
+struct TileStreamTile {
+    uint64_t src_off;
+    uint64_t src_size;
+    uint64_t dst_size;
+};
+
+/* The validated envelope. `tiles` is written by the caller's array, which is
+ * why the parse takes a capacity and refuses rather than allocating. */
+struct TileStreamInfo {
+    uint64_t tile_count;
+    uint64_t total_uncompressed;
+};
+
+inline uint16_t TileStreamRead16LE(const unsigned char* p) {
+    return static_cast<uint16_t>(static_cast<uint16_t>(p[0]) |
+                                 (static_cast<uint16_t>(p[1]) << 8));
+}
+
+inline uint32_t TileStreamRead32LE(const unsigned char* p) {
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) |
+           (static_cast<uint32_t>(p[3]) << 24);
+}
+
+/* Parses and validates the envelope at `stream[0 .. stream_size)`.
+ *
+ * On CUDEC_OK: *info holds the tile count and the total uncompressed size,
+ * and tiles[0 .. tile_count) hold the per-tile ranges, each one wholly inside
+ * the stream. On any other status nothing about *info or tiles[] is promised
+ * beyond that no read outside the stream was performed to produce it.
+ *
+ * CUDEC_ERR_INVALID_ARGUMENT is for the caller's own mistake - a null pointer,
+ * or a tile array too small for the count the stream declares. Everything the
+ * bytes get wrong is CUDEC_ERR_CORRUPT_INPUT. The container carries no
+ * optional features, so nothing here returns CUDEC_ERR_UNSUPPORTED: a
+ * tileSizeIdx this build cannot decode is refused as corrupt because the
+ * decision that only 64 KiB tiles exist is this parser's, and re-labelling it
+ * UNSUPPORTED would promise a caller a fallback path that has no meaning yet.
+ * That line moves the day a second tile size is real, and issue #177 is where
+ * it would move. */
+inline cudec_status TileStreamParse(const unsigned char* stream,
+                                    uint64_t stream_size,
+                                    TileStreamTile* tiles,
+                                    uint64_t tiles_capacity,
+                                    TileStreamInfo* info) {
+    if (stream == nullptr || tiles == nullptr || info == nullptr) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+
+    /* The header is read only after the bytes for it are known to be there.
+     * A stream shorter than 8 bytes has no tile count to trust, so there is
+     * nothing to derive a further bound from. */
+    if (stream_size < kTileStreamHeaderBytes) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+
+    const unsigned char id = stream[0];
+    const unsigned char magic = stream[1];
+    /* The container's only self-consistency check. It is one byte of
+     * redundancy and catches a range that was never a TileStream at all;
+     * it is not integrity, and nothing below treats it as such. */
+    if (id != static_cast<unsigned char>(magic ^ 0xFFu)) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+
+    const uint64_t tile_count = TileStreamRead16LE(stream + 2);
+    if (tile_count == 0) {
+        return CUDEC_ERR_CORRUPT_INPUT; /* an envelope describing nothing */
+    }
+
+    /* One 32-bit word, unpacked by shift and mask rather than read through a
+     * bitfield struct: bitfield allocation order is implementation-defined,
+     * so a struct would make this parser's acceptance depend on the compiler
+     * that built it. */
+    const uint32_t packed = TileStreamRead32LE(stream + 4);
+    const uint32_t tile_size_idx = packed & 0x3u;
+    const uint64_t last_tile_size = (packed >> 2) & 0x3FFFFu;
+    const uint32_t reserved = (packed >> 20) & 0xFFFu;
+
+    if (tile_size_idx != kTileStreamTileSizeIdx64K) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+    /* Reserved bits are refused rather than ignored. A future revision that
+     * gives them meaning must not decode here as if it had not: this parser
+     * would produce bytes under rules it has never read. */
+    if (reserved != 0) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+    /* The field is 18 bits and a tile is 65536 bytes, so the field can express
+     * sizes no tile can hold. Zero is the full-tile spelling. */
+    if (last_tile_size >= kTileStreamTileSize) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+
+    if (tiles_capacity < tile_count) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+
+    /* Now the table's own length is derivable, and it is checked against the
+     * bytes present before any entry is read. Both operands are bounded above
+     * (8 and 4 * 65535), so the sum cannot wrap. */
+    const uint64_t toc_bytes = tile_count * kTileStreamTocEntryBytes;
+    const uint64_t toc_end = kTileStreamHeaderBytes + toc_bytes;
+    if (stream_size < toc_end) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+
+    /* Entry 0 is the LAST tile's compressed size, not an offset - the table
+     * spends the slot tile 0 would need on the one size no following offset
+     * could imply. Tile 0's data therefore begins immediately after the table.
+     */
+    const uint64_t last_tile_src_size =
+        TileStreamRead32LE(stream + kTileStreamHeaderBytes);
+    /* A zero-byte tile is refused, here and by the strict monotonicity below.
+     * Every tile must produce at least one byte, and no bitstream produces a
+     * byte from no bytes; accepting one would hand the kernel a range it can
+     * only fail on later, further from the evidence. This is stricter than the
+     * container's own rules require, deliberately, and issue #179 is where it
+     * meets the real vectors. */
+    if (last_tile_src_size == 0) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+
+    /* Offsets first, as a chain: each one past the table and strictly above
+     * its predecessor. Strictness is what makes every derived size non-zero
+     * without a second subtraction to check.
+     *
+     * THERE IS DELIBERATELY NO PER-OFFSET `off < stream_size` CHECK HERE, and
+     * the reason is that it could not reject anything the end-of-stream check
+     * below does not. On an accepting path the last tile satisfies
+     * `off_last + src_size_last <= stream_size` with `src_size_last >= 1`, so
+     * `off_last < stream_size`; strict monotonicity puts every earlier offset
+     * below `off_last`. A per-offset check would therefore be a branch no
+     * input can reach as the sole cause of a refusal - unprovable by deleting
+     * it, which is the one thing a guard here has to be. The property it would
+     * have named is pinned by fixtures instead, in
+     * tests/tilestream_host_negative.cpp: an offset at the end of the stream
+     * and an offset at 0xFFFFFFFF are both refused with the branch absent.
+     *
+     * Nothing in this loop reads at `off`. The only reads are of the table,
+     * whose whole extent was bounded above. */
+    uint64_t prev_off = toc_end;
+    for (uint64_t i = 1; i < tile_count; i++) {
+        const uint64_t off = TileStreamRead32LE(
+            stream + kTileStreamHeaderBytes + i * kTileStreamTocEntryBytes);
+        if (off <= prev_off) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        tiles[i].src_off = off;
+        prev_off = off;
+    }
+
+    /* Sizes, derived from the chain. Every subtraction below is on a pair the
+     * loop above already ordered, so none of them can wrap. */
+    tiles[0].src_off = toc_end;
+    for (uint64_t i = 0; i + 1 < tile_count; i++) {
+        tiles[i].src_size = tiles[i + 1].src_off - tiles[i].src_off;
+    }
+    tiles[tile_count - 1].src_size = last_tile_src_size;
+
+    /* The last tile is the only one whose end is not implied by a following
+     * offset, so it is the only one that can run off the end of the stream.
+     * Checked with the addition on the left rather than a subtraction, and in
+     * uint64_t, so a 32-bit-sized size and a 32-bit-sized offset cannot meet
+     * above 4 GiB and wrap into a passing comparison. */
+    const uint64_t last_end =
+        tiles[tile_count - 1].src_off + tiles[tile_count - 1].src_size;
+    if (last_end > stream_size) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+
+    /* Output sizes: every tile is a full tile except possibly the last, and
+     * zero is the last one's full-tile spelling. */
+    for (uint64_t i = 0; i + 1 < tile_count; i++) {
+        tiles[i].dst_size = kTileStreamTileSize;
+    }
+    tiles[tile_count - 1].dst_size =
+        (last_tile_size == 0) ? kTileStreamTileSize : last_tile_size;
+
+    uint64_t total = tile_count * kTileStreamTileSize;
+    if (last_tile_size != 0) {
+        total -= (kTileStreamTileSize - last_tile_size);
+    }
+
+    info->tile_count = tile_count;
+    info->total_uncompressed = total;
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_TILESTREAM_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -344,6 +344,15 @@ target_include_directories(batch_limit_parity
 cudec_add_test(frame_host_negative SOURCES frame_host_negative.cpp)
 target_include_directories(frame_host_negative
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The GDeflate TileStream envelope's reject branches (issue #174), the same
+# shape and for the same reason: src/tilestream.h is pure host arithmetic over
+# a byte range, so the whole container ladder is gated on the GPU-less runner
+# and gets the ASan/UBSan pass over the pointer arithmetic a hostile envelope
+# drives. No oracle: this is fail-closed coverage, and parity against the real
+# DirectStorage vectors is issues #169 and #179.
+cudec_add_test(tilestream_host_negative SOURCES tilestream_host_negative.cpp)
+target_include_directories(tilestream_host_negative
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 # Termination as a tested invariant (issue #72): the parser's liveness
 # contract asserted per call over the truncation ladder, the mutant corpus,
 # the crafted hostile corpus, and the frame block-table walk - all of it

--- a/tests/tilestream_host_negative.cpp
+++ b/tests/tilestream_host_negative.cpp
@@ -1,0 +1,433 @@
+/* Every reject branch in src/tilestream.h, one crafted fixture each, plus a
+ * single-byte mutation sweep over the whole envelope of a valid stream
+ * (issue #174).
+ *
+ * No GPU and no CUDA call: the parser is pure host arithmetic over a byte
+ * range, so this runs on the GPU-less CI runner and, in the sanitizer build,
+ * puts ASan and UBSan over the pointer arithmetic that a hostile envelope
+ * drives. That is the point of splitting the envelope out of the kernel work -
+ * the container is where every bound the decoder later enforces comes from,
+ * and it is testable long before a tile can be decoded.
+ *
+ * It is a fail-closed test and not an oracle-parity one. Every crafted stream
+ * here is malformed by construction and its expected status is pinned; whether
+ * this parser agrees with the real DirectStorage container on well-formed
+ * input is issues #169 and #179, which have the vectors this does not.
+ *
+ * The sweep's property is the one a per-branch fixture cannot state: over
+ * every single-byte flip of a valid envelope's header and table, an ACCEPT is
+ * only ever allowed to describe tiles that lie inside the stream. A mutation
+ * that lands on a byte no rule reads may legitimately still parse, so the
+ * sweep asserts the invariant rather than the verdict.
+ *
+ * WHAT THIS FILE PROVES BY VERDICT AND WHAT IT LEAVES TO THE SANITIZER. Most
+ * of the parser's refusals change the answer when they are removed, so a
+ * fixture here reds without one. Three do not, and they are the three whose
+ * job is a BOUND rather than a policy: the 8-byte header length, the declared
+ * table length, and the non-zero tile count. Delete any of those and the next
+ * thing the parser does is read or index outside what it was given, which is
+ * not a verdict at all - it is undefined behaviour that may well still produce
+ * a refusal. The only mechanism that separates them is the ASan/UBSan build,
+ * so every stream in those three cases is handed over in an allocation exactly
+ * as long as the length the parser is told about. Nothing else in this file
+ * makes that leg load-bearing, and a longer buffer would quietly take it back
+ * out. */
+#include "require.h"
+#include "tilestream.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+using cudec_detail::kTileStreamHeaderBytes;
+using cudec_detail::kTileStreamTileSize;
+using cudec_detail::TileStreamInfo;
+using cudec_detail::TileStreamParse;
+using cudec_detail::TileStreamTile;
+
+using Bytes = std::vector<unsigned char>;
+
+void Put16(Bytes* b, uint16_t v) {
+    b->push_back(static_cast<unsigned char>(v & 0xFF));
+    b->push_back(static_cast<unsigned char>((v >> 8) & 0xFF));
+}
+
+void Put32(Bytes* b, uint32_t v) {
+    for (int i = 0; i < 4; i++) {
+        b->push_back(static_cast<unsigned char>((v >> (i * 8)) & 0xFF));
+    }
+}
+
+void Write32(Bytes* b, size_t at, uint32_t v) {
+    for (int i = 0; i < 4; i++) {
+        (*b)[at + static_cast<size_t>(i)] =
+            static_cast<unsigned char>((v >> (i * 8)) & 0xFF);
+    }
+}
+
+/* The packed word, assembled the way the parser unpacks it: 2 bits of tile
+ * size index, 18 of last-tile size, 12 reserved. */
+uint32_t Packed(uint32_t tile_size_idx, uint32_t last_tile_size,
+                uint32_t reserved) {
+    return (tile_size_idx & 0x3u) | ((last_tile_size & 0x3FFFFu) << 2) |
+           ((reserved & 0xFFFu) << 20);
+}
+
+constexpr unsigned char kMagic = 0xFB;
+constexpr unsigned char kId = static_cast<unsigned char>(kMagic ^ 0xFF);
+
+/* A well-formed envelope over `sizes`, one compressed size per tile, with the
+ * declared last-tile output size. The payload bytes are filler: this parser
+ * never reads them, and a test that made them meaningful would be asserting
+ * something it cannot check. */
+Bytes MakeEnvelope(const std::vector<uint32_t>& sizes,
+                   uint32_t last_tile_size) {
+    const uint16_t n = static_cast<uint16_t>(sizes.size());
+    Bytes b;
+    b.push_back(kId);
+    b.push_back(kMagic);
+    Put16(&b, n);
+    Put32(&b, Packed(1, last_tile_size, 0));
+
+    const uint32_t toc_end =
+        static_cast<uint32_t>(kTileStreamHeaderBytes) + 4u * n;
+    /* Entry 0 is the last tile's compressed size; entries 1..n-1 are offsets,
+     * accumulated from the end of the table. */
+    Put32(&b, sizes[sizes.size() - 1]);
+    uint32_t off = toc_end;
+    for (size_t i = 1; i < sizes.size(); i++) {
+        off += sizes[i - 1];
+        Put32(&b, off);
+    }
+    uint32_t payload = 0;
+    for (size_t i = 0; i < sizes.size(); i++) {
+        payload += sizes[i];
+    }
+    b.resize(toc_end + payload, 0xAB);
+    return b;
+}
+
+/* Offsets of the fields, for the crafted mutations below. */
+constexpr size_t kOffId = 0;
+constexpr size_t kOffPacked = 4;
+constexpr size_t kOffTileCount = 2;
+
+/* A copy of the first `n` bytes in an allocation that is exactly `n` bytes
+ * long, so a parser that read past the length it was handed reads past the
+ * ALLOCATION too and the sanitizer build says so.
+ *
+ * This matters more than it looks. Handing the parser a pointer into a longer
+ * buffer and a short length makes an over-read land on bytes that are still
+ * validly allocated: neither the verdict nor ASan can then distinguish a
+ * parser that respects the length from one that ignores it, and both
+ * length-derived bounds in src/tilestream.h - the 8-byte header and the
+ * declared table - are exactly the kind that can only be caught that way.
+ *
+ * A zero-length case still needs a non-null pointer, because a null one is the
+ * INVALID_ARGUMENT branch rather than the truncation branch. One spare byte is
+ * allocated for that case only, and the length passed is still zero. */
+class ExactBuffer {
+  public:
+    ExactBuffer(const Bytes& src, size_t n)
+        : bytes_(n == 0 ? 1 : n), size_(n) {
+        for (size_t i = 0; i < n; i++) {
+            bytes_[i] = src[i];
+        }
+    }
+    const unsigned char* data() const { return bytes_.data(); }
+    size_t size() const { return size_; }
+
+  private:
+    Bytes bytes_;
+    size_t size_;
+};
+
+cudec_status Parse(const Bytes& b, TileStreamInfo* info,
+                   std::vector<TileStreamTile>* tiles) {
+    tiles->assign(70000, TileStreamTile{0, 0, 0});
+    return TileStreamParse(b.data(), b.size(), tiles->data(), tiles->size(),
+                           info);
+}
+
+/* Every tile the parse reported must lie wholly inside the stream, and its
+ * output size must be a size a 64 KiB tile can hold. The sweep's invariant,
+ * factored out because the positive cases assert it too. */
+bool TilesAreInBounds(const std::vector<TileStreamTile>& tiles, uint64_t count,
+                      uint64_t stream_size) {
+    for (uint64_t i = 0; i < count; i++) {
+        if (tiles[i].src_size == 0) {
+            return false;
+        }
+        if (tiles[i].src_off > stream_size) {
+            return false;
+        }
+        if (tiles[i].src_size > stream_size - tiles[i].src_off) {
+            return false;
+        }
+        if (tiles[i].dst_size == 0 || tiles[i].dst_size > kTileStreamTileSize) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    TileStreamInfo info{};
+    std::vector<TileStreamTile> tiles;
+
+    /* ---- The positive cases first: a reject test whose "valid" stream is not
+     * actually valid proves nothing, because every negative below would then
+     * be rejected for the wrong reason. */
+    {
+        const Bytes one = MakeEnvelope({40}, 0);
+        REQUIRE(Parse(one, &info, &tiles) == CUDEC_OK);
+        REQUIRE(info.tile_count == 1);
+        REQUIRE(info.total_uncompressed == kTileStreamTileSize);
+        REQUIRE(tiles[0].src_off == kTileStreamHeaderBytes + 4);
+        REQUIRE(tiles[0].src_size == 40);
+        REQUIRE(tiles[0].dst_size == kTileStreamTileSize);
+        REQUIRE(TilesAreInBounds(tiles, info.tile_count, one.size()));
+    }
+    {
+        /* Three tiles with a short last one: the shape where every derivation
+         * differs from its neighbours - tile 0's offset is implicit, tile 1's
+         * size comes from the following offset, tile 2's from entry 0. */
+        const Bytes three = MakeEnvelope({10, 20, 30}, 1234);
+        REQUIRE(Parse(three, &info, &tiles) == CUDEC_OK);
+        REQUIRE(info.tile_count == 3);
+        REQUIRE(info.total_uncompressed == 2 * kTileStreamTileSize + 1234);
+        const uint64_t toc_end = kTileStreamHeaderBytes + 12;
+        REQUIRE(tiles[0].src_off == toc_end);
+        REQUIRE(tiles[0].src_size == 10);
+        REQUIRE(tiles[1].src_off == toc_end + 10);
+        REQUIRE(tiles[1].src_size == 20);
+        REQUIRE(tiles[2].src_off == toc_end + 30);
+        REQUIRE(tiles[2].src_size == 30);
+        REQUIRE(tiles[0].dst_size == kTileStreamTileSize);
+        REQUIRE(tiles[1].dst_size == kTileStreamTileSize);
+        REQUIRE(tiles[2].dst_size == 1234);
+        REQUIRE(TilesAreInBounds(tiles, info.tile_count, three.size()));
+    }
+    {
+        /* Trailing bytes after the last tile are not this parser's to refuse:
+         * the container says where tiles are, not that it ends with one. */
+        Bytes slack = MakeEnvelope({16}, 0);
+        slack.push_back(0x00);
+        REQUIRE(Parse(slack, &info, &tiles) == CUDEC_OK);
+        REQUIRE(TilesAreInBounds(tiles, info.tile_count, slack.size()));
+    }
+
+    /* ---- The caller's own mistakes: INVALID_ARGUMENT, not CORRUPT_INPUT.
+     * A caller cannot tell "your buffer is too small" from "these bytes are
+     * hostile" if both arrive as the same status. */
+    {
+        const Bytes v = MakeEnvelope({16}, 0);
+        REQUIRE(TileStreamParse(nullptr, v.size(), tiles.data(), tiles.size(),
+                                &info) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(TileStreamParse(v.data(), v.size(), nullptr, 4, &info) ==
+                CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(TileStreamParse(v.data(), v.size(), tiles.data(), tiles.size(),
+                                nullptr) == CUDEC_ERR_INVALID_ARGUMENT);
+        TileStreamTile one_slot{0, 0, 0};
+        const Bytes two = MakeEnvelope({8, 8}, 0);
+        REQUIRE(TileStreamParse(two.data(), two.size(), &one_slot, 1, &info) ==
+                CUDEC_ERR_INVALID_ARGUMENT);
+    }
+
+    /* ---- One crafted fixture per reject branch, each pinned to its status. */
+    {
+        /* Shorter than the 8-byte header, at every length below it, each in an
+         * allocation of exactly that length - see ExactBuffer for why the
+         * short-length-into-a-long-buffer spelling proves nothing here. */
+        const Bytes v = MakeEnvelope({16}, 0);
+        for (size_t n = 0; n < kTileStreamHeaderBytes; n++) {
+            const ExactBuffer buf(v, n);
+            REQUIRE_CTX(TileStreamParse(buf.data(), buf.size(), tiles.data(),
+                                        tiles.size(),
+                                        &info) == CUDEC_ERR_CORRUPT_INPUT,
+                        "header truncated to %zu bytes", n);
+        }
+    }
+    {
+        /* id != magic ^ 0xff. */
+        Bytes v = MakeEnvelope({16}, 0);
+        v[kOffId] = static_cast<unsigned char>(v[kOffId] ^ 0x01u);
+        REQUIRE(Parse(v, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+    }
+    {
+        /* numTiles == 0. */
+        Bytes v = MakeEnvelope({16}, 0);
+        v[kOffTileCount] = 0;
+        v[kOffTileCount + 1] = 0;
+        REQUIRE(Parse(v, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+    }
+    {
+        /* tileSizeIdx != 1, all three other spellings. */
+        for (uint32_t idx = 0; idx < 4; idx++) {
+            if (idx == 1) {
+                continue;
+            }
+            Bytes v = MakeEnvelope({16}, 0);
+            Write32(&v, kOffPacked, Packed(idx, 0, 0));
+            REQUIRE_CTX(Parse(v, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT,
+                        "tileSizeIdx=%u", idx);
+        }
+    }
+    {
+        /* Any reserved bit set. All twelve, one at a time: a mask that had
+         * lost a bit would still pass a single-bit fixture. */
+        for (uint32_t bit = 0; bit < 12; bit++) {
+            Bytes v = MakeEnvelope({16}, 0);
+            Write32(&v, kOffPacked, Packed(1, 0, 1u << bit));
+            REQUIRE_CTX(Parse(v, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT,
+                        "reserved bit %u", bit);
+        }
+    }
+    {
+        /* lastTileSize at and above the tile size, up to the field's width. */
+        const uint32_t cases[] = {65536, 65537, 0x3FFFF};
+        for (uint32_t last : cases) {
+            Bytes v = MakeEnvelope({16}, 0);
+            Write32(&v, kOffPacked, Packed(1, last, 0));
+            REQUIRE_CTX(Parse(v, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT,
+                        "lastTileSize=%u", last);
+        }
+    }
+    {
+        /* The declared table runs past the end of the stream. Exactly sized,
+         * for the reason ExactBuffer gives: a vector's allocation may be
+         * larger than its length, and an over-read into that slack is neither
+         * a wrong verdict nor a sanitizer report. */
+        Bytes v = MakeEnvelope({16}, 0);
+        v[kOffTileCount] = 0x10; /* 4112 tiles, table far beyond the bytes */
+        v[kOffTileCount + 1] = 0x10;
+        const ExactBuffer buf(v, v.size());
+        REQUIRE(TileStreamParse(buf.data(), buf.size(), tiles.data(),
+                                tiles.size(),
+                                &info) == CUDEC_ERR_CORRUPT_INPUT);
+    }
+    {
+        /* The last tile's compressed size is zero. */
+        Bytes v = MakeEnvelope({16}, 0);
+        Write32(&v, kTileStreamHeaderBytes, 0);
+        REQUIRE(Parse(v, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+    }
+    {
+        /* The last tile's size runs off the end of the stream. */
+        Bytes v = MakeEnvelope({16}, 0);
+        Write32(&v, kTileStreamHeaderBytes, 17);
+        REQUIRE(Parse(v, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+        /* And by exactly one byte, which is the boundary the check owns. */
+        Bytes exact = MakeEnvelope({16}, 0);
+        Write32(&exact, kTileStreamHeaderBytes, 16);
+        REQUIRE(Parse(exact, &info, &tiles) == CUDEC_OK);
+    }
+    {
+        /* An offset pointing inside the table itself. */
+        Bytes v = MakeEnvelope({16, 16}, 0);
+        Write32(&v, kTileStreamHeaderBytes + 4, 12);
+        REQUIRE(Parse(v, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+        /* And landing exactly on the table's end, which would make tile 0
+         * zero bytes long. */
+        Bytes at_end = MakeEnvelope({16, 16}, 0);
+        Write32(&at_end, kTileStreamHeaderBytes + 4,
+                static_cast<uint32_t>(kTileStreamHeaderBytes) + 8);
+        REQUIRE(Parse(at_end, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+    }
+    {
+        /* Offsets that do not increase: equal, and going backwards. */
+        Bytes equal = MakeEnvelope({16, 16, 16}, 0);
+        const uint32_t off1 =
+            static_cast<uint32_t>(kTileStreamHeaderBytes) + 12 + 16;
+        Write32(&equal, kTileStreamHeaderBytes + 8, off1);
+        REQUIRE(Parse(equal, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+
+        Bytes backwards = MakeEnvelope({16, 16, 16}, 0);
+        Write32(&backwards, kTileStreamHeaderBytes + 8, off1 - 1);
+        REQUIRE(Parse(backwards, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+    }
+    {
+        /* An offset at or beyond the end of the stream. There is no branch in
+         * the parser that names this case - src/tilestream.h argues that one
+         * could never be the sole cause of a refusal - so these two pin the
+         * PROPERTY, and they are what would red if that argument were ever
+         * wrong. */
+        Bytes v = MakeEnvelope({16, 16}, 0);
+        Write32(&v, kTileStreamHeaderBytes + 4,
+                static_cast<uint32_t>(v.size()));
+        REQUIRE(Parse(v, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+
+        Bytes far = MakeEnvelope({16, 16}, 0);
+        Write32(&far, kTileStreamHeaderBytes + 4, 0xFFFFFFFFu);
+        REQUIRE(Parse(far, &info, &tiles) == CUDEC_ERR_CORRUPT_INPUT);
+    }
+
+    /* ---- The mutation sweep. Every single-byte flip of every bit across the
+     * header and the whole table of a three-tile envelope. The verdict is not
+     * asserted - a flip in a byte no rule reads is allowed to parse - but an
+     * accepted parse must never describe a tile outside the stream. */
+    {
+        const Bytes base = MakeEnvelope({10, 20, 30}, 1234);
+        const size_t envelope_bytes = kTileStreamHeaderBytes + 12;
+        size_t accepted = 0;
+        size_t rejected = 0;
+        for (size_t byte = 0; byte < envelope_bytes; byte++) {
+            for (int bit = 0; bit < 8; bit++) {
+                Bytes v = base;
+                v[byte] = static_cast<unsigned char>(v[byte] ^ (1u << bit));
+                const cudec_status st = Parse(v, &info, &tiles);
+                if (st == CUDEC_OK) {
+                    accepted++;
+                    REQUIRE_CTX(
+                        TilesAreInBounds(tiles, info.tile_count, v.size()),
+                        "accepted mutant byte %zu bit %d describes a tile "
+                        "outside its %zu-byte stream",
+                        byte, bit, v.size());
+                    REQUIRE_CTX(info.tile_count != 0, "byte %zu bit %d", byte,
+                                bit);
+                } else {
+                    REQUIRE_CTX(st == CUDEC_ERR_CORRUPT_INPUT ||
+                                    st == CUDEC_ERR_INVALID_ARGUMENT,
+                                "byte %zu bit %d gave status %d", byte, bit,
+                                static_cast<int>(st));
+                    rejected++;
+                }
+            }
+        }
+        /* Both arms have to be non-empty, or the sweep proved nothing: all
+         * rejects would mean the invariant was never evaluated on an accept,
+         * and all accepts would mean no mutation reached a rule. */
+        REQUIRE(accepted > 0);
+        REQUIRE(rejected > 0);
+        std::printf("mutation sweep: %zu accepted, %zu rejected\n", accepted,
+                    rejected);
+    }
+
+    /* ---- Truncation sweep: the same valid stream at every length. Nothing
+     * may be accepted whose tiles reach past the length it was given. */
+    {
+        const Bytes base = MakeEnvelope({10, 20, 30}, 1234);
+        for (size_t n = 0; n <= base.size(); n++) {
+            const ExactBuffer buf(base, n);
+            const cudec_status st = TileStreamParse(
+                buf.data(), buf.size(), tiles.data(), tiles.size(), &info);
+            if (st == CUDEC_OK) {
+                REQUIRE_CTX(TilesAreInBounds(tiles, info.tile_count, n),
+                            "accepted at length %zu describes a tile outside "
+                            "it",
+                            n);
+            } else {
+                REQUIRE_CTX(st == CUDEC_ERR_CORRUPT_INPUT,
+                            "length %zu gave status %d", n,
+                            static_cast<int>(st));
+            }
+        }
+    }
+
+    std::printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
# What & why

A candidate byte range becomes a validated tile table, one source offset and
compressed size per tile plus the total uncompressed size, or it is refused
with a defined status. It decodes nothing, reads no tile payload and touches
no device.

Closes #174.

The envelope is where every bound a GDeflate decoder has comes from. The page
bitstream carries no uncompressed size and no checksum of any kind (MASTERPLAN
section 11.4), so a tile size this parser gets wrong is a bound the kernel
later enforces against the wrong number, and nothing downstream can re-derive
it. That is why it is worth having before a tile can be decoded at all.

`src/tilestream.h` is a header rather than the `.h`/`.cpp` pair the issue
named, and the header says why where a reader meets it: every format parser in
this tree is a header, and the `.cpp` files under `src/` are host orchestration
the CUDA build adds to the library, which is the one build where this parser is
not wanted. The ABI entry that links it is #177.

The field layout is #174's statement of the DirectStorage container, not a
quotation from a specification this repository holds. The dossier records that
enveloping is external and does not pin this container, so until #170 and #169
land this parser is self-consistent and unconfirmed, and a divergence they find
is a defect here rather than in them. That is written in the header too.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved: every reject branch has a fixture, and the two
      whose job is a length bound are handed streams in allocations exactly as
      long as the length the parser is told about, so an over-read is an
      over-read of the allocation.
- [ ] Oracle coverage: there is no oracle for this container yet. This is
      fail-closed coverage only; parity against the real DirectStorage vectors
      is #169 and #179, and the test file says so.
- [x] Determinism preserved: a pure function of the input bytes.
- [x] No CUDA call and no exception on any path.
- [ ] An adversarial review was NOT run as the four-lens panel. The reading
      below is a single pass, and the mutation matrix under Verification is the
      evidence it carries in place of one. There was no second reader.
- [ ] Review record: not produced, per the line above.

## What the single reading changed before this was committed

The parser and the test were written first and read afterwards, and the reading
moved two things. Both are recorded because the second is a refusal that no
longer exists.

**Every guard was deleted, one at a time, and the suite re-run.** Eight of the
twelve reddened. Four did not, and they split into two different problems.

`off >= stream_size` inside the offset loop **could not be made to bite**, and
it is gone. It could never be the sole cause of a refusal: an accepted last
tile satisfies `off_last + src_size_last <= stream_size` with a size of at
least one byte, so `off_last < stream_size`, and strict monotonicity puts every
earlier offset below it. Nothing in that loop reads at `off`; the only reads
are of the table, whose extent is bounded above it. The property it would have
named is pinned by fixtures instead, an offset at the end of the stream and an
offset at `0xFFFFFFFF`, and both are still refused with the branch absent.

The other three, the 8-byte header length, the declared table length and the
non-zero tile count, are bounds rather than policies, and removing one is not
a wrong verdict at all. It is a read or an index outside what the parser was
given, which may still produce a refusal by accident. Only the sanitizer
separates them, and the test was handing those cases a short length into a
longer buffer, which puts the over-read on validly allocated bytes where
neither the answer nor ASan can see it. They now go through an exactly-sized
allocation. Nothing else in the file makes that leg load-bearing and a longer
buffer would quietly take it back out, so the file says that where the helper
is defined.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. `src/tilestream.h` is
      host C++ with no CUDA in the translation unit, and the test is registered
      without the `gpu` label.

## Performance checklist

Not applicable: nothing here is on a measured path.

## Quality checklist

- [x] Minimal: one branch was removed for being unprovable rather than kept as
      defence in depth.
- [x] Comments explain why. The header carries the provenance of the layout,
      the reason the total is computed in 64-bit, and the derivation behind the
      absent offset check.
- [x] The new structural property, that the envelope's reject branches are
      gated with no GPU, is locked by registering the test in the GPU-less CI
      selection and in the ASan/UBSan set by name, not only by adding a file.

## Verification

The container is unreachable on this machine, so `ctest` was not run:

```
$ docker version --format '{{.Server.Version}}'
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine;
check if the path is correct and if the daemon is running
$ command -v nvcc
(no output)
```

`tests/` and `bench/` only configure under `CUDEC_ENABLE_CUDA=ON`, so there is
no local route to the ctest entry this adds. CI is the gate for it. What could
be produced here is the compile and the run of the new test directly, which
needs neither CUDA nor an oracle:

```
$ g++ --version | head -1
g++.exe (MinGW-W64 x86_64-ucrt-posix-seh, built by Brecht Sanders, r3) 16.1.0
$ g++ -std=c++17 -Wall -Wextra -Werror -O1 -I include -I src -I tests \
    -o ts tests/tilestream_host_negative.cpp && ./ts; echo "exit=$?"
mutation sweep: 28 accepted, 132 rejected
PASS
exit=0
```

The guard matrix, each row built by replacing one condition with `if (false)`
and re-running the same binary:

```
header length          survives   bound, not a verdict - ASan leg
id == magic ^ 0xff     red        tilestream_host_negative.cpp:259
tile count != 0        survives   bound, not a verdict - ASan leg
tileSizeIdx == 1       red        :276  tileSizeIdx=0
reserved == 0          red        :286  reserved bit 0
lastTileSize < 64Ki    red        :296  lastTileSize=65536
tiles_capacity         red        :237
table length           survives   bound, not a verdict - ASan leg
last tile size != 0    red        :317
offsets increase       red        :333
last tile end in range red        :323
```

**The ASan/UBSan leg was not executed here and is not claimed.** The MinGW
toolchain on this host ships neither runtime:

```
$ g++ -fsanitize=address ... -o ts tests/tilestream_host_negative.cpp
ld.exe: cannot find -lasan: No such file or directory
$ g++ -fsanitize=undefined ...
ld.exe: cannot find -lubsan: No such file or directory
```

So the three rows above marked as the sanitizer's are owed to the `sanitize`
job in this pull request and were not proven on this machine. The exact-sizing
change is what makes that job able to see them; whether it does is what its
result says, and nothing here says it in advance.

- [ ] `cmake --build build` - not run, see above.
- [ ] `ctest --test-dir build` - not run, see above.
- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.

```
$ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

- [x] Docs synced: nothing here changes behaviour, API or a number, and the
      MASTERPLAN's GDeflate section is a format dossier this does not touch.

## Notes

This parser is stricter than the container needs in one place and it is
deliberate: a tile with zero compressed bytes is refused, because no bitstream
produces a byte from no bytes and accepting one would hand the kernel a range
it could only fail on later, further from the evidence. #179 is where that
meets the real vectors, and it is the one rule here most likely to have to
move.

There was no second reader on this change.
