### PR TITLE
Size the streaming wave by its staging, not by a chunk count [#33]

### DIFF
--- a/docs/BENCHMARK-METHODOLOGY.md
+++ b/docs/BENCHMARK-METHODOLOGY.md
@@ -199,19 +199,28 @@ device-to-host readback - wall-clocked. On Silesia, reusing a warmed context:
 
 | Output target            | Steady-state (reused ctx) | Cold (fresh ctx) |
 | ------------------------ | ------------------------- | ---------------- |
-| Device out               | ~0.92 GB/s (229.5 ms)     | ~0.89 GB/s       |
-| Host out (sync readback) | ~0.58 GB/s (365.2 ms)     | ~0.57 GB/s       |
+| Device out               | ~7.65 GB/s (27.7 ms)      | ~1.39 GB/s       |
+| Host out (sync readback) | ~1.36 GB/s (155.4 ms)     | ~0.76 GB/s       |
 
-This is a different, honest metric - not a regression of the ~18 GB/s
-device-resident kernel throughput. Read it plainly:
+Recorded 2026-08-09, after the wave sizing landed (issue #33); the rows it
+replaced read 229.5 ms and 365.2 ms at a fixed 64-chunk wave. This is a
+different, honest metric - not a regression of the ~18 GB/s device-resident
+kernel throughput. Read it plainly:
 
-- **The streaming wall is submission-bound, not compute-bound.** Against a
-  ~12 ms device-resident decode and a ~4 ms compressed host-to-device copy,
-  the ~230 ms steady-state wall is dominated by the **per-wave serial
-  submission** of the batch (Silesia is ~51 waves of 64 chunks) on this
-  WSL2/WDDM path, where each submission flush costs milliseconds. Raising the
-  wave granularity so the path submits once is the real lever, tracked as
-  [issue #33](https://github.com/iderex/cudec/issues/33).
+- **The streaming wall was submission-bound, not compute-bound, and that is
+  what was fixed.** Against a ~12 ms device-resident decode and a ~4 ms
+  compressed host-to-device copy, the old ~230 ms steady-state wall was
+  dominated by the **per-wave serial submission** of the batch (Silesia was
+  ~51 waves of 64 chunks) on this WSL2/WDDM path, where each submission flush
+  costs milliseconds. Sizing the wave by its staging cost instead
+  ([issue #33](https://github.com/iderex/cudec/issues/33)) makes Silesia one
+  submission on the device path and brings the wall to 27.7 ms, an 8.5×
+  improvement won in 5 of 5 alternated passes. Peak staging is bounded at
+  384 MiB by construction, which is the price and is stated in
+  [BENCHMARKS.md](BENCHMARKS.md) beside the table.
+- **Host output is still ~5× the device path**, and not because of the wave:
+  its readback targets pageable caller memory one chunk at a time, so it is
+  3239 synchronous copies at any wave size. That is issues #133 and #135.
 - **The per-call allocation is not the dominant cost** (~8 ms cold − steady),
   correcting the earlier assumption; the reusable context earns its place as a
   simplification and as the primitive #33 builds on, not as a speedup.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -658,6 +658,68 @@ The device-resident M1 row (~18 GB/s, H2D/D2H excluded) remains the kernel
 throughput; the streaming numbers are a different, honest metric (copy +
 per-wave submission included) and are not a regression of it.
 
+### The wave is sized by staging, not by a chunk count (issue #33)
+
+The attribution above named the lever and this is it taken. `kWaveChunks = 64`
+is gone; the wave is now the largest number of chunks whose staging fits a
+384 MiB budget, capped at 4096 chunks. The budget is charged against the
+LARGEST chunk in the call rather than the mean, so peak staging stays inside it
+for any distribution including a hostile one, and the chunk ceiling bounds the
+metadata staging on its own - without it a batch of zero-length chunks divides
+the budget by one. Silesia's 3239 chunks become ONE wave on the device-output
+path and two on the host-output path, against ~51 before.
+
+Measured 2026-08-09, same container and RTX 3080. **Both binaries built once
+up front and then alternated**, baseline and patched, pass after pass - the
+protocol perf pass 4 established, because this host drifts over minutes.
+3 warmup + 30 runs per number, `--gpu-stream-ctx`.
+
+| Pass   | Baseline device out | Patched device out |
+| ------ | ------------------- | ------------------ |
+| 1      | 232.5 ms            | 27.2 ms            |
+| 2      | 235.6 ms            | 27.7 ms            |
+| 3      | 235.0 ms            | 27.8 ms            |
+| 4      | 235.5 ms            | 28.2 ms            |
+| 5      | 235.4 ms            | 27.6 ms            |
+| median | **235.4 ms**        | **27.7 ms**        |
+
+| Pass   | Baseline host out | Patched host out |
+| ------ | ----------------- | ---------------- |
+| 1      | 377.5 ms          | 155.4 ms         |
+| 2      | 391.1 ms          | 155.0 ms         |
+| 3      | 374.3 ms          | 173.9 ms         |
+| median | **377.5 ms**      | **155.4 ms**     |
+
+Device output is **8.5× faster** (0.90 → 7.65 GB/s), won in 5 of 5 passes; host
+output is **2.4× faster** (0.56 → 1.36 GB/s), won in 3 of 3. The steady-state
+device wall lands at 27.7 ms against the ~16 ms floor the issue named (a ~12 ms
+device-resident decode plus a ~4 ms compressed H2D), so the residual is now
+~12 ms rather than ~213 ms. That residual is not isolated here and no claim is
+made about it.
+
+**Host output does not reach the same place, and the reason is not the wave.**
+Its D2H targets pageable caller memory one chunk at a time, so it is 3239
+synchronous copies whatever the wave size; the wave change removes the
+submission cost around them and leaves the copies. That path is what issues
+#133 and #135 are about.
+
+**The price, stated rather than implied.** Peak staging rises from ~4 MB per
+wave to at most the budget: device memory (compressed source plus, for host
+output, the destination arena) stays within 384 MiB by construction, and pinned
+host memory within the same bound for the source. For Silesia that is ~102 MB
+pinned and ~102 MB device on the device-output path. One exception is
+deliberate: a single chunk larger than the whole budget still decodes, alone in
+its own wave, because the budget sizes a wave and is not a capacity limit on
+the ABI.
+
+Cold (first decode on a fresh context) moves the other way and is reported for
+the same reason: 241.5 → 152.5 ms on the device path, so the larger allocation
+costs more to make and still finishes ahead of the baseline's submission count.
+
+`stream_twin` - the same input decoded on a reused context is bit-identical to
+a fresh-context decode - stays green, along with the rest of the suite
+(`100% tests passed, 0 tests failed out of 36`).
+
 ## M2: the frame path end to end, swept over block count (issue #132)
 
 The frame entry point had no bench at all, so the per-block choreography

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -17,12 +17,15 @@
  * bought almost no overlap. Measuring a context that allocates nothing in steady
  * state also corrected #24's own diagnosis: the per-call allocation is NOT the
  * dominant cost - reuse saves only ~8 ms (cold - steady) of the ~230 ms wall.
- * The dominant streaming cost is the per-wave serial submission (~51 waves for
- * Silesia), tracked as the real lever in issue #33. Under correctness > measured
- * performance > minimal code, the N-stream ring is therefore dropped for a
- * single stream whose one reusable staging set is grown on demand and reused;
- * the amortization this context buys is real but small. See docs/BENCHMARKS.md
- * for the corrected overlap analysis and the output-D2H future lever. */
+ * The dominant streaming cost was the per-wave serial submission (~51 waves for
+ * Silesia at the fixed 64-chunk wave), and issue #33 took that lever: the wave
+ * is now sized by the staging it costs, Silesia submits once on the
+ * device-output path, and the steady-state device wall is 27.7 ms against
+ * 235.4 ms. Under correctness > measured performance > minimal code, the
+ * N-stream ring is therefore dropped for a single stream whose one reusable
+ * staging set is grown on demand and reused. See docs/BENCHMARKS.md for the
+ * corrected overlap analysis, the wave measurement, and the output-D2H future
+ * lever. */
 #include "batch_limits.h"
 #include "cudec.h"
 
@@ -36,18 +39,70 @@
 
 namespace cudec_stream_detail {
 
-constexpr size_t kWaveChunks = 64; /* chunks per wave: amortizes launch cost */
+/* The wave is what one submission carries, and the submission count is the
+ * streaming wall on this platform: issue #33 measured Silesia's ~230 ms
+ * steady-state against a ~12 ms device-resident decode and a ~4 ms compressed
+ * H2D, and attributed the ~213 ms residual to the 51 serial submissions a
+ * fixed 64-chunk wave produced. So the wave is sized by the staging it costs
+ * rather than by a chunk count, and both bounds below are needed.
+ *
+ * The byte budget bounds peak staging: pinned + device compressed source, and
+ * (host-output only) the device destination arena. It is charged against the
+ * LARGEST chunk in the call rather than the mean, so the bound holds for any
+ * distribution including a hostile one - a batch of tiny chunks with one huge
+ * one cannot talk the sizer into a wave that allocates far past the budget.
+ *
+ * The chunk ceiling bounds the metadata staging independently, at
+ * 4 * kWaveChunksMax * 8 bytes. Without it a batch of zero-length chunks
+ * divides the budget by one and asks for a wave of kMaxBatchChunks entries. */
+constexpr size_t kWaveStagingBudget = size_t{384} << 20;
+constexpr size_t kWaveChunksMax = 4096;
 
 /* The batch entry's launch limit bounds a stream batch too, and it is
  * cudec_detail::kMaxBatchChunks in src/batch_limits.h for both of them - the
  * duplicate that used to live here is what issue #39 was about. */
 using cudec_detail::kMaxBatchChunks;
 
-/* Metadata layout inside p_meta/d_meta for a wave of up to kWaveChunks chunks:
- * [src_ptrs][src_sizes][dst_ptrs][dst_caps], each kWaveChunks wide, 8-byte
- * elements. Fixed size, so the metadata staging never grows past this. */
-constexpr size_t kMetaStride = kWaveChunks * sizeof(void*);
-constexpr size_t kMetaBytes = 4 * kMetaStride;
+/* Metadata layout inside p_meta/d_meta for a wave of `wave_chunks` chunks:
+ * [src_ptrs][src_sizes][dst_ptrs][dst_caps], each `wave_chunks` wide, 8-byte
+ * elements. The stride is per call because the wave size is. */
+inline size_t MetaStride(size_t wave_chunks) {
+    return wave_chunks * sizeof(void*);
+}
+
+/* Chunks per wave for this call. Never zero: a single chunk larger than the
+ * budget still has to be decoded, and it goes alone rather than being
+ * refused - the budget sizes a wave, it is not a capacity limit on the ABI. */
+inline size_t ChooseWaveChunks(const size_t* h_src_sizes,
+                               const size_t* dst_caps, size_t chunk_count,
+                               bool host_out) {
+    size_t per_chunk_max = 1;
+    for (size_t i = 0; i < chunk_count; i++) {
+        size_t bytes = h_src_sizes[i];
+        if (host_out) {
+            /* Saturating: the sum only feeds a division that picks a wave
+             * size, so clamping it costs one chunk per wave and never a
+             * wrong bound. The real per-wave totals are summed exactly
+             * below, where an overflow is a reject. */
+            bytes = (SIZE_MAX - bytes < dst_caps[i]) ? SIZE_MAX
+                                                     : bytes + dst_caps[i];
+        }
+        if (bytes > per_chunk_max) {
+            per_chunk_max = bytes;
+        }
+    }
+    size_t wave = kWaveStagingBudget / per_chunk_max;
+    if (wave == 0) {
+        wave = 1;
+    }
+    if (wave > kWaveChunksMax) {
+        wave = kWaveChunksMax;
+    }
+    if (wave > chunk_count) {
+        wave = chunk_count;
+    }
+    return wave;
+}
 
 inline bool MulOverflows(size_t a, size_t b) {
     return a != 0 && b > SIZE_MAX / a;
@@ -187,7 +242,12 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
                              cudec_mem_space dst_space,
                              cudec_chunk_result* h_results) {
     const bool host_out = (dst_space == CUDEC_MEM_HOST);
-    const size_t wave_count = (chunk_count + kWaveChunks - 1) / kWaveChunks;
+    const size_t wave_chunks =
+        ChooseWaveChunks(h_src_sizes, dst_caps, chunk_count, host_out);
+    const size_t wave_count =
+        (chunk_count + wave_chunks - 1) / wave_chunks;
+    const size_t meta_stride = MetaStride(wave_chunks);
+    const size_t meta_bytes = 4 * meta_stride;
 
     /* Fail-closed the per-chunk channel up front: any post-validation early
      * return below (a size-overflow reject or a staging-grow failure) then
@@ -202,9 +262,9 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
     size_t max_wave_src = 0;
     size_t max_wave_dst = 0;
     for (size_t w = 0; w < wave_count; w++) {
-        const size_t begin = w * kWaveChunks;
-        const size_t end = (begin + kWaveChunks < chunk_count)
-                               ? begin + kWaveChunks
+        const size_t begin = w * wave_chunks;
+        const size_t end = (begin + wave_chunks < chunk_count)
+                               ? begin + wave_chunks
                                : chunk_count;
         size_t wsrc = 0, wdst = 0;
         for (size_t i = begin; i < end; i++) {
@@ -246,8 +306,8 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
     CUDEC_CUDA_CHECK(call, { ctx.poisoned = true; return CUDEC_ERR_CUDA; })
     GROW(ctx.p_src.ensure(max_wave_src));
     GROW(ctx.d_src.ensure(max_wave_src));
-    GROW(ctx.p_meta.ensure(kMetaBytes));
-    GROW(ctx.d_meta.ensure(kMetaBytes));
+    GROW(ctx.p_meta.ensure(meta_bytes));
+    GROW(ctx.d_meta.ensure(meta_bytes));
     if (host_out) {
         GROW(ctx.d_dst.ensure(max_wave_dst));
     }
@@ -278,9 +338,9 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
     }
 
     for (size_t w = 0; w < wave_count; w++) {
-        const size_t begin = w * kWaveChunks;
-        const size_t end = (begin + kWaveChunks < chunk_count)
-                               ? begin + kWaveChunks
+        const size_t begin = w * wave_chunks;
+        const size_t end = (begin + wave_chunks < chunk_count)
+                               ? begin + wave_chunks
                                : chunk_count;
         const size_t wn = end - begin;
 
@@ -303,11 +363,11 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
         const void** m_src = reinterpret_cast<const void**>(
             static_cast<unsigned char*>(ctx.p_meta.p));
         size_t* m_ssz = reinterpret_cast<size_t*>(
-            static_cast<unsigned char*>(ctx.p_meta.p) + kMetaStride);
+            static_cast<unsigned char*>(ctx.p_meta.p) + meta_stride);
         void** m_dst = reinterpret_cast<void**>(
-            static_cast<unsigned char*>(ctx.p_meta.p) + 2 * kMetaStride);
+            static_cast<unsigned char*>(ctx.p_meta.p) + 2 * meta_stride);
         size_t* m_cap = reinterpret_cast<size_t*>(
-            static_cast<unsigned char*>(ctx.p_meta.p) + 3 * kMetaStride);
+            static_cast<unsigned char*>(ctx.p_meta.p) + 3 * meta_stride);
 
         size_t src_off = 0;
         size_t dst_off = 0;
@@ -333,18 +393,18 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
         unsigned char* dm = static_cast<unsigned char*>(ctx.d_meta.p);
         const void* const* dd_src = reinterpret_cast<const void* const*>(dm);
         const size_t* dd_ssz =
-            reinterpret_cast<const size_t*>(dm + kMetaStride);
+            reinterpret_cast<const size_t*>(dm + meta_stride);
         void* const* dd_dst =
-            reinterpret_cast<void* const*>(dm + 2 * kMetaStride);
+            reinterpret_cast<void* const*>(dm + 2 * meta_stride);
         const size_t* dd_cap =
-            reinterpret_cast<const size_t*>(dm + 3 * kMetaStride);
+            reinterpret_cast<const size_t*>(dm + 3 * meta_stride);
 
         if (src_off != 0 &&
             cudaMemcpyAsync(d_src, p_src, src_off, cudaMemcpyHostToDevice,
                             stream) != cudaSuccess) {
             WAVE_FAIL(CUDEC_ERR_CUDA);
         }
-        if (cudaMemcpyAsync(ctx.d_meta.p, ctx.p_meta.p, kMetaBytes,
+        if (cudaMemcpyAsync(ctx.d_meta.p, ctx.p_meta.p, meta_bytes,
                             cudaMemcpyHostToDevice, stream) != cudaSuccess) {
             WAVE_FAIL(CUDEC_ERR_CUDA);
         }


### PR DESCRIPTION
Closes #33.

## The lever, taken

`kWaveChunks = 64` submitted Silesia's 3239 chunks in ~51 serial waves. #29
measured the steady-state wall at ~230 ms against a ~12 ms device-resident
decode and a ~4 ms compressed H2D and attributed the ~213 ms residual to the
submission count by exclusion. The wave is now sized by the staging it costs.

Three properties, and each of the two bounds is load-bearing:

- **Byte budget, 384 MiB.** Charged against the LARGEST chunk in the call, not
  the mean, so peak staging holds for any distribution. A batch of tiny chunks
  with one huge one cannot talk the sizer into a wave that allocates far past
  the budget, which a mean would allow.
- **Chunk ceiling, 4096.** Bounds the metadata staging on its own. Without it
  a batch of zero-length chunks divides the budget by one and asks for a wave
  of `kMaxBatchChunks` entries.
- **Floor of one.** A single chunk larger than the whole budget still decodes,
  alone in its wave. The budget sizes a wave; it is not a capacity limit on
  the ABI, and turning it into one would be a new refusal nobody asked for.

Silesia becomes one submission on the device-output path (source staging only)
and two on the host-output path (source plus the destination arena).

## The measurement

RTX 3080, driver 560.94, pinned container
(`nvidia/cuda:12.6.2-devel-ubuntu24.04`), 2026-08-09. **Both binaries built
once up front and then alternated**, baseline and patched, pass after pass -
the protocol perf pass 4 established after an A/B/A that rebuilt between arms
read a drift as an effect. 3 warmup + 30 runs per number, `--gpu-stream-ctx`
over the hash-pinned Silesia corpus.

| Pass   | Baseline device out | Patched device out |
| ------ | ------------------- | ------------------ |
| 1      | 232.5 ms            | 27.2 ms            |
| 2      | 235.6 ms            | 27.7 ms            |
| 3      | 235.0 ms            | 27.8 ms            |
| 4      | 235.5 ms            | 28.2 ms            |
| 5      | 235.4 ms            | 27.6 ms            |
| median | **235.4 ms**        | **27.7 ms**        |

| Pass   | Baseline host out | Patched host out |
| ------ | ----------------- | ---------------- |
| 1      | 377.5 ms          | 155.4 ms         |
| 2      | 391.1 ms          | 155.0 ms         |
| 3      | 374.3 ms          | 173.9 ms         |
| median | **377.5 ms**      | **155.4 ms**     |

Device output 8.5x (0.90 -> 7.65 GB/s), won 5 of 5. Host output 2.4x
(0.56 -> 1.36 GB/s), won 3 of 3. There is no overlap between the two arms'
ranges on either path, so nothing here rests on a median alone.

The acceptance asked for a number approaching the ~16 ms floor. 27.7 ms leaves
a ~12 ms residual rather than the ~213 ms one. That residual is **not**
isolated and no claim is made about what it is.

## What the change does not fix

Host output stays ~5x the device path, and the wave is not the reason: its D2H
targets pageable caller memory one chunk at a time, so it is 3239 synchronous
copies at any wave size. Removing the submission cost around them leaves them.
That is issues #133 and #135, and this PR touches neither.

## The price

Peak staging rises from ~4 MB per wave to at most the budget: device memory
(compressed source plus, for host output, the destination arena) within
384 MiB by construction, pinned host memory within the same bound for the
source. For Silesia that is ~102 MB pinned and ~102 MB device on the
device-output path. Cold (first decode on a fresh context) moves the other
way and is reported rather than dropped: 241.5 -> 152.5 ms on the device path,
so the larger allocation costs more to make and still finishes ahead of the
baseline's submission count.

Both figures go into `docs/BENCHMARKS.md` beside the tables, and
`docs/BENCHMARK-METHODOLOGY.md`'s streaming rows are updated with the date and
the numbers they replace named.

## Correctness

    cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
    ctest --test-dir build-cuda --no-tests=error --output-on-failure
    100% tests passed, 0 tests failed out of 36

`stream_twin` is the property that matters here and it is green: the same
input decoded on a reused context - after any number of prior decodes,
including one that grew the staging - is bit-identical to a fresh-context
decode. Chunk results do not depend on which wave carried them, so the wave
size is not an axis of the output; that is by construction rather than by a
test, and it is stated as such.

Host-only build unchanged:

    cmake -B build-host2 && cmake --build build-host2 -j
    [100%] Built target example_decode_frame

Formatting:

    npx prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

## Not covered

No Compute Sanitizer sweep. `src/stream.cpp` is host-side stream choreography
and adds no device code, but the sweep is owed on any change that touches the
decode path and it cannot be produced on this route - the four tools cannot
attach to the device here, which issue #258 holds. Stated rather than left
looking answered.

No second person read this change. The evidence above stands in place of one.
