### PR TITLE
Decode Zstd FSE table descriptions and build their tables [#217]

### DIFF
--- a/src/zstd_fse.h
+++ b/src/zstd_fse.h
@@ -1,0 +1,523 @@
+/* Zstd FSE table descriptions: the decode of a Set_Compressed distribution
+ * and the construction of the decoding table it describes. Single-sourced for
+ * host and device, the sibling of src/lz4_block.h, src/snappy_block.h and
+ * src/zstd_bitstream.h. Internal header, not part of the ABI.
+ *
+ * The two halves ship together because the build has no reject path that a
+ * validated description can reach: it is a pure function of counts that
+ * already summed to the table size, and the only honest proof of it is a
+ * cell-by-cell diff against the reference. Every refusal that a stream can
+ * cause lives in the description decode. The build's own refusals exist for
+ * the caller that hands it a vector no description produced, and the twin
+ * reaches each of them by calling it directly.
+ *
+ * THE BIT ORDER IS NOT THE ONE src/zstd_bitstream.h READS, and the issue this
+ * lands under assumed it was, so it is stated where a reader will trip over
+ * it. A table description is written FORWARD and read FORWARD, low bit of the
+ * low byte first; the reader in src/zstd_bitstream.h walks a Zstd bitstream
+ * BACKWARD from a start marker in its final byte, high bit first. Those are
+ * different serialisations of different objects. RFC 8878 section 4.1.1 gives
+ * the forward one for the distribution header, and the reference implements
+ * it in lib/common/entropy_common.c, FSE_readNCount_body, which reads a
+ * 32-bit little-endian window and shifts up from bit 0. The backward reader
+ * is what the FSE state cores and the literal streams run over, one layer up.
+ * A description decoded with the backward reader would produce plausible
+ * symbols out of the wrong bits, which is the failure this note exists to
+ * prevent.
+ *
+ * WHERE THIS IS STRICTER THAN THE REFERENCE, deliberately. The reference
+ * anchors its 32-bit window at four bytes before the end once the walk gets
+ * close, so bits beyond the description read as zeros and a late refusal
+ * catches the case afterwards. This reader never yields a bit it did not
+ * read: a field whose width reaches past the buffer is refused on the spot,
+ * before the value is used. Fail-closed is allowed to be stricter than the
+ * oracle and the twin asserts the direction rather than assuming it.
+ *
+ * NO ALLOCATION. Counts, cells and the per-symbol next-state workspace are
+ * all caller-provided and their capacities are arguments, so a kernel can
+ * point them at shared memory and a hostile accuracy log cannot make this
+ * header ask for a byte the caller did not size. */
+#ifndef CUDEC_ZSTD_FSE_H
+#define CUDEC_ZSTD_FSE_H
+
+#include "cudec.h"
+
+#include <stdint.h>
+
+/* Guarded: src/lz4_block.h, src/snappy_block.h and src/zstd_bitstream.h
+ * define the same macro for the same reason, and a device translation unit
+ * that decodes more than one format includes more than one header. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+constexpr unsigned kZstdFseBitsPerByte = 8;
+
+/* FSE_MIN_TABLELOG and FSE_TABLELOG_ABSOLUTE_MAX in the reference's fse.h.
+ * The four-bit accuracy-log field is stored biased by the minimum, so the
+ * widest log the field can express is the minimum plus fifteen. */
+constexpr unsigned kZstdFseMinAccuracyLog = 5;
+constexpr unsigned kZstdFseMaxAccuracyLog = 15;
+
+/* FSE_MAX_SYMBOL_VALUE. A count vector is indexed by an unsigned char, so
+ * this is the widest alphabet the format can describe at all. */
+constexpr unsigned kZstdFseMaxSymbolValue = 255;
+
+/* The per-field bounds of the three sequence tables, RFC 8878 section
+ * 3.1.1.3.2.2. They are the caller's to pass in - this header enforces
+ * whatever bound it is given and does not know which field it is decoding -
+ * but they live here because they are format constants and a caller that
+ * spells one out itself is a caller that can spell it wrong.
+ *
+ * The reference carries the same six as LLFSELog/OffFSELog/MLFSELog and
+ * MaxLL/MaxOff/MaxML in lib/decompress/zstd_decompress_block.c. */
+constexpr unsigned kZstdLitLenAccuracyLogMax = 9;
+constexpr unsigned kZstdOffsetAccuracyLogMax = 8;
+constexpr unsigned kZstdMatchLenAccuracyLogMax = 9;
+constexpr unsigned kZstdLitLenSymbolMax = 35;
+constexpr unsigned kZstdOffsetSymbolMax = 31;
+constexpr unsigned kZstdMatchLenSymbolMax = 52;
+
+/* The odd term in the spread stride, FSE_TABLESTEP in the reference's fse.h.
+ * It is what makes the stride odd, and an odd stride is coprime with a
+ * power-of-two table size, which is why the walk covers every cell. */
+constexpr unsigned kZstdFseSpreadStepBias = 3;
+
+/* The reject ladder, enumerated once, in the shape src/snappy_block.h and
+ * src/zstd_bitstream.h use: every refusal returns through one choke point
+ * naming its rung, so the twin can require a negative per rung instead of
+ * counting statuses that repeat. The oracle collapses all of these into
+ * corruption_detected, so the rung is this tree's own vocabulary and the twin
+ * proves each one is reachable rather than reading it back out of libzstd. */
+enum ZstdFseReject {
+    kZstdFseRejectNone = 0,
+    /* An argument outside what the format can express: an alphabet past 255,
+     * an accuracy-log bound outside [5, 15], or a null buffer. A caller bug
+     * rather than a stream, refused rather than clamped. */
+    kZstdFseRejectBadRequest,
+    kZstdFseRejectEmptyDescription,
+    kZstdFseRejectAccuracyLogTooLarge,
+    /* A field whose width reaches past the buffer the caller supplied. */
+    kZstdFseRejectDescriptionTruncated,
+    /* The description ended with probability still unallocated: the alphabet
+     * ran out, or a repeat run walked past its last symbol.
+     *
+     * THERE IS NO SEPARATE OVERSHOOT RUNG AND THE ISSUE THIS LANDS UNDER
+     * ASKED FOR ONE. Probabilities summing PAST the table size is not a
+     * reachable state here, and it is a property of the encoding rather than
+     * of this code. Each field is read against a limit derived from what is
+     * left: small_limit is 2*threshold-1 minus the budget, the widest value
+     * the full-width form can carry is 2*threshold-1, and subtracting the
+     * limit from it leaves exactly the budget - so a decoded probability is
+     * never larger than the slots remaining, whatever bits the stream
+     * carries. The budget therefore reaches one or stays above it, and the
+     * only way a description fails to complete is this rung. A guard for the
+     * other direction would be one no negative could reach. */
+    kZstdFseRejectSymbolPastMax,
+    /* Build side: the cell array the caller supplied is smaller than the
+     * table the accuracy log asks for. */
+    kZstdFseRejectBuildCapacity,
+    /* Build side: a count vector whose magnitudes do not sum to the table
+     * size, or which carries a probability below the "less than one" code.
+     * Unreachable from a description this header decoded; reachable, and
+     * reached by the twin, from a caller that builds a vector by hand. */
+    kZstdFseRejectBuildCountsNotNormalized,
+    kZstdFseRejectCount
+};
+
+CUDEC_HOST_DEVICE inline cudec_status ZstdFseRefuse(ZstdFseReject rung,
+                                                    cudec_status status,
+                                                    ZstdFseReject* out) {
+    if (out != 0) {
+        *out = rung;
+    }
+    return status;
+}
+
+/* Position of the highest set bit, 0-indexed. Only ever called on a non-zero
+ * value - the caller reaches it with a remaining budget of at least two - so
+ * there is no "no bits set" answer to define. A counted loop over a
+ * compile-time bound rather than an intrinsic, because this header compiles
+ * for both the host and the device. */
+constexpr unsigned kZstdFseWordBits = 32;
+
+CUDEC_HOST_DEVICE inline unsigned ZstdFseHighestSetBit(uint32_t value) {
+    unsigned highest = 0;
+    for (unsigned bit = 0; bit < kZstdFseWordBits; bit++) {
+        if ((value >> bit) & 1u) {
+            highest = bit;
+        }
+    }
+    return highest;
+}
+
+/* One decoding-table cell. Field for field the reference's FSE_decode_t in
+ * lib/common/fse.h - newState, symbol, nbBits - which is what makes the twin's
+ * cell-by-cell diff a comparison of the same three quantities rather than of
+ * a layout this tree invented. The layout itself is not load-bearing here;
+ * the kernel's shared-memory form is settled with the kernel. */
+struct ZstdFseCell {
+    uint16_t new_state;
+    uint8_t symbol;
+    uint8_t nb_bits;
+};
+
+/* The forward, low-bit-first reader the table description is written in.
+ *
+ * Position is carried as a byte index plus a bit offset inside that byte
+ * rather than as a bit count, so no bound comparison needs the total bit
+ * count of the buffer and there is no multiplication to overflow on a size
+ * the caller chose. Peek fills bits at or past the end with zero and the
+ * caller must not use a value it has not proved available - which is what
+ * Available is for, and every call site checks it before Advance. */
+struct ZstdFseDescReader {
+    const unsigned char* src;
+    uint64_t size;
+    uint64_t byte_pos = 0;
+    unsigned bit_pos = 0;
+
+    /* True when `count` more bits sit inside the buffer. The widest count any
+     * call site passes is sixteen - an accuracy log of fifteen makes the
+     * probability field that wide and nothing here reads more - so the
+     * arithmetic below stays far inside its type. */
+    CUDEC_HOST_DEVICE bool Available(unsigned count) const {
+        const unsigned needed_bits = bit_pos + count;
+        const uint64_t needed_bytes =
+            (needed_bits + kZstdFseBitsPerByte - 1) / kZstdFseBitsPerByte;
+        /* byte_pos <= size is an invariant: Advance is only called after
+         * Available said yes. */
+        return needed_bytes <= size - byte_pos;
+    }
+
+    /* `count` bits from the current position, low bit first, as the low bits
+     * of the result. Bits at or past the end read as zero, which is only ever
+     * observed by a caller that then refuses. */
+    CUDEC_HOST_DEVICE uint32_t Peek(unsigned count) const {
+        uint32_t value = 0;
+        uint64_t byte = byte_pos;
+        unsigned bit = bit_pos;
+        for (unsigned i = 0; i < count; i++) {
+            unsigned taken = 0;
+            if (byte < size) {
+                taken = (src[byte] >> bit) & 1u;
+            }
+            value |= static_cast<uint32_t>(taken) << i;
+            bit++;
+            if (bit == kZstdFseBitsPerByte) {
+                bit = 0;
+                byte++;
+            }
+        }
+        return value;
+    }
+
+    CUDEC_HOST_DEVICE void Advance(unsigned count) {
+        const unsigned total = bit_pos + count;
+        byte_pos += total / kZstdFseBitsPerByte;
+        bit_pos = total % kZstdFseBitsPerByte;
+    }
+
+    /* Whole bytes the description occupied. A description that ends mid-byte
+     * still owns that byte: the field after it starts on the next one. */
+    CUDEC_HOST_DEVICE uint64_t BytesConsumed() const {
+        return byte_pos + (bit_pos != 0 ? 1u : 0u);
+    }
+};
+
+/* Decodes a Set_Compressed table description.
+ *
+ * `counts` receives max_symbol_value + 1 entries and every symbol the
+ * description does not mention is left at zero, so a caller never reads a
+ * stale probability for an absent symbol. `out_max_symbol` is the highest
+ * symbol the description actually reached, which is at most the bound passed
+ * in and is what the table build is then given.
+ *
+ * `out_consumed` is the byte count the description occupied, and it is the
+ * value the sequences section and the Huffman weight path position
+ * themselves from. An off-by-one there is silent corruption downstream, which
+ * is why it is an output of this function rather than something a caller
+ * recomputes.
+ *
+ * `size` is the bytes remaining in the block, not the description's length -
+ * the length is not known until the description has been decoded. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdFseReadNCount(
+    const unsigned char* src, uint64_t size, unsigned max_symbol_value,
+    unsigned max_accuracy_log, int16_t* counts, unsigned* out_max_symbol,
+    unsigned* out_accuracy_log, uint64_t* out_consumed,
+    ZstdFseReject* reject) {
+    *out_max_symbol = 0;
+    *out_accuracy_log = 0;
+    *out_consumed = 0;
+    if (reject != 0) {
+        *reject = kZstdFseRejectNone;
+    }
+    if (src == 0 || counts == 0 || max_symbol_value > kZstdFseMaxSymbolValue ||
+        max_accuracy_log < kZstdFseMinAccuracyLog ||
+        max_accuracy_log > kZstdFseMaxAccuracyLog) {
+        return ZstdFseRefuse(kZstdFseRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    if (size == 0) {
+        return ZstdFseRefuse(kZstdFseRejectEmptyDescription,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const unsigned max_symbol_count = max_symbol_value + 1;
+    for (unsigned symbol = 0; symbol < max_symbol_count; symbol++) {
+        counts[symbol] = 0;
+    }
+
+    ZstdFseDescReader reader{src, size};
+    constexpr unsigned kAccuracyLogFieldBits = 4;
+    if (!reader.Available(kAccuracyLogFieldBits)) {
+        return ZstdFseRefuse(kZstdFseRejectDescriptionTruncated,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const unsigned accuracy_log =
+        reader.Peek(kAccuracyLogFieldBits) + kZstdFseMinAccuracyLog;
+    reader.Advance(kAccuracyLogFieldBits);
+    if (accuracy_log > max_accuracy_log) {
+        return ZstdFseRefuse(kZstdFseRejectAccuracyLogTooLarge,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    /* The budget, in table slots, plus one: the format's own accounting, and
+     * the reason a probability is stored one higher than it is worth. */
+    int32_t remaining = static_cast<int32_t>(1u << accuracy_log) + 1;
+    int32_t threshold = static_cast<int32_t>(1u << accuracy_log);
+    unsigned field_bits = accuracy_log + 1;
+    unsigned symbol_count = 0;
+    bool previous_zero = false;
+
+    /* Counted, and the bound is the alphabet: every iteration stores exactly
+     * one probability, so a description cannot describe more symbols than the
+     * field admits however it is spelled. Falling out of the loop rather than
+     * breaking leaves `remaining` above one, which the check below refuses -
+     * the exit is a reject either way, never a silent truncation. */
+    for (unsigned iteration = 0; iteration < max_symbol_count; iteration++) {
+        if (previous_zero) {
+            /* Runs of absent symbols: a two-bit code of three means three
+             * more absent symbols and another code follows. Counted by the
+             * alphabet for the same reason as the outer loop - each code
+             * that continues the run adds three symbols, so the alphabet
+             * bounds the run length. */
+            bool run_open = true;
+            const unsigned run_limit = max_symbol_count;
+            for (unsigned step = 0; step < run_limit && run_open; step++) {
+                constexpr unsigned kRepeatFieldBits = 2;
+                constexpr unsigned kRepeatContinues = 3;
+                if (!reader.Available(kRepeatFieldBits)) {
+                    return ZstdFseRefuse(kZstdFseRejectDescriptionTruncated,
+                                         CUDEC_ERR_CORRUPT_INPUT, reject);
+                }
+                const unsigned repeat = reader.Peek(kRepeatFieldBits);
+                reader.Advance(kRepeatFieldBits);
+                symbol_count += repeat;
+                if (repeat != kRepeatContinues) {
+                    run_open = false;
+                }
+                if (symbol_count >= max_symbol_count) {
+                    return ZstdFseRefuse(kZstdFseRejectSymbolPastMax,
+                                         CUDEC_ERR_CORRUPT_INPUT, reject);
+                }
+            }
+            if (run_open) {
+                return ZstdFseRefuse(kZstdFseRejectSymbolPastMax,
+                                     CUDEC_ERR_CORRUPT_INPUT, reject);
+            }
+            previous_zero = false;
+        }
+
+        /* The variable-width probability. The low `field_bits - 1` bits are
+         * enough for the values below `small_limit`; anything at or above it
+         * needs the full width. The peek is taken at the full width and the
+         * narrower consumption is what is charged, so a value decided by bits
+         * inside the buffer is never refused for bits outside it. */
+        const int32_t small_limit = (2 * threshold - 1) - remaining;
+        const uint32_t peeked = reader.Peek(field_bits);
+        const int32_t narrow =
+            static_cast<int32_t>(peeked & static_cast<uint32_t>(threshold - 1));
+        int32_t probability = 0;
+        unsigned width = 0;
+        if (narrow < small_limit) {
+            probability = narrow;
+            width = field_bits - 1;
+        } else {
+            probability = static_cast<int32_t>(
+                peeked & static_cast<uint32_t>(2 * threshold - 1));
+            if (probability >= threshold) {
+                probability -= small_limit;
+            }
+            width = field_bits;
+        }
+        if (!reader.Available(width)) {
+            return ZstdFseRefuse(kZstdFseRejectDescriptionTruncated,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        reader.Advance(width);
+
+        /* Stored one high so that "less than one" has an encoding: the value
+         * minus one is the probability, and minus one itself is the symbol
+         * that occupies a single slot at the top of the table. Either way one
+         * slot per unit of magnitude comes out of the budget. */
+        probability--;
+        remaining -= probability < 0 ? -probability : probability;
+        counts[symbol_count] = static_cast<int16_t>(probability);
+        symbol_count++;
+        previous_zero = probability == 0;
+
+        if (remaining < threshold) {
+            if (remaining <= 1) {
+                break;
+            }
+            field_bits =
+                ZstdFseHighestSetBit(static_cast<uint32_t>(remaining)) + 1;
+            threshold = static_cast<int32_t>(1u << (field_bits - 1));
+        }
+        if (symbol_count >= max_symbol_count) {
+            break;
+        }
+    }
+
+    if (remaining != 1) {
+        /* The exact-one termination is the format's own end condition, and it
+         * is the only accept. See the rung's own note for why the budget
+         * cannot be below one here. */
+        return ZstdFseRefuse(kZstdFseRejectSymbolPastMax,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    *out_max_symbol = symbol_count - 1;
+    *out_accuracy_log = accuracy_log;
+    *out_consumed = reader.BytesConsumed();
+    return CUDEC_OK;
+}
+
+/* Builds the decoding table a validated count vector describes.
+ *
+ * `cells` receives 1 << accuracy_log entries and `symbol_next` is a
+ * max_symbol_value + 1 entry scratch the build uses to hand out successive
+ * states per symbol. Both are the caller's, sized by it and checked here.
+ *
+ * The vector is validated before a cell is written rather than after: the
+ * spread walk's bound is the table size only while the magnitudes sum to it,
+ * and the "less than one" symbols are placed from the top of the table
+ * downwards, which walks off the bottom of the array if there are more of
+ * them than the table has cells. Both are refusals rather than assumptions
+ * because this entry point is callable with a vector no description
+ * produced. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdFseBuildDTable(
+    const int16_t* counts, unsigned max_symbol_value, unsigned accuracy_log,
+    ZstdFseCell* cells, uint32_t cell_capacity, uint16_t* symbol_next,
+    ZstdFseReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdFseRejectNone;
+    }
+    if (counts == 0 || cells == 0 || symbol_next == 0 ||
+        max_symbol_value > kZstdFseMaxSymbolValue ||
+        accuracy_log < kZstdFseMinAccuracyLog ||
+        accuracy_log > kZstdFseMaxAccuracyLog) {
+        return ZstdFseRefuse(kZstdFseRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    const uint32_t table_size = 1u << accuracy_log;
+    if (cell_capacity < table_size) {
+        return ZstdFseRefuse(kZstdFseRejectBuildCapacity,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    const unsigned max_symbol_count = max_symbol_value + 1;
+
+    /* The magnitudes must sum to exactly the table size. Checked as it goes
+     * so the accumulator cannot run away, and checked before anything is
+     * written so no bound below depends on an unvalidated number. */
+    uint32_t claimed = 0;
+    for (unsigned symbol = 0; symbol < max_symbol_count; symbol++) {
+        const int16_t probability = counts[symbol];
+        if (probability < -1) {
+            return ZstdFseRefuse(kZstdFseRejectBuildCountsNotNormalized,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        const uint32_t magnitude = probability < 0
+                                       ? 1u
+                                       : static_cast<uint32_t>(probability);
+        if (magnitude > table_size - claimed) {
+            return ZstdFseRefuse(kZstdFseRejectBuildCountsNotNormalized,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        claimed += magnitude;
+    }
+    if (claimed != table_size) {
+        return ZstdFseRefuse(kZstdFseRejectBuildCountsNotNormalized,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    /* The "less than one" symbols occupy the top of the table, one each,
+     * highest cell first. high_threshold ends as the last cell the spread
+     * walk below may touch. The sum check above bounds their number by the
+     * table size, so the index cannot walk below zero. */
+    uint32_t high_threshold = table_size - 1;
+    for (unsigned symbol = 0; symbol < max_symbol_count; symbol++) {
+        if (counts[symbol] < 0) {
+            cells[high_threshold].symbol = static_cast<uint8_t>(symbol);
+            high_threshold--;
+            symbol_next[symbol] = 1;
+        } else {
+            symbol_next[symbol] = static_cast<uint16_t>(counts[symbol]);
+        }
+    }
+
+    /* The spread. Each symbol's slots are laid down at a fixed stride that is
+     * odd and therefore coprime with the power-of-two table size, so the walk
+     * visits every cell exactly once - which is what makes the count vector's
+     * sum the whole of the bound. */
+    const uint32_t table_mask = table_size - 1;
+    const uint32_t step =
+        (table_size >> 1) + (table_size >> 3) + kZstdFseSpreadStepBias;
+    uint32_t position = 0;
+    for (unsigned symbol = 0; symbol < max_symbol_count; symbol++) {
+        const int16_t probability = counts[symbol];
+        for (int16_t slot = 0; slot < probability; slot++) {
+            cells[position].symbol = static_cast<uint8_t>(symbol);
+            position = (position + step) & table_mask;
+            /* The reserved top of the table is skipped rather than written
+             * over. fuel: the stride's full cycle is the table size, so no
+             * more than that many probes separate two cells outside the
+             * reserved area; a vector that could exhaust it is one the sum
+             * check above already refused. */
+            uint32_t fuel = table_size;
+            while (position > high_threshold) {
+                if (fuel == 0) {
+                    return ZstdFseRefuse(
+                        kZstdFseRejectBuildCountsNotNormalized,
+                        CUDEC_ERR_CORRUPT_INPUT, reject);
+                }
+                fuel--;
+                position = (position + step) & table_mask;
+            }
+        }
+    }
+
+    /* The states. A cell's symbol has already been laid down; what is left is
+     * how many bits the decoder reads at that cell and which state it lands
+     * in, both derived from how many of that symbol's slots have been handed
+     * out so far. */
+    for (uint32_t cell = 0; cell < table_size; cell++) {
+        const uint8_t symbol = cells[cell].symbol;
+        const uint16_t next_state = symbol_next[symbol];
+        symbol_next[symbol] = static_cast<uint16_t>(next_state + 1);
+        const unsigned bits =
+            accuracy_log - ZstdFseHighestSetBit(next_state);
+        cells[cell].nb_bits = static_cast<uint8_t>(bits);
+        cells[cell].new_state =
+            static_cast<uint16_t>((next_state << bits) - table_size);
+    }
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_ZSTD_FSE_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -322,6 +322,22 @@ cudec_add_test(zstd_frame_twin SOURCES zstd_frame_twin.cpp LIBS zstd_full)
 target_include_directories(zstd_frame_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_compile_definitions(zstd_frame_twin PRIVATE ZSTD_STATIC_LINKING_ONLY)
+# The Zstd FSE table description decode and the table it builds (issue #217),
+# held to FSE_readNCount and FSE_buildDTable_wksp cell by cell. Host-side and
+# GPU-less. It links zstd_full alone for the reason zstd_oracle_smoke gives
+# above and because FSE_writeNCount lives on the compress side: the test
+# writes the descriptions its negatives are mutations of, and proves its own
+# writer against the reference's before using it. It compiles zstd_corpus.cpp
+# for the same reason zstd_corpus_selfproof does - the #185 fixtures are where
+# the Set_Compressed fields this sweeps over come from.
+# FSE_STATIC_LINKING_ONLY is what exposes FSE_buildDTable_wksp and
+# FSE_decode_t; the non-wksp entry point is not exported by the pinned
+# release.
+cudec_add_test(zstd_fse_twin SOURCES zstd_fse_twin.cpp zstd_corpus.cpp LIBS
+               zstd_full)
+target_include_directories(zstd_fse_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_compile_definitions(zstd_fse_twin PRIVATE FSE_STATIC_LINKING_ONLY)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/zstd_corpus.cpp
+++ b/tests/zstd_corpus.cpp
@@ -317,6 +317,7 @@ bool ParseZstdFrameShape(const Bytes& frame, ZstdFrameShape* out,
                     *why = "reserved bits set in symbol compression modes";
                     return false;
                 }
+                block.tables_offset = r.pos;
             }
             /* The walk stops at the mode byte, so it resumes from the block
              * size the header declared rather than from where it stopped. */
@@ -324,6 +325,7 @@ bool ParseZstdFrameShape(const Bytes& frame, ZstdFrameShape* out,
                 *why = "compressed block runs past the frame";
                 return false;
             }
+            block.block_end = block_start + block_size;
             r.pos = block_start + block_size;
         } else if (!r.Skip(block.block_type == kZstdBlockRle ? 1u
                                                              : block_size)) {

--- a/tests/zstd_corpus.h
+++ b/tests/zstd_corpus.h
@@ -60,6 +60,14 @@ struct ZstdBlockShape {
     unsigned ll_mode = 0;
     unsigned of_mode = 0;
     unsigned ml_mode = 0;
+    /* Where the three FSE table descriptions begin, as an offset into the
+     * frame, and where the block ends. The walk already stands on the first
+     * of those bytes when it has read the mode byte, and throwing the
+     * position away made every consumer re-derive it - so it is reported
+     * instead. Set only where sequence_count > 0; block_end is set for every
+     * compressed block. */
+    size_t tables_offset = 0;
+    size_t block_end = 0;
 };
 
 struct ZstdFrameShape {

--- a/tests/zstd_fse_twin.cpp
+++ b/tests/zstd_fse_twin.cpp
@@ -1,0 +1,767 @@
+/* The CPU twin of the Zstd FSE table description decode and the decoding
+ * table built from it (src/zstd_fse.h), issue #217. The sibling of
+ * tests/parser_twin.cpp, tests/snappy_parser_twin.cpp and
+ * tests/zstd_bitstream_twin.cpp: the single-source unit executed on the host,
+ * on the GPU-less CI runner, and held to the pinned reference's verdicts.
+ *
+ * Three proofs, and they are different in kind.
+ *
+ * THE DESCRIPTIONS ARE BUILT BY AN ENCODER THIS FILE OWNS, and the first
+ * thing the test does is prove that encoder byte for byte against
+ * FSE_writeNCount over every vector it is used with. Without that step a
+ * hand-built negative would only prove that the twin agrees with a writer
+ * nobody checked; with it, the malformed streams below are malformed
+ * versions of bytes the reference itself would have written.
+ *
+ * THE PARITY SWEEP runs over two sources. The vectors above, which reach
+ * shapes a compressor rarely emits - a single symbol taking the whole table,
+ * eight "less than one" probabilities, a zero run long enough to need the
+ * repeat continuation - and the #185 corpus, which is what the issue's done
+ * condition names: every Set_Compressed field of every block of every
+ * fixture, positioned from the frame walker in tests/zstd_corpus.h. Both
+ * compare the accuracy log, the counts, the highest symbol AND the consumed
+ * byte count, then diff the built table cell by cell against
+ * FSE_buildDTable_wksp. A table that differs in one cell is a failure even
+ * where the header parse agreed.
+ *
+ * THE NEGATIVES are hand-built, one per reject rung, with the oracle's
+ * verdict asserted beside the twin's wherever the oracle has one at this
+ * layer. Three of them it does not have one, and each says so where it is
+ * written: the caller-argument rung and the two build-side rungs are not
+ * streams at all. The per-field accuracy-log bound is a fourth case and a
+ * different one - the oracle ACCEPTS the description and refuses it one level
+ * up, in ZSTD_buildSeqTable, so that negative asserts the acceptance.
+ *
+ * The reference's refusal codes do not discriminate - unrelated malformed
+ * descriptions all come back corruption_detected, measured on #189 - so a
+ * negative here asserts that the oracle refused and that the twin refused
+ * through the rung the negative was written for. Reading a reason out of the
+ * oracle's code would be reading something it does not report. */
+#include "require.h"
+#include "zstd_corpus.h"
+#include "zstd_fse.h"
+
+/* The reference's FSE entry points are internal to libzstd: `fse.h` carries
+ * no C++ linkage guard of its own, unlike the public `zstd.h` the other M5
+ * tests reach for, so the include is wrapped here rather than the header
+ * being copied or its declarations restated. FSE_STATIC_LINKING_ONLY is what
+ * exposes FSE_buildDTable_wksp, FSE_decode_t and the two sizing macros; the
+ * non-wksp FSE_buildDTable is not exported by this release. */
+extern "C" {
+#include <common/fse.h>
+}
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+using Counts = std::vector<int16_t>;
+
+/* Which reject rungs a declared negative reached. Same discipline as the
+ * bitstream twin: the enumeration lives once, in the header, and main()
+ * requires every rung to have been named by a negative written to reach it.
+ * A rung added to the unit with no negative behind it reds this test. */
+bool g_reject_covered[cudec_detail::kZstdFseRejectCount] = {false};
+
+void CoverRung(cudec_detail::ZstdFseReject rung) {
+    if (rung != cudec_detail::kZstdFseRejectNone) {
+        g_reject_covered[rung] = true;
+    }
+}
+
+/* The forward, low-bit-first writer a table description is spelled in. The
+ * mirror of the reader in src/zstd_fse.h, and proven against
+ * FSE_writeNCount before anything else uses it. */
+struct BitWriter {
+    Bytes bytes;
+    unsigned bit = 0;
+
+    void Put(uint32_t value, unsigned count) {
+        for (unsigned i = 0; i < count; i++) {
+            if (bit == 0) {
+                bytes.push_back(0);
+            }
+            if ((value >> i) & 1u) {
+                bytes.back() =
+                    static_cast<unsigned char>(bytes.back() | (1u << bit));
+            }
+            bit++;
+            if (bit == 8) {
+                bit = 0;
+            }
+        }
+    }
+};
+
+/* Writes the description of a normalized count vector, following
+ * FSE_writeNCount_generic in lib/compress/fse_compress.c. The two-byte flush
+ * the reference performs is a buffering detail; what it produces is the same
+ * bit string this writer appends, and the byte-for-byte assertion in step 1
+ * of main() is what says so rather than this comment. */
+Bytes EncodeNCount(const Counts& counts, unsigned accuracy_log) {
+    BitWriter writer;
+    const int32_t table_size = static_cast<int32_t>(1u << accuracy_log);
+    /* A vector whose magnitudes do not sum to the table size is not a
+     * description this writer can spell: the threshold walk at the bottom of
+     * the loop divides until the remaining budget fits, and a budget that
+     * went past zero never does. Refused here, so a mistyped vector reds the
+     * test instead of hanging it - which is how the one in this file's first
+     * draft announced itself. */
+    int32_t magnitude_sum = 0;
+    for (size_t symbol = 0; symbol < counts.size(); symbol++) {
+        magnitude_sum += counts[symbol] < 0 ? -counts[symbol] : counts[symbol];
+    }
+    if (magnitude_sum != table_size) {
+        return Bytes();
+    }
+    writer.Put(accuracy_log - cudec_detail::kZstdFseMinAccuracyLog, 4);
+    int32_t remaining = table_size + 1;
+    int32_t threshold = table_size;
+    unsigned field_bits = accuracy_log + 1;
+    size_t symbol = 0;
+    bool previous_zero = false;
+    while (symbol < counts.size() && remaining > 1) {
+        if (previous_zero) {
+            size_t start = symbol;
+            while (symbol < counts.size() && counts[symbol] == 0) {
+                symbol++;
+            }
+            if (symbol == counts.size()) {
+                break;
+            }
+            while (symbol >= start + 3) {
+                start += 3;
+                writer.Put(3, 2);
+            }
+            writer.Put(static_cast<uint32_t>(symbol - start), 2);
+        }
+        int32_t count = counts[symbol];
+        symbol++;
+        const int32_t small_limit = (2 * threshold - 1) - remaining;
+        remaining -= count < 0 ? -count : count;
+        count++;
+        if (count >= threshold) {
+            count += small_limit;
+        }
+        writer.Put(static_cast<uint32_t>(count),
+                   field_bits - (count < small_limit ? 1u : 0u));
+        previous_zero = count == 1;
+        while (remaining < threshold) {
+            field_bits--;
+            threshold >>= 1;
+        }
+    }
+    return writer.bytes;
+}
+
+/* One normalized distribution and the log it is normalized to. */
+struct Vector {
+    const char* name;
+    unsigned accuracy_log;
+    Counts counts;
+};
+
+std::vector<Vector> MakeVectors() {
+    std::vector<Vector> vectors;
+    /* The whole table on one symbol: the widest single probability the format
+     * can express at this log, and the encoding that needs the full field
+     * width on its first and only field. */
+    vectors.push_back({"single-symbol", 5, {32}});
+    /* An ordinary spread with no absent symbols. */
+    vectors.push_back({"dense", 5, {20, 6, 4, 1, 1}});
+    /* One "less than one" probability - the -1 code, which is what puts a
+     * symbol at the top of the table instead of into the spread walk. */
+    vectors.push_back({"one-lowprob", 5, {20, 6, 4, 1, -1}});
+    /* Eight of them, so the reserved top of the table is a quarter of it and
+     * the spread walk has to skip over the reserved area repeatedly. */
+    vectors.push_back(
+        {"many-lowprob", 5, {8, 8, 8, -1, -1, -1, -1, -1, -1, -1, -1}});
+    /* Absent symbols between present ones: single zeros, which the format
+     * spells as a two-bit run of length zero after a zero probability. */
+    vectors.push_back({"sparse", 6, {30, 0, 0, 0, 20, 0, 10, -1, -1, 0, 2}});
+    /* A run of twenty-nine absent symbols, which needs the 0b11 repeat
+     * continuation nine times over - the branch a dense vector never
+     * reaches. */
+    {
+        Counts counts(31, 0);
+        counts[0] = 500;
+        counts[30] = 12;
+        vectors.push_back({"long-zero-run", 9, counts});
+    }
+    /* A literal-length shaped vector at the field's own maximum log and
+     * highest symbol, so the sweep covers the widest sequence table the
+     * format admits. */
+    {
+        Counts counts(36, 0);
+        counts[0] = 200;
+        counts[1] = 100;
+        counts[2] = 100;
+        counts[3] = 50;
+        counts[35] = 50;
+        for (size_t symbol = 4; symbol < 14; symbol++) {
+            counts[symbol] = 1;
+        }
+        counts[16] = -1;
+        counts[17] = -1;
+        vectors.push_back({"litlen-wide", 9, counts});
+    }
+    return vectors;
+}
+
+/* The reference's decode of a description, as a verdict plus what it read. */
+struct OracleRead {
+    bool ok = false;
+    unsigned accuracy_log = 0;
+    unsigned max_symbol = 0;
+    size_t consumed = 0;
+    Counts counts;
+};
+
+OracleRead ReadWithOracle(const unsigned char* src, size_t size,
+                          unsigned max_symbol_value) {
+    OracleRead result;
+    std::vector<short> counts(max_symbol_value + 1, 0);
+    unsigned max_symbol = max_symbol_value;
+    unsigned accuracy_log = 0;
+    const size_t read = FSE_readNCount(counts.data(), &max_symbol,
+                                       &accuracy_log, src, size);
+    if (FSE_isError(read)) {
+        return result;
+    }
+    result.ok = true;
+    result.accuracy_log = accuracy_log;
+    result.max_symbol = max_symbol;
+    result.consumed = read;
+    result.counts.assign(counts.begin(), counts.end());
+    return result;
+}
+
+/* The reference's decoding table, flattened to the three fields per cell that
+ * the twin also produces. */
+bool BuildWithOracle(const Counts& counts, unsigned max_symbol,
+                     unsigned accuracy_log,
+                     std::vector<cudec_detail::ZstdFseCell>* out) {
+    std::vector<short> narrow(counts.begin(), counts.end());
+    std::vector<FSE_DTable> table(FSE_DTABLE_SIZE_U32(accuracy_log), 0);
+    std::vector<unsigned> work(
+        FSE_BUILD_DTABLE_WKSP_SIZE_U32(cudec_detail::kZstdFseMaxAccuracyLog,
+                                       cudec_detail::kZstdFseMaxSymbolValue),
+        0);
+    const size_t built = FSE_buildDTable_wksp(
+        table.data(), narrow.data(), max_symbol, accuracy_log, work.data(),
+        work.size() * sizeof(unsigned));
+    if (FSE_isError(built)) {
+        return false;
+    }
+    const FSE_decode_t* cells =
+        reinterpret_cast<const FSE_decode_t*>(table.data() + 1);
+    const size_t table_size = static_cast<size_t>(1u) << accuracy_log;
+    out->resize(table_size);
+    for (size_t cell = 0; cell < table_size; cell++) {
+        (*out)[cell].new_state = cells[cell].newState;
+        (*out)[cell].symbol = cells[cell].symbol;
+        (*out)[cell].nb_bits = cells[cell].nbBits;
+    }
+    return true;
+}
+
+/* Storage the twin writes into. Sized for the widest table the format admits
+ * so one instance serves every case; the unit itself allocates nothing. */
+struct TwinStorage {
+    Counts counts =
+        Counts(cudec_detail::kZstdFseMaxSymbolValue + 1, 0);
+    std::vector<cudec_detail::ZstdFseCell> cells = std::vector<
+        cudec_detail::ZstdFseCell>(
+        static_cast<size_t>(1u) << cudec_detail::kZstdFseMaxAccuracyLog);
+    std::vector<uint16_t> symbol_next = std::vector<uint16_t>(
+        cudec_detail::kZstdFseMaxSymbolValue + 1, 0);
+};
+
+/* Both sides over one description, every quantity compared. Returns false on
+ * the first divergence and says which one it was. */
+bool ParityHolds(const unsigned char* src, size_t size,
+                 unsigned max_symbol_value, unsigned max_accuracy_log,
+                 const char* where, size_t* cells_compared) {
+    TwinStorage storage;
+    unsigned twin_max_symbol = 0;
+    unsigned twin_accuracy_log = 0;
+    uint64_t twin_consumed = 0;
+    cudec_detail::ZstdFseReject rung = cudec_detail::kZstdFseRejectNone;
+    const cudec_status status = cudec_detail::ZstdFseReadNCount(
+        src, size, max_symbol_value, max_accuracy_log, storage.counts.data(),
+        &twin_max_symbol, &twin_accuracy_log, &twin_consumed, &rung);
+    const OracleRead oracle = ReadWithOracle(src, size, max_symbol_value);
+
+    if (!oracle.ok) {
+        std::fprintf(stderr,
+                     "%s: the oracle refused a description the sweep expects "
+                     "it to accept\n",
+                     where);
+        return false;
+    }
+    if (status != CUDEC_OK) {
+        std::fprintf(stderr, "%s: twin refused (rung %d) where the oracle "
+                             "accepted\n",
+                     where, static_cast<int>(rung));
+        return false;
+    }
+    if (twin_accuracy_log != oracle.accuracy_log) {
+        std::fprintf(stderr, "%s: accuracy log %u vs %u\n", where,
+                     twin_accuracy_log, oracle.accuracy_log);
+        return false;
+    }
+    if (twin_max_symbol != oracle.max_symbol) {
+        std::fprintf(stderr, "%s: highest symbol %u vs %u\n", where,
+                     twin_max_symbol, oracle.max_symbol);
+        return false;
+    }
+    if (twin_consumed != oracle.consumed) {
+        std::fprintf(stderr, "%s: consumed %llu vs %zu bytes\n", where,
+                     static_cast<unsigned long long>(twin_consumed),
+                     oracle.consumed);
+        return false;
+    }
+    for (unsigned symbol = 0; symbol <= max_symbol_value; symbol++) {
+        if (storage.counts[symbol] != oracle.counts[symbol]) {
+            std::fprintf(stderr, "%s: count[%u] %d vs %d\n", where, symbol,
+                         static_cast<int>(storage.counts[symbol]),
+                         static_cast<int>(oracle.counts[symbol]));
+            return false;
+        }
+    }
+
+    /* The table the counts describe, cell by cell. */
+    std::vector<cudec_detail::ZstdFseCell> reference;
+    if (!BuildWithOracle(storage.counts, twin_max_symbol, twin_accuracy_log,
+                         &reference)) {
+        std::fprintf(stderr, "%s: the oracle refused to build the table\n",
+                     where);
+        return false;
+    }
+    const cudec_status build = cudec_detail::ZstdFseBuildDTable(
+        storage.counts.data(), twin_max_symbol, twin_accuracy_log,
+        storage.cells.data(), static_cast<uint32_t>(storage.cells.size()),
+        storage.symbol_next.data(), &rung);
+    if (build != CUDEC_OK) {
+        std::fprintf(stderr, "%s: twin refused to build (rung %d)\n", where,
+                     static_cast<int>(rung));
+        return false;
+    }
+    for (size_t cell = 0; cell < reference.size(); cell++) {
+        const cudec_detail::ZstdFseCell& have = storage.cells[cell];
+        const cudec_detail::ZstdFseCell& want = reference[cell];
+        if (have.symbol != want.symbol || have.nb_bits != want.nb_bits ||
+            have.new_state != want.new_state) {
+            std::fprintf(stderr,
+                         "%s: cell %zu is (symbol %u, nbBits %u, newState %u) "
+                         "and the oracle has (symbol %u, nbBits %u, newState "
+                         "%u)\n",
+                         where, cell, have.symbol, have.nb_bits,
+                         have.new_state, want.symbol, want.nb_bits,
+                         want.new_state);
+            return false;
+        }
+    }
+    *cells_compared += reference.size();
+    return true;
+}
+
+/* The per-field bounds, in the order the three descriptions appear inside a
+ * compressed block: literal lengths, offsets, match lengths. */
+struct FieldBound {
+    const char* name;
+    unsigned symbol_max;
+    unsigned accuracy_log_max;
+};
+
+const FieldBound kSequenceFields[3] = {
+    {"literal-lengths", cudec_detail::kZstdLitLenSymbolMax,
+     cudec_detail::kZstdLitLenAccuracyLogMax},
+    {"offsets", cudec_detail::kZstdOffsetSymbolMax,
+     cudec_detail::kZstdOffsetAccuracyLogMax},
+    {"match-lengths", cudec_detail::kZstdMatchLenSymbolMax,
+     cudec_detail::kZstdMatchLenAccuracyLogMax}};
+
+}  // namespace
+
+int main() {
+    const std::vector<Vector> vectors = MakeVectors();
+
+    /* 1. The writer this file uses for everything below, proven against the
+     * reference's own. Byte for byte: a description that differs from what
+     * FSE_writeNCount emits is not the object the negatives claim to be
+     * mutations of. */
+    for (const Vector& vector : vectors) {
+        const Bytes mine = EncodeNCount(vector.counts, vector.accuracy_log);
+        REQUIRE_CTX(!mine.empty(),
+                    "%s: the vector does not sum to its own table size",
+                    vector.name);
+        std::vector<short> narrow(vector.counts.begin(), vector.counts.end());
+        Bytes theirs(mine.size() + 16, 0xCC);
+        const size_t written = FSE_writeNCount(
+            theirs.data(), theirs.size(), narrow.data(),
+            static_cast<unsigned>(vector.counts.size() - 1),
+            vector.accuracy_log);
+        REQUIRE_CTX(!FSE_isError(written),
+                    "%s: the reference refused to write this vector",
+                    vector.name);
+        REQUIRE_CTX(written == mine.size(),
+                    "%s: reference wrote %zu bytes, this file's writer wrote "
+                    "%zu",
+                    vector.name, written, mine.size());
+        REQUIRE_CTX(std::memcmp(mine.data(), theirs.data(), written) == 0,
+                    "%s: the two descriptions differ", vector.name);
+    }
+
+    /* 2. Parity over those vectors. The description is followed by slack, as
+     * it is inside a real block: the caller passes the bytes remaining rather
+     * than the description's own length, which is not known until it has been
+     * decoded. */
+    size_t cells_compared = 0;
+    size_t descriptions_compared = 0;
+    for (const Vector& vector : vectors) {
+        Bytes description = EncodeNCount(vector.counts, vector.accuracy_log);
+        const size_t exact = description.size();
+        description.resize(exact + 8, 0x00);
+        const unsigned symbol_max =
+            static_cast<unsigned>(vector.counts.size() - 1);
+        REQUIRE_CTX(ParityHolds(description.data(), description.size(),
+                                symbol_max,
+                                cudec_detail::kZstdFseMaxAccuracyLog,
+                                vector.name, &cells_compared),
+                    "%s: with trailing slack", vector.name);
+        /* And again at the exact length, which is the boundary the stricter
+         * reading of the last field runs into. */
+        REQUIRE_CTX(ParityHolds(description.data(), exact, symbol_max,
+                                cudec_detail::kZstdFseMaxAccuracyLog,
+                                vector.name, &cells_compared),
+                    "%s: at the exact description length", vector.name);
+        descriptions_compared += 2;
+    }
+
+    /* 3. The corpus half of the issue's done condition: every Set_Compressed
+     * field of every block of every #185 fixture, positioned from the frame
+     * walker. The walk over the three fields is the sequences section's own
+     * order, and a field in any other mode is stepped over by the width the
+     * format gives it - one byte for RLE, none for Predefined or Repeat. */
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    REQUIRE(!fixtures.empty());
+    size_t corpus_fields = 0;
+    size_t corpus_blocks = 0;
+    for (const ZstdFixture& fixture : fixtures) {
+        ZstdFrameShape shape;
+        std::string why;
+        REQUIRE_CTX(ParseZstdFrameShape(fixture.compressed, &shape, &why),
+                    "%s: %s", fixture.name.c_str(), why.c_str());
+        for (const ZstdBlockShape& block : shape.blocks) {
+            if (block.sequence_count == 0) {
+                continue;
+            }
+            corpus_blocks++;
+            const unsigned modes[3] = {block.ll_mode, block.of_mode,
+                                       block.ml_mode};
+            size_t offset = block.tables_offset;
+            for (unsigned field = 0; field < 3; field++) {
+                REQUIRE_CTX(offset <= block.block_end, "%s: field %s starts "
+                                                       "past the block",
+                            fixture.name.c_str(), kSequenceFields[field].name);
+                if (modes[field] == kZstdTableRle) {
+                    offset += 1;
+                    continue;
+                }
+                if (modes[field] != kZstdTableCompressed) {
+                    continue;
+                }
+                const std::string where =
+                    fixture.name + " / " + kSequenceFields[field].name;
+                const unsigned char* src = fixture.compressed.data() + offset;
+                const size_t size = block.block_end - offset;
+                REQUIRE_CTX(
+                    ParityHolds(src, size, kSequenceFields[field].symbol_max,
+                                kSequenceFields[field].accuracy_log_max,
+                                where.c_str(), &cells_compared),
+                    "%s", where.c_str());
+                /* Advancing by the twin's own consumed count is what makes
+                 * the next field's position depend on it: an off-by-one there
+                 * lands the following description on the wrong byte and the
+                 * sweep reds, which is the downstream failure the issue names
+                 * as silent corruption. */
+                TwinStorage storage;
+                unsigned max_symbol = 0;
+                unsigned accuracy_log = 0;
+                uint64_t consumed = 0;
+                REQUIRE(cudec_detail::ZstdFseReadNCount(
+                            src, size, kSequenceFields[field].symbol_max,
+                            kSequenceFields[field].accuracy_log_max,
+                            storage.counts.data(), &max_symbol, &accuracy_log,
+                            &consumed, nullptr) == CUDEC_OK);
+                offset += static_cast<size_t>(consumed);
+                corpus_fields++;
+                descriptions_compared++;
+            }
+        }
+    }
+    REQUIRE_CTX(corpus_fields > 0,
+                "the corpus produced no Set_Compressed table description - "
+                "the tables-compressed family has stopped carrying one, and "
+                "this half of the proof would pass vacuously");
+
+    /* 4. The negatives, one per rung.
+     *
+     * The base description every mutation starts from, so a mutation's effect
+     * is the only difference between it and a stream the reference writes. */
+    const Vector& base = vectors[1];
+    const Bytes valid = EncodeNCount(base.counts, base.accuracy_log);
+    const unsigned base_symbol_max =
+        static_cast<unsigned>(base.counts.size() - 1);
+    TwinStorage storage;
+    unsigned max_symbol = 0;
+    unsigned accuracy_log = 0;
+    uint64_t consumed = 0;
+    cudec_detail::ZstdFseReject rung = cudec_detail::kZstdFseRejectNone;
+
+    /* An alphabet wider than a count vector can be indexed by. Not a stream:
+     * the oracle has no verdict to give on a caller's argument, and this rung
+     * exists so that a caller bug is refused rather than clamped into a read
+     * past the end of its own array. */
+    REQUIRE(cudec_detail::ZstdFseReadNCount(
+                valid.data(), valid.size(),
+                cudec_detail::kZstdFseMaxSymbolValue + 1,
+                cudec_detail::kZstdFseMaxAccuracyLog, storage.counts.data(),
+                &max_symbol, &accuracy_log, &consumed, &rung) !=
+            CUDEC_OK);
+    REQUIRE(rung == cudec_detail::kZstdFseRejectBadRequest);
+    CoverRung(rung);
+
+    /* No bytes at all. */
+    REQUIRE(cudec_detail::ZstdFseReadNCount(
+                valid.data(), 0, base_symbol_max,
+                cudec_detail::kZstdFseMaxAccuracyLog, storage.counts.data(),
+                &max_symbol, &accuracy_log, &consumed, &rung) != CUDEC_OK);
+    REQUIRE(rung == cudec_detail::kZstdFseRejectEmptyDescription);
+    CoverRung(rung);
+
+    /* An accuracy log past the absolute maximum the format defines. The
+     * four-bit field is biased by five, so a field of eleven asks for
+     * sixteen, and the reference refuses it in FSE_readNCount itself. */
+    {
+        Bytes stream = valid;
+        stream[0] = static_cast<unsigned char>((stream[0] & 0xF0u) | 0x0Bu);
+        REQUIRE(cudec_detail::ZstdFseReadNCount(
+                    stream.data(), stream.size(), base_symbol_max,
+                    cudec_detail::kZstdFseMaxAccuracyLog,
+                    storage.counts.data(), &max_symbol, &accuracy_log,
+                    &consumed, &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdFseRejectAccuracyLogTooLarge);
+        CoverRung(rung);
+        REQUIRE(!ReadWithOracle(stream.data(), stream.size(), base_symbol_max)
+                     .ok);
+    }
+
+    /* The per-field bound, which is a different refusal from the one above
+     * and is the one this unit is asked to enforce. A description at accuracy
+     * log ten is well-formed and FSE_readNCount accepts it; what refuses it
+     * is the offsets field's own maximum of eight, which the reference
+     * applies one level up in ZSTD_buildSeqTable
+     * (lib/decompress/zstd_decompress_block.c). So the oracle's verdict here
+     * is an ACCEPT at ten, asserted, and the twin's refusal is the bound
+     * being enforced where this tree enforces it. */
+    {
+        Counts wide(5, 0);
+        wide[0] = 900;
+        wide[1] = 100;
+        wide[2] = 20;
+        wide[3] = 3;
+        wide[4] = 1;
+        const Bytes stream = EncodeNCount(wide, 10);
+        const OracleRead oracle =
+            ReadWithOracle(stream.data(), stream.size(), 4);
+        REQUIRE(oracle.ok);
+        REQUIRE(oracle.accuracy_log == 10);
+        REQUIRE(cudec_detail::ZstdFseReadNCount(
+                    stream.data(), stream.size(), 4,
+                    cudec_detail::kZstdOffsetAccuracyLogMax,
+                    storage.counts.data(), &max_symbol, &accuracy_log,
+                    &consumed, &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdFseRejectAccuracyLogTooLarge);
+        CoverRung(rung);
+    }
+
+    /* A description cut short mid-probability. Every prefix shorter than the
+     * whole is offered, so the cut lands in the accuracy-log field, in a
+     * probability and in a repeat run in turn rather than at one chosen
+     * place. */
+    {
+        size_t truncations = 0;
+        for (size_t length = 0; length < valid.size(); length++) {
+            const Bytes stream(valid.begin(), valid.begin() + length);
+            const cudec_status status = cudec_detail::ZstdFseReadNCount(
+                stream.empty() ? valid.data() : stream.data(), length,
+                base_symbol_max, cudec_detail::kZstdFseMaxAccuracyLog,
+                storage.counts.data(), &max_symbol, &accuracy_log, &consumed,
+                &rung);
+            REQUIRE_CTX(status != CUDEC_OK,
+                        "a %zu-byte prefix of a %zu-byte description was "
+                        "accepted",
+                        length, valid.size());
+            if (length > 0) {
+                REQUIRE(rung ==
+                        cudec_detail::kZstdFseRejectDescriptionTruncated);
+                CoverRung(rung);
+                REQUIRE_CTX(
+                    !ReadWithOracle(stream.data(), length, base_symbol_max).ok,
+                    "the oracle accepted a %zu-byte prefix", length);
+                truncations++;
+            }
+        }
+        REQUIRE(truncations > 0);
+    }
+
+    /* THE OVERSHOOT THE ISSUE ASKS FOR IS NOT A NEGATIVE, AND THIS IS WHERE
+     * IT WOULD HAVE BEEN. A description cannot claim more slots than the
+     * table has: the field's own limit is derived from the budget left, so
+     * the widest value the encoding can carry decodes to exactly that budget
+     * and no more. src/zstd_fse.h says so at the rung that is therefore
+     * absent, and this is that statement executed rather than argued - the
+     * widest field the format admits at accuracy log five, which is the
+     * whole table on one symbol, lands on exactly one slot left over.
+     *
+     * A stream that CLAIMED more would be a stream the writer above cannot
+     * spell, and every bit pattern it could carry instead is one of the ones
+     * the sweep already walked. */
+    {
+        BitWriter writer;
+        writer.Put(0, 4); /* accuracy log five, a table of thirty-two */
+        /* remaining 33, threshold 32, field six bits, so the limit below
+         * which the narrow form is used is thirty. All six bits set is the
+         * widest value the field can hold. */
+        writer.Put(63, 6);
+        const Bytes stream = writer.bytes;
+        REQUIRE(cudec_detail::ZstdFseReadNCount(
+                    stream.data(), stream.size(), base_symbol_max,
+                    cudec_detail::kZstdFseMaxAccuracyLog,
+                    storage.counts.data(), &max_symbol, &accuracy_log,
+                    &consumed, &rung) == CUDEC_OK);
+        REQUIRE(max_symbol == 0);
+        REQUIRE(storage.counts[0] == 32);
+        const OracleRead oracle =
+            ReadWithOracle(stream.data(), stream.size(), base_symbol_max);
+        REQUIRE(oracle.ok);
+        REQUIRE(oracle.max_symbol == 0);
+        REQUIRE(oracle.counts[0] == 32);
+    }
+
+    /* An alphabet that runs out with probability still unallocated: a valid
+     * six-symbol description read against a field whose highest symbol is
+     * three. The reference reports maxSymbolValue_tooSmall for this, which is
+     * a refusal like any other at this layer. */
+    {
+        const Bytes stream = EncodeNCount(base.counts, base.accuracy_log);
+        REQUIRE(cudec_detail::ZstdFseReadNCount(
+                    stream.data(), stream.size(), 3,
+                    cudec_detail::kZstdFseMaxAccuracyLog,
+                    storage.counts.data(), &max_symbol, &accuracy_log,
+                    &consumed, &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdFseRejectSymbolPastMax);
+        CoverRung(rung);
+        REQUIRE(!ReadWithOracle(stream.data(), stream.size(), 3).ok);
+    }
+
+    /* The same rung reached through a repeat run instead: a zero probability
+     * followed by continuation codes that walk the symbol index past the
+     * field's highest symbol. */
+    {
+        BitWriter writer;
+        writer.Put(0, 4); /* accuracy log five, table of thirty-two */
+        /* remaining 33, threshold 32: a stored value of one is below the
+         * narrow form's limit of thirty, so it is five bits wide, and a
+         * stored one is a probability of zero, which opens a run. */
+        writer.Put(1, 5);
+        for (unsigned code = 0; code < 4; code++) {
+            writer.Put(3, 2);
+        }
+        const Bytes stream = writer.bytes;
+        REQUIRE(cudec_detail::ZstdFseReadNCount(
+                    stream.data(), stream.size(), 5,
+                    cudec_detail::kZstdFseMaxAccuracyLog,
+                    storage.counts.data(), &max_symbol, &accuracy_log,
+                    &consumed, &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdFseRejectSymbolPastMax);
+        CoverRung(rung);
+        REQUIRE(!ReadWithOracle(stream.data(), stream.size(), 5).ok);
+    }
+
+    /* The build's own two rungs. Neither is reachable from a description the
+     * decode above accepted, which is why they are reached by calling the
+     * build directly - the caller this refuses is a future one that assembles
+     * a count vector itself. */
+    {
+        Counts counts(2, 0);
+        counts[0] = 20;
+        counts[1] = 12;
+        REQUIRE(cudec_detail::ZstdFseBuildDTable(
+                    counts.data(), 1, 5, storage.cells.data(), 31,
+                    storage.symbol_next.data(), &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdFseRejectBuildCapacity);
+        CoverRung(rung);
+
+        counts[1] = 11; /* thirty-one slots claimed of thirty-two */
+        REQUIRE(cudec_detail::ZstdFseBuildDTable(
+                    counts.data(), 1, 5, storage.cells.data(),
+                    static_cast<uint32_t>(storage.cells.size()),
+                    storage.symbol_next.data(), &rung) != CUDEC_OK);
+        REQUIRE(rung ==
+                cudec_detail::kZstdFseRejectBuildCountsNotNormalized);
+        CoverRung(rung);
+
+        counts[1] = 13; /* one slot too many */
+        REQUIRE(cudec_detail::ZstdFseBuildDTable(
+                    counts.data(), 1, 5, storage.cells.data(),
+                    static_cast<uint32_t>(storage.cells.size()),
+                    storage.symbol_next.data(), &rung) != CUDEC_OK);
+        REQUIRE(rung ==
+                cudec_detail::kZstdFseRejectBuildCountsNotNormalized);
+
+        counts[1] = -2; /* below the "less than one" code */
+        REQUIRE(cudec_detail::ZstdFseBuildDTable(
+                    counts.data(), 1, 5, storage.cells.data(),
+                    static_cast<uint32_t>(storage.cells.size()),
+                    storage.symbol_next.data(), &rung) != CUDEC_OK);
+        REQUIRE(rung ==
+                cudec_detail::kZstdFseRejectBuildCountsNotNormalized);
+
+        /* And the build's caller-argument rung, for the same reason the
+         * decode's exists. */
+        REQUIRE(cudec_detail::ZstdFseBuildDTable(
+                    counts.data(), 1, cudec_detail::kZstdFseMaxAccuracyLog + 1,
+                    storage.cells.data(),
+                    static_cast<uint32_t>(storage.cells.size()),
+                    storage.symbol_next.data(), &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdFseRejectBadRequest);
+    }
+
+    /* 5. Every rung named by a negative written to reach it, walked rather
+     * than restated: a rung added to the unit with none behind it lands here
+     * as a hole with its number on it. */
+    for (int declared = cudec_detail::kZstdFseRejectNone + 1;
+         declared < cudec_detail::kZstdFseRejectCount; declared++) {
+        REQUIRE_CTX(g_reject_covered[declared],
+                    "reject rung %d has no declared negative that reaches it "
+                    "- add one, or the rung is untested",
+                    declared);
+    }
+
+    std::printf("PASS: %zu descriptions compared against FSE_readNCount "
+                "(%zu of them Set_Compressed fields inside %zu corpus "
+                "blocks), %zu table cells diffed against FSE_buildDTable, "
+                "%d of %d reject rungs covered by a declared negative\n",
+                descriptions_compared, corpus_fields, corpus_blocks,
+                cells_compared,
+                static_cast<int>(cudec_detail::kZstdFseRejectCount) - 1,
+                static_cast<int>(cudec_detail::kZstdFseRejectCount) - 1);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #217.

A Zstd `Set_Compressed` table description had no decoder in this tree. The
sequences section positions itself from the consumed byte count of the three
descriptions ahead of it, and every serial FSE core reads out of the table
they describe, so nothing above this could be built. `src/zstd_fse.h` is that
unit, single-sourced for host and device beside `src/lz4_block.h`,
`src/snappy_block.h` and `src/zstd_bitstream.h`.

Description decode and table build ship in one change because the build has
no reject path a validated description can reach. It is a pure function of
counts that already summed to the table size, so the only honest proof of it
is a cell-by-cell diff rather than a status comparison, and that diff needs
the decode in front of it.

`tests/zstd_fse_twin.cpp` is the proof. The frame walker in
`tests/zstd_corpus.h` gained two fields it already had in hand: where a
block's table descriptions begin and where the block ends. It stood on those
bytes and threw the position away, which left every consumer to re-derive the
walk it had just done.

## Two things the issue assumed, which turned out otherwise

**The bit order.** The issue says this unit "reads its bits through the reader
of the sibling issue". It cannot: a table description is written forward and
read forward, low bit of the low byte first, while `src/zstd_bitstream.h`
walks a Zstd bitstream backward from a start marker, high bit first. Those are
different serialisations of different objects, and a description read with the
backward reader produces plausible symbols out of the wrong bits. The forward
reader lives in `src/zstd_fse.h` and the header says why where a reader will
meet it. The backward reader is still what the state cores and the literal
streams run over, one layer up, so nothing about that sibling changes.

**The overshoot reject.** The issue asks for "a sum that overshoots
`1 << accuracy_log` is a reject" and for a negative that reaches it. That
state is not reachable, and it is a property of the encoding rather than of
this code: each probability field is read against a limit derived from the
budget left, so the widest value the full-width form can carry decodes to
exactly the remaining budget and never past it. A rung for it would be one no
negative could reach, which this repo's own rule forbids, so the rung is
absent and the header states the derivation at the place where it would have
been. The test executes the boundary instead of arguing it: the widest field
the format admits at accuracy log five, the whole table on one symbol, lands
on exactly one slot left over, and both implementations agree on the counts.

The remaining reject direction, a description that ends with probability still
unallocated, is one rung and has two negatives behind it.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)

## Engineering checklist

- [x] Fail-closed preserved: every refusal returns through one choke point
      naming its rung, and the twin requires a declared negative per rung.
- [x] Oracle coverage: `FSE_readNCount` for the description and
      `FSE_buildDTable_wksp` for the table, both from the pinned facebook/zstd
      1.5.7 the tree already fetches.
- [x] Determinism preserved: the unit is a pure function of its input bytes
      and allocates nothing.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      This change adds no CUDA call and no ABI surface.
- [ ] An adversarial review (`/security-review`) was run.
- [ ] Review record.

No second reader stands behind this change and no review lens was run. The
evidence below is what stands in place of one, and it is stated as evidence
rather than as clearance.

## GPU sanitizer gate

`src/zstd_fse.h` is a `CUDEC_HOST_DEVICE` header, so it is on the surface the
gate covers and this section is not being waived. No route to a device the
sanitizer can attach to was available.

The sanitizer cannot attach on this machine at all, which is #258 and is open.
The container that supplies the alternative route was not reachable either:

    docker version --format "{{.Server.Version}}"
    failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine;
    check if the path is correct and if the daemon is running

Bringing it up is a decision for the machine's owner, so it was left alone.

```
commit:    (no sweep ran)
gpu:       (no sweep ran)
cuda:      (no sweep ran)
sanitizer: (no sweep ran)
```

Nothing in this change is compiled into device code by any target that exists
today. The header is host-and-device by construction so the kernel can take it
unchanged, and that is the point at which the device gate becomes load-bearing
for it.

## Verification

`ctest` did not run and no CUDA build was produced: `tests/` is added only
inside the `CUDEC_ENABLE_CUDA` block of the top-level `CMakeLists.txt`, and
this host has no CUDA toolchain on any route it offers. What ran instead is
the same test source, the same header and the same oracle sources, on a Linux
toolchain, against the release the tree pins:

    sha256sum zstd-1.5.7.tar.gz
    eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3
    clang++ --version | head -1
    Ubuntu clang version 18.1.3 (1ubuntu1)
    g++ --version | head -1
    g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0

The hash is the one in `tests/CMakeLists.txt:60`.

1. The twin under ASan and UBSan, non-recovering, over the real header and
   the real oracle:

       clang++ -std=c++17 -Wall -Wextra -Werror -O1 -g \
         -fsanitize=address,undefined -fno-sanitize-recover=all \
         -DFSE_STATIC_LINKING_ONLY -I include -I src -I tests -isystem <zstd>/lib \
         tests/zstd_fse_twin.cpp tests/zstd_corpus.cpp libzstdfull.a -o zstd_fse_twin
       ./zstd_fse_twin
       PASS: 852 descriptions compared against FSE_readNCount (838 of them
       Set_Compressed fields inside 332 corpus blocks), 58624 table cells
       diffed against FSE_buildDTable, 7 of 7 reject rungs covered by a
       declared negative
       exit=0

2. The same source under the project's strict flags with the other compiler
   and no sanitizer, because the CI host build uses one and the sanitize job
   the other:

       g++ -std=c++17 -Wall -Wextra -Werror -O2 ... -o zstd_fse_twin_gcc
       build exit=0
       run exit=0, same PASS line

3. Every guard proven by deleting it. Each mutant is the header with one guard
   replaced by `if (false)` or `while (false)` and nothing else changed, built
   and run against the unmodified test:

       truncation check on the probability field   exit=1
       reserved-top skip in the spread walk        exit=1
       counts sum check                            exit=1
       per-field accuracy log bound                exit=1
       cell capacity check                         exit=1
       unmutated                                   exit=0

   The second one is the interesting failure: the suite reds on a cell diff
   rather than on a status, which is what the cell-by-cell comparison is for.

       one-lowprob: cell 9 is (symbol 0, nbBits 1, newState 20) and the
       oracle has (symbol 3, nbBits 5, newState 0)

4. The description writer the negatives are mutations of is itself proven
   against `FSE_writeNCount` byte for byte, over every vector it is used with,
   before any of them runs. That is step 1 of the test and it fails the suite
   on a single differing byte.

5. The local gate legs that run on this host.

       cmake -B build && cmake --build build
       [100%] Built target example_decode_frame

       git ls-files "*.md" "*.yml" "*.yaml" | xargs npx --yes prettier@3 --check
       All matched files use Prettier code style!

   Prettier is run over the tracked set rather than over the whole tree: an
   untracked `build-host/` directory left in this checkout carries a generated
   `CMakeConfigureLog.yaml` that the wider glob picks up. It is not part of
   this change and was not removed.

   The host-only configuration compiles `src/version.c` and the examples and
   reaches neither new file, so that leg is reported for what it is rather
   than as coverage of this change. CI builds the CUDA configuration and runs
   the GPU-less subset with `ctest -LE gpu`, which is where `zstd_fse_twin` is
   gated.

- [x] `cmake --build build` builds clean.
- [ ] `ctest --test-dir build` green.
- [x] Prettier clean over the tracked tree.
- [x] Docs synced: no behaviour this change touches is described in
      MASTERPLAN, README or BENCHMARKS.

## What is deliberately not here

`zstd_fse_twin` is **not** added to the sanitize job's explicit name list in
`.github/workflows/ci.yml`. It runs in CI through the build job's
`ctest -LE gpu`, so it is gated; what it does not get is the ASan/UBSan run
that list selects. The evidence above includes a sanitized run of exactly this
binary, but that is a local run and not the gate. The reason for leaving the
workflow alone is that another change is in flight against the same file and
two edits to it would collide; adding the two lines is a short follow-up once
that lands.

## Quality checklist

- [x] Minimal: one header, one test, two fields on an existing struct.
- [x] Self-documenting; the comments carry the why, including the two places
      the issue's assumptions did not hold.
- [x] The new structural property is locked by the rung walk at the end of the
      twin: a rung added to the header with no negative behind it reds it.
