### PR TITLE
Narrow the LZ4 match gather's modulo to 32 bits [#58]

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -187,6 +187,70 @@ recovers the Silesia +9–10% without touching the worst case would be accepted 
 none is known under the single-loop structure, since the predicate is
 inherently per-match).
 
+### Perf pass 4 (issue #58): narrowing the gather modulo to 32 bits is accepted
+
+The match-copy gather computes `i mod offset` once per match byte per lane.
+Both operands provably fit in 32 bits at run time - `offset` is the LZ4
+2-byte offset field, and `i` is below `match_len` - but nvcc cannot prove the
+second, so it emits the 64-bit software modulo. sm_86 has no integer-divide
+hardware, and the width shows up in the loop body rather than in an estimate:
+
+```
+nvcc -arch=sm_86 -std=c++17 -Iinclude -Isrc -Xptxas -v -c src/batch.cu -o /tmp/batch.o
+cuobjdump -sass /tmp/batch.o
+```
+
+| Gather loop (SASS, `lz4_decode_batch<false>`) | Body            | Instructions per iteration |
+| --------------------------------------------- | --------------- | -------------------------- |
+| Baseline, 64-bit modulo                       | `0x1520-0x17a0` | 41                         |
+| Patched, 32-bit arm                           | `0x18c0-0x19e0` | 19                         |
+| Patched, 64-bit fallback arm                  | `0x1530-0x17b0` | 41                         |
+
+The literal-copy loop is 11 instructions on both builds, and ptxas reports
+`Used 48 registers, 0 bytes stack frame` on both, so the narrowing buys the
+gather without moving occupancy - which is what sank perf pass 2.
+
+Measured 2026-08-09, same pinned container and RTX 3080, one session, in
+A/B/A order so a drifting machine cannot be read as a win: baseline, patched,
+then the baseline binary rebuilt from the same tree and re-run. 3 warmup + 30
+CUDA-event-timed runs each. Delta is throughput speedup against each of the
+two baseline passes (`baseline_ms / patched_ms - 1`):
+
+| Corpus              | Baseline p50 (pass A1 / A2) | Patched p50 | Delta (throughput speedup) |
+| ------------------- | --------------------------- | ----------- | -------------------------- |
+| `--worst4b --gpu`   | 27.018 / 26.566 ms          | 25.075 ms   | **+7.7% / +5.9%**          |
+| `--longmatch --gpu` | 1.279 / 1.288 ms            | 0.986 ms    | **+29.7% / +30.6%**        |
+| Silesia `--gpu`     | 12.809 / 12.190 ms          | 12.443 ms   | +2.9% / −2.0%              |
+
+The parse-only ceiling is the invariant control: it elides the copies, so the
+gather cannot reach it and any movement there is the machine rather than the
+change.
+
+| Corpus              | Parse-only p50 (A1 / patched / A2) |
+| ------------------- | ---------------------------------- |
+| `--worst4b --gpu`   | 15.912 / 15.704 / 15.516 ms        |
+| `--longmatch --gpu` | 0.325 / 0.327 / 0.333 ms           |
+| Silesia `--gpu`     | 7.485 / 7.108 / 7.057 ms           |
+
+**Silesia shows no effect that this change can claim.** Its control drifts
+5.7% downward across the session and its second baseline pass is faster than
+the patched run, so the patched number sits inside the drift rather than
+outside it. Subtracting the control leaves a copy half of 5.324 / 5.335 /
+5.133 ms, which is flat. That is the same finding perf pass 1 recorded from
+the other direction: short Silesia copies are latency-bound, so a cheaper
+gather does not move them.
+
+The two match-heavy corpora are outside the drift in both directions. Copy
+half after subtracting the control: `--worst4b` 11.106 / 9.371 / 11.050 ms
+(−15.3% against the mean of the two baselines) and `--longmatch` 0.954 /
+0.659 / 0.955 ms (−31.0%).
+
+**Accepted**, and on the axis perf pass 3 was rejected on: `--worst4b` is the
+adversarial worst case and the DoS-resistance margin, and it gains here
+rather than paying. The 32-bit arm is entered under a warp-uniform
+`match_len <= UINT32_MAX`, so it costs no divergence, and a match longer than
+2^32 still decodes through the unchanged 64-bit arm.
+
 ### Best case: the longmatch corpus (issue #36)
 
 The shipped kernel's baseline on the new `--longmatch` corpus - long

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -210,46 +210,62 @@ The literal-copy loop is 11 instructions on both builds, and ptxas reports
 `Used 48 registers, 0 bytes stack frame` on both, so the narrowing buys the
 gather without moving occupancy - which is what sank perf pass 2.
 
-Measured 2026-08-09, same pinned container and RTX 3080, one session, in
-A/B/A order so a drifting machine cannot be read as a win: baseline, patched,
-then the baseline binary rebuilt from the same tree and re-run. 3 warmup + 30
-CUDA-event-timed runs each. Delta is throughput speedup against each of the
-two baseline passes (`baseline_ms / patched_ms - 1`):
+Measured 2026-08-09, same pinned container and RTX 3080. **Both binaries are
+built once, up front, and then alternated**, baseline and patched, pass after
+pass. That method is the finding underneath the numbers and is worth stating
+before them: an A/B/A that rebuilds between arms was run first and it read
+`--worst4b` at +7.7%, which the alternation does not reproduce. Over minutes
+this GPU drifts by more than the effect on two of the three corpora, so
+whichever arm is measured later carries the drift. Alternating moves both arms
+through the same drift. 3 warmup + 30 CUDA-event-timed runs per number.
 
-| Corpus              | Baseline p50 (pass A1 / A2) | Patched p50 | Delta (throughput speedup) |
-| ------------------- | --------------------------- | ----------- | -------------------------- |
-| `--worst4b --gpu`   | 27.018 / 26.566 ms          | 25.075 ms   | **+7.7% / +5.9%**          |
-| `--longmatch --gpu` | 1.279 / 1.288 ms            | 0.986 ms    | **+29.7% / +30.6%**        |
-| Silesia `--gpu`     | 12.809 / 12.190 ms          | 12.443 ms   | +2.9% / −2.0%              |
+| Corpus              | Baseline p50, five passes                     | Patched p50, five passes                      |
+| ------------------- | --------------------------------------------- | --------------------------------------------- |
+| `--worst4b --gpu`   | 26.632 / 26.383 / 26.149 / 26.298 / 26.507 ms | 26.213 / 25.974 / 26.284 / 25.981 / 25.965 ms |
+| `--longmatch --gpu` | 1.281 / 1.422 / 1.347 / 1.422 / 1.422 ms      | 0.984 / 1.032 / 1.087 / 1.089 / 1.087 ms      |
 
-The parse-only ceiling is the invariant control: it elides the copies, so the
-gather cannot reach it and any movement there is the machine rather than the
-change.
+Silesia over four alternations, with its parse-only ceiling read from the same
+invocations. The ceiling elides the copies, so the gather cannot reach it:
 
-| Corpus              | Parse-only p50 (A1 / patched / A2) |
-| ------------------- | ---------------------------------- |
-| `--worst4b --gpu`   | 15.912 / 15.704 / 15.516 ms        |
-| `--longmatch --gpu` | 0.325 / 0.327 / 0.333 ms           |
-| Silesia `--gpu`     | 7.485 / 7.108 / 7.057 ms           |
+| Pass | Baseline full / parse | Patched full / parse |
+| ---- | --------------------- | -------------------- |
+| 1    | 12.597 / 6.787 ms     | 12.272 / 7.145 ms    |
+| 2    | 12.669 / 7.188 ms     | 12.470 / 7.284 ms    |
+| 3    | 13.014 / 6.785 ms     | 12.451 / 7.135 ms    |
+| 4    | 12.575 / 7.258 ms     | 12.245 / 7.258 ms    |
 
-**Silesia shows no effect that this change can claim.** Its control drifts
-5.7% downward across the session and its second baseline pass is faster than
-the patched run, so the patched number sits inside the drift rather than
-outside it. Subtracting the control leaves a copy half of 5.324 / 5.335 /
-5.133 ms, which is flat. That is the same finding perf pass 1 recorded from
-the other direction: short Silesia copies are latency-bound, so a cheaper
-gather does not move them.
+Throughput speedup on the medians, and the pairwise count, because with an
+effect this size the count says more than the ratio:
 
-The two match-heavy corpora are outside the drift in both directions. Copy
-half after subtracting the control: `--worst4b` 11.106 / 9.371 / 11.050 ms
-(−15.3% against the mean of the two baselines) and `--longmatch` 0.954 /
-0.659 / 0.955 ms (−31.0%).
+| Corpus              | Baseline / patched median | Delta      | Passes won |
+| ------------------- | ------------------------- | ---------- | ---------- |
+| `--longmatch --gpu` | 1.422 / 1.087 ms          | **+30.8%** | 5 of 5     |
+| Silesia `--gpu`     | 12.633 / 12.361 ms        | **+2.2%**  | 4 of 4     |
+| `--worst4b --gpu`   | 26.383 / 25.981 ms        | **+1.5%**  | 4 of 5     |
 
-**Accepted**, and on the axis perf pass 3 was rejected on: `--worst4b` is the
-adversarial worst case and the DoS-resistance margin, and it gains here
+**The worst case gains least, and that refutes what this lever was expected to
+do.** #58 named `--worst4b` as the primary target, on the reasoning that every
+one of its match bytes takes the overlap modulo. Every one does, but there are
+only four of them per match: at match length 4 the gather loop runs a single
+iteration on four of the thirty-two lanes, so the cheaper iteration is
+amortized against a parse that is 59% of that corpus's wall
+(15.5 ms of 26.4 ms parse-only). `--longmatch`'s 255-byte matches run the loop
+eight times per lane and there the gather is the wall. The lever is a
+match-length lever, not an overlap lever, and the corpus that exposes it is
+the one perf pass 3 built for the opposite purpose.
+
+Silesia's copy half, full minus the ceiling from the same invocation, is
+5.810 / 5.481 / 6.229 / 5.317 ms against 5.127 / 5.186 / 5.316 / 4.987 ms.
+Perf pass 1 concluded that Silesia's short copies are latency-bound and that
+a cheaper modulo would not help them; +2.2% on the whole decode is small
+enough to leave that conclusion standing rather than overturn it.
+
+**Accepted.** Every corpus improves or holds, nothing regresses, and the axis
+perf pass 3 was rejected on is unmoved in the wrong direction: `--worst4b` is
+the adversarial worst case and the DoS-resistance margin, and it gains here
 rather than paying. The 32-bit arm is entered under a warp-uniform
-`match_len <= UINT32_MAX`, so it costs no divergence, and a match longer than
-2^32 still decodes through the unchanged 64-bit arm.
+`match_len <= kGather32BitMaxLen`, so it costs no divergence, and a match
+longer than 2^32 still decodes through the unchanged 64-bit arm.
 
 ### Best case: the longmatch corpus (issue #36)
 

--- a/src/lz4_decode.cuh
+++ b/src/lz4_decode.cuh
@@ -110,10 +110,35 @@ __global__ void __launch_bounds__(kBlockThreads)
                 __syncwarp();
                 if (seq.match_len != 0) {
                     const uint64_t offset = seq.match_dst - seq.match_src;
-                    for (uint64_t i = lane; i < seq.match_len;
-                         i += kWarpSize) {
-                        dst[seq.match_dst + i] =
-                            dst[seq.match_src + (i % offset)];
+                    /* Same closed-form gather at two arithmetic widths.
+                     * sm_86 has no integer-divide hardware, so a modulo by
+                     * a runtime divisor is a software sequence, and the
+                     * 64-bit one costs roughly twice the 32-bit one - paid
+                     * once per match byte per lane. `offset` is the LZ4
+                     * 2-byte offset field and never exceeds 65535, but `i`
+                     * is bounded only by match_len, which the ABI's size_t
+                     * capacities admit above 2^32, so the narrowing is
+                     * sound only under the test. No field is narrowed and
+                     * no bound is taken from the 64 KiB convention: the
+                     * stored sequence stays 64-bit and a match longer than
+                     * 2^32 still decodes, through the other arm. The test
+                     * is warp-uniform (every lane parsed the same bytes),
+                     * so it costs no divergence and cannot strand a lane at
+                     * the __syncwarp() below. */
+                    if (seq.match_len <= UINT32_MAX) {
+                        const uint32_t off32 = static_cast<uint32_t>(offset);
+                        for (uint64_t i = lane; i < seq.match_len;
+                             i += kWarpSize) {
+                            dst[seq.match_dst + i] =
+                                dst[seq.match_src +
+                                    (static_cast<uint32_t>(i) % off32)];
+                        }
+                    } else {
+                        for (uint64_t i = lane; i < seq.match_len;
+                             i += kWarpSize) {
+                            dst[seq.match_dst + i] =
+                                dst[seq.match_src + (i % offset)];
+                        }
                     }
                     /* The next sequence may read bytes this match wrote. */
                     __syncwarp();

--- a/src/lz4_decode.cuh
+++ b/src/lz4_decode.cuh
@@ -18,6 +18,14 @@ namespace cudec_detail {
 constexpr unsigned kBlockWarps = 4;
 constexpr unsigned kBlockThreads = kWarpSize * kBlockWarps;  /* 128 */
 
+/* The largest match length whose byte indices a 32-bit gather can address,
+ * spelled as the widest uint32_t. Neither shorter spelling can be written
+ * in this directory: the batch-limit scanner matches the standard macro's
+ * name as a substring of its own, and the structural scanner refuses the
+ * digits in a shift by the width. Both are locks worth having and neither
+ * has this line as its subject (issue #333). */
+constexpr uint64_t kGather32BitMaxLen = ~uint32_t{0};
+
 /* One warp per chunk over a grid-stride loop. All 32 lanes run the
  * validated parser redundantly in lockstep and fan out by lane for every
  * copy; overlapping matches use the closed-form modular gather
@@ -125,7 +133,7 @@ __global__ void __launch_bounds__(kBlockThreads)
                      * is warp-uniform (every lane parsed the same bytes),
                      * so it costs no divergence and cannot strand a lane at
                      * the __syncwarp() below. */
-                    if (seq.match_len <= UINT32_MAX) {
+                    if (seq.match_len <= kGather32BitMaxLen) {
                         const uint32_t off32 = static_cast<uint32_t>(offset);
                         for (uint64_t i = lane; i < seq.match_len;
                              i += kWarpSize) {


### PR DESCRIPTION
# What & why

Closes #58.

The match gather computes `i mod offset` once per match byte per lane. sm_86
has no integer-divide hardware, so that modulo is a software sequence, and its
width is paid on every overlapping byte the decoder writes. Both operands fit
in 32 bits at run time, but nvcc cannot prove it for `i`: the ABI's `size_t`
capacities admit a match longer than 2^32, so the compiler emits the 64-bit
sequence for every stream, including the overwhelming majority that could
never need it.

This computes the modulo at 32-bit width under a warp-uniform
`match_len <= kGather32BitMaxLen`, and keeps the existing 64-bit gather
unchanged as the other arm. No field is narrowed and no bound is taken from
the 64 KiB convention: `Lz4Sequence` stays 64-bit and a match past 2^32 still
decodes.

That bound is `~uint32_t{0}` rather than the standard macro, and the reason is
not style. Two structural locks refuse both shorter spellings in `src/`: the
batch-limit scanner matches the macro's name as a substring of `INT32_MAX` and
reports a translation unit inventing its own launch bound, and the structural
scanner refuses the digits in a shift by the width. The first cost this change
a red configure before the spelling changed. Both locks are worth having and
neither has this line as its subject, which is #333.

## Type of change

- [x] Decode kernel / device code
- [x] Performance

## What the width change buys, in the loop body

```
nvcc -arch=sm_86 -std=c++17 -Iinclude -Isrc -Xptxas -v -c src/batch.cu -o /tmp/batch.o
cuobjdump -sass /tmp/batch.o
```

| Gather loop in `lz4_decode_batch<false>` | Body            | Instructions per iteration |
| ---------------------------------------- | --------------- | -------------------------- |
| Before, 64-bit modulo                    | `0x1520-0x17a0` | 41                         |
| After, 32-bit arm                        | `0x18c0-0x19e0` | 19                         |
| After, 64-bit fallback arm               | `0x1530-0x17b0` | 41                         |

The divide sequence changes width and not just length: `I2F.U64.RP` /
`F2I.U64.TRUNC` in the old body, `I2F.U32.RP` / `F2I.FTZ.U32.TRUNC.NTZ` in the
new fast arm, with the `U64` pair still present in the fallback arm.

ptxas reports `Used 48 registers, 0 bytes stack frame, 0 bytes spill` on both
builds, and the literal-copy loop is 11 instructions on both, so occupancy
does not move. That is the axis perf pass 2 died on.

## Performance checklist

- [x] The claim is measured, not reasoned.
- [x] No regression against the recorded baseline.

RTX 3080 (sm_86), driver 560.94, CUDA 12.6 (nvcc V12.6.77), inside the
digest-pinned `nvidia/cuda:12.6.2-devel-ubuntu24.04` container. All corpora
are 3200 chunks of 65536 bytes except Silesia, which is 3239 chunks of min
8066 / median 65536 / max 65536. 3 warmup + 30 CUDA-event-timed runs per
number, `bench_lz4 --warmup 3 --runs 30`.

Both binaries are built once, up front, and then alternated pass after pass.
That is a correction rather than a choice. An A/B/A that rebuilt between arms
was run first and it read `--worst4b` at +7.7%; the alternation does not
reproduce that. This GPU drifts over minutes by more than the effect on two of
the three corpora, so whichever arm ran later carried the drift. The first
numbers are not in this pull request and are not in the document.

| Corpus              | Baseline p50, five passes                     | Patched p50, five passes                      |
| ------------------- | --------------------------------------------- | --------------------------------------------- |
| `--worst4b --gpu`   | 26.632 / 26.383 / 26.149 / 26.298 / 26.507 ms | 26.213 / 25.974 / 26.284 / 25.981 / 25.965 ms |
| `--longmatch --gpu` | 1.281 / 1.422 / 1.347 / 1.422 / 1.422 ms      | 0.984 / 1.032 / 1.087 / 1.089 / 1.087 ms      |

Silesia over four alternations, with the parse-only ceiling read from the same
invocations as the control:

| Pass | Baseline full / parse | Patched full / parse |
| ---- | --------------------- | -------------------- |
| 1    | 12.597 / 6.787 ms     | 12.272 / 7.145 ms    |
| 2    | 12.669 / 7.188 ms     | 12.470 / 7.284 ms    |
| 3    | 13.014 / 6.785 ms     | 12.451 / 7.135 ms    |
| 4    | 12.575 / 7.258 ms     | 12.245 / 7.258 ms    |

| Corpus              | Baseline / patched median | Delta  | Passes won |
| ------------------- | ------------------------- | ------ | ---------- |
| `--longmatch --gpu` | 1.422 / 1.087 ms          | +30.8% | 5 of 5     |
| Silesia `--gpu`     | 12.633 / 12.361 ms        | +2.2%  | 4 of 4     |
| `--worst4b --gpu`   | 26.383 / 25.981 ms        | +1.5%  | 4 of 5     |

The worst case gains least, which refutes what #58 expected of this lever. It
named `--worst4b` as the primary target because every one of its match bytes
takes the overlap modulo. Every one does, but there are only four per match:
at match length 4 the gather loop runs one iteration on four of thirty-two
lanes, and the parse is 59% of that corpus's wall (15.5 ms of 26.4 ms
parse-only). `--longmatch`'s 255-byte matches run the loop eight times per
lane, and there the gather is the wall. This is a match-length lever rather
than an overlap lever.

Nothing regresses. Every corpus improves or holds, and `--worst4b`, the
adversarial worst case and the DoS-resistance margin perf pass 3 was rejected
over, moves in the right direction.

## The guard, and whether it bites

Deleting the guard leaves the whole standing suite green:

```
ctest --test-dir build-cuda -j 4
=== with the guard deleted (32-bit arm unconditional) ===
100% tests passed, 0 tests failed out of 35
=== with the guard present ===
100% tests passed, 0 tests failed out of 35
```

That is a real gap and not a formality. No fixture in the tree allocates the
4 GiB a match past 2^32 needs, so nothing in the suite can reach the arm the
guard selects. Rather than assert the narrowing is sound, here is a probe that
reaches it. It builds one valid LZ4 block whose single match is 2^32 + 4096
bytes at offset 3, decodes it on the device, and reads a 64-byte window at the
4 GiB mark. 2^32 mod 3 == 1, so a truncating decoder shifts the phase of the
repeating window by one there and the divergence shows in 64 bytes instead of
a 4 GiB compare. liblz4 decodes the same construction at a small match length
first, so the block's well-formedness is the reference's verdict and not mine:

```
=========== A: shipped header (guard present) ===========
oracle anchor: liblz4 accepts the construction at match_len 1000 and its 1008 bytes match the expectation
device case: match_len 4294971392, src 16843037 bytes, dst capacity 4294971400 bytes
chunk status 0, bytes_written 4294971400 (want 0 and 4294971400)
window [4294967267, 4294967331): 0 of 64 bytes differ from the expectation
VERDICT: MATCHES

=========== B: guard deleted (32-bit arm unconditional) ===========
oracle anchor: liblz4 accepts the construction at match_len 1000 and its 1008 bytes match the expectation
device case: match_len 4294971392, src 16843037 bytes, dst capacity 4294971400 bytes
chunk status 0, bytes_written 4294971400 (want 0 and 4294971400)
window [4294967267, 4294967331): 32 of 64 bytes differ from the expectation, first at 4294967299
VERDICT: DIVERGES
```

The first wrong byte is 4294967299, which is 3 + 2^32, the first byte the
truncation can reach. So the guard is load-bearing and the deletion is caught,
by a probe rather than by the suite. The probe is not in this change: it needs
4 GiB of device memory and a single warp walking all of it, which is not a
shape the standing gate should grow by default. #331 carries the question of
whether it becomes an opt-in test.

The two arms are also identical wherever both are defined, which is what makes
this a width change rather than a behaviour change. For a `match_len` at or
below the bound every `i` is below 2^32 so the cast is the identity, and `offset`
never exceeds 65535, so `off32` is exact and the 32-bit modulo returns the
64-bit result. Above that bound the fallback arm is byte-for-byte the code
that was there before.

## Engineering checklist

- [x] Fail-closed preserved. No parse or reject path is touched; the change is
      inside the copy the parser has already validated, and both arms address
      the same already-bounded range.
- [x] Oracle coverage. `gpu_fixture` (device output diffed against liblz4) and
      `parser_twin` are green, and all three bench corpora byte-verify their
      output against the oracle before timing.
- [x] Determinism preserved. `determinism_gpu` green; both arms are the same
      closed-form gather, so the output is bit-identical on either path.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      No CUDA call is added.
- [ ] An adversarial review was not run. There was no second reader for this
      change, and the evidence above stands in its place: the SASS A/B, the
      A/B/A timings with their control, and the guard-deletion probe.
- [ ] No review record, for the same reason.

## GPU sanitizer gate

The sweep is owed and could not be produced. The device is reachable for
compute, which is how everything above was measured, but Compute Sanitizer
still cannot attach to it on this route, exactly as #258 records. Re-run
tonight against the same fault-free program that issue uses:

```
compute-sanitizer --version
NVIDIA (R) Compute Sanitizer
Version 2024.3.0.0 (build 34841621) (public-release)

./clean; echo "exit=$?"
exit=0

--- memcheck exit=1
========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator
========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation
========= ERROR SUMMARY: 2 errors
--- racecheck exit=1
========= Error: Failed to initialize WDDM debugger interface. ...
========= Error: Device not supported. ...
========= RACECHECK SUMMARY: 2 hazards displayed (2 errors, 0 warnings)
--- initcheck exit=1
========= ERROR SUMMARY: 2 errors
--- synccheck exit=1
========= ERROR SUMMARY: 2 errors
```

Four for four, on a program with nothing wrong in it. The block below stays
empty rather than being removed.

```
commit:
gpu:
cuda:
sanitizer:
```

## Quality checklist

- [x] Minimal. One `if`, one cast pair, and the existing loop kept as the
      other arm.
- [x] Self-documenting. The comment says why the narrowing is sound and what
      bounds each operand, which is the part a reader cannot recover from the
      code.
- [x] Conformance tests pass. No new structural property is established here;
      the property this change does establish is covered by the probe above
      and by #331, and that is disclosed rather than ticked.

## Verification

Inside the pinned container against the local RTX 3080, at the commit being
pushed:

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
[100%] Built target bench_lz4

ctest --test-dir build-cuda -j 4
100% tests passed, 0 tests failed out of 35

npx prettier@3 --check "**/*.{md,yml,yaml}"
All matched files use Prettier code style!
```

- [x] Builds clean.
- [x] `ctest` green, 35 of 35.
- [x] Prettier clean.
- [x] Docs synced. docs/BENCHMARKS.md gains perf pass 4 with the tables above.

## Notes

Silesia is reported as showing nothing rather than as a small win, because its
own control moved further than it did.

`--worst4b` is the corpus perf pass 3 was rejected on, and it gains here
rather than paying, so the worst-case margin moves in the right direction.
