### PR TITLE
Walk a built FSE table over a backward bitstream [#219]

### DIFF
--- a/src/zstd_fse.h
+++ b/src/zstd_fse.h
@@ -41,6 +41,7 @@
 #define CUDEC_ZSTD_FSE_H
 
 #include "cudec.h"
+#include "zstd_bitstream.h"
 
 #include <stdint.h>
 
@@ -128,6 +129,15 @@ enum ZstdFseReject {
      * Unreachable from a description this header decoded; reachable, and
      * reached by the twin, from a caller that builds a vector by hand. */
     kZstdFseRejectBuildCountsNotNormalized,
+    /* Core side: the stream held fewer bits than the two initial states need,
+     * or a zero-bit cell was reached through a reader that never started. */
+    kZstdFseRejectStateInitTruncated,
+    /* Core side: a state landed outside the table. Well-formed tables cannot
+     * produce one - the successor of every cell is inside - so this refuses a
+     * cell array that came from somewhere else. */
+    kZstdFseRejectStateOutOfTable,
+    /* Core side: the caller's capacity filled before the bits ran out. */
+    kZstdFseRejectOutputFull,
     kZstdFseRejectCount
 };
 
@@ -516,6 +526,153 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdFseBuildDTable(
             static_cast<uint16_t>((next_state << bits) - table_size);
     }
     return CUDEC_OK;
+}
+
+/* The decode cores that walk a built table over a backward bitstream.
+ *
+ * A state is an index into the table. Initialising it reads accuracy_log
+ * bits; decoding a symbol reads the cell's own bit count and lands on the
+ * cell's successor. The emit precedes the update, which is the whole of the
+ * ordering: a decoder that updates first emits the symbol of a cell the
+ * encoder never wrote.
+ *
+ * WHERE THE STREAM ENDS IS DECIDED BY THE BITS, not by a length. An FSE
+ * stream carries no symbol count: the encoder wrote exactly the bits the
+ * decoder needs for every update except the last, so the run ends when an
+ * update would need more bits than are left. The reference reaches the same
+ * point from the other side, by noticing after the fact that its read pointer
+ * passed the start of the buffer (FSE_decompress_usingDTable_generic in
+ * lib/common/fse_decompress.c), and emitting one final symbol from the other
+ * state. This unit refuses to read the bits instead of reading them and
+ * noticing, which is the same stopping point and no fabricated bit.
+ *
+ * THE OUTPUT BOUND IS NOT DECORATION. A table whose cells all read zero bits
+ * is well formed - one symbol holding the whole table produces exactly that -
+ * and over such a table the bit budget never runs down. The caller's capacity
+ * is what ends the run there, and reaching it is a refusal rather than a
+ * truncated answer. */
+struct ZstdFseState {
+    uint32_t value;
+};
+
+CUDEC_HOST_DEVICE inline cudec_status ZstdFseInitState(ZstdBitReader* reader,
+                                                       unsigned accuracy_log,
+                                                       ZstdFseState* state,
+                                                       ZstdFseReject* reject) {
+    uint64_t bits = 0;
+    if (reader->ReadBits(accuracy_log, &bits) != CUDEC_OK) {
+        return ZstdFseRefuse(kZstdFseRejectStateInitTruncated,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    state->value = static_cast<uint32_t>(bits);
+    return CUDEC_OK;
+}
+
+/* One symbol. `spent` comes back true when the update would have needed more
+ * bits than the stream holds: the symbol just emitted is real and the state
+ * is left where it was, and the caller stops after taking one more symbol
+ * from its other state.
+ *
+ * `table_size` is checked against the state on every call rather than trusted
+ * from the build. A cell array is the one thing here a caller can hand in
+ * from anywhere, and an index into it that came out of a stream is exactly
+ * the read this project does not allow to go unbounded. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdFseNextSymbol(
+    ZstdBitReader* reader, const ZstdFseCell* cells, uint32_t table_size,
+    ZstdFseState* state, uint8_t* symbol, bool* spent,
+    ZstdFseReject* reject) {
+    *spent = false;
+    if (state->value >= table_size) {
+        return ZstdFseRefuse(kZstdFseRejectStateOutOfTable,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const ZstdFseCell cell = cells[state->value];
+    *symbol = cell.symbol;
+    if (cell.nb_bits > reader->BitsRemaining()) {
+        *spent = true;
+        return CUDEC_OK;
+    }
+    uint64_t bits = 0;
+    const cudec_status status = reader->ReadBits(cell.nb_bits, &bits);
+    if (status != CUDEC_OK) {
+        /* Reachable: a reader whose Start never succeeded reports no bits
+         * remaining and refuses a zero-width read, so the check above lets a
+         * zero-bit cell through to here. */
+        return ZstdFseRefuse(kZstdFseRejectStateInitTruncated, status, reject);
+    }
+    state->value = cell.new_state + static_cast<uint32_t>(bits);
+    return CUDEC_OK;
+}
+
+/* The two-state interleaved run, which is the shape the Huffman weight
+ * description is written in: two states initialised in order from one stream,
+ * symbols taken from them alternately, and the pair of final symbols taken
+ * once the bits run out.
+ *
+ * The reader must already have been started. Symbols land in `out` and the
+ * count comes back in `out_count`. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdFseDecode2State(
+    ZstdBitReader* reader, const ZstdFseCell* cells, uint32_t table_size,
+    unsigned accuracy_log, uint8_t* out, uint32_t out_capacity,
+    uint32_t* out_count, ZstdFseReject* reject) {
+    *out_count = 0;
+    if (reject != 0) {
+        *reject = kZstdFseRejectNone;
+    }
+    if (cells == 0 || out == 0 || accuracy_log < kZstdFseMinAccuracyLog ||
+        accuracy_log > kZstdFseMaxAccuracyLog ||
+        table_size != (1u << accuracy_log)) {
+        return ZstdFseRefuse(kZstdFseRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    ZstdFseState first;
+    ZstdFseState second;
+    cudec_status status =
+        ZstdFseInitState(reader, accuracy_log, &first, reject);
+    if (status != CUDEC_OK) {
+        return status;
+    }
+    status = ZstdFseInitState(reader, accuracy_log, &second, reject);
+    if (status != CUDEC_OK) {
+        return status;
+    }
+
+    uint32_t produced = 0;
+    /* Counted, and the bound is the caller's capacity: every iteration writes
+     * one symbol, so a table over which the bit budget never runs down ends
+     * here rather than spinning. */
+    for (uint32_t step = 0; step < out_capacity; step++) {
+        ZstdFseState* active = (step % 2u) == 0 ? &first : &second;
+        ZstdFseState* other = (step % 2u) == 0 ? &second : &first;
+        uint8_t symbol = 0;
+        bool spent = false;
+        status = ZstdFseNextSymbol(reader, cells, table_size, active, &symbol,
+                                   &spent, reject);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+        out[produced] = symbol;
+        produced++;
+        if (!spent) {
+            continue;
+        }
+        /* The last update could not be paid for, so the run ends with one
+         * more symbol from the other state - the reference's own tail. */
+        if (produced == out_capacity) {
+            return ZstdFseRefuse(kZstdFseRejectOutputFull,
+                                 CUDEC_ERR_OUTPUT_TOO_SMALL, reject);
+        }
+        if (other->value >= table_size) {
+            return ZstdFseRefuse(kZstdFseRejectStateOutOfTable,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        out[produced] = cells[other->value].symbol;
+        produced++;
+        *out_count = produced;
+        return CUDEC_OK;
+    }
+    return ZstdFseRefuse(kZstdFseRejectOutputFull, CUDEC_ERR_OUTPUT_TOO_SMALL,
+                         reject);
 }
 
 }  // namespace cudec_detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -323,7 +323,10 @@ target_include_directories(zstd_frame_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_compile_definitions(zstd_frame_twin PRIVATE ZSTD_STATIC_LINKING_ONLY)
 # The Zstd FSE table description decode and the table it builds (issue #217),
-# held to FSE_readNCount and FSE_buildDTable_wksp cell by cell. Host-side and
+# held to FSE_readNCount and FSE_buildDTable_wksp cell by cell, plus the state
+# cores that walk that table over a backward bitstream (issue #219), held to
+# the reference's own decode of streams its compress pipeline wrote and of the
+# Huffman weight descriptions the corpus carries. Host-side and
 # GPU-less. It links zstd_full alone for the reason zstd_oracle_smoke gives
 # above and because FSE_writeNCount lives on the compress side: the test
 # writes the descriptions its negatives are mutations of, and proves its own

--- a/tests/zstd_corpus.cpp
+++ b/tests/zstd_corpus.cpp
@@ -227,6 +227,8 @@ bool ReadLiteralsSection(Reader* r, ZstdBlockShape* shape) {
         compressed = static_cast<size_t>((packed >> 18) & 0x3ffffu);
     }
     shape->literals_streams = size_format == 0 ? 1u : 4u;
+    shape->literals_payload_offset = r->pos;
+    shape->literals_payload_size = compressed;
     return r->Skip(compressed);
 }
 

--- a/tests/zstd_corpus.h
+++ b/tests/zstd_corpus.h
@@ -68,6 +68,14 @@ struct ZstdBlockShape {
      * compressed block. */
     size_t tables_offset = 0;
     size_t block_end = 0;
+    /* Where a Compressed or Treeless literals section's payload begins and
+     * how long it is, as an offset into the frame. Reported for the same
+     * reason as the two above: the walk reads the size in order to step over
+     * it, and a consumer that wants the Huffman tree description would
+     * otherwise re-read the header to find where the walk had just been. Set
+     * only for those two literals types. */
+    size_t literals_payload_offset = 0;
+    size_t literals_payload_size = 0;
 };
 
 struct ZstdFrameShape {

--- a/tests/zstd_fse_twin.cpp
+++ b/tests/zstd_fse_twin.cpp
@@ -1,10 +1,11 @@
-/* The CPU twin of the Zstd FSE table description decode and the decoding
- * table built from it (src/zstd_fse.h), issue #217. The sibling of
+/* The CPU twin of the Zstd FSE unit (src/zstd_fse.h): the table description
+ * decode and the table built from it (issue #217), and the state cores that
+ * walk that table over a backward bitstream (issue #219). The sibling of
  * tests/parser_twin.cpp, tests/snappy_parser_twin.cpp and
  * tests/zstd_bitstream_twin.cpp: the single-source unit executed on the host,
  * on the GPU-less CI runner, and held to the pinned reference's verdicts.
  *
- * Three proofs, and they are different in kind.
+ * Five proofs, and they are different in kind.
  *
  * THE DESCRIPTIONS ARE BUILT BY AN ENCODER THIS FILE OWNS, and the first
  * thing the test does is prove that encoder byte for byte against
@@ -36,7 +37,18 @@
  * descriptions all come back corruption_detected, measured on #189 - so a
  * negative here asserts that the oracle refused and that the twin refused
  * through the rung the negative was written for. Reading a reason out of the
- * oracle's code would be reading something it does not report. */
+ * oracle's code would be reading something it does not report.
+ *
+ * THE STATE CORES are proven twice over. Once against a table this file
+ * writes by hand, where every cell names itself and lands on the state the
+ * next bits spell, so the expected symbol sequence is the stream's successive
+ * bit groups and a reader checks it by reading the bit string - that isolates
+ * the emit-before-update ordering and the state arithmetic from the table
+ * builder. And once against the reference end to end, over streams the
+ * reference's own compress pipeline wrote and over the Huffman weight
+ * descriptions the #185 corpus really carries, where the whole chain -
+ * description, table, two-state run, tail rule - has to agree symbol for
+ * symbol with FSE_decompress. */
 #include "require.h"
 #include "zstd_corpus.h"
 #include "zstd_fse.h"
@@ -368,6 +380,173 @@ bool ParityHolds(const unsigned char* src, size_t size,
     }
     *cells_compared += reference.size();
     return true;
+}
+
+/* An FSE-compressed buffer decoded the way the reference's FSE_decompress
+ * decodes one: the NCount description, the table it describes, then the
+ * two-state interleaved run over everything after it. This is the whole of
+ * the unit under test wired together in the order a caller uses it. */
+bool TwinFseDecompress(const unsigned char* src, size_t size,
+                       std::vector<uint8_t>* out,
+                       cudec_detail::ZstdFseReject* rung) {
+    TwinStorage storage;
+    unsigned max_symbol = 0;
+    unsigned accuracy_log = 0;
+    uint64_t consumed = 0;
+    if (cudec_detail::ZstdFseReadNCount(
+            src, size, cudec_detail::kZstdFseMaxSymbolValue,
+            cudec_detail::kZstdFseMaxAccuracyLog, storage.counts.data(),
+            &max_symbol, &accuracy_log, &consumed, rung) != CUDEC_OK) {
+        return false;
+    }
+    const uint32_t table_size = 1u << accuracy_log;
+    if (cudec_detail::ZstdFseBuildDTable(
+            storage.counts.data(), max_symbol, accuracy_log,
+            storage.cells.data(), static_cast<uint32_t>(storage.cells.size()),
+            storage.symbol_next.data(), rung) != CUDEC_OK) {
+        return false;
+    }
+    cudec_detail::ZstdBitReader reader{src + consumed,
+                                       size - static_cast<size_t>(consumed)};
+    if (reader.Start() != CUDEC_OK) {
+        return false;
+    }
+    out->assign(1u << 16, 0);
+    uint32_t produced = 0;
+    if (cudec_detail::ZstdFseDecode2State(
+            &reader, storage.cells.data(), table_size, accuracy_log,
+            out->data(), static_cast<uint32_t>(out->size()), &produced,
+            rung) != CUDEC_OK) {
+        out->clear();
+        return false;
+    }
+    out->resize(produced);
+    return true;
+}
+
+/* An FSE stream written by the reference's own compress pipeline. There is no
+ * one-call FSE_compress in this release, so the four steps are spelled out:
+ * the histogram, the normalized distribution, its description, and the
+ * two-state interleaved body. That is the object the weight description in a
+ * real frame is, and it is what the cores are then held to. Empty when the
+ * source has fewer than two distinct symbols, which the caller reports. */
+Bytes ReferenceFseCompress(const Bytes& source) {
+    unsigned histogram[256] = {0};
+    for (size_t i = 0; i < source.size(); i++) {
+        histogram[source[i]]++;
+    }
+    unsigned max_symbol = 0;
+    unsigned distinct = 0;
+    for (unsigned symbol = 0; symbol < 256; symbol++) {
+        if (histogram[symbol] != 0) {
+            max_symbol = symbol;
+            distinct++;
+        }
+    }
+    if (distinct < 2) {
+        return Bytes();
+    }
+    const unsigned table_log =
+        FSE_optimalTableLog(12, source.size(), max_symbol);
+    std::vector<short> norm(max_symbol + 1, 0);
+    if (FSE_isError(FSE_normalizeCount(norm.data(), table_log, histogram,
+                                       source.size(), max_symbol, 0))) {
+        return Bytes();
+    }
+    Bytes out(source.size() + 4096, 0);
+    const size_t header = FSE_writeNCount(out.data(), out.size(), norm.data(),
+                                          max_symbol, table_log);
+    if (FSE_isError(header)) {
+        return Bytes();
+    }
+    std::vector<FSE_CTable> ctable(
+        FSE_CTABLE_SIZE_U32(table_log, max_symbol), 0);
+    std::vector<unsigned> work(
+        FSE_BUILD_CTABLE_WORKSPACE_SIZE_U32(max_symbol, table_log) + 8, 0);
+    if (FSE_isError(FSE_buildCTable_wksp(ctable.data(), norm.data(),
+                                         max_symbol, table_log, work.data(),
+                                         work.size() * sizeof(unsigned)))) {
+        return Bytes();
+    }
+    const size_t body = FSE_compress_usingCTable(
+        out.data() + header, out.size() - header, source.data(),
+        source.size(), ctable.data());
+    if (FSE_isError(body) || body == 0) {
+        return Bytes();
+    }
+    out.resize(header + body);
+    return out;
+}
+
+/* The reference's own decode of such a stream. */
+bool ReferenceFseDecompress(const unsigned char* src, size_t size,
+                            std::vector<uint8_t>* out) {
+    std::vector<unsigned> work(
+        FSE_DECOMPRESS_WKSP_SIZE_U32(12, FSE_MAX_SYMBOL_VALUE) + 8, 0);
+    out->assign(1u << 16, 0);
+    const size_t produced = FSE_decompress_wksp_bmi2(
+        out->data(), out->size(), src, size, 12, work.data(),
+        work.size() * sizeof(unsigned), 0);
+    if (FSE_isError(produced)) {
+        out->clear();
+        return false;
+    }
+    out->resize(produced);
+    return true;
+}
+
+/* A table this file writes rather than builds, so the cores are proven
+ * without the table builder in the loop. Every cell names itself as its own
+ * symbol and lands on the state the next bits spell, so a decode over it is
+ * literally the stream's successive accuracy-log-wide groups - an expectation
+ * a reader checks by reading the bit string, not by running the code.
+ *
+ * It is not a distribution any encoder would emit, and it does not need to
+ * be: what it isolates is the emit-before-update ordering and the state
+ * arithmetic, which are the two things a table-driven check cannot separate. */
+std::vector<cudec_detail::ZstdFseCell> MakeSelfNamingTable(
+    unsigned accuracy_log) {
+    const size_t table_size = static_cast<size_t>(1u) << accuracy_log;
+    std::vector<cudec_detail::ZstdFseCell> cells(table_size);
+    for (size_t cell = 0; cell < table_size; cell++) {
+        cells[cell].symbol = static_cast<uint8_t>(cell);
+        cells[cell].nb_bits = static_cast<uint8_t>(accuracy_log);
+        cells[cell].new_state = 0;
+    }
+    return cells;
+}
+
+/* A backward bitstream carrying the given fixed-width groups in consumption
+ * order, and nothing else.
+ *
+ * The final byte is 0x01, whose highest set bit is bit zero, so it
+ * contributes the start marker and no data - which makes the live bit count
+ * exactly eight times the bytes before it. Consumption then walks those bytes
+ * downwards from the last, most significant bit first, which is where each
+ * group's own most significant bit goes. The total width must land on a byte
+ * boundary; a caller that asks otherwise gets an empty stream. */
+Bytes BackwardStreamOfGroups(const uint8_t* groups, size_t count,
+                             unsigned width) {
+    const size_t bits = count * width;
+    if (bits == 0 || bits % 8 != 0) {
+        return Bytes();
+    }
+    Bytes stream(bits / 8 + 1, 0);
+    stream.back() = 0x01;
+    const size_t last_data = stream.size() - 2;
+    size_t index = 0;
+    for (size_t group = 0; group < count; group++) {
+        for (unsigned bit = 0; bit < width; bit++) {
+            const unsigned value =
+                (groups[group] >> (width - 1u - bit)) & 1u;
+            if (value != 0) {
+                stream[last_data - index / 8] = static_cast<unsigned char>(
+                    stream[last_data - index / 8] | (1u << (7 - index % 8)));
+            }
+            index++;
+        }
+    }
+    return stream;
 }
 
 /* The per-field bounds, in the order the three descriptions appear inside a
@@ -744,7 +923,250 @@ int main() {
         REQUIRE(rung == cudec_detail::kZstdFseRejectBadRequest);
     }
 
-    /* 5. Every rung named by a negative written to reach it, walked rather
+    /* 5. The state cores over a table this file writes by hand, so the
+     * ordering and the state arithmetic are proven with the table builder out
+     * of the loop.
+     *
+     * Every cell of the table names itself and reads accuracy_log bits into a
+     * successor of zero, so the decode is exactly the stream's successive
+     * five-bit groups in consumption order. The stream below carries eight of
+     * them, spelled out here rather than computed:
+     *
+     *     00001 00010 00011 00100 00101 00110 00111 01000
+     *
+     * The first two are the initial states, and the tail rule is what makes
+     * the last two come out: after the sixth group there are no bits left for
+     * an update, so the symbol standing in the other state is taken and the
+     * run stops. Eight groups in, eight symbols out. */
+    {
+        const unsigned kLog = 5;
+        const uint8_t groups[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+        const Bytes stream =
+            BackwardStreamOfGroups(groups, sizeof(groups), kLog);
+        const std::vector<cudec_detail::ZstdFseCell> cells =
+            MakeSelfNamingTable(kLog);
+        cudec_detail::ZstdBitReader reader{stream.data(), stream.size()};
+        REQUIRE(reader.Start() == CUDEC_OK);
+        REQUIRE(reader.BitsRemaining() == sizeof(groups) * kLog);
+        uint8_t out[16] = {0};
+        uint32_t produced = 0;
+        REQUIRE(cudec_detail::ZstdFseDecode2State(
+                    &reader, cells.data(), 1u << kLog, kLog, out,
+                    static_cast<uint32_t>(sizeof(out)), &produced, &rung) ==
+                CUDEC_OK);
+        REQUIRE_CTX(produced == sizeof(groups), "produced %u symbols",
+                    produced);
+        for (size_t i = 0; i < sizeof(groups); i++) {
+            REQUIRE_CTX(out[i] == groups[i], "symbol %zu is %u, want %u", i,
+                        out[i], groups[i]);
+        }
+        REQUIRE(reader.AtEnd());
+    }
+
+    /* 6. The cores against the reference over real FSE streams: the pinned
+     * compressor writes them, FSE_decompress reads them, and the unit under
+     * test reads the same bytes. This is the whole chain - description,
+     * table, two-state run - held to the reference's own answer.
+     *
+     * The sources are shaped to move the accuracy log and the alphabet: a
+     * heavily skewed one, a two-symbol one, a spread one, and a text-like
+     * one. FSE_compress declines a source it cannot beat, which is reported
+     * rather than skipped silently. */
+    {
+        size_t streams_compared = 0;
+        size_t symbols_compared = 0;
+        for (unsigned shape = 0; shape < 4; shape++) {
+            Bytes source(4096, 0);
+            uint32_t seed = 0x9E3779B9u + shape;
+            for (size_t i = 0; i < source.size(); i++) {
+                seed = seed * 1664525u + 1013904223u;
+                const unsigned draw = (seed >> 16) & 0xFFu;
+                if (shape == 0) {
+                    source[i] = static_cast<unsigned char>(draw < 200 ? 7
+                                                           : draw % 5u);
+                } else if (shape == 1) {
+                    source[i] = static_cast<unsigned char>(draw < 128 ? 0 : 1);
+                } else if (shape == 2) {
+                    source[i] = static_cast<unsigned char>(draw % 60u);
+                } else {
+                    source[i] = static_cast<unsigned char>(
+                        draw < 180 ? 'a' + (draw % 12u) : ' ');
+                }
+            }
+            const Bytes packed = ReferenceFseCompress(source);
+            REQUIRE_CTX(!packed.empty(),
+                        "shape %u: the reference's compress pipeline produced "
+                        "no stream, so there is nothing to compare over",
+                        shape);
+
+            std::vector<uint8_t> reference;
+            REQUIRE_CTX(ReferenceFseDecompress(packed.data(), packed.size(),
+                                               &reference),
+                        "shape %u: the reference refused its own stream",
+                        shape);
+            const size_t reference_size = reference.size();
+
+            std::vector<uint8_t> mine;
+            cudec_detail::ZstdFseReject core_rung =
+                cudec_detail::kZstdFseRejectNone;
+            REQUIRE_CTX(TwinFseDecompress(packed.data(), packed.size(), &mine,
+                                          &core_rung),
+                        "shape %u: the twin refused (rung %d)", shape,
+                        static_cast<int>(core_rung));
+            REQUIRE_CTX(mine.size() == reference_size,
+                        "shape %u: %zu symbols against the reference's %zu",
+                        shape, mine.size(), reference_size);
+            REQUIRE(equal_bytes(mine.data(), reference.data(), mine.size()));
+            /* And against the source, which is what the round trip is worth
+             * saying out loud: the symbols are the original bytes. */
+            REQUIRE(mine.size() == source.size());
+            REQUIRE(equal_bytes(mine.data(), source.data(), mine.size()));
+            streams_compared++;
+            symbols_compared += mine.size();
+        }
+        REQUIRE(streams_compared == 4);
+        std::printf("      %zu FSE streams, %zu symbols, against "
+                    "FSE_decompress\n",
+                    streams_compared, symbols_compared);
+    }
+
+    /* 7. The weight descriptions the #185 corpus actually carries. A
+     * Compressed literals section opens with the Huffman tree description,
+     * and a first byte below 128 says the weights are an FSE stream of that
+     * many bytes - the same object as the streams above, reached where the
+     * format really puts it. */
+    {
+        size_t weight_streams = 0;
+        for (const ZstdFixture& fixture : fixtures) {
+            ZstdFrameShape shape;
+            std::string why;
+            REQUIRE(ParseZstdFrameShape(fixture.compressed, &shape, &why));
+            for (const ZstdBlockShape& block : shape.blocks) {
+                if (block.block_type != kZstdBlockCompressed ||
+                    block.literals_type != kZstdLiteralsCompressed ||
+                    block.literals_payload_size < 2) {
+                    continue;
+                }
+                const unsigned char* payload =
+                    fixture.compressed.data() + block.literals_payload_offset;
+                const unsigned header = payload[0];
+                if (header >= 128) {
+                    /* The direct weight table, four bits a weight, which is
+                     * not an FSE stream and is not this unit's business. */
+                    continue;
+                }
+                REQUIRE(header + 1u <= block.literals_payload_size);
+                std::vector<uint8_t> reference;
+                REQUIRE_CTX(ReferenceFseDecompress(payload + 1, header,
+                                                   &reference),
+                            "%s: the reference refused a weight stream out of "
+                            "its own frame",
+                            fixture.name.c_str());
+                const size_t reference_size = reference.size();
+                std::vector<uint8_t> mine;
+                cudec_detail::ZstdFseReject core_rung =
+                    cudec_detail::kZstdFseRejectNone;
+                REQUIRE_CTX(TwinFseDecompress(payload + 1, header, &mine,
+                                              &core_rung),
+                            "%s: the twin refused a weight stream (rung %d)",
+                            fixture.name.c_str(),
+                            static_cast<int>(core_rung));
+                REQUIRE_CTX(mine.size() == reference_size,
+                            "%s: %zu weights against the reference's %zu",
+                            fixture.name.c_str(), mine.size(), reference_size);
+                REQUIRE(equal_bytes(mine.data(), reference.data(),
+                                    mine.size()));
+                weight_streams++;
+            }
+        }
+        REQUIRE_CTX(weight_streams > 0,
+                    "no fixture carried an FSE-coded Huffman weight "
+                    "description - this half of the proof would pass "
+                    "vacuously");
+        std::printf("      %zu Huffman weight streams out of the corpus\n",
+                    weight_streams);
+    }
+
+    /* 8. The cores' own negatives. */
+    {
+        const unsigned kLog = 5;
+        const std::vector<cudec_detail::ZstdFseCell> cells =
+            MakeSelfNamingTable(kLog);
+        uint8_t out[16] = {0};
+        uint32_t produced = 0;
+
+        /* A table size that is not the accuracy log's. */
+        const uint8_t plain[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+        const Bytes ordinary =
+            BackwardStreamOfGroups(plain, sizeof(plain), kLog);
+        cudec_detail::ZstdBitReader reader{ordinary.data(), ordinary.size()};
+        REQUIRE(reader.Start() == CUDEC_OK);
+        REQUIRE(cudec_detail::ZstdFseDecode2State(
+                    &reader, cells.data(), (1u << kLog) - 1u, kLog, out,
+                    static_cast<uint32_t>(sizeof(out)), &produced, &rung) !=
+                CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdFseRejectBadRequest);
+        CoverRung(rung);
+
+        /* Fewer bits than the two initial states need: nine live bits where
+         * ten are wanted. */
+        {
+            const Bytes stream = {0xFF, 0x02};
+            cudec_detail::ZstdBitReader thin{stream.data(), stream.size()};
+            REQUIRE(thin.Start() == CUDEC_OK);
+            REQUIRE(thin.BitsRemaining() == 9);
+            REQUIRE(cudec_detail::ZstdFseDecode2State(
+                        &thin, cells.data(), 1u << kLog, kLog, out,
+                        static_cast<uint32_t>(sizeof(out)), &produced,
+                        &rung) != CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdFseRejectStateInitTruncated);
+            CoverRung(rung);
+        }
+
+        /* A cell array that lands a state outside its own table. No table
+         * this tree builds can do it, which is why the array is written here
+         * instead of built. */
+        {
+            std::vector<cudec_detail::ZstdFseCell> broken = cells;
+            broken[1].new_state = static_cast<uint16_t>(1u << kLog);
+            const uint8_t groups[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+            const Bytes stream =
+                BackwardStreamOfGroups(groups, sizeof(groups), kLog);
+            cudec_detail::ZstdBitReader walk{stream.data(), stream.size()};
+            REQUIRE(walk.Start() == CUDEC_OK);
+            REQUIRE(cudec_detail::ZstdFseDecode2State(
+                        &walk, broken.data(), 1u << kLog, kLog, out,
+                        static_cast<uint32_t>(sizeof(out)), &produced,
+                        &rung) != CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdFseRejectStateOutOfTable);
+            CoverRung(rung);
+        }
+
+        /* A table whose every cell reads no bits at all. It is well formed -
+         * one symbol holding the whole table produces exactly this - and the
+         * bit budget never runs down over it, so the capacity is what ends
+         * the run, and ending there is a refusal. */
+        {
+            std::vector<cudec_detail::ZstdFseCell> stuck = cells;
+            for (size_t cell = 0; cell < stuck.size(); cell++) {
+                stuck[cell].nb_bits = 0;
+                stuck[cell].new_state = 0;
+            }
+            const uint8_t groups[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+            const Bytes stream =
+                BackwardStreamOfGroups(groups, sizeof(groups), kLog);
+            cudec_detail::ZstdBitReader walk{stream.data(), stream.size()};
+            REQUIRE(walk.Start() == CUDEC_OK);
+            REQUIRE(cudec_detail::ZstdFseDecode2State(
+                        &walk, stuck.data(), 1u << kLog, kLog, out,
+                        static_cast<uint32_t>(sizeof(out)), &produced,
+                        &rung) != CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdFseRejectOutputFull);
+            CoverRung(rung);
+        }
+    }
+
+    /* 9. Every rung named by a negative written to reach it, walked rather
      * than restated: a rung added to the unit with none behind it lands here
      * as a hole with its number on it. */
     for (int declared = cudec_detail::kZstdFseRejectNone + 1;


### PR DESCRIPTION
# What & why

Closes #219.

The table `src/zstd_fse.h` builds had nothing that reads it. This adds the
three cores that do: initialise a state from the stream, emit the cell's
symbol, move to the cell's successor, and the two-state interleaved run over
one stream that the Huffman weight description is written in. The three-state
sequence loop is not here; it is #196's, and it builds on these.

The emit precedes the update, and that ordering is the whole of the core: a
decoder that updates first emits the symbol of a cell the encoder never wrote.

## Where the run ends

An FSE stream carries no symbol count. The encoder paid for every state update
except the last, so the run ends when an update would need more bits than the
stream has left, and one final symbol is taken from the other state. The
reference reaches the same stopping point from the other side, in
`FSE_decompress_usingDTable_generic`: it performs the update anyway, notices
afterwards that its read pointer passed the start of the buffer, and emits the
final symbol then. This unit refuses to read the bits instead of reading them
and noticing. Same symbols, no fabricated bit, and the parity sweep below is
what says the two agree rather than this paragraph.

There is one shape where the bits never run out. A table whose every cell
reads zero bits is well formed - a single symbol holding the whole table
produces exactly that - and over it the budget never runs down. The caller's
output capacity is what ends the run there, and reaching it is a refusal
rather than a short answer.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)

## Engineering checklist

- [x] Fail-closed preserved: three new rungs, each with a declared negative,
      and the twin's rung walk reds on a rung that has none.
- [x] Oracle coverage: `FSE_decompress_wksp` over streams the reference's own
      compress pipeline wrote, and over the Huffman weight descriptions the
      #185 corpus carries.
- [x] Determinism preserved: pure function of the input bytes, no allocation.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      This change adds no CUDA call and no ABI surface.
- [ ] An adversarial review (`/security-review`) was run.
- [ ] Review record.

No second reader stands behind this change and no review lens was run. The
evidence below is what stands in place of one, and it is stated as evidence
rather than as clearance.

## GPU sanitizer gate

`src/zstd_fse.h` is a `CUDEC_HOST_DEVICE` header, so this section applies and
is not being waived. No route to a device the sanitizer can attach to was
available: the sanitizer cannot attach on this machine at all, which is #258
and is open, and the container that would supply the other route is not
running.

    docker version --format "{{.Server.Version}}"
    failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine;
    check if the path is correct and if the daemon is running

Bringing it up is a decision for the machine's owner, so it was left alone.

```
commit:    (no sweep ran)
gpu:       (no sweep ran)
cuda:      (no sweep ran)
sanitizer: (no sweep ran)
```

No target that exists today compiles this header into device code.

## Verification

`ctest` did not run and no CUDA build was produced: `tests/` is added only
inside the `CUDEC_ENABLE_CUDA` block of the top-level `CMakeLists.txt` and
this host has no CUDA toolchain. The same sources ran on a Linux toolchain
against the release the tree pins, `zstd-1.5.7.tar.gz` at
`eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3`, the hash
in `tests/CMakeLists.txt:60`.

1. The twin under ASan and UBSan, non-recovering:

       clang++ -std=c++17 -Wall -Wextra -Werror -O1 -g \
         -fsanitize=address,undefined -fno-sanitize-recover=all \
         -DFSE_STATIC_LINKING_ONLY ... -o zstd_fse_twin
       ./zstd_fse_twin
             4 FSE streams, 16384 symbols, against FSE_decompress
             14 Huffman weight streams out of the corpus
       PASS: 852 descriptions compared against FSE_readNCount (838 of them
       Set_Compressed fields inside 332 corpus blocks), 58624 table cells
       diffed against FSE_buildDTable, 10 of 10 reject rungs covered by a
       declared negative
       exit=0

   The two new lines are this change. The weight streams are the ones the
   corpus really carries: a Compressed literals section opens with the Huffman
   tree description, and a first byte below 128 says the weights are an FSE
   stream of that many bytes, which is the same object as the four above
   reached where the format puts it.

2. The same source under the project's strict flags with the other compiler
   and no sanitizer:

       g++ -std=c++17 -Wall -Wextra -Werror -O2 ... -o final
       build rc=0, run exit=0, same output

3. Every new guard proven by deleting it. Each mutant is the header with one
   thing changed and nothing else, built and run against the unmodified test:

       state bound on symbol decode          exit=1
       the spent test that ends the run      exit=1
       the tail symbol from the other state  exit=1
       the symbol the cell names             exit=1
       unmutated                             exit=0

   The first replaces the bound with a mask, which is the plausible wrong fix
   rather than a removal, and it still reds.

4. The cores are also proven with the table builder out of the loop, against
   a table this test writes by hand: every cell names itself and lands on the
   state the next bits spell, so the expected symbol sequence is the stream's
   successive five-bit groups, spelled out in the test as

       00001 00010 00011 00100 00101 00110 00111 01000

   Eight groups in, eight symbols out, the last two produced by the tail rule.
   That is what isolates the emit-before-update ordering and the state
   arithmetic from anything the builder does.

5. The local gate legs that run on this host.

       cmake -B build && cmake --build build
       [100%] Built target example_decode_frame

       git ls-files "*.md" "*.yml" "*.yaml" | xargs npx --yes prettier@3 --check
       All matched files use Prettier code style!

   Prettier is run over the tracked set: an untracked `build-host/` directory
   left in this checkout carries a generated `CMakeConfigureLog.yaml` that the
   wider glob picks up. It is not part of this change and was not removed.

- [x] `cmake --build build` builds clean.
- [ ] `ctest --test-dir build` green.
- [x] Prettier clean over the tracked tree.
- [x] Docs synced: no behaviour this change touches is described in
      MASTERPLAN, README or BENCHMARKS.

## What the issue asked for that is not here

The issue's third negative is "a stream with bits left over where exact
consumption is required". This core does not have that case: it runs until the
bits are spent by construction, so leftover bits cannot occur inside it. Where
exactness matters is one level up, in a caller that decodes a known number of
symbols and then checks the reader, and that check belongs with the caller
rather than here. Nothing is claimed about it.

`zstd_fse_twin` is still not in the sanitize job's explicit name list in
`.github/workflows/ci.yml`, for the reason PR #322 gave: another change is in
flight against that file. It runs in CI through `ctest -LE gpu`.

## Quality checklist

- [x] Minimal: three cores in the header they belong to, no new file.
- [x] Self-documenting; the stopping rule and its relation to the reference's
      are written at the code rather than here.
- [x] The rung walk at the end of the twin locks the new structural property:
      a rung added with no negative behind it reds it.
