### PR TITLE
Build the pinned GDeflate reference as a test-only oracle [#168]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,7 @@ jobs:
           grep -E ': launch_fail$' host-selected.txt &&
           grep -E ': bench_selfcheck$' host-selected.txt &&
           grep -E ': bench_worst4b_selfcheck$' host-selected.txt &&
+          grep -E ': oracle_gdeflate$' host-selected.txt &&
           echo "Deferred to the local GPU gate:" &&
           ctest --test-dir build-cuda -L gpu -N | tee gpu-deferred.txt &&
           grep -E ': smoke$' gpu-deferred.txt &&

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -6,3 +6,32 @@ laws that apply to them, including copyright and data protection law. The
 project does not endorse or support unlawful use of any kind, and nothing
 in it is designed to enable such use. The license contains the full
 warranty and liability disclaimer.
+
+## Where the GDeflate verification apparatus came from
+
+cudec distributes none of the sources below. They are fetched at configure
+time by the test build, the way the LZ4, Snappy and Zstd references already
+are, and the no-vendored-binaries rule keeps them out of this tree. Neither
+upstream ships a NOTICE file, so Apache-2.0 section 4(d) has nothing to
+propagate here; this section exists because recording where the verification
+apparatus came from is worth doing on its own terms, and it is what
+`docs/MASTERPLAN.md` section 11.9 decided to carry.
+
+**The NVIDIA fork of libdeflate, branch `gdeflate`**, pinned at commit
+`8ba9502fb30d2bf728592d121f0d402e40c8cb05`. It is the reference GDeflate
+codec cudec's decoder is diff-tested against, and the compressor that
+generates the M4 corpora. Its licensing is mixed per file rather than
+uniform: the repository's `COPYING` is Eric Biggers' MIT text from upstream
+libdeflate, and `lib/gdeflate_compress.c` and `lib/gdeflate_decompress.c`
+each carry that MIT notice together with an `SPDX-License-Identifier:
+Apache-2.0` line and an NVIDIA copyright.
+
+**The GDeflate subtree of `microsoft/DirectStorage`**, which carries its own
+Apache-2.0 `LICENSE` with NVIDIA and Microsoft copyrights, and whose
+`GDeflateTest` vectors are the one piece of interop evidence in M4 that comes
+from a different implementation lineage than the fork above.
+
+**The IETF draft `draft-uralsky-gdeflate-00`**, "GDEFLATE bitstream format
+specification", used under the BCP 78 terms it is published with. It is one
+of the three artifacts the format dossier in `docs/MASTERPLAN.md` section 11
+is assembled from, because no canonical GDeflate specification exists.

--- a/cmake/CudecGDeflateOracle.cmake
+++ b/cmake/CudecGDeflateOracle.cmake
@@ -1,0 +1,109 @@
+# The NVIDIA/libdeflate GDeflate oracle, in one file for the reason the lz4
+# and snappy modules give: a second FetchContent_Declare under the same name
+# is not an error, the first declaration silently wins, and two copies of a
+# pin can drift with nothing to report which one the build used. Only tests/
+# reaches this today; fuzz/ is the second consumer the M4 fuzz rungs add.
+include_guard(GLOBAL)
+
+# Supply chain: the hash-verified archive is the only acceptable oracle
+# source. Stated here as well as in tests/CMakeLists.txt because whichever
+# directory reaches this file first is the one that fetches.
+set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
+include(FetchContent)
+
+# The M4 oracle. The pin is the commit and the SHA-256 of the archive at that
+# commit, both decided in issue #147 and recorded in docs/MASTERPLAN.md
+# section 11.7 - this executes that decision rather than taking it again.
+#
+# Three things about this pin differ from the other three oracles, and the
+# policy bullet in section 5 names them so a later reader does not read them
+# as oversights. In short: the fork publishes no release asset and no tag, so
+# a commit archive is the only thing it offers; no second packaging ecosystem
+# carries it, so the commit sha and the archive hash together are the
+# cross-check; and the fork sits far behind upstream libdeflate, which is
+# acceptable in a thing whose job is to be where real data came from and is
+# the reason it is never a source to derive from.
+#
+# Re-derived at pin time (2026-08-08) rather than carried over:
+#
+#   gh api repos/NVIDIA/libdeflate/commits/gdeflate \
+#     --jq '{sha: .sha, date: .commit.committer.date}'
+#   {"date":"2026-07-29T18:49:44Z",
+#    "sha":"8ba9502fb30d2bf728592d121f0d402e40c8cb05"}
+#
+#   gh api repos/ebiggers/libdeflate/compare/master...NVIDIA:libdeflate:gdeflate \
+#     --jq '{status, ahead_by, behind_by}'
+#   {"ahead_by":4,"behind_by":425,"status":"diverged"}
+#
+#   curl -sSL -o gdeflate.tar.gz https://github.com/NVIDIA/libdeflate/archive/\
+#     8ba9502fb30d2bf728592d121f0d402e40c8cb05.tar.gz
+#   sha256sum gdeflate.tar.gz
+#   d1b4c38dce43e68a5f4c28d0fbb3f81a01953039a3dea63f4bd1a84d7ff80592
+#   156610 bytes
+#
+# The pinned commit is the branch head as of that read, so the pin does not
+# lag the fork; the fork lags upstream.
+set(CUDEC_GDEFLATE_COMMIT 8ba9502fb30d2bf728592d121f0d402e40c8cb05)
+FetchContent_Declare(
+  gdeflate
+  URL https://github.com/NVIDIA/libdeflate/archive/${CUDEC_GDEFLATE_COMMIT}.tar.gz
+  URL_HASH
+    SHA256=d1b4c38dce43e68a5f4c28d0fbb3f81a01953039a3dea63f4bd1a84d7ff80592
+  # The fork ships Makefiles and no CMakeLists.txt, so MakeAvailable only
+  # populates the source tree today. The subdirectory named here does not
+  # exist on purpose: if a later pin gains a top-level CMakeLists, this keeps
+  # its build system out instead of silently adopting it.
+  SOURCE_SUBDIR cudec-uses-no-libdeflate-cmake
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+FetchContent_MakeAvailable(gdeflate)
+# And the same statement as a check rather than as a comment: upstream's build
+# system defines this target, so its presence means the line above stopped
+# working.
+if(TARGET libdeflate_static)
+  message(
+    FATAL_ERROR
+      "libdeflate's own build system was added to this tree - the oracle rule "
+      "is one target over the translation units the oracle's path needs "
+      "(docs/MASTERPLAN.md section 5)")
+endif()
+
+# Six translation units, which is the whole GDeflate path in both directions.
+# Derived by linking and reading what the linker asked for, not by copying
+# upstream's Makefile:
+#
+# - gdeflate_compress.c / gdeflate_decompress.c are the two entry points.
+# - deflate_compress.c holds the match finder and the block emitter that
+#   gdeflate_compress.c drives; the GDeflate compressor is a thin layer on it.
+# - utils.c is the allocator the alloc_/free_ calls go through.
+# - x86/cpu_features.c and arm/cpu_features.c define the dispatch symbols the
+#   decompressor references. Both compile everywhere: each file's body sits
+#   behind its own architecture guard, so the one that is not this machine's
+#   contributes nothing. Compiling only the matching one would make the
+#   translation-unit list depend on the host, which is a build that differs
+#   between the container and a contributor's machine for no gain.
+#
+# adler32.c, crc32.c and the zlib/gzip wrappers are deliberately absent:
+# GDeflate carries no checksum of any kind (docs/MASTERPLAN.md section 11.4),
+# so nothing on this path reaches them.
+#
+# SYSTEM include and none of the project's strict flags, the rule the other
+# three oracles follow: third-party code is audited by hash, not reformatted.
+add_library(
+  gdeflate_oracle STATIC
+  ${gdeflate_SOURCE_DIR}/lib/gdeflate_compress.c
+  ${gdeflate_SOURCE_DIR}/lib/gdeflate_decompress.c
+  ${gdeflate_SOURCE_DIR}/lib/deflate_compress.c
+  ${gdeflate_SOURCE_DIR}/lib/utils.c
+  ${gdeflate_SOURCE_DIR}/lib/x86/cpu_features.c
+  ${gdeflate_SOURCE_DIR}/lib/arm/cpu_features.c)
+target_include_directories(
+  gdeflate_oracle SYSTEM PUBLIC ${gdeflate_SOURCE_DIR}
+                                ${gdeflate_SOURCE_DIR}/common)
+# -O2 for the reason lz4_oracle and snappy_oracle carry it: the documented
+# container command sets no CMAKE_BUILD_TYPE, and the reference codec runs
+# over whole corpora during fixture generation.
+target_compile_options(gdeflate_oracle PRIVATE -O2)
+
+# Never instrumented, in either the sanitizer gate or the fuzz gate, for the
+# reason the other oracles state: a sanitizer finding inside third-party code
+# audited by hash would red a gate that exists to judge this project's parser.

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -234,7 +234,23 @@ is not an empty AMD field), and **hackability**.
   and without the project's strict flags; only the translation units the
   oracle's decode path needs, never its build system. For liblz4 that is one
   file; the Snappy oracle needs two, because the source abstraction its
-  exact-consume decode reads through lives in a second one.
+  exact-consume decode reads through lives in a second one; the GDeflate
+  oracle needs six, because it is the only one that also compresses.
+- **The GDeflate oracle deviates from that policy in three named ways**, and
+  they are deliberate rather than oversights. The NVIDIA fork of libdeflate
+  publishes no release asset and no tag at all, so the pin is a commit
+  archive - one step further from the preferred shape than snappy's tag
+  archive. No second packaging ecosystem carries the fork, so the
+  cross-check is the commit sha together with the archive hash rather than a
+  second party's hash. And the fork sits far behind upstream libdeflate,
+  including whatever correctness fixes those commits carry, which is
+  acceptable in a thing whose job is to be where real data came from and is
+  the reason it is never a source to derive from. It is under the manual-bump
+  rule above like every other FetchContent pin: Dependabot cannot see it, and
+  it moves only in a deliberate pull request under the supply-chain sweep.
+  The pin, the deviations and the commands that re-derive them are in
+  `cmake/CudecGDeflateOracle.cmake`, next to the pin they are about;
+  section 11.7 is where they were decided.
 - Fuzzing: mutation-based corpus fuzzing of the host-side parsers, plus
   GPU-vs-oracle diff loops on mutated streams for the kernels.
 - Benchmarks live in `bench/` with recorded methodology; every published

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,13 @@ include(${PROJECT_SOURCE_DIR}/cmake/CudecLz4Oracle.cmake)
 # same pin (issue #90), for the reason the liblz4 include above carries.
 include(${PROJECT_SOURCE_DIR}/cmake/CudecSnappyOracle.cmake)
 
+# The NVIDIA/libdeflate fork and its gdeflate_oracle target, the M4 oracle
+# (issue #168). In its own module from the start rather than after a second
+# consumer appears: the M4 fuzz rungs are that consumer, and the pin's three
+# deviations from the standing policy are argued next to the pin instead of
+# here.
+include(${PROJECT_SOURCE_DIR}/cmake/CudecGDeflateOracle.cmake)
+
 # facebook/zstd, the M5 oracle, pinned by the SHA-256 of the
 # MAINTAINER-UPLOADED release asset - the shape the pinning policy prefers and
 # lz4 already uses, rather than the auto-generated /archive/ tarball snappy
@@ -225,6 +232,15 @@ cudec_add_test(oracle_lz4 SOURCES oracle_lz4.cpp LIBS cudec_test_fixtures)
 # and nothing about cudec's own Snappy path, which does not exist yet.
 cudec_add_test(oracle_snappy SOURCES oracle_snappy.cpp LIBS
                cudec_test_fixtures)
+# The M4 oracle proving itself (issue #168), the counterpart of oracle_snappy
+# one milestone later: the pin downloads and builds, both directions link, a
+# stream it produced comes back byte-identical, and the three answering
+# behaviours the M4 parity tests have to be written around are pinned rather
+# than assumed. It links gdeflate_oracle alone - the shared fixture library
+# carries no GDeflate anything yet, and adding this to it would put the fork's
+# headers in front of every test that includes fixtures.h.
+cudec_add_test(oracle_gdeflate SOURCES oracle_gdeflate.cpp LIBS
+               gdeflate_oracle)
 # The reference's own decode behaviours, executed rather than read (issue
 # #155). Host-side and GPU-less on purpose: it is the oracle answering, and
 # the answers are what the M3 fail-closed matrix is allowed to lock against.

--- a/tests/oracle_gdeflate.cpp
+++ b/tests/oracle_gdeflate.cpp
@@ -1,0 +1,236 @@
+/* The GDeflate oracle proving itself before any GDeflate decoder exists
+ * (issue #168): the pinned fork builds, both directions link and are
+ * callable, a stream it produced comes back byte-identical, and the two
+ * verdicts a later parity test will read are shown to be read from the
+ * reference rather than assumed.
+ *
+ * No cudec code is under test here. This is the reference the whole M4 ladder
+ * will be held to, checked for being present and honest at all.
+ *
+ * It also pins three facts about HOW the reference answers, because each one
+ * decides how a parity test has to be written and each one is easy to get
+ * wrong in the direction that reads green:
+ *
+ *   1. A wrong stream can return SUCCESS. `libdeflate_gdeflate_decompress`
+ *      hands back an actual output size, and its own header says it "can be
+ *      used only in cases where the actual uncompressed size is known" - so
+ *      SUCCESS means "the bits ran out cleanly", not "you got what you put
+ *      in". A parity test that reads the status and not the size has a hole
+ *      exactly where a corrupt stream lands.
+ *   2. Truncating a page does not reliably refuse it. GDeflate carries no
+ *      checksum anywhere (docs/MASTERPLAN.md section 11.4) and the decoder
+ *      stops when the output is full, so trailing compressed bytes it never
+ *      needed can be cut away with the output still byte-identical. So
+ *      truncation is not the lever that proves a verdict was read, the way
+ *      it is for the Snappy oracle.
+ *   3. Level 0 is the one level whose block type the source guarantees. The
+ *      fork's own libdeflate.h defines it as "create a valid stream, but only
+ *      emit uncompressed blocks", which is why section 11.8 puts it in the
+ *      sweep, and it is measurable from the outside as output no smaller than
+ *      input.
+ *
+ * The reject ladder, the dossier probes and the corpus are #183, #170 and
+ * their siblings. This is the rung that says the oracle is there. */
+#include "require.h"
+
+#include <libdeflate.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+/* 64 KiB, the GDeflate page, fixed by the format rather than by this test
+ * (docs/MASTERPLAN.md section 11.2). Page counts below are derived from it so
+ * that a pin whose geometry moved would red here rather than pass quietly. */
+constexpr size_t kPageBytes = 65536;
+
+/* Compressible but not trivially so: a run-length pattern would be carried by
+ * a single block type and would prove nothing about the rest of the path. */
+std::vector<unsigned char> MakeInput(size_t n) {
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; i++) {
+        v[i] = static_cast<unsigned char>((i / 7) ^ (i >> 3));
+    }
+    return v;
+}
+
+struct Compressed {
+    std::vector<unsigned char> bytes;
+    std::vector<libdeflate_gdeflate_out_page> pages;
+    size_t total;
+};
+
+/* Compress at `level`, with the page split the reference itself asks for:
+ * compress_bound reports both the worst-case size and the page count, and the
+ * page count is the thing the caller may not invent. */
+bool Compress(int level, const std::vector<unsigned char>& in, Compressed* out) {
+    libdeflate_gdeflate_compressor* c =
+        libdeflate_alloc_gdeflate_compressor(level);
+    if (c == nullptr) {
+        return false;
+    }
+    size_t npages = 0;
+    const size_t bound =
+        libdeflate_gdeflate_compress_bound(c, in.size(), &npages);
+    if (bound == 0 || npages == 0) {
+        libdeflate_free_gdeflate_compressor(c);
+        return false;
+    }
+    out->bytes.assign(bound, 0);
+    out->pages.assign(npages, libdeflate_gdeflate_out_page{});
+    const size_t per = bound / npages;
+    for (size_t i = 0; i < npages; i++) {
+        out->pages[i].data = out->bytes.data() + i * per;
+        out->pages[i].nbytes = per;
+    }
+    out->total = libdeflate_gdeflate_compress(c, in.data(), in.size(),
+                                              out->pages.data(), npages);
+    libdeflate_free_gdeflate_compressor(c);
+    return out->total != 0;
+}
+
+/* The in-pages the decompressor reads, built from what the compressor
+ * actually wrote into each out-page rather than from the sizes it was
+ * offered. */
+std::vector<libdeflate_gdeflate_in_page> InPages(const Compressed& c) {
+    std::vector<libdeflate_gdeflate_in_page> in(c.pages.size());
+    for (size_t i = 0; i < c.pages.size(); i++) {
+        in[i].data = c.pages[i].data;
+        in[i].nbytes = c.pages[i].nbytes;
+    }
+    return in;
+}
+
+}  // namespace
+
+int main() {
+    /* ---- Round trip at the four levels section 11.8 names, each with the
+     * page count derived from the input rather than assumed. */
+    const int levels[] = {0, 1, 6, 12};
+    for (int level : levels) {
+        const std::vector<unsigned char> original = MakeInput(300000);
+        Compressed c;
+        REQUIRE_CTX(Compress(level, original, &c), "level %d", level);
+
+        const size_t want_pages =
+            (original.size() + kPageBytes - 1) / kPageBytes;
+        REQUIRE_CTX(c.pages.size() == want_pages,
+                    "level %d: %zu pages for %zu bytes, want %zu", level,
+                    c.pages.size(), original.size(), want_pages);
+
+        libdeflate_gdeflate_decompressor* d =
+            libdeflate_alloc_gdeflate_decompressor();
+        REQUIRE(d != nullptr);
+        std::vector<libdeflate_gdeflate_in_page> in = InPages(c);
+        std::vector<unsigned char> back(original.size(), 0);
+        size_t got = 0;
+        const libdeflate_result r = libdeflate_gdeflate_decompress(
+            d, in.data(), in.size(), back.data(), back.size(), &got);
+        REQUIRE_CTX(r == LIBDEFLATE_SUCCESS, "level %d: result %d", level,
+                    static_cast<int>(r));
+        REQUIRE_CTX(got == original.size(), "level %d: %zu of %zu bytes",
+                    level, got, original.size());
+        REQUIRE_CTX(equal_bytes(back.data(), original.data(), original.size()),
+                    "level %d", level);
+        libdeflate_free_gdeflate_decompressor(d);
+
+        /* Level 0 emits uncompressed blocks by construction, which is the
+         * only block-type guarantee the source gives and the reason the sweep
+         * carries the level at all. Measured from the outside: a stream made
+         * only of stored blocks cannot be smaller than what went in. */
+        if (level == 0) {
+            REQUIRE_CTX(c.total >= original.size(),
+                        "level 0 produced %zu bytes from %zu - it is not "
+                        "emitting stored blocks",
+                        c.total, original.size());
+        } else {
+            REQUIRE_CTX(c.total < original.size(), "level %d: %zu from %zu",
+                        level, c.total, original.size());
+        }
+    }
+
+    /* ---- One page exactly: the input that fills a tile to the byte, which
+     * is the geometry every M4 rung is written against. */
+    {
+        const std::vector<unsigned char> original = MakeInput(kPageBytes);
+        Compressed c;
+        REQUIRE(Compress(6, original, &c));
+        REQUIRE_CTX(c.pages.size() == 1, "%zu pages for one tile",
+                    c.pages.size());
+
+        libdeflate_gdeflate_decompressor* d =
+            libdeflate_alloc_gdeflate_decompressor();
+        REQUIRE(d != nullptr);
+        std::vector<libdeflate_gdeflate_in_page> in = InPages(c);
+        std::vector<unsigned char> back(original.size(), 0);
+        size_t got = 0;
+        REQUIRE(libdeflate_gdeflate_decompress(d, in.data(), in.size(),
+                                               back.data(), back.size(),
+                                               &got) == LIBDEFLATE_SUCCESS);
+        REQUIRE(got == original.size());
+        REQUIRE(equal_bytes(back.data(), original.data(), original.size()));
+
+        /* The negative that proves the verdict is being read rather than
+         * assumed. Byte 1 of the page is inside the header the whole page
+         * hangs off, and corrupting it is refused outright. */
+        std::vector<unsigned char> broken = c.bytes;
+        broken[1] = static_cast<unsigned char>(broken[1] ^ 0x01u);
+        std::vector<libdeflate_gdeflate_in_page> bad_in = in;
+        bad_in[0].data = broken.data();
+        size_t bad_got = 0;
+        const libdeflate_result bad = libdeflate_gdeflate_decompress(
+            d, bad_in.data(), bad_in.size(), back.data(), back.size(),
+            &bad_got);
+        REQUIRE_CTX(bad == LIBDEFLATE_BAD_DATA, "corrupt page gave result %d",
+                    static_cast<int>(bad));
+        REQUIRE(bad_got == 0);
+
+        /* And the fact that decides how every parity test after this one has
+         * to be written: a different corruption comes back SUCCESS with a
+         * SHORT output. Reading the status alone would call this a decode. */
+        std::vector<unsigned char> short_stream = c.bytes;
+        short_stream[0] = static_cast<unsigned char>(short_stream[0] ^ 0x01u);
+        std::vector<libdeflate_gdeflate_in_page> short_in = in;
+        short_in[0].data = short_stream.data();
+        std::vector<unsigned char> short_out(original.size(), 0);
+        size_t short_got = 0;
+        const libdeflate_result shortr = libdeflate_gdeflate_decompress(
+            d, short_in.data(), short_in.size(), short_out.data(),
+            short_out.size(), &short_got);
+        REQUIRE_CTX(shortr == LIBDEFLATE_SUCCESS,
+                    "expected the short-output shape, got result %d",
+                    static_cast<int>(shortr));
+        REQUIRE_CTX(short_got < original.size(),
+                    "expected a short decode, got %zu of %zu bytes", short_got,
+                    original.size());
+
+        /* Truncation, recorded as the lever it is NOT. The trailing
+         * compressed bytes of this page are never read, so cutting them away
+         * leaves the output byte-identical, and a later test that reached for
+         * truncation to prove a refusal would be proving nothing. */
+        std::vector<libdeflate_gdeflate_in_page> cut_in = in;
+        REQUIRE(cut_in[0].nbytes > 64);
+        cut_in[0].nbytes -= 64;
+        std::vector<unsigned char> cut_out(original.size(), 0);
+        size_t cut_got = 0;
+        const libdeflate_result cutr = libdeflate_gdeflate_decompress(
+            d, cut_in.data(), cut_in.size(), cut_out.data(), cut_out.size(),
+            &cut_got);
+        REQUIRE_CTX(cutr == LIBDEFLATE_SUCCESS,
+                    "a 64-byte truncation changed the verdict to %d - the "
+                    "comment above this line is now wrong and the M4 reject "
+                    "ladder should be told",
+                    static_cast<int>(cutr));
+        REQUIRE(cut_got == original.size());
+        REQUIRE(equal_bytes(cut_out.data(), original.data(), original.size()));
+
+        libdeflate_free_gdeflate_decompressor(d);
+    }
+
+    std::printf("PASS: gdeflate oracle round-trips at levels 0/1/6/12, "
+                "refuses a corrupt page header, and reports a short decode "
+                "as SUCCESS\n");
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #168.

The M4 ladder has nothing to be held to until a reference exists inside the
build. This adds one: the NVIDIA fork of libdeflate, pinned by commit and by
the SHA-256 of the archive at that commit, built as a static library over the
six translation units its GDeflate path needs in both directions, linked by
one test and nothing else.

The pin, the NOTICE contents and the second-decoder rejection were decided in
#147 and recorded in `docs/MASTERPLAN.md` sections 11.7 and 11.9. This
executes them; it takes no decision of its own.

## Type of change

- [x] Build / CI / supply chain
- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)

## What the six translation units are, and how the list was derived

Not copied from upstream's Makefile, which builds far more than this path
needs. Derived by linking and reading what the linker asked for:

```
$ gcc -O2 -I<src> -I<src>/common -o probe probe.c \
    <src>/lib/gdeflate_compress.c <src>/lib/gdeflate_decompress.c \
    <src>/lib/utils.c
undefined reference to `libdeflate_deflate_compress_bound'
undefined reference to `_libdeflate_setup_cpu_features'
undefined reference to `_libdeflate__cpu_features'
```

`deflate_compress.c` supplies the first, and the two `cpu_features.c` files
under `lib/x86` and `lib/arm` supply the other two. Both architecture files
are compiled, not just this machine's: each one's body sits behind its own
architecture guard, so the foreign one contributes nothing, and picking one
would make the translation-unit list depend on the host.

`adler32.c`, `crc32.c` and the zlib/gzip wrappers are absent because GDeflate
carries no checksum of any kind (`docs/MASTERPLAN.md` section 11.4), so
nothing on this path reaches them.

## Verification

**The archive is the one the plan pinned.** Fetched and hashed here rather
than carried over from the section that names it:

```
$ curl -sSL -o gd.tar.gz \
    https://github.com/NVIDIA/libdeflate/archive/8ba9502fb30d2bf728592d121f0d402e40c8cb05.tar.gz
$ sha256sum gd.tar.gz
d1b4c38dce43e68a5f4c28d0fbb3f81a01953039a3dea63f4bd1a84d7ff80592 *gd.tar.gz
$ stat -c %s gd.tar.gz
156610
```

**A wrong hash reds the configure step**, which is the guard this module
rests on, so it was made to bite rather than asserted. Two configures of the
same module against the same local archive, differing only in the `URL_HASH`
line:

```
$ cmake -S . -B b-good ; echo "exit=$?"
-- PINPROBE OK
-- Configuring done (27.9s)
exit=0
$ cmake -S . -B b-bad ; echo "exit=$?"      # SHA256=0000...0000
  does not match expected value
exit=1
```

The good configure also shows the `if(TARGET libdeflate_static)` guard not
firing, which is the statement that upstream's build system stayed out of
this tree, made as a check rather than as a comment.

**The test passes**, built by hand against the same six units because this
machine cannot configure the project's own test tree (that needs
`CUDEC_ENABLE_CUDA=ON`, and there is no CUDA toolchain here):

```
$ ./oracle_gdeflate ; echo "exit=$?"
PASS: gdeflate oracle round-trips at levels 0/1/6/12, refuses a corrupt page
header, and reports a short decode as SUCCESS
exit=0
```

- Prettier (`**/*.{md,yml,yaml}`) - clean, run at this commit.
- `cmake --build build` / `ctest --test-dir build` - not run here. The test
  net only configures under `CUDEC_ENABLE_CUDA=ON` and the container is not
  reachable on this machine, so the `build` job is the gate for the CMake
  wiring and for the test under `ctest -LE gpu`.

**One host artefact, disclosed rather than worked around.** On this Windows
machine the oracle's `deflate_compress.c` will not compile with MinGW gcc:
libdeflate defines `_rotr64` as a function-like macro and MinGW's own
`stdlib.h` declares a function of that name. The hand-built probe above forces
`-include stdlib.h` to get past it. This affects no build the project has:
`CUDEC_ENABLE_CUDA` requires a GCC/Clang host toolchain and CI builds inside
the pinned Linux container, where glibc declares no such symbol. Nothing was
added to the module for it.

## Engineering checklist

- [x] Fail-closed preserved: no cudec parse or decode path is touched. What
      this change adds is a reference and a test that runs it.
- [ ] Oracle coverage: there is no cudec GDeflate decoder to diff against
      yet. This is the rung that puts the oracle in place; parity is #170,
      #179 and #183.
- [x] Determinism preserved: nothing on any decode path changed.
- [x] No CUDA call and no exception on any path.
- [ ] An adversarial review was NOT run as the four-lens panel. The
      derivation of the translation-unit set, the hash probe in both
      directions and the local test run are the evidence this carries in
      place of one, and there was no second reader.
- [ ] Review record: not produced, per the line above.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

```
```

No route to a device the sanitizer can attach to is available on this
machine, which #258 records with its commands. The block is left empty rather
than removed, per CONTRIBUTING.md.

## Quality checklist

- [x] Minimal: one CMake module, one test, one policy bullet, one attribution
      section. The module carries no code the pin does not need.
- [x] Self-documenting: the pin's three deviations are argued next to the pin,
      and the test says at its top which reference behaviours it exists to
      hold still.
- [x] The structural property this establishes - that upstream's own build
      system never enters the tree - is locked as a configure-time
      `FATAL_ERROR` rather than as a comment.

## Notes

Three behaviours of the reference are pinned by the new test because each one
decides how the later parity tests have to be written, and each is easy to get
wrong in the direction that reads green: a short decode comes back as
`LIBDEFLATE_SUCCESS`, so a parity test reading the status alone has a hole
exactly where a corrupt stream lands; truncating trailing compressed bytes
does not move the verdict, because the format carries no checksum, so
truncation is not the lever it is for the Snappy oracle; and level 0 is the
one level whose block type the source guarantees, measurable from outside as
output no smaller than input.

`tests/CMakeLists.txt` and `.github/workflows/ci.yml` gain one line each. The
oracle links into the new test alone and never into the shared fixture
library, so no existing test gains the fork's headers.
