### PR TITLE
Mutate Zstd frames against the reference's branch set [#187]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -305,6 +305,15 @@ target_compile_definitions(zstd_probes PRIVATE ZSTD_STATIC_LINKING_ONLY)
 # decision and the coverage matrix.
 cudec_add_test(zstd_corpus_selfproof SOURCES zstd_corpus_selfproof.cpp
                zstd_corpus.cpp LIBS zstd_full)
+# The Zstd mutation corpus proving itself (issue #187): the mutants are
+# deterministic and digest-pinned, every fixture yields at least one the
+# reference refuses, and the aimed header-field classes are asserted by name so
+# a walker change cannot drop one in silence. It links zstd_full and compiles
+# zstd_corpus.cpp for the reason zstd_corpus_selfproof gives above - the
+# generator lives beside the corpus rather than in fixtures.cpp, because the
+# decode-only and full zstd archives may never meet in one link.
+cudec_add_test(zstd_mutants SOURCES zstd_mutants.cpp zstd_corpus.cpp LIBS
+               zstd_full)
 cudec_add_test(zstd_bitstream_twin SOURCES zstd_bitstream_twin.cpp)
 target_include_directories(zstd_bitstream_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)

--- a/tests/zstd_corpus.cpp
+++ b/tests/zstd_corpus.cpp
@@ -479,12 +479,23 @@ bool ZstdOracleDecodes(const Bytes& frame, Bytes* out) {
         ZSTD_getFrameContentSize(frame.data(), frame.size());
     /* A frame without a content size still has to be decodable here, so the
      * bound comes from the corpus rather than from the frame: nothing this
-     * generator emits exceeds it, and a hostile frame is not this function's
-     * job. */
+     * generator emits exceeds it.
+     *
+     * IT IS A CEILING AND NOT ONLY A FALLBACK, and it became one when the
+     * mutation layer arrived (issue #187). A mutant that moves the content
+     * size field declares whatever the bits say, and taking that at its word
+     * asked the allocator for it - which is a std::bad_alloc rather than a
+     * verdict, measured the first time this ran over mutants. The reference
+     * still decides: it gets the buffer this harness will actually produce
+     * and answers on it, and a frame declaring more than the ceiling comes
+     * back refused with dstSize_tooSmall. No corpus frame reaches the
+     * ceiling, so no unmutated verdict moves. */
+    const size_t kOutputCeiling = size_t{1} << 22;
     const size_t bound =
         (declared == ZSTD_CONTENTSIZE_UNKNOWN ||
-         declared == ZSTD_CONTENTSIZE_ERROR)
-            ? size_t{1} << 22
+         declared == ZSTD_CONTENTSIZE_ERROR ||
+         declared > static_cast<unsigned long long>(kOutputCeiling))
+            ? kOutputCeiling
             : static_cast<size_t>(declared);
     out->assign(bound, 0);
     const size_t written =
@@ -648,4 +659,124 @@ std::vector<ZstdFixture> MakeZstdFixtures() {
         fixtures.push_back(fixture);
     }
     return fixtures;
+}
+
+std::vector<ZstdMutant> MutateZstdFrame(const Bytes& frame, uint64_t seed) {
+    std::vector<ZstdMutant> out;
+    const size_t n = frame.size();
+    if (n == 0) {
+        return out;
+    }
+    const auto add = [&out](std::string description, Bytes bytes) {
+        out.push_back(ZstdMutant{std::move(description), std::move(bytes)});
+    };
+    /* One byte, one xor. Every aimed mutation below is this: the smallest
+     * change that moves a named field into a different branch of the
+     * reference's decoder. */
+    const auto xor_at = [&frame, &add, n](const char* name, size_t offset,
+                                          unsigned char mask) {
+        if (offset >= n) {
+            return;
+        }
+        Bytes bytes = frame;
+        bytes[offset] = static_cast<unsigned char>(bytes[offset] ^ mask);
+        add(std::string(name) + "-at-" + std::to_string(offset),
+            std::move(bytes));
+    };
+
+    /* ---- The aimed set, walked out of the frame's own headers ---------- */
+
+    /* The magic, which is the first thing the reference looks at. */
+    xor_at("magic-byte-0", 0, 0x01);
+    xor_at("magic-byte-3", 3, 0x80);
+
+    /* The frame header descriptor: the reserved bit the reference refuses
+     * outright, the checksum flag, the content-size width and the dictionary
+     * id width. Each moves a different branch of ZSTD_getFrameHeader. */
+    xor_at("descriptor-reserved-bit", 4, 0x08);
+    xor_at("descriptor-checksum-flag", 4, 0x04);
+    xor_at("descriptor-content-size-width", 4, 0x40);
+    xor_at("descriptor-dictionary-id-width", 4, 0x01);
+    xor_at("descriptor-single-segment", 4, 0x20);
+    /* Whatever byte follows it - the window descriptor when there is one,
+     * otherwise the first content-size byte. Both are size fields the
+     * reference bounds. */
+    xor_at("byte-after-descriptor", 5, 0x0F);
+
+    ZstdFrameShape shape;
+    std::string why;
+    if (ParseZstdFrameShape(frame, &shape, &why)) {
+        /* Block headers, and inside a compressed block the section headers
+         * the walker reached. Only the first two blocks are aimed at: the
+         * families that carry many blocks carry the same shapes in each, and
+         * a mutant per block would multiply the corpus without adding a
+         * branch. */
+        size_t index = 0;
+        for (const ZstdBlockShape& block : shape.blocks) {
+            if (index >= 2) {
+                break;
+            }
+            const std::string tag = "block" + std::to_string(index) + "-";
+            if (block.tables_offset != 0) {
+                /* The Symbol_Compression_Modes byte sits immediately before
+                 * the first table description, and its low two bits are
+                 * reserved: setting one is a refusal the reference states in
+                 * so many words. */
+                xor_at((tag + "symbol-modes-reserved-bits").c_str(),
+                       block.tables_offset - 1, 0x03);
+                xor_at((tag + "symbol-modes-litlen").c_str(),
+                       block.tables_offset - 1, 0xC0);
+                xor_at((tag + "symbol-modes-offset").c_str(),
+                       block.tables_offset - 1, 0x30);
+                /* The accuracy log of whichever table description starts
+                 * there: the low nibble of its first byte. */
+                xor_at((tag + "first-table-accuracy-log").c_str(),
+                       block.tables_offset, 0x0F);
+                xor_at((tag + "first-table-body").c_str(),
+                       block.tables_offset + 1, 0x55);
+            }
+            if (block.literals_payload_size != 0) {
+                /* The Huffman tree description opens the payload of a
+                 * Compressed literals section, and its first byte decides
+                 * between an FSE-coded weight stream and a direct table. */
+                xor_at((tag + "huffman-description-header").c_str(),
+                       block.literals_payload_offset, 0x80);
+                xor_at((tag + "huffman-description-body").c_str(),
+                       block.literals_payload_offset + 1, 0x0F);
+            }
+            /* The last byte a block's payload declares. For a compressed
+             * block that is the tail of the sequence bitstream, which is
+             * where the reference's own sequence loop runs out. */
+            if (block.block_end > 0) {
+                xor_at((tag + "payload-last-byte").c_str(),
+                       block.block_end - 1, 0xFF);
+            }
+            index++;
+        }
+    }
+
+    /* ---- The blind set, which is what reaches the entropy payloads ----- */
+
+    for (const size_t quarters : {size_t{1}, size_t{2}, size_t{3}}) {
+        const size_t keep = n * quarters / 4;
+        if (keep < n && keep > 0) {
+            add("truncate-to-" + std::to_string(keep),
+                Bytes{frame.begin(), frame.begin() + static_cast<long>(keep)});
+        }
+    }
+    for (size_t k = 1; k <= 4 && k < n; k++) {
+        add("drop-" + std::to_string(k) + "-tail",
+            Bytes{frame.begin(), frame.end() - static_cast<long>(k)});
+        add("drop-" + std::to_string(k) + "-head",
+            Bytes{frame.begin() + static_cast<long>(k), frame.end()});
+    }
+    uint64_t state = seed;
+    for (int i = 0; i < 12; i++) {
+        Bytes flipped = frame;
+        const size_t offset = static_cast<size_t>(Mix(&state) % n);
+        flipped[offset] = static_cast<unsigned char>(
+            flipped[offset] ^ (1u << (Mix(&state) % 8)));
+        add("flip-bit-at-" + std::to_string(offset), std::move(flipped));
+    }
+    return out;
 }

--- a/tests/zstd_corpus.h
+++ b/tests/zstd_corpus.h
@@ -134,4 +134,41 @@ std::vector<std::vector<unsigned char>> MakeZstdBatchFrames(
 bool ZstdOracleDecodes(const std::vector<unsigned char>& frame,
                        std::vector<unsigned char>* out);
 
+/* One mutated frame and what was done to it. The description is the repro
+ * key: a failure names the fixture and this string and nothing else is
+ * needed to rebuild the bytes. */
+struct ZstdMutant {
+    std::string description;
+    std::vector<unsigned char> frame;
+};
+
+/* The mutation layer over Zstd frames (issue #187).
+ *
+ * TWO KINDS OF MUTATION, and the second is the point. The blind kind -
+ * truncations and seeded single-bit flips - is what the LZ4 and Snappy
+ * corpora already do, and over a frame format with a header, a block table
+ * and two checksums it mostly lands in an entropy payload and produces a
+ * checksum failure. The aimed kind walks the frame's own headers and moves
+ * one named field at a time: the magic, each descriptor flag, the window
+ * byte, the content size, a block header's type and size, the literals
+ * section's type and size format, the Huffman description's first byte, the
+ * sequence count, the Symbol_Compression_Modes byte including its reserved
+ * bits, and an FSE table description's accuracy log. That set is read out of
+ * what the reference decoder branches on rather than out of anything cudec
+ * does.
+ *
+ * WHERE THE AIM STOPS is where the walker stops: it reads headers and steps
+ * over payloads by their declared sizes, so a mutation cannot be aimed at a
+ * field inside an entropy bitstream. The blind flips are what reach those,
+ * and they reach them without knowing what they hit.
+ *
+ * A MUTANT IS NOT ASSUMED INVALID. Some of these are accepted by the
+ * reference, and that is kept rather than filtered: cudec being stricter than
+ * the reference is a divergence in the same way cudec being looser is. The
+ * verdict always comes from ZstdOracleDecodes, never from this function.
+ *
+ * Deterministic: same frame and seed, same mutants, byte for byte. */
+std::vector<ZstdMutant> MutateZstdFrame(const std::vector<unsigned char>& frame,
+                                        uint64_t seed);
+
 #endif /* CUDEC_TESTS_ZSTD_CORPUS_H */

--- a/tests/zstd_mutants.cpp
+++ b/tests/zstd_mutants.cpp
@@ -1,0 +1,193 @@
+/* The Zstd mutation corpus proving itself (issue #187), the counterpart of
+ * the mutant halves of oracle_lz4.cpp and snappy_corpus.cpp.
+ *
+ * What this establishes, and none of it is about cudec - there is no Zstd
+ * decoder in this tree yet, and this file would be wrong to wait for one:
+ *
+ *  - the mutants are generated deterministically, two passes byte for byte,
+ *    with a pinned digest that catches a drift both passes share;
+ *  - the mutations BITE: every fixture yields at least one mutant the pinned
+ *    reference refuses, so a generator that quietly stopped changing
+ *    anything reds here rather than reporting a clean negative net;
+ *  - the aimed mutations are present by name. The blind truncations and bit
+ *    flips would keep the count up on their own, so the named header fields
+ *    are asserted individually - a walker that stopped reporting an offset
+ *    would otherwise drop a whole branch class in silence;
+ *  - the accepted mutants are kept and counted rather than filtered out.
+ *    cudec being STRICTER than the reference is a divergence in exactly the
+ *    way cudec being looser is, and the corpus that will catch it has to
+ *    carry the streams the reference accepts.
+ *
+ * The verdict is always the reference's. ZstdOracleDecodes is the only thing
+ * in this file that decides whether a stream is valid.
+ *
+ * WHY THE GENERATOR IS NOT IN tests/fixtures.cpp, which is where the issue
+ * put it. That translation unit lives in the cudec_test_fixtures archive,
+ * which links the decode-only zstd oracle; a Zstd mutation corpus needs the
+ * compressor, and tests/CMakeLists.txt states that the decode-only and full
+ * archives must never meet in one link because every decode symbol is in
+ * both. So the layer sits beside MakeZstdFixtures in tests/zstd_corpus.cpp,
+ * which already links the full archive and already owns the frame walker the
+ * aimed mutations are positioned from. */
+#include "require.h"
+#include "zstd_corpus.h"
+
+#include <cstdio>
+#include <set>
+#include <string>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* Mutant-corpus drift tripwire, the instrument oracle_lz4.cpp,
+ * snappy_corpus.cpp and zstd_corpus_selfproof.cpp all carry: a zstd bump or
+ * a generator change moves these bytes, and it should have to update this
+ * number on purpose. The verdicts are folded in too, so a mutant that starts
+ * being accepted moves the digest even when its bytes do not. FNV-1a, not
+ * crypto: a tripwire against drift, not a defence. */
+constexpr uint64_t kExpectedZstdMutantDigest = 0xd92c1bc7ecf524e6ull;
+
+uint64_t Fnv1a64(uint64_t hash, const void* data, size_t size) {
+    const unsigned char* bytes = static_cast<const unsigned char*>(data);
+    for (size_t i = 0; i < size; i++) {
+        hash ^= bytes[i];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+/* The aimed mutations that must exist somewhere in the corpus, by the prefix
+ * their description carries. Each names a field the reference decoder
+ * branches on; a walker or generator change that stops producing one lands
+ * here as a missing name rather than as a slightly smaller corpus. */
+const char* const kRequiredAims[] = {
+    "magic-byte-0",
+    "magic-byte-3",
+    "descriptor-reserved-bit",
+    "descriptor-checksum-flag",
+    "descriptor-content-size-width",
+    "descriptor-dictionary-id-width",
+    "descriptor-single-segment",
+    "byte-after-descriptor",
+    "block0-symbol-modes-reserved-bits",
+    "block0-symbol-modes-litlen",
+    "block0-symbol-modes-offset",
+    "block0-first-table-accuracy-log",
+    "block0-first-table-body",
+    "block0-huffman-description-header",
+    "block0-huffman-description-body",
+    "block0-payload-last-byte"};
+
+bool StartsWith(const std::string& text, const char* prefix) {
+    const std::string want(prefix);
+    return text.size() >= want.size() &&
+           text.compare(0, want.size(), want) == 0;
+}
+
+}  // namespace
+
+int main() {
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    REQUIRE(!fixtures.empty());
+
+    /* The corpus is only a negative net if the unmutated frames are on the
+     * other side of the line. A generator whose fixtures the reference
+     * already refused would make every "rejected" below meaningless. */
+    for (const ZstdFixture& fixture : fixtures) {
+        Bytes decoded;
+        REQUIRE_CTX(ZstdOracleDecodes(fixture.compressed, &decoded),
+                    "%s: the reference refused an unmutated fixture",
+                    fixture.name.c_str());
+    }
+
+    uint64_t digest = 14695981039346656037ull;
+    size_t mutants = 0;
+    size_t rejected = 0;
+    size_t accepted = 0;
+    std::set<std::string> aims_seen;
+
+    for (size_t index = 0; index < fixtures.size(); index++) {
+        const ZstdFixture& fixture = fixtures[index];
+        const uint64_t seed = 0x5a5a0000ull + index;
+        const std::vector<ZstdMutant> first =
+            MutateZstdFrame(fixture.compressed, seed);
+        const std::vector<ZstdMutant> second =
+            MutateZstdFrame(fixture.compressed, seed);
+        REQUIRE_CTX(!first.empty(), "%s: no mutants at all",
+                    fixture.name.c_str());
+        REQUIRE_CTX(first.size() == second.size(),
+                    "%s: two passes produced %zu and %zu mutants",
+                    fixture.name.c_str(), first.size(), second.size());
+
+        size_t rejected_here = 0;
+        for (size_t m = 0; m < first.size(); m++) {
+            REQUIRE_CTX(first[m].description == second[m].description,
+                        "%s: mutant %zu is named %s in one pass and %s in the "
+                        "other",
+                        fixture.name.c_str(), m, first[m].description.c_str(),
+                        second[m].description.c_str());
+            REQUIRE_CTX(first[m].frame == second[m].frame,
+                        "%s: mutant %s differs between passes",
+                        fixture.name.c_str(), first[m].description.c_str());
+
+            for (const char* aim : kRequiredAims) {
+                if (StartsWith(first[m].description, aim)) {
+                    aims_seen.insert(aim);
+                }
+            }
+
+            Bytes decoded;
+            const bool ok = ZstdOracleDecodes(first[m].frame, &decoded);
+            if (ok) {
+                accepted++;
+            } else {
+                rejected++;
+                rejected_here++;
+            }
+            digest = Fnv1a64(digest, fixture.name.data(), fixture.name.size());
+            digest = Fnv1a64(digest, first[m].description.data(),
+                             first[m].description.size());
+            if (!first[m].frame.empty()) {
+                digest = Fnv1a64(digest, first[m].frame.data(),
+                                 first[m].frame.size());
+            }
+            const unsigned char verdict = ok ? 1u : 0u;
+            digest = Fnv1a64(digest, &verdict, 1);
+            mutants++;
+        }
+        REQUIRE_CTX(rejected_here > 0,
+                    "%s: not one of its %zu mutants was refused by the "
+                    "reference - the mutations are not biting on this fixture",
+                    fixture.name.c_str(), first.size());
+    }
+
+    /* Every aimed field reached, by name. */
+    for (const char* aim : kRequiredAims) {
+        REQUIRE_CTX(aims_seen.count(aim) == 1,
+                    "no mutant aims at '%s' - the generator or the frame "
+                    "walker stopped producing that class, and the count "
+                    "alone would not have shown it",
+                    aim);
+    }
+
+    /* The accepted side is not empty either. A mutation set that only ever
+     * produced refusals would prove nothing about over-strictness, which is
+     * half of what the corpus is for. */
+    REQUIRE_CTX(accepted > 0,
+                "every mutant was refused - the corpus carries nothing the "
+                "reference accepts, so it cannot catch a decoder that is "
+                "stricter than the reference");
+
+    REQUIRE_CTX(digest == kExpectedZstdMutantDigest,
+                "mutant corpus digest is 0x%016llx - an oracle or generator "
+                "change moved it; update the pin deliberately",
+                static_cast<unsigned long long>(digest));
+
+    std::printf("PASS: %zu mutants over %zu zstd fixtures, %zu refused and "
+                "%zu accepted by the pinned reference, %zu aimed field "
+                "classes present by name, generation deterministic\n",
+                mutants, fixtures.size(), rejected, accepted,
+                aims_seen.size());
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #187.

The LZ4 and Snappy corpora each carry a mutation layer. Zstd had none, so every
fixture in the M5 corpus was an accept pair with nothing on the other side of
the line, and the negative net M5 will be judged against did not exist.

`MutateZstdFrame` produces two kinds of mutant, and the second is the point of
the issue.

**The aimed kind** walks the frame's own headers through `ParseZstdFrameShape`
and moves one named field at a time: the magic, the descriptor's reserved bit,
checksum flag, content-size width, dictionary-id width and single-segment flag,
the byte after the descriptor, a block's payload tail, the Huffman tree
description's first byte and its body, the `Symbol_Compression_Modes` byte
including its reserved low bits, and an FSE table description's accuracy log.
That set is read out of what the reference decoder branches on, not out of
anything cudec does.

**The blind kind** is the truncations and seeded single-bit flips the other two
formats already use. It is what reaches the entropy payloads, because the
walker reads headers and steps over payloads by their declared sizes, so an
aimed mutation cannot land inside a bitstream. That limit is written at the
generator.

Accepted mutants are kept rather than filtered out. A decoder stricter than the
reference is a divergence in exactly the way a looser one is, and only the
accepted streams can catch it. The verdict is always `ZstdOracleDecodes`'.

## Two things the issue's shape did not survive contact with

**The generator is not in `tests/fixtures.cpp`.** The issue names that file as
the surface. It cannot be: that translation unit is compiled into the
`cudec_test_fixtures` archive, which links the decode-only zstd oracle, and a
Zstd mutation corpus needs the compressor to have fixtures at all.
`tests/CMakeLists.txt` states that the decode-only and full archives must never
meet in one link, because every decode symbol is in both and the linker would
resolve some from each. So the layer sits beside `MakeZstdFixtures` in
`tests/zstd_corpus.cpp`, which already links the full archive and already owns
the frame walker the aimed mutations are positioned from.

**`ZstdOracleDecodes` had to stop believing the frame.** It sized its output
buffer from `ZSTD_getFrameContentSize`, with a corpus-derived bound used only
when the frame declared nothing. A mutant that moves the content-size field
declares whatever the bits say, and taking that at its word asked the allocator
for it:

    terminate called after throwing an instance of 'std::bad_alloc'

That is not a verdict. The bound is now a ceiling in every case: the reference
still decides, on the buffer this harness will actually produce, and a frame
declaring more than the ceiling comes back refused with `dstSize_tooSmall`. No
corpus frame reaches the ceiling, and `zstd_corpus_selfproof` with its own
pinned digest is unchanged, which is what says no unmutated verdict moved.

## Type of change

- [x] Test / harness

## Engineering checklist

- [x] Fail-closed preserved: this change adds no decode path. The one
      behavioural change is the oracle wrapper refusing an allocation it
      cannot make instead of attempting it.
- [x] Oracle coverage: every verdict in the new corpus is the pinned
      facebook/zstd 1.5.7's own.
- [x] Determinism: two generation passes are compared mutant for mutant, and
      the digest catches a drift both passes share.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      This change adds no CUDA call and touches no ABI.
- [ ] An adversarial review (`/security-review`) was run.
- [ ] Review record.

No second reader stands behind this change and no review lens was run. The
evidence below is what stands in place of one, and it is stated as evidence
rather than as clearance.

## GPU sanitizer gate

Nothing in this change is compiled into device code: it is two test-side
translation units and one CMake registration. The gate does not apply, and it
is not being waived for anything that would need it.

## Verification

`ctest` did not run and no CUDA build was produced: `tests/` is added only
inside the `CUDEC_ENABLE_CUDA` block of the top-level `CMakeLists.txt` and this
host has no CUDA toolchain. The same sources ran on a Linux toolchain against
the release the tree pins, `zstd-1.5.7.tar.gz` at
`eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3`.

1. The pinned digest is reproducible here before anything was pinned to it.
   `zstd_corpus_selfproof`, which already carries a pinned digest over the
   unmutated fixtures, is green on this toolchain:

       PASS: 19 zstd fixtures round-trip over 340 blocks; 26 coverage cells
       demanded and met; 8 batch frames rejoin; generation deterministic

   That is what makes a new pin over bytes derived from the same fixtures safe
   rather than hopeful.

2. The new test, under both compilers, and the digest agrees across them:

       g++ -std=c++17 -Wall -Wextra -Werror -O2 ...
       PASS: 784 mutants over 19 zstd fixtures, 652 refused and 132 accepted
       by the pinned reference, 16 aimed field classes present by name,
       generation deterministic
       exit=0

       clang++ -std=c++17 -Wall -Wextra -Werror -O1 -g \
         -fsanitize=address,undefined -fno-sanitize-recover=all ...
       same PASS line
       exit=0

3. Every assertion proven by breaking what it watches. Each mutant is the
   generator with one thing changed and nothing else, run against the
   unmodified test:

       the aimed mutations changing a byte   exit=1
       one aimed field class dropped         exit=1
       the blind bit flips                   exit=1
       unmutated                             exit=0

   The second is the one worth naming: removing a single `xor_at` call leaves
   783 mutants and every count still healthy, and the by-name assertion is what
   reds. That is the silent-shrink case the issue's own history warns about.

4. `zstd_corpus_selfproof` re-run after the oracle-wrapper change, to show the
   ceiling moved no existing verdict:

       PASS: 19 zstd fixtures round-trip over 340 blocks; 26 coverage cells
       demanded and met; 8 batch frames rejoin; generation deterministic

5. The local gate legs that run on this host.

       cmake -B build && cmake --build build
       [100%] Built target example_decode_frame

       git ls-files "*.md" "*.yml" "*.yaml" | xargs npx --yes prettier@3 --check
       All matched files use Prettier code style!

   Prettier is run over the tracked set: an untracked `build-host/` directory
   left in this checkout carries a generated `CMakeConfigureLog.yaml` that the
   wider glob picks up. It is not part of this change and was not removed.

- [x] `cmake --build build` builds clean.
- [ ] `ctest --test-dir build` green.
- [x] Prettier clean over the tracked tree.
- [x] Docs synced: `docs/ZSTD-CORPUS.md` describes the fixture families and
      their coverage matrix, neither of which this change alters. The mutation
      layer's own limits are written at the generator.

## What is deliberately not here

The aimed set stops where the walker stops. Fields inside an entropy payload -
a weight in the Huffman description, a probability in an FSE table body, a code
in the sequence bitstream - are reached only by the blind flips, which reach
them without knowing what they hit. Aiming into those needs positioning that
does not exist yet and belongs with the units that will decode them.

Only the first two blocks of a frame are aimed at. The multi-block families
carry the same shapes in every block, so a mutant per block would multiply the
corpus without adding a branch. That is a bound and it is stated rather than
left to be inferred from the count.

## Quality checklist

- [x] Minimal: one generator beside the corpus it mutates, one self-proof, one
      registration.
- [x] Self-documenting; the placement decision and the allocation ceiling are
      argued where they are, not here.
- [x] New structural properties locked: the by-name aim check and the
      per-fixture bite check both red on a generator that stops working.
