### PR TITLE
Upload the frame path's metadata in one transfer [#134]

### DIFF
--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -73,7 +73,7 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
      * scope exit. The shared grow-only DevBuf serves this by a single ensure()
      * from cap 0 - every size below is non-zero (guarded by n != 0), so the
      * first ensure allocates exactly once, identical to a bare cudaMalloc. */
-    cudec_cuda::DevBuf d_src, d_dst, dd_src, dd_dst, dd_ssz, dd_dcp, dd_res;
+    cudec_cuda::DevBuf d_src, d_dst, dd_meta, dd_res;
     if (n != 0) {
         /* One destination slot of block_max per compressed block. Guard the
          * product against size_t overflow before asking the driver. */
@@ -104,25 +104,46 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
                                   cudaMemcpyHostToDevice));
         }
 
-        FRAME_CUDA(dd_src.ensure(n * sizeof(void*)));
-        FRAME_CUDA(dd_dst.ensure(n * sizeof(void*)));
-        FRAME_CUDA(dd_ssz.ensure(n * sizeof(size_t)));
-        FRAME_CUDA(dd_dcp.ensure(n * sizeof(size_t)));
+        /* The four metadata arrays go up in ONE transfer out of one packed
+         * allocation, in the layout src/stream.cpp already uses:
+         * [src_ptrs][src_sizes][dst_ptrs][dst_caps], each n elements wide at
+         * a uniform stride. Four separate uploads is four submissions per
+         * decode where one will do, and this path pays that per frame. The
+         * stride is written in units of void* for every section, including
+         * the two that hold size_t, so the assert below is what keeps that
+         * from being a silent misalignment on a host where the two differ. */
+        static_assert(sizeof(size_t) == sizeof(void*),
+                      "the packed metadata gives every section a void*-sized "
+                      "stride; a host where size_t is narrower would "
+                      "misalign the two size sections");
+        /* Packing multiplies the request by four, so the product gets the
+         * same treatment n * block_max already gets above: checked before
+         * the driver sees it, rejected rather than wrapped. */
+        if (n > SIZE_MAX / (4 * sizeof(void*))) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        const size_t meta_stride = n * sizeof(void*);
+        FRAME_CUDA(dd_meta.ensure(4 * meta_stride));
         FRAME_CUDA(dd_res.ensure(n * sizeof(cudec_chunk_result)));
-        FRAME_CUDA(cudaMemcpy(dd_src.p, h_src.data(), n * sizeof(void*),
-                              cudaMemcpyHostToDevice));
-        FRAME_CUDA(cudaMemcpy(dd_dst.p, h_dst.data(), n * sizeof(void*),
-                              cudaMemcpyHostToDevice));
-        FRAME_CUDA(cudaMemcpy(dd_ssz.p, h_ssz.data(), n * sizeof(size_t),
-                              cudaMemcpyHostToDevice));
-        FRAME_CUDA(cudaMemcpy(dd_dcp.p, h_dcp.data(), n * sizeof(size_t),
+
+        /* One host staging buffer in the same layout, filled section by
+         * section, so the upload is a straight copy of it. */
+        std::vector<unsigned char> h_meta(4 * meta_stride);
+        std::memcpy(h_meta.data(), h_src.data(), meta_stride);
+        std::memcpy(h_meta.data() + meta_stride, h_ssz.data(), meta_stride);
+        std::memcpy(h_meta.data() + 2 * meta_stride, h_dst.data(),
+                    meta_stride);
+        std::memcpy(h_meta.data() + 3 * meta_stride, h_dcp.data(),
+                    meta_stride);
+        FRAME_CUDA(cudaMemcpy(dd_meta.p, h_meta.data(), 4 * meta_stride,
                               cudaMemcpyHostToDevice));
 
+        unsigned char* const d_meta = static_cast<unsigned char*>(dd_meta.p);
         const cudec_status launched = cudec_lz4_decompress_batch(
-            static_cast<const void* const*>(dd_src.p),
-            static_cast<const size_t*>(dd_ssz.p),
-            static_cast<void* const*>(dd_dst.p),
-            static_cast<const size_t*>(dd_dcp.p), n,
+            reinterpret_cast<const void* const*>(d_meta),
+            reinterpret_cast<const size_t*>(d_meta + meta_stride),
+            reinterpret_cast<void* const*>(d_meta + 2 * meta_stride),
+            reinterpret_cast<const size_t*>(d_meta + 3 * meta_stride), n,
             static_cast<cudec_chunk_result*>(dd_res.p), nullptr);
         if (launched != CUDEC_OK) {
             return launched;


### PR DESCRIPTION
# What & why

Closes #134.

`DecodeAndAssemble` allocated four device buffers for the per-block source
pointers, source sizes, destination pointers and destination capacities, and
filled them with four blocking H2D copies. `src/stream.cpp` solved this
already, and its layout is the one adopted here: one region,
`[src_ptrs][src_sizes][dst_ptrs][dst_caps]`, four sections at a uniform
stride, uploaded once. The frame path predates that work and never picked it
up.

**Based on `issue/132`, not on `main`.** This change's own acceptance asks for
a before/after from `bench_lz4 --frame`, and that mode is #132. #132 says to
land it before the sibling children.

**No check has run on this pull request, and none will while it sits here.**
`.github/workflows/ci.yml` triggers on `pull_request: branches: [main]` only,
so a pull request based on another branch gets no build, no format, no
sanitize and no fuzz. A base change is not one of the default `pull_request`
event types either, so when #132 merges and GitHub retargets this to `main`,
the checks still will not start on their own: the branch has to be rebased
onto `main` and pushed, and that push is what produces the gate. Do not read
the absent checks as passing ones. What was run locally instead is under
Verification, including the sanitize job's own configuration.

## Type of change

- [x] API surface (host side of the frame entry point)
- [x] Performance

## What it removes, counted rather than asserted

Inside `DecodeAndAssemble`, on the two files:

```
  baseline: H2D memcpy 5, ensure() 7
  patched:  H2D memcpy 2, ensure() 4
```

Two rather than one because the other H2D is the compressed-source staging,
which was already a single transfer and is not metadata. So exactly one
metadata copy remains, which is what the issue asks for, and three device
allocations go with the three copies that went.

## What it does not claim

No throughput claim. The change removes a fixed cost per decode, so it is
resolvable only where the wall is short, and the shortest wall this harness
can put it under is a 3 MB frame at the 64 KB rung. Both binaries built once,
then alternated, 5 warmup + 60 measured runs per number:

| Pass | Split p50 | Packed p50 |
| ---- | --------- | ---------- |
| 1    | 13.093 ms | 14.630 ms  |
| 2    | 14.933 ms | 14.627 ms  |
| 3    | 15.501 ms | 15.470 ms  |
| 4    | 13.688 ms | 13.962 ms  |
| 5    | 12.982 ms | 12.842 ms  |
| 6    | 12.859 ms | 12.815 ms  |
| 7    | 14.127 ms | 12.790 ms  |
| 8    | 13.230 ms | 13.633 ms  |

Medians 13.459 ms against 13.798 ms, with the packed build ahead in five of
eight passes. The run-to-run spread is about 10% either way, which is far
larger than a saving of a few hundred microseconds, so **nothing is claimed
from these numbers in either direction.** An earlier four-pass run had the
packed build ahead 4 of 4 on this rung; eight passes did not reproduce it, and
that first run is not the evidence here.

The issue expected the win to be "largest as a fraction on few-block frames".
The measurement says otherwise, and the reason is in #132's rungs: on this
path a frame with fewer, larger blocks has a **longer** wall, not a shorter
one, because the block count is the parallelism. So the fixed saving is
smallest as a fraction exactly where the issue expected it to be largest.

## Constraints from the issue

- [x] Section stride keeps every section naturally aligned, and a wrong-sized
      element is now a compile-time failure rather than a silent misalignment.
      A `static_assert(sizeof(size_t) == sizeof(void*))` says it out loud; the
      streaming path relies on the same equality and nothing in the tree said
      so.
- [x] The `n != 0` guard and the `n * block_max` overflow check are unchanged.
- [x] `dd_res` stays its own allocation. It is a D2H destination, not
      metadata.
- [x] No behavioural change: the same pointers, sizes and capacities reach the
      kernel, at the same values, in the same order.

The packed request is four strides rather than one, so it gets the same
treatment `n * block_max` already gets: checked against `SIZE_MAX` before the
driver sees it, rejected rather than wrapped. That check is new, and it is the
one line here that is not a rearrangement.

## Engineering checklist

- [x] Fail-closed preserved. No parse path is touched. The one new branch is a
      reject on an overflowing metadata size.
- [x] Oracle coverage. `frame_twin` decodes frames produced by liblz4's frame
      compressor and compares byte-exact against both the original and
      `LZ4F_decompress`; it is green.
- [x] Determinism preserved. The kernel receives identical arguments.
- [x] Every CUDA API call's error is checked. The new `ensure` and `cudaMemcpy`
      go through the existing `FRAME_CUDA` macro.
- [ ] An adversarial review was not run. There was no second reader for this
      change. What stands in its place: the 36-of-36 suite including
      `frame_twin` and `frame_host_negative`, the static count of what the
      diff removes, and the fact that the arguments reaching the kernel are
      unchanged by construction.
- [ ] No review record, for the same reason.

## GPU sanitizer gate

Owed and not produced. This is host C++ that drives the device batch entry
point, so it is on the untrusted-input path the gate exists for, and the
change reorganises device allocations. Compute Sanitizer still cannot attach
on this route, which is what #258 records, re-checked tonight against the
fault-free program that issue uses: all four tools report the same two
initialization errors on a program with nothing wrong in it.

```
commit:
gpu:
cuda:
sanitizer:
```

## Verification

Inside the pinned container against the local RTX 3080, at the commit being
pushed:

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
ctest --test-dir build-cuda -j 4
100% tests passed, 0 tests failed out of 36
```

The sanitize job's own configuration, run here because CI will not run it on
this pull request and because `src/frame.cpp` is precisely what that job
instruments:

```
cmake -B build-san -DCUDEC_ENABLE_CUDA=ON -DCUDEC_SANITIZE=address,undefined
cmake --build build-san -j

ldd build-san/tests/parser_twin | grep -c 'libasan\|libubsan'
2

ctest --test-dir build-san --no-tests=error --output-on-failure -R   '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|zstd_frame_twin|termination)$'
100% tests passed, 0 tests failed out of 10
```

Both sanitizer runtimes are linked, so the green is a green from an
instrumented binary rather than from a dropped flag.

- [x] Builds clean.
- [x] `ctest` green, including `frame_twin` and `frame_host_negative`.
- [x] ASan + UBSan green over the host untrusted-input subset, run locally
      because CI cannot run it here.
- [x] Prettier clean (no markdown or YAML changed).
- [ ] Docs synced: nothing to sync. No behaviour, API or recorded number
      moves, and the frame rows #132 records are unaffected because the change
      is not measurable at that scale.

## Notes

The four host vectors are still built separately and then copied into one
staging buffer, rather than being filled through typed pointers into the
staging buffer directly as `src/stream.cpp` does. The streaming path fills a
pinned buffer it reuses across waves, where the extra copy would be on the hot
path; here the staging buffer is built once per decode and freed, and keeping
the four typed vectors leaves the loop that fills them readable and unchanged
by this diff. Worth revisiting only if this path ever grows a reused context.
