### PR TITLE
Record the asset-like corpus baseline [#139]

### DIFF
--- a/docs/BENCHMARK-METHODOLOGY.md
+++ b/docs/BENCHMARK-METHODOLOGY.md
@@ -145,6 +145,28 @@ an attacker who fully controls a valid input can force. The honest findings:
 - **The GPU advantage holds under the worst input:** 8.1 GB/s worst-case GPU
   is still ~5.4× the CPU worst case and ~2.3× the CPU's Silesia _average_.
 
+### asset-like (generated game-asset model)
+
+Recorded 2026-08-09, same platform and same container digest as the tables
+above. `bench_lz4 --assetlike --gpu --warmup 3 --runs 30`. The corpus is a
+MODEL of the workload and not the workload; nothing here is a measurement on
+real game data.
+
+| Path                                   | Throughput | Share of the decode |
+| -------------------------------------- | ---------- | ------------------- |
+| CPU oracle, liblz4 single thread       | 10.03 GB/s | -                   |
+| GPU decode, device-resident (cudec)    | 44.2 GB/s  | 4.748 ms            |
+| GPU parse-only ceiling (copies elided) | 81.5 GB/s  | 2.574 ms, 54%       |
+
+The right-hand column is the split rather than a comparison against Silesia,
+and that is deliberate: the Silesia rows above predate the gather narrowing
+(issue #58), so a ratio against them would mix two kernels. Within this
+invocation, copies are 2.174 ms of the 4.748 ms decode, and the GPU runs
+~4.4× the CPU oracle - a smaller factor than Silesia's, on an input where the
+oracle also has little to do. Where the regime sits against the other corpora
+on today's kernel is not established by this row and needs them re-measured in
+one session.
+
 ### enwik8 (text-heavy)
 
 Recorded 2026-08-05, same platform and same container digest as the tables

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -408,6 +408,66 @@ counted one. Stated as the reading it is.
 Reproduce with `bench/get-corpora.sh` followed by
 `bench_lz4 bench/corpora/enwik8 --gpu --warmup 3 --runs 30`.
 
+### Game-asset-like: the generated asset corpus (issue #139)
+
+The regime the README leads with, and the only corpus here whose source data
+is barely compressible. One 64 KB block tiled by four regions in the
+proportions of a shipped asset package - BC1-shaped block-compressed texture,
+interleaved 32-byte vertex records, a triangle-list index buffer, 16-bit
+stereo PCM audio - replicated to 3200 chunks. Unlike `--worst4b` and
+`--longmatch` the wire is ordinary `LZ4_compress_default` output: the shape
+being modelled is the source data, and letting the standard compressor decide
+the sequence structure is the point. Oracle-validated before any timing and
+regime-locked by the CPU-only `bench_assetlike_selfcheck` ctest.
+
+**It is a MODEL of the workload, not the workload.** A synthetic
+texture/mesh/audio mixture reproduces the regime and is not a measurement on
+real game data. No number below may be quoted as one.
+
+Recorded 2026-08-09 in the digest-pinned dev container
+(`nvidia/cuda:12.6.2-devel-ubuntu24.04`) on the same RTX 3080 as every row
+above, `--assetlike --gpu --warmup 3 --runs 30`.
+
+```
+## bench_lz4 report
+- decoder: CPU oracle, LZ4_decompress_safe (liblz4 1.10.0), single thread
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 12.6, runtime 12.6
+- cudec: 100 (the CPU rows time the liblz4 oracle baseline; the GPU rows below, when --gpu is set, time cudec's decoder)
+- corpus: asset-like, 3200 chunks, 209.72 MB original, 169.56 MB compressed (ratio 0.809), generated in-harness, a MODEL of a game asset package (BC1 texture, interleaved geometry, 16-bit PCM audio) and not a measurement on real game data; compressed by LZ4_compress_default and oracle-validated
+- chunk sizes: min 65536 / median 65536 / max 65536 bytes
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is LZ4_decompress_safe only (no clears, no allocation); output byte-verified once before timing; percentiles are nearest-rank
+- wall per run: p50 20.914 ms / p90 22.437 ms / p99 24.521 ms
+- decode throughput: p50 10.028 GB/s / p90 9.347 GB/s / p99 8.552 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs): p50 4.748 ms, 44.2 GB/s
+- GPU parse-only ceiling (copies elided): p50 2.574 ms, 81.5 GB/s - ceilings this design AND any two-phase phase-1 (shared parse)
+```
+
+Three consecutive invocations of that command gave GPU decode p50 4.748,
+4.756 and 4.307 ms (44.2, 44.1, 48.7 GB/s). The block above is the first of
+them; the spread is the session drift perf pass 4 measured on this host and
+is why the paragraphs below read only what one invocation says about itself.
+
+**No comparison against the Silesia row is drawn here, and the omission is
+deliberate.** The Silesia figures in this document were taken before the
+gather narrowing landed (perf pass 4, issue #58), so a ratio against them
+would mix two kernels and one GPU's drift into a single number. What the
+asset-like invocation says about itself, from its own timings:
+
+- The copy half is 4.748 - 2.574 = 2.174 ms, about 46% of the decode. That is
+  a copy-heavier split than the corpus's compressibility suggests: at ratio
+  0.809 there is little to decode, and most of the output is literal bytes
+  moved rather than matches gathered.
+- The GPU-over-CPU factor is ~4.4× (44.2 against 10.028 GB/s), the two
+  measured in the same invocation. The CPU oracle is fast here for the same
+  reason: a barely-compressible input gives `LZ4_decompress_safe` little work
+  per output byte.
+
+What this row does **not** establish is where the asset-like regime sits
+relative to the other corpora on today's kernel. That needs the other rows
+re-measured in one session, which is a separate piece of work and is not
+claimed here.
+
 ### Cost of the termination fuel cap (issue #72)
 
 The sequence loop in `src/lz4_decode.cuh` now carries an explicit decrementing

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -341,8 +341,8 @@ matches, a higher incompressible share, a different sequence density - and is
 expressly not a substitute for a measurement on real game data. That sentence
 sits beside the corpus entry in
 [BENCHMARK-METHODOLOGY.md](BENCHMARK-METHODOLOGY.md), and the baseline block
-in [BENCHMARKS.md](BENCHMARKS.md) carries it too once that block is recorded,
-so anyone quoting a number from the corpus sees what it was measured against.
+in [BENCHMARKS.md](BENCHMARKS.md) carries it too, so anyone quoting a number
+from the corpus sees what it was measured against.
 
 A hash-pinned asset pack would have been more representative, and for
 benchmarking that is what counts - the argument against the decision at full


### PR DESCRIPTION
Closes #139.

## What was already there, and what was not

The decision is recorded in the masterplan's section 8 "Settled:" paragraph,
the generator is `--assetlike` in `bench/bench_lz4.cpp`, the regime lock is
the CPU-only `bench_assetlike_selfcheck` ctest, and the corpus entry with its
model-not-workload caveat is in `docs/BENCHMARK-METHODOLOGY.md`. Four of the
five done-when bullets.

The fifth was the baseline block in `docs/BENCHMARKS.md`, and the masterplan
itself said so in the future tense ("carries it too once that block is
recorded"). This records it and puts that sentence in the present.

## The measurement

RTX 3080, driver 560.94, in the digest-pinned container
(`nvidia/cuda:12.6.2-devel-ubuntu24.04`), 2026-08-09.

    ./build-cuda/bench/bench_lz4 --assetlike --gpu --warmup 3 --runs 30
    - corpus: asset-like, 3200 chunks, 209.72 MB original, 169.56 MB
      compressed (ratio 0.809)
    - chunk sizes: min 65536 / median 65536 / max 65536 bytes
    - decode throughput: p50 10.028 GB/s / p90 9.347 GB/s / p99 8.552 GB/s
    - GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs):
      p50 4.748 ms, 44.2 GB/s
    - GPU parse-only ceiling (copies elided): p50 2.574 ms, 81.5 GB/s

The full report block goes into `docs/BENCHMARKS.md` verbatim, as every other
row does.

Three consecutive invocations of the same command:

    GPU decode p50: 4.748 ms (44.2 GB/s)
                    4.756 ms (44.1 GB/s)
                    4.307 ms (48.7 GB/s)

That is ~10% of session drift, the same effect perf pass 4 measured on this
host. It is written beside the block rather than smoothed into an average, and
it is why the prose reads only what one invocation says about itself.

## What the row deliberately does not say

No ratio against the Silesia rows. Those were taken before the gather
narrowing landed (#58), so a comparison would put two kernels and this host's
drift into one number, which is the defect this repository's methodology
section exists against. The row reads its own invocation instead: copies are
4.748 - 2.574 = 2.174 ms, about 46% of the decode, and the GPU-over-CPU factor
is ~4.4× with both halves timed in the same run. Where the asset-like regime
sits against the other corpora on today's kernel needs them all re-measured in
one session, and the row says that rather than implying an answer.

The methodology document gains the matching table, with the same omission
stated in the same place.

## Gate

    npx prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

Documentation only - no source, test or build file changes, so the container
test run is unchanged from `main` at `ffd0789`, where it was
`100% tests passed, 0 tests failed out of 36`.

No second person read this change. The evidence above stands in place of one.
