### PR TITLE
Merge the frame assembly's device-to-host copies [#133]

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -766,6 +766,69 @@ No decoder code moved for these numbers. This is the harness the frame-path
 changes are to be measured against, and it exists so that they can be
 rejected the way perf pass 3 was.
 
+### Frame assembly: merging the per-block device-to-host copies (issue #133)
+
+The sweep above priced the block count at roughly 34 microseconds a block, and
+the shape that produces it is one blocking `cudaMemcpy` per compressed block in
+the assembly loop. Assembly now issues those copies on one non-default stream
+with a single terminal synchronization, and merges consecutive blocks that are
+contiguous on both the device side and the output side into one copy before
+issuing anything.
+
+**Three shapes were measured and two were rejected.** The issue proposed the
+first two and neither pays:
+
+| Shape                                                            | 64 KB   | 256 KB  | 1 MB   |
+| ---------------------------------------------------------------- | ------- | ------- | ------ |
+| Async copies straight into the caller's `out`, one terminal sync | -1.9 %  | +3.0 %  | +1.8 % |
+| Async copies through a 32 MiB pinned bounce buffer, in waves     | -2.5 %  | +25.5 % | +10.8% |
+| Merge contiguous runs, async on one stream, one terminal sync    | -29.9 % | -11.1 % | -3.1 % |
+
+The first is the naive swap, and it is flat because `out` is the caller's
+buffer and is pageable: a device-to-pageable `cudaMemcpyAsync` is synchronous
+with respect to the host by specification, so the stall it was meant to remove
+is still paid. The second removes the stall for real, and loses anyway - it
+adds one host memcpy of the whole output, and past the 64 KB rung there are too
+few submissions left for the saved latency to cover that.
+
+The third wins because it removes submissions instead of relocating them, and
+what lets it is a property of the format rather than of this corpus: every data
+block but the last decodes to exactly the frame's block max, which is also the
+device slot stride, so a run of full blocks is one contiguous device range.
+Silesia's 3234-block frame becomes a handful of copies. Both sides of the
+adjacency are tested per block, so a frame that breaks either just gets more
+copies.
+
+**Numbers.** Three interleaved passes, after / before / after / before / after /
+before in one session, both binaries built from the same tree, recorded
+2026-08-10 inside the digest-pinned `nvidia/cuda:12.6.2-devel-ubuntu24.04`
+container (`sha256:738fba0f...`) on the RTX 3080 (sm_86, driver 560.94, CUDA
+12.6, nvcc V12.6.77), 3 warmup + 30 measured runs per rung, output
+byte-verified against the original once per rung before timing. Reproduce with
+`bench_lz4 --frame bench/corpora/silesia/* --warmup 3 --runs 30`. Every sample
+is listed rather than averaged away.
+
+| Block max | Before p50 (3 samples)         | After p50 (3 samples)          | Change      |
+| --------- | ------------------------------ | ------------------------------ | ----------- |
+| 64 KB     | 549.923 / 519.201 / 545.261 ms | 374.037 / 375.946 / 381.386 ms | **-29.9 %** |
+| 256 KB    | 440.591 / 438.248 / 441.267 ms | 393.992 / 389.628 / 390.543 ms | **-11.1 %** |
+| 1 MB      | 448.822 / 440.027 / 442.964 ms | 429.779 / 438.233 / 423.059 ms | -3.1 %      |
+
+The two sides do not overlap at any rung, and the gap widens with the block
+count, which is what a per-block cost being removed looks like. The 1 MB rung
+has only 203 blocks and correspondingly little to win.
+
+A first attempt at this A/B was discarded rather than reported: two of its
+twelve rung measurements came out near three times their neighbours, which is
+host contention and not a property of either binary. The table above is a
+second session with no other container running.
+
+**What this does not claim.** The single terminal synchronization is not what
+paid - that shape is the first row of the first table, and it is flat. The win
+is the merge. The ~450 ms floor all three rungs share is untouched and is still
+the transfers plus the host-side checksum, so the frame path still runs far
+below the kernel it wraps.
+
 ## Community AMD results
 
 **No community results yet.** Nothing in this section is a measurement; it

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -161,8 +161,57 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
     }
 
     /* Place each block at its prefix offset: uncompressed blocks copied from
-     * the frame, compressed blocks copied straight from device to `out` (no
-     * intermediate host buffer, no second copy). */
+     * the frame, compressed blocks copied from the device.
+     *
+     * Each compressed block used to cost its own blocking cudaMemcpy, which is
+     * one host stall per block; the block-count sweep in docs/BENCHMARKS.md is
+     * what made that visible, at roughly 34 microseconds a block. The copies
+     * are now issued on one stream and drained once, and consecutive blocks
+     * that are contiguous on BOTH sides are merged into a single copy first,
+     * so the submission count follows the frame's layout instead of its block
+     * count.
+     *
+     * The merge is what makes this pay, and what makes it pay is a property of
+     * the format rather than of the corpus: every data block of a frame except
+     * the last decodes to exactly block_max, which is the device stride, so a
+     * run of full blocks is contiguous in device memory; and compressed blocks
+     * land at consecutive output offsets wherever no uncompressed block
+     * separates them. Both are tested per block below rather than assumed, so
+     * a frame that breaks either just gets more copies, never wrong bytes.
+     *
+     * Every destination range written here is disjoint from every other one -
+     * they are prefix offsets into `out` - so the copies may complete in any
+     * order, and the interleaved host memcpy for an uncompressed block touches
+     * bytes no copy is targeting. That disjointness is what makes the order
+     * free; nothing here depends on a D2H into pageable memory happening to be
+     * synchronous.
+     *
+     * The drain has to happen before d_dst is freed - an in-flight copy out of
+     * freed device memory is a use-after-free that does not fail loudly - so
+     * the guard below runs it on EVERY exit path from here on, including the
+     * error returns, and the ordinary path checks its status as well. */
+    cudec_cuda::StreamOwner asm_stream;
+    if (n != 0) {
+        FRAME_CUDA(asm_stream.create());
+    }
+    struct AsmDrain {
+        cudaStream_t s;
+        ~AsmDrain() {
+            if (s != nullptr) {
+                (void)cudaStreamSynchronize(s);
+            }
+        }
+    } asm_drain{asm_stream.s};
+
+    /* The open run of merged blocks; run_len == 0 means no run is open.
+     * Neither sum below can overflow: a run that started at block k0 holds at
+     * most one block_max per block, so run_dev + run_len is at most
+     * n * block_max, which the guard above already refused an overflow of; and
+     * run_out + run_len is at most `total`, which the capacity walk computed
+     * without one. */
+    size_t run_dev = 0;
+    size_t run_out = 0;
+    size_t run_len = 0;
     size_t off = 0;
     size_t k = 0;
     for (size_t i = 0; i < blocks.size(); i++) {
@@ -174,15 +223,32 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
             off += blocks[i].src_len;
         } else {
             const size_t len = decoded_len[i];
-            if (len != 0) {
-                const unsigned char* dsrc =
-                    static_cast<unsigned char*>(d_dst.p) + k * block_max;
-                FRAME_CUDA(cudaMemcpy(out + off, dsrc, len,
-                                      cudaMemcpyDeviceToHost));
+            const size_t dev = k * block_max;
+            if (run_len != 0 && run_dev + run_len == dev &&
+                run_out + run_len == off) {
+                run_len += len;
+            } else {
+                if (run_len != 0) {
+                    FRAME_CUDA(cudaMemcpyAsync(
+                        out + run_out,
+                        static_cast<unsigned char*>(d_dst.p) + run_dev, run_len,
+                        cudaMemcpyDeviceToHost, asm_stream.s));
+                }
+                run_dev = dev;
+                run_out = off;
+                run_len = len;
             }
             off += len;
             k++;
         }
+    }
+    if (run_len != 0) {
+        FRAME_CUDA(cudaMemcpyAsync(
+            out + run_out, static_cast<unsigned char*>(d_dst.p) + run_dev,
+            run_len, cudaMemcpyDeviceToHost, asm_stream.s));
+    }
+    if (n != 0) {
+        FRAME_CUDA(cudaStreamSynchronize(asm_stream.s));
     }
 
     *total_out = total;

--- a/tests/frame_twin.cu
+++ b/tests/frame_twin.cu
@@ -253,6 +253,113 @@ int main() {
         REQUIRE(seam_rejects > 0); /* the kernel-status seam is actually hit */
     }
 
+    /* 2d. A stored block BETWEEN two compressed ones.
+     *
+     * Assembly merges decoded blocks that are adjacent in device memory into
+     * one copy, and only COMPRESSED blocks occupy device slots. So this is the
+     * frame where the two sides of that adjacency disagree: blocks 0 and 2 sit
+     * back to back in device memory and 64 KiB apart in the output, because
+     * the stored block 1 lands between them there and nowhere else. A merge
+     * that checked only the device side would write block 2 over block 1's
+     * bytes. Nothing above builds this shape - every case there is all
+     * compressed or all stored - so without it that half of the check is
+     * unproven, and it was: deleting it left this suite green.
+     *
+     * The block table is asserted rather than assumed, because the fixture is
+     * only worth its name while liblz4 still stores the middle block. LZ4F
+     * stores a block it cannot shrink, and the top bit of the 4-byte block
+     * size is what says it did. */
+    {
+        const size_t bm = size_t{64} << 10;
+        std::vector<unsigned char> mixed;
+        for (int part = 0; part < 3; part++) {
+            /* Part 1 is PRNG bytes, which LZ4F cannot shrink; 0 and 2 are the
+             * repeating-text mode and compress. */
+            const auto p = MakeData(bm, 0x900 + part, part == 1 ? 1 : 0);
+            mixed.insert(mixed.end(), p.begin(), p.end());
+        }
+        const auto frame = CompressFrame(mixed, true, false, false);
+
+        size_t pos = 7; /* magic(4) FLG(1) BD(1) HC(1), then the block table */
+        int compressed_before = 0;
+        int stored = 0;
+        int compressed_after = 0;
+        for (int b = 0; b < 3; b++) {
+            REQUIRE_CTX(pos + 4 <= frame.size(), "mixed table block %d", b);
+            const uint32_t bs = static_cast<uint32_t>(frame[pos]) |
+                                (static_cast<uint32_t>(frame[pos + 1]) << 8) |
+                                (static_cast<uint32_t>(frame[pos + 2]) << 16) |
+                                (static_cast<uint32_t>(frame[pos + 3]) << 24);
+            if ((bs >> 31) != 0) {
+                stored++;
+            } else if (stored == 0) {
+                compressed_before++;
+            } else {
+                compressed_after++;
+            }
+            pos += 4 + (bs & 0x7FFFFFFFu);
+        }
+        REQUIRE_CTX(compressed_before == 1 && stored == 1 &&
+                        compressed_after == 1,
+                    "stored-between-compressed fixture is %d/%d/%d, not 1/1/1",
+                    compressed_before, stored, compressed_after);
+
+        REQUIRE(CheckFrameOk("stored-between-compressed", frame, mixed) == 0);
+    }
+
+    /* 2e. A SHORT compressed block followed by a full one.
+     *
+     * The other half of the same adjacency test. Device slots are strided by
+     * the frame's block max whatever a block actually decodes to, so a block
+     * that decodes short leaves a hole before the next slot, and merging
+     * across it would copy the hole into the output. LZ4F never emits a short
+     * block anywhere but last, so no compressor-built frame reaches this; the
+     * frame format permits it and liblz4 accepts it, which makes it exactly
+     * the crafted-input case this decoder is supposed to survive. Built by
+     * splicing one frame's block record in front of another's, both frames
+     * carrying the same descriptor, so the header stays the one LZ4F wrote.
+     *
+     * Deleting the device-side test leaves this red and the rest of the suite
+     * green. */
+    {
+        const auto short_data = MakeData(1000, 0xA01, 0);
+        const auto full_data = MakeData(size_t{64} << 10, 0xA02, 0);
+        const auto fa = CompressFrame(short_data, true, false, false);
+        const auto fb = CompressFrame(full_data, true, false, false);
+
+        /* magic(4) FLG(1) BD(1) HC(1) | size(4) payload | end mark(4). */
+        auto record = [](const std::vector<unsigned char>& f) {
+            const uint32_t bs = static_cast<uint32_t>(f[7]) |
+                                (static_cast<uint32_t>(f[8]) << 8) |
+                                (static_cast<uint32_t>(f[9]) << 16) |
+                                (static_cast<uint32_t>(f[10]) << 24);
+            return std::vector<unsigned char>(
+                f.begin() + 7, f.begin() + 7 + 4 + (bs & 0x7FFFFFFFu));
+        };
+        REQUIRE((static_cast<uint32_t>(fa[10]) >> 7) == 0); /* both compressed */
+        REQUIRE((static_cast<uint32_t>(fb[10]) >> 7) == 0);
+        REQUIRE(fa[5] == fb[5] && fa[6] == fb[6]); /* same FLG and BD */
+
+        std::vector<unsigned char> spliced(fa.begin(), fa.begin() + 7);
+        const auto ra = record(fa);
+        const auto rb = record(fb);
+        spliced.insert(spliced.end(), ra.begin(), ra.end());
+        spliced.insert(spliced.end(), rb.begin(), rb.end());
+        spliced.insert(spliced.end(), 4, 0); /* end mark */
+
+        std::vector<unsigned char> expect = short_data;
+        expect.insert(expect.end(), full_data.begin(), full_data.end());
+
+        /* The oracle has to accept it, or the fixture is proving a reject
+         * rather than a placement. */
+        std::vector<unsigned char> oout(expect.size() + 4096);
+        REQUIRE(Lz4fDecode(spliced, &oout) == true);
+        REQUIRE(oout.size() == expect.size());
+        REQUIRE(equal_bytes(oout.data(), expect.data(), expect.size()));
+
+        REQUIRE(CheckFrameOk("short-then-full", spliced, expect) == 0);
+    }
+
     /* 3. Reject branches. */
     const auto data = MakeData(200000, 0x999, 2);
 


### PR DESCRIPTION
Closes #133.

## What changed

The frame assembly loop issued one blocking `cudaMemcpy` per compressed block.
It now issues the copies on one non-default stream with a single terminal
`cudaStreamSynchronize`, and before issuing anything it merges consecutive
blocks that are contiguous on both sides into one copy.

The merge is what pays, and what lets it is a property of the frame format
rather than of this corpus. Device slots are strided by the frame's block max,
and every data block but the last decodes to exactly that, so a run of full
blocks is one contiguous device range. Compressed blocks land at consecutive
output offsets wherever no uncompressed block separates them. Both sides are
tested per block, so a frame that breaks either just gets more copies and never
wrong bytes.

## Which shape, and why not the other two

The issue proposed two shapes and asked for whichever the bench rewards. Both
were built and measured, and both were rejected.

| Shape                                                           | 64 KB   | 256 KB  | 1 MB    |
| --------------------------------------------------------------- | ------- | ------- | ------- |
| Async copies straight into the caller's `out`, one terminal sync | -1.9 %  | +3.0 %  | +1.8 %  |
| Async copies through a 32 MiB pinned bounce buffer, in waves     | -2.5 %  | +25.5 % | +10.8 % |
| Merge contiguous runs, async on one stream, one terminal sync    | -29.9 % | -11.1 % | -3.1 %  |

The first is flat for the reason the issue's own design note predicts: `out` is
the caller's buffer and is pageable, and a device-to-pageable
`cudaMemcpyAsync` is synchronous with respect to the host by specification, so
the stall it was meant to remove is still paid. The second removes the stall for
real and loses anyway, because it adds one host memcpy of the whole output and
past the 64 KB rung there are too few submissions left for the saved latency to
cover it.

So the terminal synchronization is not what paid. That is the first row, and it
is flat. The win is the merge.

## Numbers

Three interleaved passes, after / before / after / before / after / before in one
session, both binaries built from the same tree, recorded 2026-08-10 inside the
digest-pinned `nvidia/cuda:12.6.2-devel-ubuntu24.04` container
(`sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`) on
the RTX 3080 (sm_86, driver 560.94, CUDA 12.6, nvcc V12.6.77), 3 warmup + 30
measured runs per rung, output byte-verified against the original once per rung
before timing.

```
bench_lz4 --frame bench/corpora/silesia/* --warmup 3 --runs 30
```

| Block max | Before p50 (3 samples)         | After p50 (3 samples)          | Change      |
| --------- | ------------------------------ | ------------------------------ | ----------- |
| 64 KB     | 549.923 / 519.201 / 545.261 ms | 374.037 / 375.946 / 381.386 ms | **-29.9 %** |
| 256 KB    | 440.591 / 438.248 / 441.267 ms | 393.992 / 389.628 / 390.543 ms | **-11.1 %** |
| 1 MB      | 448.822 / 440.027 / 442.964 ms | 429.779 / 438.233 / 423.059 ms | -3.1 %      |

The two sides do not overlap at any rung. The gap widens with the block count,
which is what removing a per-block cost looks like; the 1 MB rung has 203 blocks
and correspondingly little to win.

A first attempt at this A/B was discarded rather than reported. Two of its twelve
rung measurements came out near three times their neighbours, which is host
contention rather than a property of either binary. The table above is a second
session with nothing else running against the device.

## Proof that the guards bite

The merge test has two halves, and each has a fixture that goes red when that
half is deleted and stays green when it is present. Neither shape was in the
suite before, and the first measurement of that is the reason both exist: with
the output half deleted, the whole suite stayed green.

`tests/frame_twin.cu` 2d, a stored block between two compressed ones. Only
compressed blocks occupy device slots, so blocks 0 and 2 are adjacent in device
memory and 64 KiB apart in the output. With the output-side test deleted:

```
first byte mismatch at offset 65540:
  [65540] have 41 want a2
FAIL /w/tests/frame_twin.cu:119: equal_bytes(...) | stored-between-compressed bytes
0% tests passed, 1 tests failed out of 1
```

The `41` is block 2's text arriving where block 1's stored bytes belong.

`tests/frame_twin.cu` 2e, a short compressed block followed by a full one. No
compressor emits a short block anywhere but last, so this one is spliced from
two frames carrying the same descriptor; the frame format permits it and liblz4
accepts it, which is asserted in the fixture before the placement is checked.
With the device-side test deleted:

```
FAIL /w/tests/frame_twin.cu:119: equal_bytes(...) | short-then-full bytes
0% tests passed, 1 tests failed out of 1
```

Each deletion reddens only its own fixture. Both fixtures assert the frame shape
they claim to build, so they cannot quietly stop covering it if liblz4's
behaviour moves.

## Fail-closed and lifetime

The capacity check is untouched and still runs before the first byte is written,
so a too-small `dst` still yields `CUDEC_ERR_OUTPUT_TOO_SMALL` with no partial
output. Every CUDA failure still maps to `CUDEC_ERR_CUDA` through `FRAME_CUDA`,
and the terminal synchronization's status is checked rather than dropped.

The drain is an RAII guard, so it runs on every exit path from the loop
including the error returns, and it is declared after the device buffer it
protects so it is destroyed first. An in-flight copy can never outlive the
device memory it reads. Neither offset sum in the merge can overflow: the
device side is bounded by `n * block_max`, whose overflow is already refused
above, and the output side by `total`, which the capacity walk computed without
one.

## Gate

Full suite inside the digest-pinned container on the RTX 3080:

```
100% tests passed, 0 tests failed out of 36
```

`frame_twin` and `frame_host_negative` are both in that set. Prettier reports
`docs/BENCHMARKS.md` clean.

The device-side sanitizer net did NOT run. Compute Sanitizer cannot attach to
this device through the WSL2 paravirtualized path, which is #258, and the remedy
the tool names is a machine-wide elevation that is not taken here. Nothing in
this PR should be read as having passed that gate.

This change had no second reader. The evidence above stands in place of one.
