### PR TITLE
Cover every documented build tree with one ignore pattern [#327]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,20 @@
-# Build output - reproducible from the sources via CMake.
-build/
-build-cuda/
-build-san/
-# The out-of-tree consumer's own build trees and the prefix they consume, all
-# produced by the install proof in ci.yml and reproducible the same way.
-build-consumer/
-build-consumer-badver/
-build-consumer-cuda/
-build-consumer-nocuda/
+# Build output - reproducible from the sources via CMake. A pattern rather
+# than a list of names: the list was per-directory-name and went stale by
+# construction, once per documented build configuration. fuzz/README.md tells
+# a reader to configure into build-fuzz, which no name here covered, so a
+# sanitizer-instrumented binary and its corpus sat untracked and visible in
+# `git status` where one wide `git add` would have taken them. CUDEC_ENABLE_HIP
+# is real in CMakeLists.txt and build-hip is the next name that would have been
+# missing.
+#
+# What the width costs, stated rather than discovered later: a directory whose
+# name starts with `build` can no longer be added to the tree without -f. No
+# tracked path starts with `build` today (`git ls-files | grep -cE '^build'`
+# is 0), and none is planned; if one is ever wanted, the negation belongs here
+# beside this comment rather than a return to the enumeration.
+build*/
+# The prefix the out-of-tree consumer install proof in ci.yml consumes, and
+# its log. Both reproducible the same way; neither starts with `build`.
 prefix-host/
 prefix-cuda/
 badver.log


### PR DESCRIPTION
Closes #327.

The ignore list named build directories one at a time. `fuzz/README.md` tells a
reader to configure into `build-fuzz`, and no entry covered it, so the fuzz
build output - a sanitizer-instrumented binary and its corpus - sat untracked
and visible in `git status`, one wide `git add` away from a commit.
`build-host` was in the same state, and `build-hip` would have been next since
`CUDEC_ENABLE_HIP` is already real in `CMakeLists.txt`.

## The guard bites

`check-ignore` only decides a trailing-slash pattern for a path that exists, so
each directory was created with a file in it before the probe, and the two
runs differ only in which `.gitignore` is in place:

    for d in build-fuzz build-hip build-san build-consumer; do mkdir -p "$d"; : > "$d/probe.o"; done
    git show origin/main:.gitignore > /tmp/old ; cp .gitignore /tmp/new
    # then, per file: git check-ignore -q "$d/probe.o"

| directory        | mainline `.gitignore` | this change |
| ---------------- | --------------------- | ----------- |
| `build-fuzz`     | **not ignored**       | ignored     |
| `build-hip`      | **not ignored**       | ignored     |
| `build-host`     | **not ignored**       | ignored     |
| `build-san`      | ignored               | ignored     |
| `build-consumer` | ignored               | ignored     |
| `build`          | ignored               | ignored     |
| `build-cuda`     | ignored               | ignored     |

The three probe directories were removed afterwards; `git status --short`
reports only `.gitignore`.

## Nothing tracked disappears

A wider pattern can hide a file the tree is meant to carry. It hides none:

    git ls-files | grep -cE '^build'
    0
    git ls-files | git check-ignore --stdin --no-index | wc -l
    0

`prefix-host/`, `prefix-cuda/` and `badver.log` do not start with `build`, so
they keep their own entries and their own reason.

## What the width costs

A directory whose name starts with `build` can no longer be added without
`-f`. That is the trade the pattern makes for not going stale once per new
build configuration, it is written into the file beside the pattern rather
than left for the next reader to discover, and the repair if one is ever
wanted is a negation next to that comment rather than a return to the list.

## No second reader

This change had no second reader. The commands above stand in place of one.
Nothing here was run through ctest: the test tree configures only under
`CUDEC_ENABLE_CUDA` and this host has no CUDA compiler, but `.gitignore` is
read by git rather than by the build, and `git check-ignore` is the thing that
decides it.
