### PR TITLE
Match the batch-limit scanner's constant as a whole identifier [#333]

### DIFF
--- a/src/lz4_decode.cuh
+++ b/src/lz4_decode.cuh
@@ -18,14 +18,6 @@ namespace cudec_detail {
 constexpr unsigned kBlockWarps = 4;
 constexpr unsigned kBlockThreads = kWarpSize * kBlockWarps;  /* 128 */
 
-/* The largest match length whose byte indices a 32-bit gather can address,
- * spelled as the widest uint32_t. Neither shorter spelling can be written
- * in this directory: the batch-limit scanner matches the standard macro's
- * name as a substring of its own, and the structural scanner refuses the
- * digits in a shift by the width. Both are locks worth having and neither
- * has this line as its subject (issue #333). */
-constexpr uint64_t kGather32BitMaxLen = ~uint32_t{0};
-
 /* One warp per chunk over a grid-stride loop. All 32 lanes run the
  * validated parser redundantly in lockstep and fan out by lane for every
  * copy; overlapping matches use the closed-form modular gather
@@ -133,7 +125,7 @@ __global__ void __launch_bounds__(kBlockThreads)
                      * is warp-uniform (every lane parsed the same bytes),
                      * so it costs no divergence and cannot strand a lane at
                      * the __syncwarp() below. */
-                    if (seq.match_len <= kGather32BitMaxLen) {
+                    if (seq.match_len <= UINT32_MAX) {
                         const uint32_t off32 = static_cast<uint32_t>(offset);
                         for (uint64_t i = lane; i < seq.match_len;
                              i += kWarpSize) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -614,32 +614,82 @@ foreach(_tu lz4_decode.cuh stream.cpp)
 endforeach()
 # Every source, not a list somebody has to remember to extend: a new
 # translation unit carrying its own bound is exactly the case this is for.
-file(GLOB_RECURSE _batch_limit_sources RELATIVE
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src CONFIGURE_DEPENDS
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cc
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cpp
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cu
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cuh
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.h
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.hpp
-     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.inl)
-if(NOT _batch_limit_sources)
-  message(FATAL_ERROR "the batch-limit sweep found no sources under src/ - the "
-                      "glob has stopped matching (issue #39)")
-endif()
-foreach(_source IN LISTS _batch_limit_sources)
-  if(NOT _source STREQUAL "batch_limits.h")
-    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source} _source_src)
-    if(_source_src MATCHES "INT32_MAX")
-      message(
-        FATAL_ERROR
-          "src/${_source} builds its own bound from INT32_MAX - the batch "
-          "launch limit is cudec_detail::kMaxBatchChunks in "
-          "src/batch_limits.h (issue #39)")
+# One function, so the rule can be run against planted sources before it is
+# trusted against the tree - the discipline issue #72's scanner established,
+# and the reason a tightening is showable rather than asserted.
+function(cudec_check_batch_limit_sweep src_dir out_violations)
+  set(_violations "")
+  file(GLOB_RECURSE _sources RELATIVE ${src_dir} CONFIGURE_DEPENDS
+       ${src_dir}/*.c ${src_dir}/*.cc ${src_dir}/*.cpp ${src_dir}/*.cu
+       ${src_dir}/*.cuh ${src_dir}/*.h ${src_dir}/*.hpp ${src_dir}/*.inl)
+  if(NOT _sources)
+    string(APPEND _violations
+           "  the sweep found no sources under ${src_dir} - the glob has "
+           "stopped matching (issue #39)\n")
+  endif()
+  foreach(_source IN LISTS _sources)
+    if(_source STREQUAL "batch_limits.h")
+      continue()
+    endif()
+    file(READ ${src_dir}/${_source} _source_src)
+    # The whole identifier, never a substring. UINT32_MAX carries INT32_MAX
+    # inside it, so a width test on an arithmetic operand was refused with a
+    # message about the batch launch bound - naming something its author had
+    # not done, and leaving "stop writing the standard constant" as the
+    # shortest way past a rule whose subject the line was not (issue #333).
+    if(_source_src MATCHES "(^|[^A-Za-z_0-9])INT32_MAX([^A-Za-z_0-9]|$)")
+      string(APPEND _violations
+             "  ${_source} builds its own bound from INT32_MAX - the batch "
+             "launch limit is cudec_detail::kMaxBatchChunks in "
+             "src/batch_limits.h (issue #39)\n")
+    endif()
+  endforeach()
+  set(${out_violations} "${_violations}" PARENT_SCOPE)
+endfunction()
+
+# Both directions, planted first. The accepted probe must come back silent
+# and the refused one is matched against the TEXT the rule emits rather than
+# against a non-empty result: a rule narrowed without the second probe is a
+# rule nobody can show still bites.
+set(_batch_limit_probe_root ${CMAKE_CURRENT_BINARY_DIR}/batch-limit-probes)
+file(REMOVE_RECURSE ${_batch_limit_probe_root})
+file(WRITE ${_batch_limit_probe_root}/unsigned_constant/probe.cuh
+     "static bool fits32(uint64_t n) { return n <= UINT32_MAX; }\n")
+file(WRITE ${_batch_limit_probe_root}/own_bound/probe.cuh
+     "static const size_t kChunks = (size_t)INT32_MAX * kWarpSize;\n")
+set(_batch_limit_probes
+    "unsigned_constant|"
+    "own_bound|probe.cuh builds its own bound from INT32_MAX")
+foreach(_entry IN LISTS _batch_limit_probes)
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\2" _expected "${_entry}")
+  cudec_check_batch_limit_sweep(${_batch_limit_probe_root}/${_probe}
+                                _probe_result)
+  if(_expected STREQUAL "")
+    # Checked here rather than through string(FIND): an empty needle is found
+    # at position 0 in every string, so the branch below would assert nothing.
+    if(_probe_result)
+      message(FATAL_ERROR "the batch-limit sweep refuses a compliant probe: "
+                          "'${_probe}' must come back silent (issue #333). It "
+                          "reported:\n${_probe_result}")
+    endif()
+  else()
+    string(FIND "${_probe_result}" "${_expected}" _found_at)
+    if(_found_at EQUAL -1)
+      message(FATAL_ERROR "the batch-limit sweep is dead: probe '${_probe}' "
+                          "did not report \"${_expected}\" (issue #333). It "
+                          "reported:\n${_probe_result}")
     endif()
   endif()
 endforeach()
+
+# And now against the tree the rule is for.
+cudec_check_batch_limit_sweep(${CMAKE_CURRENT_SOURCE_DIR}/../src
+                              _batch_limit_violations)
+if(_batch_limit_violations)
+  message(FATAL_ERROR "a source under src/ builds its own batch launch bound "
+                      "(issue #39):\n${_batch_limit_violations}")
+endif()
 
 # Reads a source and hands back its lines with C comments blanked in place,
 # one list element per source line, so a rule can quote the line number a


### PR DESCRIPTION
Closes #333.

## What was wrong

The batch-limit sweep in `tests/CMakeLists.txt` read every source under `src/`
and refused any whose text contained `INT32_MAX`, matched as a plain
substring. `UINT32_MAX` contains it, so a width test on an arithmetic operand
was refused with a message about the batch launch bound, naming a thing its
author had not done. The way past it was to stop writing the standard
constant, and `src/lz4_decode.cuh` carried a `kGather32BitMaxLen` and a
comment explaining the workaround.

## What changed

The match now requires a non-identifier byte, or the file boundary, on both
sides of the name. `UINT32_MAX`, `MY_INT32_MAX` and `INT32_MAX_PLUS` pass; a
bare `INT32_MAX` is still refused, and the rule's subject is untouched -
`batch_limits.h` was already exempt by name.

The sweep moves into `cudec_check_batch_limit_sweep(src_dir out_violations)`
first, for the reason issue #72's scanner is a function: a rule that cannot be
run against planted sources cannot be shown to still bite after it is
narrowed. Two probes run before the tree does. One carries `UINT32_MAX` and
must come back silent; one carries a bare `INT32_MAX` and must be reported.
The violating probe is matched against the text its own rule emits rather than
against a non-empty result, so one branch of the function cannot cover for
another that has stopped matching.

`src/lz4_decode.cuh` takes `seq.match_len <= UINT32_MAX` back and drops the
constant and the comment that pointed here.

## Proof that the guard bites

Two mutations, configure only, in the pinned container. Neither is in the
tree.

Substring match restored:

    cmake -B build-mutA -DCUDEC_ENABLE_CUDA=ON
    CMake Error at tests/CMakeLists.txt:672 (message):
      the batch-limit sweep refuses a compliant probe: 'unsigned_constant'
      must come back silent (issue #333).  It reported:
        probe.cuh builds its own bound from INT32_MAX - the batch launch
        limit is cudec_detail::kMaxBatchChunks in src/batch_limits.h
        (issue #39)

A regex that can never match:

    cmake -B build-mutB -DCUDEC_ENABLE_CUDA=ON
    CMake Error at tests/CMakeLists.txt:679 (message):
      the batch-limit sweep is dead: probe 'own_bound' did not report
      "probe.cuh builds its own bound from INT32_MAX" (issue #333).  It
      reported:

The narrowing itself, checked against five spellings before it went into the
file:

    cmake -P rx.cmake
    -- accept: static bool fits32(uint64_t n) { return n <= UINT32_MAX; }
    -- REFUSE: static const size_t kChunks = (size_t)INT32_MAX * kWarpSize;
    -- REFUSE: INT32_MAX
    -- accept: x = MY_INT32_MAX;
    -- accept: x = INT32_MAX_PLUS;

## Gate

GPU run on the RTX 3080 in the pinned container
(`nvidia/cuda:12.6.2-devel-ubuntu24.04`, nvcc V12.6.77, `-arch=sm_86`):

    cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j \
      && ctest --test-dir build-cuda --output-on-failure
    100% tests passed, 0 tests failed out of 36
    Total Test time (real) =   9.64 sec

Formatting:

    npx prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

## Scope limits

Comments are not stripped before the scan, so a source whose prose spells the
constant is still refused. That is unchanged behaviour and outside what this
issue asks for. The rule remains what its own comment calls it: a drift
detector under the spelling somebody will type, not tamper-proofing - a copy
that computes the same number a different way is still not caught.

No second person read this change. The evidence above stands in place of one.
