### PR TITLE
Reach the >4 GiB match arm with a test [#331]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,29 @@ and need a CUDA 12.x toolchain plus a GPU for the tests - see the README's
 container command for the maintained path (build directory `build-cuda`,
 `ctest --test-dir build-cuda`).
 
+### The tests that allocate over 4 GiB
+
+Some arms of the decoder are selected by a capacity test and nothing smaller
+reaches them: `src/lz4_decode.cuh` picks a 64-bit overlap gather for a match
+longer than 2^32, and no ordinary fixture is that large. `huge_match_gpu`
+reaches that one with a single 4 GiB decode. It is built by every CUDA
+configure, so it cannot rot, and it is registered as a ctest entry only under
+`-DCUDEC_HUGE_TESTS=ON`, because 4 GiB walked by one warp is not a shape every
+run should carry. Its label is `huge` rather than `gpu`, which keeps it out of
+the sanitizer sweep:
+
+```sh
+cmake -B build-huge -DCUDEC_ENABLE_CUDA=ON -DCUDEC_HUGE_TESTS=ON
+cmake --build build-huge -j
+ctest --test-dir build-huge -L huge --output-on-failure
+```
+
+On a device that cannot hold the allocation it FAILS with the shortfall in the
+message, and does not skip. A skip on the only test that reaches an arm reads
+exactly like a pass, and the guard was unprovable for as long as no test
+selected it. Write the next capacity-selected arm the same way: reach it, or
+say in the pull request that nothing does.
+
 ### The GPU sanitizer gate
 
 Any change that touches device code carries a Compute Sanitizer sweep, from M1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,12 +183,12 @@ endif()
 # worth more than parallel wall time. A GPU test never self-skips - the
 # banned pattern is recorded in docs/MASTERPLAN.md section 5.
 function(cudec_add_test name)
-  cmake_parse_arguments(T "GPU" "" "SOURCES;LIBS" ${ARGN})
+  cmake_parse_arguments(T "GPU;HUGE" "" "SOURCES;LIBS" ${ARGN})
   # The host-only sanitizer gate (issue #42) builds only the GPU-less,
   # host-instrumentable subset: a GPU test is a .cu binary linked by nvcc,
   # which cannot pull in the ASan-instrumented cudec without sanitizing the
   # device link. Skip them so the sanitizer build stays pure host.
-  if(T_GPU AND CUDEC_SANITIZE)
+  if((T_GPU OR T_HUGE) AND CUDEC_SANITIZE)
     return()
   endif()
   add_executable(${name} ${T_SOURCES})
@@ -208,10 +208,23 @@ function(cudec_add_test name)
       ${name} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:${CUDEC_SANITIZE_COMPILE_FLAGS}>)
     target_link_options(${name} PRIVATE ${CUDEC_SANITIZE_LINK_FLAGS})
   endif()
+  # HUGE is built by every CUDA configure - a target nobody compiles rots
+  # unnoticed - and registered as a ctest entry only when asked for, because
+  # ctest offers no build-side way to keep an entry out of a bare `ctest`
+  # run: CONFIGURATIONS is ignored when no -C is given, and DISABLED hides
+  # the entry from -L as well. So the registration is the gate.
+  if(T_HUGE AND NOT CUDEC_HUGE_TESTS)
+    return()
+  endif()
   add_test(NAME ${name} COMMAND ${name})
   set_tests_properties(${name} PROPERTIES TIMEOUT
                                           ${CUDEC_TEST_TIMEOUT_SECONDS})
-  if(T_GPU)
+  if(T_HUGE)
+    # Its own label rather than gpu: scripts/sanitize-gpu.sh sweeps every
+    # gpu-labelled target with all four tools, and a multi-gigabyte
+    # single-warp decode under memcheck is not that sweep's business.
+    set_tests_properties(${name} PROPERTIES LABELS huge RUN_SERIAL TRUE)
+  elseif(T_GPU)
     set_tests_properties(${name} PROPERTIES LABELS gpu RUN_SERIAL TRUE)
   endif()
 endfunction()
@@ -450,6 +463,22 @@ if(TARGET determinism_gpu)
   target_include_directories(determinism_gpu
                              PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 endif()
+
+# The one arm of the decode kernel no ordinary fixture reaches: a match past
+# 2^32, which selects the 64-bit gather (issue #331). Deleting the test that
+# selects it leaves the rest of the suite green, so without this the guard
+# cannot be shown to do anything. It allocates 4 GiB and walks it with a
+# single warp, which is why the entry exists only under the option, and why
+# the test refuses rather than skips on a device that cannot hold it.
+#
+#     cmake -B build-huge -DCUDEC_ENABLE_CUDA=ON -DCUDEC_HUGE_TESTS=ON
+#     cmake --build build-huge -j
+#     ctest --test-dir build-huge -L huge --output-on-failure
+option(CUDEC_HUGE_TESTS
+       "Register the ctest entries that allocate over 4 GiB on the device"
+       OFF)
+cudec_add_test(huge_match_gpu SOURCES huge_match_gpu.cu LIBS
+               cudec_test_fixtures HUGE)
 
 # ---- Structural conformance, configure time: a violation reds every CI
 # build. These are drift detectors, not tamper-proofing - the honest limits

--- a/tests/huge_match_gpu.cu
+++ b/tests/huge_match_gpu.cu
@@ -1,0 +1,227 @@
+/* The match longer than 2^32, decoded on the device (issue #331).
+ *
+ * src/lz4_decode.cuh runs the closed-form overlap gather at two arithmetic
+ * widths and picks the 32-bit one under `seq.match_len <= UINT32_MAX`. Every
+ * other test in the tree stays far below that bound, so deleting the test and
+ * leaving the narrow arm unconditional left the whole suite green - a guard
+ * the suite could not prove. This reaches it.
+ *
+ * One valid LZ4 block: three literals, one match of 2^32 + 4096 bytes at
+ * offset 3, a five-byte literals-only tail. The output is "ABC" repeating,
+ * so the expected byte at index i is "ABC"[i % 3] for as far as the match
+ * reaches, and no 4 GiB comparison is needed to separate the two decoders:
+ * 2^32 mod 3 == 1, so a gather that truncates its loop index to 32 bits
+ * shifts the phase of the window by one at the 4 GiB mark. A 64-byte window
+ * astride that mark carries the whole verdict.
+ *
+ * The block's well-formedness is liblz4's verdict rather than an assertion
+ * about the format: the same construction at a small match length is decoded
+ * by LZ4_decompress_safe first, and only then is the large one built.
+ *
+ * It allocates 4 GiB and walks all of it with a single warp, because one
+ * chunk is one warp by design. That is why it is not in the default run, and
+ * why a device that cannot hold the allocation FAILS here rather than
+ * skipping: a skip on the only test that reaches an arm reports the same
+ * silence as a pass. */
+#include "cudec.h"
+#include "fixtures.h"
+#include "require.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+const unsigned char kSeed[3] = {'A', 'B', 'C'};
+const unsigned char kTail[5] = {'w', 'x', 'y', 'z', '.'};
+
+/* LZ4 block: token, literals, 2-byte offset, match-length continuation, then
+ * a terminal literals-only sequence. Nothing here is cudec's encoder - the
+ * bytes are hand-built so the reference can rule on them. */
+std::vector<unsigned char> MakeBlock(uint64_t match_len) {
+    std::vector<unsigned char> out;
+    const uint64_t encoded = match_len - 4; /* LZ4 minmatch */
+    const uint64_t low = encoded < 15 ? encoded : 15;
+    out.push_back(static_cast<unsigned char>((3u << 4) | low));
+    out.insert(out.end(), kSeed, kSeed + sizeof(kSeed));
+    out.push_back(3); /* offset, little-endian */
+    out.push_back(0);
+    if (encoded >= 15) {
+        uint64_t rest = encoded - 15;
+        while (rest >= 255) {
+            out.push_back(0xFF);
+            rest -= 255;
+        }
+        out.push_back(static_cast<unsigned char>(rest));
+    }
+    out.push_back(static_cast<unsigned char>(sizeof(kTail) << 4));
+    out.insert(out.end(), kTail, kTail + sizeof(kTail));
+    return out;
+}
+
+uint64_t DecodedSize(uint64_t match_len) {
+    return sizeof(kSeed) + match_len + sizeof(kTail);
+}
+
+unsigned char ExpectedByte(uint64_t match_len, uint64_t i) {
+    const uint64_t copied = sizeof(kSeed) + match_len;
+    if (i < copied) {
+        return kSeed[i % sizeof(kSeed)];
+    }
+    return kTail[i - copied];
+}
+
+/* The reference's verdict on the shape, at a length that fits in a host
+ * buffer. If liblz4 refuses this, the large block below is not a decoder
+ * disagreement, it is a malformed stream, and saying so here keeps the two
+ * apart. */
+int CheckShapeAgainstOracle() {
+    const uint64_t match_len = 4096;
+    const std::vector<unsigned char> block = MakeBlock(match_len);
+    const size_t decoded_size = static_cast<size_t>(DecodedSize(match_len));
+    std::vector<unsigned char> decoded;
+    REQUIRE(OracleDecodes(block, decoded_size, &decoded));
+    REQUIRE(decoded.size() == decoded_size);
+    for (size_t i = 0; i < decoded_size; i++) {
+        REQUIRE_CTX(decoded[i] == ExpectedByte(match_len, i),
+                    "oracle byte %zu is 0x%02X, expected 0x%02X", i,
+                    decoded[i], ExpectedByte(match_len, i));
+    }
+    return 0;
+}
+
+struct DeviceBatch {
+    unsigned char* src = nullptr;
+    unsigned char* dst = nullptr;
+    const void** src_ptrs = nullptr;
+    void** dst_ptrs = nullptr;
+    size_t* src_sizes = nullptr;
+    size_t* dst_caps = nullptr;
+    cudec_chunk_result* results = nullptr;
+};
+
+}  // namespace
+
+int main() {
+    if (CheckShapeAgainstOracle() != 0) {
+        return 1;
+    }
+
+    /* 2^32 + 4096: past the bound by more than a page, so the divergence is
+     * not a one-byte edge effect, and 4096 mod 3 != 0 so the tail of the
+     * match is not accidentally in phase either way. */
+    const uint64_t match_len = (uint64_t{1} << 32) + 4096;
+    const std::vector<unsigned char> block = MakeBlock(match_len);
+    const uint64_t dst_capacity = DecodedSize(match_len);
+
+    /* Refused, never skipped. cudaMemGetInfo is asked before anything is
+     * allocated so the message names the shortfall instead of an
+     * out-of-memory return several calls later. */
+    size_t free_bytes = 0;
+    size_t total_bytes = 0;
+    REQUIRE_CUDA(cudaMemGetInfo(&free_bytes, &total_bytes));
+    const uint64_t needed = dst_capacity + block.size();
+    REQUIRE_CTX(free_bytes >= needed,
+                "this test needs %llu bytes on the device and %zu are free "
+                "of %zu total - it is refused rather than skipped, because "
+                "it is the only test that reaches the >4 GiB match arm",
+                static_cast<unsigned long long>(needed), free_bytes,
+                total_bytes);
+
+    DeviceBatch b;
+    REQUIRE_CUDA(cudaMalloc(&b.src, block.size()));
+    REQUIRE_CUDA(cudaMalloc(&b.dst, static_cast<size_t>(dst_capacity)));
+    REQUIRE_CUDA(cudaMemcpy(b.src, block.data(), block.size(),
+                            cudaMemcpyHostToDevice));
+
+    const void* h_src_ptr = b.src;
+    void* h_dst_ptr = b.dst;
+    const size_t h_src_size = block.size();
+    const size_t h_dst_cap = static_cast<size_t>(dst_capacity);
+    REQUIRE_CUDA(cudaMalloc(&b.src_ptrs, sizeof(h_src_ptr)));
+    REQUIRE_CUDA(cudaMalloc(&b.dst_ptrs, sizeof(h_dst_ptr)));
+    REQUIRE_CUDA(cudaMalloc(&b.src_sizes, sizeof(h_src_size)));
+    REQUIRE_CUDA(cudaMalloc(&b.dst_caps, sizeof(h_dst_cap)));
+    REQUIRE_CUDA(cudaMalloc(&b.results, sizeof(*b.results)));
+    REQUIRE_CUDA(cudaMemcpy(b.src_ptrs, &h_src_ptr, sizeof(h_src_ptr),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(b.dst_ptrs, &h_dst_ptr, sizeof(h_dst_ptr),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(b.src_sizes, &h_src_size, sizeof(h_src_size),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(b.dst_caps, &h_dst_cap, sizeof(h_dst_cap),
+                            cudaMemcpyHostToDevice));
+
+    cudaStream_t stream;
+    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    REQUIRE(cudec_lz4_decompress_batch(b.src_ptrs, b.src_sizes, b.dst_ptrs,
+                                       b.dst_caps, 1, b.results,
+                                       stream) == CUDEC_OK);
+    REQUIRE_CUDA(cudaStreamSynchronize(stream));
+
+    cudec_chunk_result result{};
+    REQUIRE_CUDA(cudaMemcpy(&result, b.results, sizeof(result),
+                            cudaMemcpyDeviceToHost));
+    REQUIRE_CTX(result.status == CUDEC_OK, "chunk status %d", result.status);
+    REQUIRE_CTX(result.bytes_written == dst_capacity,
+                "bytes_written %llu, expected %llu",
+                static_cast<unsigned long long>(result.bytes_written),
+                static_cast<unsigned long long>(dst_capacity));
+
+    /* The 64-byte window astride the 4 GiB mark. 3 + 2^32 is the first byte
+     * a truncated loop index can reach, and it sits inside this window. */
+    const uint64_t window_begin = (uint64_t{1} << 32) - 29;
+    const size_t window_bytes = 64;
+    unsigned char window[window_bytes];
+    REQUIRE_CUDA(cudaMemcpy(window, b.dst + window_begin, window_bytes,
+                            cudaMemcpyDeviceToHost));
+    size_t differing = 0;
+    for (size_t i = 0; i < window_bytes; i++) {
+        if (window[i] != ExpectedByte(match_len, window_begin + i)) {
+            differing++;
+        }
+    }
+    REQUIRE_CTX(differing == 0,
+                "window [%llu, %llu): %zu of %zu bytes differ",
+                static_cast<unsigned long long>(window_begin),
+                static_cast<unsigned long long>(window_begin + window_bytes),
+                differing, window_bytes);
+
+    /* Both ends too, so a decode that got the window right by writing
+     * nothing at all cannot pass. */
+    unsigned char head[16];
+    unsigned char tail[16];
+    REQUIRE_CUDA(
+        cudaMemcpy(head, b.dst, sizeof(head), cudaMemcpyDeviceToHost));
+    REQUIRE_CUDA(cudaMemcpy(tail, b.dst + dst_capacity - sizeof(tail),
+                            sizeof(tail), cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < sizeof(head); i++) {
+        REQUIRE_CTX(head[i] == ExpectedByte(match_len, i),
+                    "head byte %zu is 0x%02X, expected 0x%02X", i, head[i],
+                    ExpectedByte(match_len, i));
+    }
+    for (size_t i = 0; i < sizeof(tail); i++) {
+        const uint64_t at = dst_capacity - sizeof(tail) + i;
+        REQUIRE_CTX(tail[i] == ExpectedByte(match_len, at),
+                    "tail byte %llu is 0x%02X, expected 0x%02X",
+                    static_cast<unsigned long long>(at), tail[i],
+                    ExpectedByte(match_len, at));
+    }
+
+    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    REQUIRE_CUDA(cudaFree(b.results));
+    REQUIRE_CUDA(cudaFree(b.dst_caps));
+    REQUIRE_CUDA(cudaFree(b.src_sizes));
+    REQUIRE_CUDA(cudaFree(b.dst_ptrs));
+    REQUIRE_CUDA(cudaFree(b.src_ptrs));
+    REQUIRE_CUDA(cudaFree(b.dst));
+    REQUIRE_CUDA(cudaFree(b.src));
+
+    std::printf(
+        "PASS: 2^32 + 4096 byte match at offset 3 decodes bit-exact across "
+        "the 4 GiB mark\n");
+    return 0;
+}


### PR DESCRIPTION
Closes #331.

## The arm and why it was unreachable

`src/lz4_decode.cuh` runs the closed-form overlap gather at two arithmetic
widths and picks the 32-bit one under `seq.match_len <= UINT32_MAX`. Nothing
in the suite allocated the 4 GiB a match past 2^32 needs, so nothing ever
selected the 64-bit arm, and the guard could be deleted without a single test
noticing.

## What lands

`tests/huge_match_gpu.cu`. One valid LZ4 block: three literals, one match of
2^32 + 4096 bytes at offset 3, a five-byte literals-only tail. Destination
capacity 4294971400, source 16843037 bytes, almost all of it the match-length
continuation run.

No 4 GiB comparison is needed. The output is `ABC` repeating and 2^32 mod 3
== 1, so a gather that truncates its loop index to 32 bits shifts the phase of
the window at the 4 GiB mark. A 64-byte window at [4294967267, 4294967331)
carries the whole verdict; the head and the tail are checked too, so a decode
that wrote nothing cannot pass by agreeing with poison.

The block's well-formedness is the reference's verdict rather than an
assertion about the format. The same construction at match length 4096 goes
through `LZ4_decompress_safe` first, and the large block is built only if the
oracle agrees byte for byte.

## How it runs, and how it does not

Built by every CUDA configure, so the target cannot rot; registered as a ctest
entry only under `-DCUDEC_HUGE_TESTS=ON`. ctest has no build-side way to keep
an entry out of a bare `ctest` run, and both plausible mechanisms were tried
rather than assumed:

    add_test(NAME optin ...)
    set_tests_properties(optin PROPERTIES LABELS huge CONFIGURATIONS huge)
    $ ctest
    2/2 Test #2: optin ......................   Passed

`CONFIGURATIONS` is ignored when no `-C` is given, and `DISABLED` would hide
the entry from `-L` as well. So the registration is the gate.

The label is `huge`, not `gpu`: `scripts/sanitize-gpu.sh` discovers its
targets with `ctest -L gpu -N` and runs four tools over every one of them, and
a 4 GiB single-warp decode is not that sweep's business.

    cmake -B build-huge -DCUDEC_ENABLE_CUDA=ON -DCUDEC_HUGE_TESTS=ON
    cmake --build build-huge -j
    ctest --test-dir build-huge -L huge --output-on-failure

CONTRIBUTING gains that block, in a subsection beside the container command,
with the rule the next capacity-selected arm should follow.

## Refused, never skipped

A device that cannot hold the allocation fails with the shortfall in the
message. Reached by raising the requirement in a throwaway edit, not in the
tree:

    FAIL tests/huge_match_gpu.cu:127: free_bytes >= needed | this test needs
    17247257748 bytes on the device and 9513730048 are free of 10736893952
    total - it is refused rather than skipped, because it is the only test
    that reaches the >4 GiB match arm

A skip on the only test that reaches an arm reports the same silence as a
pass, which is how the arm got here.

## Proof that it bites

RTX 3080, driver 560.94, in the pinned container
(`nvidia/cuda:12.6.2-devel-ubuntu24.04`, nvcc V12.6.77, `-arch=sm_86`).

Guard present, the whole opt-in tree:

    ctest --test-dir build-huge --no-tests=error --output-on-failure
    100% tests passed, 0 tests failed out of 37
    Label Time Summary:
    gpu     =   5.37 sec*proc (8 tests)
    huge    =  19.33 sec*proc (1 test)

The arm made unconditional (`if (true)` in place of the test, not in the
tree):

    ctest --test-dir build-huge -L huge --output-on-failure
    1/1 Test #31: huge_match_gpu ..............***Failed   10.69 sec
    FAIL tests/huge_match_gpu.cu:187: differing == 0 | window
    [4294967267, 4294967331): 32 of 64 bytes differ

    ctest --test-dir build-huge -LE huge
    (the other 36 entries: green)

32 of 64 differing is the count the issue recorded, so the shape reproduces
rather than merely failing.

The default tree is unchanged in what it runs:

    cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON
    ctest --test-dir build-cuda -N | grep -c 'Test *#'
    36
    ctest --test-dir build-cuda -N | grep -i huge   # exit 1, no match

    ctest --test-dir build-cuda --no-tests=error --output-on-failure
    100% tests passed, 0 tests failed out of 36

Formatting:

    npx prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

## Not covered

The Compute Sanitizer sweep over this change has NOT been run. The four tools
cannot attach to the device on this route, which issue #258 holds; this test
carries the `huge` label and would be outside the sweep's discovery in any
case.

No second person read this change. The evidence above stands in place of one.
