### PR TITLE
Add the max-element-density Snappy corpus to the bench harness

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -97,6 +97,16 @@ target_compile_options(bench_snappy PRIVATE -Wall -Wextra -Werror -O2)
 # CPU-only, so it runs on the GPU-less runner.
 add_test(NAME bench_snappy_selfcheck COMMAND bench_snappy --selfcheck)
 
+# The maximum-element-density corpus (issue #166). Kept separate from the
+# Silesia path above because the two rot differently: that one rots on shape
+# and digests, this one rots on adversariality. Its construction is checked
+# twice before anything is timed - the oracle on validity, the density floors
+# on whether it is still the worst case it reports - and this entry runs the
+# identical construction on a handful of chunks. CPU-only, like the entry
+# above.
+add_test(NAME bench_snappy_worst_selfcheck COMMAND bench_snappy --worst
+                                                   --selfcheck)
+
 # The Zstd worst-case corpus (issue #229). No CUDA in it at all: the frames
 # are constructed on the host, emitted through the reference's own
 # sequence-compression entry point and decoded by the reference, so the
@@ -139,6 +149,6 @@ add_test(NAME bench_zstd_worst_selfcheck COMMAND bench_zstd --worst
 set_tests_properties(
   bench_selfcheck bench_worst4b_selfcheck bench_longmatch_selfcheck
   bench_assetlike_selfcheck bench_zstd_worst_selfcheck bench_frame_selfcheck
-  bench_snappy_selfcheck
+  bench_snappy_selfcheck bench_snappy_worst_selfcheck
   PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 cudec_assert_test_timeouts()

--- a/bench/bench_snappy.cpp
+++ b/bench/bench_snappy.cpp
@@ -41,6 +41,32 @@ constexpr size_t kMaxRuns = 1000000;
  * so a failure reproduces. */
 constexpr size_t kSelfcheckBytes = 3u << 20;
 
+/* The maximum-element-density corpus (issue #166). Same 64 KiB unit and the
+ * same ~200 MB scale as the LZ4 worst-4Bmatch rows, so the two adversarial
+ * numbers are directly comparable once a Snappy kernel exists. */
+constexpr size_t kWorstChunks = 3200;
+constexpr size_t kWorstSelfcheckChunks = 4;
+
+/* Two floors, because the corpus can stop being adversarial in two ways and
+ * neither of them stops it decoding.
+ *
+ * A generator whose copies grew longer still emits one element per two
+ * compressed bytes, so the element rate alone would not notice; what moves is
+ * the compressed share, from a half toward a fifth. A generator that switched
+ * to a costlier element form keeps the compressed share and loses the element
+ * rate. The ideal stream sits at 0.500 on both, and the slack below is there
+ * for the preamble and the tail literal rather than for drift. */
+constexpr double kWorstMinCompressedShare = 0.49;
+constexpr double kWorstMinElementsPerByte = 0.49;
+
+/* The minimum-cost Snappy element: a one-byte tag plus one offset byte, four
+ * output bytes. Tag 0x01 is kind 01 (copy, 1-byte offset) with the length
+ * field zero, which the format reads as 4, and the three high bits zero, so
+ * the offset is the following byte alone. */
+constexpr unsigned char kMinCopyTag = 0x01;
+constexpr unsigned char kMinCopyOffset = 0x01;
+constexpr size_t kMinCopyOutput = 4;
+
 enum class Shape {
     /* One Snappy raw stream per input file. */
     kWhole,
@@ -149,9 +175,144 @@ bool AppendFile(const std::string& path, Shape shape, Corpus* corpus) {
 void CompressAll(Corpus* corpus) {
     for (const auto& original : corpus->originals) {
         corpus->compressed.push_back(SnappyCompressBlock(original));
-        corpus->original_bytes += original.size();
-        corpus->compressed_bytes += corpus->compressed.back().size();
     }
+}
+
+/* The byte counts every report line divides by, taken from the streams that
+ * are actually there. Separate from CompressAll because one corpus is not
+ * compressed by the reference at all: the adversarial stream below is
+ * constructed byte by byte, and a tally that only ran inside the compressor
+ * would report zeroes for it. */
+void Tally(Corpus* corpus) {
+    corpus->original_bytes = 0;
+    corpus->compressed_bytes = 0;
+    for (size_t i = 0; i < corpus->originals.size(); i++) {
+        corpus->original_bytes += corpus->originals[i].size();
+        corpus->compressed_bytes += corpus->compressed[i].size();
+    }
+}
+
+void AppendVarint32(size_t value, std::vector<unsigned char>* out) {
+    while (value >= 0x80) {
+        out->push_back(static_cast<unsigned char>((value & 0x7f) | 0x80));
+        value >>= 7;
+    }
+    out->push_back(static_cast<unsigned char>(value));
+}
+
+/* Builds one adversarial-but-valid Snappy stream: back-to-back minimum-cost
+ * copies at offset 1. That is the maximum element density the format can
+ * carry, one element per two compressed bytes and one per four decoded
+ * bytes, and it is where a per-element decoder floors.
+ *
+ * The reference compressor never emits it - it extends an offset-1 run into
+ * one long copy, which is the best case rather than the worst - so the stream
+ * is constructed here and the oracle passes verdict on it before anything is
+ * timed.
+ *
+ * Wire layout: the varint preamble, one literal byte to give the first copy
+ * something to read, then {tag, offset} pairs, then a literal tail of
+ * whatever the four-byte copies could not reach. Every byte of the output is
+ * the same seed, so the whole block is one run and the decode is bounded by
+ * element count rather than by bytes moved. */
+bool BuildWorstDensityBlock(size_t out_bytes,
+                            std::vector<unsigned char>* original,
+                            std::vector<unsigned char>* compressed,
+                            size_t* elements) {
+    constexpr unsigned char kSeed = 0xA5;
+    /* The literal seed plus one copy is the smallest stream that is still the
+     * shape this corpus is named for. Below it the tail would be the whole
+     * block, so refuse loudly rather than return something that is not
+     * adversarial. */
+    constexpr size_t kMinBytes = 256;
+    /* A literal run of at most this many bytes is encoded by the one-byte
+     * literal tag alone, which is what the tail below relies on. */
+    constexpr size_t kMaxTailLiteral = 60;
+
+    if (out_bytes < kMinBytes) {
+        std::fprintf(stderr, "the max-density block needs at least %zu output "
+                             "bytes, got %zu\n",
+                     kMinBytes, out_bytes);
+        return false;
+    }
+
+    original->assign(out_bytes, kSeed);
+
+    std::vector<unsigned char>& c = *compressed;
+    c.clear();
+    AppendVarint32(out_bytes, &c);
+    c.push_back(0x00); /* literal, length 1 */
+    c.push_back(kSeed);
+    size_t produced = 1;
+    *elements = 1;
+
+    while (produced + kMinCopyOutput <= out_bytes) {
+        c.push_back(kMinCopyTag);
+        c.push_back(kMinCopyOffset);
+        produced += kMinCopyOutput;
+        (*elements)++;
+    }
+
+    const size_t tail = out_bytes - produced;
+    if (tail > kMaxTailLiteral) {
+        std::fprintf(stderr, "the max-density tail is %zu bytes, which this "
+                             "construction does not encode\n",
+                     tail);
+        return false;
+    }
+    if (tail != 0) {
+        c.push_back(static_cast<unsigned char>((tail - 1) << 2));
+        c.insert(c.end(), tail, kSeed);
+        (*elements)++;
+    }
+    return true;
+}
+
+/* Refuses the corpus if it stopped being adversarial. Validity is the
+ * oracle's job and happens separately; this is the other half, because a
+ * valid-but-easy stream round-trips and would leave the report claiming a
+ * worst case it no longer measures. */
+bool CheckDensity(const Corpus& corpus, size_t elements) {
+    const double share = static_cast<double>(corpus.compressed_bytes) /
+                         static_cast<double>(corpus.original_bytes);
+    const double per_byte = static_cast<double>(elements) /
+                            static_cast<double>(corpus.compressed_bytes);
+    if (share < kWorstMinCompressedShare) {
+        std::fprintf(stderr,
+                     "the max-density corpus compressed to %.4f of its "
+                     "output, below the %.2f floor: its elements are "
+                     "producing more bytes each than the minimum copy, so "
+                     "this is no longer the worst case it reports\n",
+                     share, kWorstMinCompressedShare);
+        return false;
+    }
+    if (per_byte < kWorstMinElementsPerByte) {
+        std::fprintf(stderr,
+                     "the max-density corpus carries %.4f elements per "
+                     "compressed byte, below the %.2f floor: its elements "
+                     "cost more than the minimum copy encoding\n",
+                     per_byte, kWorstMinElementsPerByte);
+        return false;
+    }
+    return true;
+}
+
+/* Replicates the adversarial block to `chunks` identical chunks. The block is
+ * the same whatever the replica count, so the selfcheck exercises the
+ * identical construction on a handful of them. */
+bool BuildWorstDensityCorpus(size_t chunks, Corpus* corpus, size_t* elements) {
+    std::vector<unsigned char> original, compressed;
+    size_t per_block = 0;
+    if (!BuildWorstDensityBlock(kChunkBytes, &original, &compressed,
+                                &per_block)) {
+        return false;
+    }
+    for (size_t i = 0; i < chunks; i++) {
+        corpus->originals.push_back(original);
+        corpus->compressed.push_back(compressed);
+    }
+    *elements = per_block * chunks;
+    return true;
 }
 
 /* The oracle is the sole authority on validity, and it says so before any
@@ -262,7 +423,7 @@ void PrintReport(const Corpus& corpus, const std::vector<double>& sorted,
 }
 
 bool RunCorpus(Corpus* corpus, size_t warmup, size_t runs) {
-    CompressAll(corpus);
+    Tally(corpus);
     if (corpus->original_bytes == 0) {
         std::fprintf(stderr, "corpus is empty - nothing to benchmark\n");
         return false;
@@ -349,6 +510,7 @@ int main(int argc, char** argv) {
     bool selfcheck = false;
     bool whole = false;
     bool chunked = false;
+    bool worst = false;
     std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
@@ -358,6 +520,8 @@ int main(int argc, char** argv) {
             whole = true;
         } else if (arg == "--chunked") {
             chunked = true;
+        } else if (arg == "--worst") {
+            worst = true;
         } else if (arg == "--runs" && i + 1 < argc) {
             if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
                 std::fprintf(stderr, "--runs must be in [1, %zu]\n", kMaxRuns);
@@ -374,22 +538,66 @@ int main(int argc, char** argv) {
             return 2;
         } else if (!arg.empty() && arg[0] == '-') {
             std::fprintf(stderr, "usage: bench_snappy [--runs N] [--warmup N] "
-                                 "[--whole] [--chunked] [--selfcheck] "
-                                 "[corpus files...]\n");
+                                 "[--whole] [--chunked] [--worst] "
+                                 "[--selfcheck] [corpus files...]\n");
             return 2;
         } else {
             files.push_back(arg);
         }
     }
+    if (selfcheck) {
+        warmup = 1;
+        runs = 3;
+    }
+
+    /* The adversarial corpus is constructed rather than compressed, and its
+     * shape is the whole point of it, so it takes neither corpus files nor a
+     * shape flag and runs on its own. */
+    if (worst) {
+        if (!files.empty() || whole || chunked) {
+            std::fprintf(stderr, "--worst builds its own corpus and has one "
+                                 "shape; it takes no files and no shape "
+                                 "flag\n");
+            return 2;
+        }
+        Corpus corpus;
+        corpus.shape = Shape::kChunked;
+        corpus.name = "max element density (constructed)";
+        corpus.provenance =
+            "hand-constructed in-harness as back-to-back minimum-cost copies "
+            "at offset 1, which the reference compressor never emits; every "
+            "stream validated by the pinned snappy oracle before timing";
+        size_t elements = 0;
+        if (!BuildWorstDensityCorpus(
+                selfcheck ? kWorstSelfcheckChunks : kWorstChunks, &corpus,
+                &elements)) {
+            return 1;
+        }
+        Tally(&corpus);
+        /* Before the report and before any timing: an easy corpus must not
+         * reach a run that would print "worst case" over it. */
+        if (!CheckDensity(corpus, elements)) {
+            return 1;
+        }
+        if (!RunCorpus(&corpus, warmup, runs)) {
+            return 1;
+        }
+        std::printf("- element density: %zu elements, %.4f per compressed "
+                    "byte, %.4f decoded bytes each\n",
+                    elements,
+                    static_cast<double>(elements) /
+                        static_cast<double>(corpus.compressed_bytes),
+                    static_cast<double>(corpus.original_bytes) /
+                        static_cast<double>(elements));
+        return 0;
+    }
+
     /* Neither shape named means both, which is the recorded run. */
     if (!whole && !chunked) {
         whole = true;
         chunked = true;
     }
-    if (selfcheck) {
-        warmup = 1;
-        runs = 3;
-    }
+
     if (files.empty() && !selfcheck) {
         std::fprintf(stderr, "bench_snappy needs corpus files (the recorded "
                              "run uses bench/corpora/silesia/*); --selfcheck "
@@ -439,6 +647,7 @@ int main(int argc, char** argv) {
                     path.substr(slash == std::string::npos ? 0 : slash + 1);
             }
         }
+        CompressAll(&corpus);
         if (!RunCorpus(&corpus, warmup, runs)) {
             return 1;
         }


### PR DESCRIPTION
# What & why

Closes #166.

The Snappy bench harness had only the Silesia corpus, which measures the
format's ordinary case. The regime a per-element decoder floors in is the
opposite one, and the reference compressor never emits it: it extends an
offset-1 run into a single long copy, which is the best case rather than the
worst. So the corpus is constructed, and the reference is the authority on
whether the construction is a real Snappy stream rather than the author of it.

Back-to-back minimum-cost copies at offset 1. One element per two compressed
bytes, one per four decoded bytes, which is the maximum element density the
format can carry. This is the Snappy analog of the LZ4 worst-4Bmatch block, at
the same 64 KiB unit and the same 200 MB scale, so the two adversarial numbers
will be comparable once a Snappy kernel exists.

The means is C++ in `bench/bench_snappy.cpp` beside the corpus it contrasts
with, because the two corpora share the report, the timing loop and the oracle
gate and differ only in how the streams are produced.

## Type of change

- [x] Build / CI / supply chain
- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved. The construction refuses a block below 256 bytes
      and a tail the one-byte literal tag cannot encode, rather than emitting
      something that is not the shape it is named for. `--worst` refuses to be
      combined with corpus files or a shape flag.
- [x] Oracle coverage: the pinned snappy 1.2.2 decoder passes verdict on every
      constructed stream and the round trip is compared byte for byte, both
      before any timing.
- [x] Determinism preserved. Nothing in the library moves; the construction
      takes no randomness at all.
- [x] No CUDA call is added.
- [x] Adversarial review: one reader, four lenses. See the disclosure at the
      end.
- [x] Review record below.

## Review record

CONFIRMED 0 / PLAUSIBLE 1.

- Correctness. The tag byte is derived from the format rather than copied: kind
  01 is the one-byte-offset copy, a zero length field reads as 4, and zero in
  the three high bits leaves the offset as the following byte alone. The
  measured density says the derivation is right, 3.9998 decoded bytes per
  element against a designed 4. The tail arithmetic cannot underflow because
  the loop stops while at least the tail remains and the tail is checked
  against what the one-byte literal tag encodes. No finding.
- Robustness. PLAUSIBLE: `CheckDensity` divides by `compressed_bytes`, which
  would be a division by zero on an empty corpus. Disposition DECLINE with the
  reason, rather than a guard nothing can reach: the only caller builds the
  corpus immediately above it from a block that is refused below 256 bytes,
  so a zero-byte corpus does not exist at that call site. Adding a branch no
  input reaches would be a guard that cannot be shown to bite.
- Performance. The corpus is built once and replicated by copy, which is what
  the LZ4 worst-case path does for the same reason. Outside every timed
  region. No finding.
- Integration. `bench/` stays consumer-only. The new ctest entry carries the
  mandatory finite timeout and passes `cudec_assert_test_timeouts()`, and it
  carries no gpu label, so it runs in the CI selection rather than being
  deferred to the local gate.

## The two locks, and the proof that each bites

Validity is not enough. A valid-but-easy stream round-trips and would leave the
report printing "max element density" over a corpus that no longer is one. So
there are two floors, because the corpus can stop being adversarial in two ways
that do not overlap:

- A generator whose copies grew longer still emits one element per two
  compressed bytes, so an element-rate floor would not notice. What moves is
  the compressed share, from a half toward a fifth.
- A generator that switched to a costlier element form keeps the compressed
  share and loses the element rate.

Both proven in the container on this branch, by breaking them one at a time and
restoring after each.

Copies lengthened from 4 to 11, which is the same one-byte-offset copy form
with its length field filled:

```
=== PROOF 1: lengthen the copies, the density floor must red ===
the max-density corpus compressed to 0.1820 of its output, below the 0.49 floor: its elements are producing more bytes each than the minimum copy, so this is no longer the worst case it reports
0% tests passed, 1 tests failed out of 1
```

One byte of the constructed stream flipped:

```
=== PROOF 2: corrupt one byte, the oracle gate must reject before timing ===
the oracle refuses stream 0 of max element density (constructed)
0% tests passed, 1 tests failed out of 1
```

```
=== restored, both selfchecks green again ===
100% tests passed, 0 tests failed out of 2
```

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. `bench_snappy` is a
      plain C++ target with no CUDA in it, and no `.cu` file is modified.

So the block is not read as an answered one: #258 records that no route to a
device the sanitizer can attach to is available on this machine.

## Performance checklist

- [x] Measured, not reasoned.
- [x] No regression against docs/BENCHMARKS.md. Nothing recorded there moves.

The corpus at its full scale, in the container on the local host. This is
evidence that the construction is adversarial, not a baseline entry: the issue
asks for the corpus, its oracle gate and its density lock, and recording a
number for a decoder that does not exist yet would be an entry nothing reads.

```
bench_snappy --worst --warmup 3 --runs 30

- corpus: max element density (constructed), 64 KiB-chunked streams, 3200 streams, 209.72 MB original, 104.88 MB compressed (ratio 0.500), hand-constructed in-harness as back-to-back minimum-cost copies at offset 1, which the reference compressor never emits; every stream validated by the pinned snappy oracle before timing
- wall per run: p50 1246.117 ms / p90 1368.566 ms / p99 1440.939 ms
- decode throughput: p50 0.168 GB/s / p90 0.153 GB/s / p99 0.146 GB/s
- element density: 52432000 elements, 0.4999 per compressed byte, 3.9998 decoded bytes each
```

0.168 GB/s against the 1.197 GB/s the same decoder reaches on Silesia in the M3
entry, on the same host and through the same timing loop. The corpus is 7.1
times harder for the reference than the ordinary case, which is what a maximum
element density is supposed to cost.

## Quality checklist

- [x] Minimal. The tally moves out of `CompressAll` into its own function
      because this corpus is not compressed by the reference at all, and an
      accounting that only ran inside the compressor would report zeroes for
      it. Everything else is reused: the report, the timing loop, the oracle
      gate and the digest.
- [x] Self-documenting. The comments say why there are two floors rather than
      one, and where the tag byte's value comes from.
- [x] Conformance tests pass. The structural property this establishes, that
      the corpus is still adversarial, is locked by the selfcheck above.

## Verification

Full gate in the pinned container against the local RTX 3080, at this branch's
head:

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j 12
ctest --test-dir build-cuda --output-on-failure

100% tests passed, 0 tests failed out of 38
Label Time Summary:
gpu    =   4.98 sec*proc (8 tests)
Total Test time (real) =   8.65 sec
```

- [x] Builds clean under `-Wall -Wextra -Werror`.
- [x] `ctest` green, 38 of 38. The count was 37 before this branch; the new
      entry is `bench_snappy_worst_selfcheck`.
- [x] Prettier clean. No `.md`, `.yml` or `.yaml` file is touched.
- [x] Docs synced. No behaviour, API or recorded number moves.

## Notes

This change had no second reader. The review record above is one reader over
four lenses, and the two break-and-restore proofs and the pasted gate output
are the evidence in place of one.
