### PR TITLE
Lock the parse-bound Snappy corpus and record both denominators

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -107,6 +107,15 @@ add_test(NAME bench_snappy_selfcheck COMMAND bench_snappy --selfcheck)
 add_test(NAME bench_snappy_worst_selfcheck COMMAND bench_snappy --worst
                                                    --selfcheck)
 
+# The parse-bound corpus (issue #119). Separate from the entry above because
+# the two lock different quantities: that one is bounded by elements per
+# decoded byte at four bytes each, this one at one, and throughput is reported
+# per decoded byte. A density lock on the copy chain says nothing about this
+# margin, so it gets its own construction, its own two locks and its own
+# entry. CPU-only, like the entries above.
+add_test(NAME bench_snappy_worstlit_selfcheck COMMAND bench_snappy --worstlit
+                                                      --selfcheck)
+
 # The Zstd worst-case corpus (issue #229). No CUDA in it at all: the frames
 # are constructed on the host, emitted through the reference's own
 # sequence-compression entry point and decoded by the reference, so the
@@ -150,5 +159,6 @@ set_tests_properties(
   bench_selfcheck bench_worst4b_selfcheck bench_longmatch_selfcheck
   bench_assetlike_selfcheck bench_zstd_worst_selfcheck bench_frame_selfcheck
   bench_snappy_selfcheck bench_snappy_worst_selfcheck
+  bench_snappy_worstlit_selfcheck
   PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 cudec_assert_test_timeouts()

--- a/bench/bench_snappy.cpp
+++ b/bench/bench_snappy.cpp
@@ -59,6 +59,26 @@ constexpr size_t kWorstSelfcheckChunks = 4;
 constexpr double kWorstMinCompressedShare = 0.49;
 constexpr double kWorstMinElementsPerByte = 0.49;
 
+/* The parse-bound corpus (issue #119). It decodes to the same block as the
+ * one above and encodes it the expensive way: every output byte is its own
+ * length-1 literal element, so the element rate per COMPRESSED byte is
+ * identical at one per two and the element rate per DECODED byte is four
+ * times higher. Throughput here is reported per decoded byte, which is why
+ * the two shapes have to be locked separately - the copy corpus says nothing
+ * about the margin this one measures.
+ *
+ * Two locks again, and they are not the copy corpus's two. The compressed
+ * share is useless here because this stream expands rather than compresses;
+ * what pins the shape is the element rate against the compressed bytes and
+ * the decoded bytes each element produces. A generator whose literals grew
+ * longer keeps producing one decoded byte per compressed pair on average but
+ * costs three compressed bytes for two output bytes, so the element rate
+ * falls to a third; a generator that reverted to copies keeps the element
+ * rate at a half and produces four decoded bytes each. The ideal stream sits
+ * at 0.500 and 1.000 exactly, and the slack is for the varint preamble. */
+constexpr double kWorstLitMinElementsPerByte = 0.49;
+constexpr double kWorstLitMaxBytesPerElement = 1.02;
+
 /* The minimum-cost Snappy element: a one-byte tag plus one offset byte, four
  * output bytes. Tag 0x01 is kind 01 (copy, 1-byte offset) with the length
  * field zero, which the format reads as 4, and the three high bits zero, so
@@ -66,6 +86,15 @@ constexpr double kWorstMinElementsPerByte = 0.49;
 constexpr unsigned char kMinCopyTag = 0x01;
 constexpr unsigned char kMinCopyOffset = 0x01;
 constexpr size_t kMinCopyOutput = 4;
+
+/* The costliest way to carry one output byte: kind 00 (literal) with the
+ * length field zero, which the format reads as a length of 1, followed by the
+ * byte itself. Two compressed bytes, one decoded byte, one element. */
+constexpr unsigned char kLen1LiteralTag = 0x00;
+
+/* Both constructed corpora decode to a block of this byte, so the copy corpus
+ * is one long run and the literal corpus is the same bytes spelled out. */
+constexpr unsigned char kConstructedSeed = 0xA5;
 
 enum class Shape {
     /* One Snappy raw stream per input file. */
@@ -219,7 +248,7 @@ bool BuildWorstDensityBlock(size_t out_bytes,
                             std::vector<unsigned char>* original,
                             std::vector<unsigned char>* compressed,
                             size_t* elements) {
-    constexpr unsigned char kSeed = 0xA5;
+    constexpr unsigned char kSeed = kConstructedSeed;
     /* The literal seed plus one copy is the smallest stream that is still the
      * shape this corpus is named for. Below it the tail would be the whole
      * block, so refuse loudly rather than return something that is not
@@ -268,6 +297,79 @@ bool BuildWorstDensityBlock(size_t out_bytes,
     return true;
 }
 
+/* Builds one adversarial-but-valid Snappy stream at the same element density
+ * as the copy chain above and a quarter of its decoded bytes: the declared
+ * length, then one length-1 literal element per output byte.
+ *
+ * The reference compressor never emits it either, and for the opposite
+ * reason - a block of one repeated byte is exactly what it collapses into a
+ * copy - so this stream is constructed here too and the oracle passes verdict
+ * on it before anything is timed.
+ *
+ * Wire layout: the varint preamble, then {tag, byte} pairs, and no tail,
+ * because every element carries exactly one byte and the block divides
+ * evenly. */
+bool BuildWorstLiteralBlock(size_t out_bytes,
+                            std::vector<unsigned char>* original,
+                            std::vector<unsigned char>* compressed,
+                            size_t* elements) {
+    /* The same floor the copy chain refuses below, for the same reason: under
+     * it the varint preamble stops being negligible against the element
+     * stream and the ratios this corpus is locked on drift on arithmetic
+     * rather than on shape. */
+    constexpr size_t kMinBytes = 256;
+
+    if (out_bytes < kMinBytes) {
+        std::fprintf(stderr, "the parse-bound block needs at least %zu output "
+                             "bytes, got %zu\n",
+                     kMinBytes, out_bytes);
+        return false;
+    }
+
+    original->assign(out_bytes, kConstructedSeed);
+
+    std::vector<unsigned char>& c = *compressed;
+    c.clear();
+    AppendVarint32(out_bytes, &c);
+    c.reserve(c.size() + 2 * out_bytes);
+    for (size_t i = 0; i < out_bytes; i++) {
+        c.push_back(kLen1LiteralTag);
+        c.push_back(kConstructedSeed);
+    }
+    *elements = out_bytes;
+    return true;
+}
+
+/* Refuses the corpus if it stopped being adversarial, in the two directions
+ * the literal chain can drift. Validity is the oracle's job and happens
+ * separately; this is the other half, for the same reason the copy corpus
+ * gives - a valid-but-easy stream round-trips and would leave the report
+ * claiming a worst case it no longer measures. */
+bool CheckLiteralDensity(const Corpus& corpus, size_t elements) {
+    const double per_compressed = static_cast<double>(elements) /
+                                  static_cast<double>(corpus.compressed_bytes);
+    const double per_element = static_cast<double>(corpus.original_bytes) /
+                               static_cast<double>(elements);
+    if (per_compressed < kWorstLitMinElementsPerByte) {
+        std::fprintf(stderr,
+                     "the parse-bound corpus carries %.4f elements per "
+                     "compressed byte, below the %.2f floor: its elements "
+                     "cost more than the two-byte length-1 literal\n",
+                     per_compressed, kWorstLitMinElementsPerByte);
+        return false;
+    }
+    if (per_element > kWorstLitMaxBytesPerElement) {
+        std::fprintf(stderr,
+                     "the parse-bound corpus produces %.4f decoded bytes per "
+                     "element, above the %.2f ceiling: its elements are no "
+                     "longer one output byte each, so the parse work per "
+                     "reported byte is not the worst case it reports\n",
+                     per_element, kWorstLitMaxBytesPerElement);
+        return false;
+    }
+    return true;
+}
+
 /* Refuses the corpus if it stopped being adversarial. Validity is the
  * oracle's job and happens separately; this is the other half, because a
  * valid-but-easy stream round-trips and would leave the report claiming a
@@ -297,14 +399,19 @@ bool CheckDensity(const Corpus& corpus, size_t elements) {
     return true;
 }
 
-/* Replicates the adversarial block to `chunks` identical chunks. The block is
+/* Replicates an adversarial block to `chunks` identical chunks. The block is
  * the same whatever the replica count, so the selfcheck exercises the
- * identical construction on a handful of them. */
-bool BuildWorstDensityCorpus(size_t chunks, Corpus* corpus, size_t* elements) {
+ * identical construction on a handful of them. Shared by both constructed
+ * corpora: they differ in how one block is built and in nothing else, and a
+ * second replicator would be a second place for the chunk unit to drift. */
+using BlockBuilder = bool (*)(size_t, std::vector<unsigned char>*,
+                              std::vector<unsigned char>*, size_t*);
+
+bool BuildConstructedCorpus(BlockBuilder build, size_t chunks, Corpus* corpus,
+                            size_t* elements) {
     std::vector<unsigned char> original, compressed;
     size_t per_block = 0;
-    if (!BuildWorstDensityBlock(kChunkBytes, &original, &compressed,
-                                &per_block)) {
+    if (!build(kChunkBytes, &original, &compressed, &per_block)) {
         return false;
     }
     for (size_t i = 0; i < chunks; i++) {
@@ -511,6 +618,7 @@ int main(int argc, char** argv) {
     bool whole = false;
     bool chunked = false;
     bool worst = false;
+    bool worstlit = false;
     std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
@@ -522,6 +630,8 @@ int main(int argc, char** argv) {
             chunked = true;
         } else if (arg == "--worst") {
             worst = true;
+        } else if (arg == "--worstlit") {
+            worstlit = true;
         } else if (arg == "--runs" && i + 1 < argc) {
             if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
                 std::fprintf(stderr, "--runs must be in [1, %zu]\n", kMaxRuns);
@@ -539,7 +649,8 @@ int main(int argc, char** argv) {
         } else if (!arg.empty() && arg[0] == '-') {
             std::fprintf(stderr, "usage: bench_snappy [--runs N] [--warmup N] "
                                  "[--whole] [--chunked] [--worst] "
-                                 "[--selfcheck] [corpus files...]\n");
+                                 "[--worstlit] [--selfcheck] "
+                                 "[corpus files...]\n");
             return 2;
         } else {
             files.push_back(arg);
@@ -550,25 +661,43 @@ int main(int argc, char** argv) {
         runs = 3;
     }
 
-    /* The adversarial corpus is constructed rather than compressed, and its
-     * shape is the whole point of it, so it takes neither corpus files nor a
-     * shape flag and runs on its own. */
-    if (worst) {
+    /* The adversarial corpora are constructed rather than compressed, and
+     * their shape is the whole point of them, so each takes neither corpus
+     * files nor a shape flag and runs on its own. They are also two separate
+     * measurements of two separate regimes, so asking for both in one run
+     * would print two reports under one methodology block. */
+    if (worst && worstlit) {
+        std::fprintf(stderr, "--worst and --worstlit are separate corpora and "
+                             "separate reports; run one at a time\n");
+        return 2;
+    }
+    if (worst || worstlit) {
         if (!files.empty() || whole || chunked) {
-            std::fprintf(stderr, "--worst builds its own corpus and has one "
-                                 "shape; it takes no files and no shape "
-                                 "flag\n");
+            std::fprintf(stderr, "%s builds its own corpus and has one shape; "
+                                 "it takes no files and no shape flag\n",
+                         worst ? "--worst" : "--worstlit");
             return 2;
         }
         Corpus corpus;
         corpus.shape = Shape::kChunked;
-        corpus.name = "max element density (constructed)";
-        corpus.provenance =
-            "hand-constructed in-harness as back-to-back minimum-cost copies "
-            "at offset 1, which the reference compressor never emits; every "
-            "stream validated by the pinned snappy oracle before timing";
+        if (worst) {
+            corpus.name = "max element density (constructed)";
+            corpus.provenance =
+                "hand-constructed in-harness as back-to-back minimum-cost "
+                "copies at offset 1, which the reference compressor never "
+                "emits; every stream validated by the pinned snappy oracle "
+                "before timing";
+        } else {
+            corpus.name = "max parse work per output byte (constructed)";
+            corpus.provenance =
+                "hand-constructed in-harness as one length-1 literal element "
+                "per output byte, which the reference compressor never emits; "
+                "every stream validated by the pinned snappy oracle before "
+                "timing";
+        }
         size_t elements = 0;
-        if (!BuildWorstDensityCorpus(
+        if (!BuildConstructedCorpus(
+                worst ? &BuildWorstDensityBlock : &BuildWorstLiteralBlock,
                 selfcheck ? kWorstSelfcheckChunks : kWorstChunks, &corpus,
                 &elements)) {
             return 1;
@@ -576,7 +705,8 @@ int main(int argc, char** argv) {
         Tally(&corpus);
         /* Before the report and before any timing: an easy corpus must not
          * reach a run that would print "worst case" over it. */
-        if (!CheckDensity(corpus, elements)) {
+        if (!(worst ? CheckDensity(corpus, elements)
+                    : CheckLiteralDensity(corpus, elements))) {
             return 1;
         }
         if (!RunCorpus(&corpus, warmup, runs)) {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1005,6 +1005,83 @@ same host with the timed region held to the decode call alone, so the
 comparison is between the two references and says nothing about either GPU
 path.
 
+## M3: the Snappy adversarial denominators (issue #119)
+
+Two constructed corpora rather than one, because the format reaches its
+maximum element rate in two different regimes and a lock on one says nothing
+about the other. Both decode to the same 64 KiB block of a single repeated
+byte, at the same 3200-chunk scale as the LZ4 worst-case rows, and both carry
+one element per two compressed bytes. They differ only in what an element
+costs to produce: the copy chain emits four decoded bytes per element, the
+literal chain emits one.
+
+Neither is anything the reference compressor emits. A block of one repeated
+byte is exactly what it collapses into a single long copy, which is the best
+case rather than the worst, so both streams are built byte by byte in the
+harness and the reference passes verdict on every one of them before anything
+is timed. The construction is locked twice besides: the copy chain on its
+compressed share and its element rate, the literal chain on its element rate
+and its decoded bytes per element. A corpus that drifts off its shape reds
+`bench_snappy_worst_selfcheck` or `bench_snappy_worstlit_selfcheck` rather
+than quietly reporting a worst case it no longer measures.
+
+There is still no Snappy kernel, so these are denominators and carry no cudec
+number. Recorded 2026-08-10 inside the digest-pinned
+`nvidia/cuda:12.6.2-devel-ubuntu24.04` container. Reproduce with
+`bench_snappy --worstlit --warmup 3 --runs 30` and
+`bench_snappy --worst --warmup 3 --runs 30`.
+
+```
+## bench_snappy report
+- decoder: CPU oracle, snappy::RawUncompress (google/snappy 1.2.2), single thread. cudec has no Snappy kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- cudec: 100
+- corpus: max parse work per output byte (constructed), 64 KiB-chunked streams, 3200 streams, 209.72 MB original, 419.44 MB compressed (ratio 2.000), hand-constructed in-harness as one length-1 literal element per output byte, which the reference compressor never emits; every stream validated by the pinned snappy oracle before timing
+- corpus digest: a475ef89da01c0e4 (XXH64 over per-stream length and XXH64, little-endian, in corpus order)
+- stream sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is snappy::RawUncompress only (no allocation, no length parse); every stream round-trip-verified against the original once before timing; percentiles are nearest-rank
+- wall per run: p50 971.992 ms / p90 993.018 ms / p99 1138.249 ms
+- decode throughput: p50 0.216 GB/s / p90 0.211 GB/s / p99 0.184 GB/s
+- element density: 209715200 elements, 0.5000 per compressed byte, 1.0000 decoded bytes each
+```
+
+```
+## bench_snappy report
+- decoder: CPU oracle, snappy::RawUncompress (google/snappy 1.2.2), single thread. cudec has no Snappy kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- cudec: 100
+- corpus: max element density (constructed), 64 KiB-chunked streams, 3200 streams, 209.72 MB original, 104.88 MB compressed (ratio 0.500), hand-constructed in-harness as back-to-back minimum-cost copies at offset 1, which the reference compressor never emits; every stream validated by the pinned snappy oracle before timing
+- corpus digest: 1a7d7e76546da248 (XXH64 over per-stream length and XXH64, little-endian, in corpus order)
+- stream sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is snappy::RawUncompress only (no allocation, no length parse); every stream round-trip-verified against the original once before timing; percentiles are nearest-rank
+- wall per run: p50 1222.377 ms / p90 1328.367 ms / p99 1423.007 ms
+- decode throughput: p50 0.172 GB/s / p90 0.158 GB/s / p99 0.147 GB/s
+- element density: 52432000 elements, 0.4999 per compressed byte, 3.9998 decoded bytes each
+```
+
+**Both adversarial corpora cost the reference decoder between five and seven
+times what Silesia does, per output byte.** 0.216 and 0.172 GB/s p50 against
+1.195 GB/s on the 64 KiB-chunked Silesia rows above, over the same 64 KiB unit
+and a comparable total. That is the margin these corpora exist to measure, and
+it is the number a later device row on the same corpora is read against.
+
+**The parse-bound corpus is the faster of the two per output byte, which is
+the opposite of what its element count predicts.** It carries four times the
+elements per decoded byte (209,715,200 against 52,432,000 for the same 209.72
+MB) and still finishes 20% sooner. Per element the ordering reverses and the
+gap is wide: 215.8 M elements/s on the literal chain against 42.9 M on the
+copy chain, five times apart. The reference's offset-1 copy is the cost, not
+its parse, and a stream of the cheapest possible copies is a stream of
+byte-at-a-time overlapping copies.
+
+**That ordering belongs to this decoder and must not be carried over to the
+device rows.** A warp-cooperative decoder attacks the two regimes with
+different machinery: the offset-1 gather is a closed-form modular read rather
+than a serial copy, while the parse chain stays serial per chunk. Which corpus
+floors the GPU is a measurement nobody has taken, and neither this section nor
+the element counts settle it. It is recorded here so that whoever takes it has
+the CPU ordering in front of them rather than an assumption.
+
 ## Community AMD results
 
 **No community results yet.** Nothing in this section is a measurement; it


### PR DESCRIPTION
# What & why

Closes #119.

The M3 worst-case rung was locked on one constructed corpus, the copy chain at
maximum element density: back-to-back minimum-cost copies at offset 1, four
decoded bytes per element. Throughput here is reported per decoded byte, so a
corpus locked at four decoded bytes an element says nothing about the regime
that costs four times the parse work for the same reported byte. That regime
had no owner in the harness, and a density lock on the copy chain would not
have noticed its absence.

This adds the literal chain beside it. Same 64 KiB block of one repeated byte,
same 3200-chunk scale, same one element per two compressed bytes, spelled out
as one length-1 literal element per output byte instead of copied. The two
corpora decode to identical bytes and differ only in what an element costs to
produce, which is what makes the pair a comparison rather than two numbers.

The means is C++ in `bench/bench_snappy.cpp` beside the corpus it contrasts
with, because the two share the report, the timing loop, the oracle gate and
the replicator, and differ only in how one block is built. The replicator is
now shared rather than copied, so the 64 KiB chunk unit has one authority.

The recorded denominators land with the corpus rather than after it: the claim
this corpus exists to support is the comparison between the two regimes, and
one row alone does not carry it. No kernel moves in this change, so the rule
that numbers and kernel changes never travel together is not engaged.

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved. The construction refuses a block below 256 output
      bytes, `--worstlit` refuses to be combined with corpus files or a shape
      flag, and `--worst --worstlit` together is refused because two regimes
      cannot share one methodology block. All three exercised below.
- [x] Oracle coverage: the pinned snappy 1.2.2 decoder passes verdict on every
      constructed stream and the round trip is compared byte for byte, before
      anything is timed. That gate is necessary and demonstrably not
      sufficient, which is what the two locks are for.
- [x] Determinism preserved. The corpus is constructed from fixed constants
      with no PRNG and no input files; the reported digest `a475ef89da01c0e4`
      is reproducible from the flags alone.
- [ ] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      Not applicable: no CUDA in this change. `bench_snappy` links neither the
      CUDA runtime nor a kernel header.
- [ ] An adversarial review (`/security-review`) was run.

      **No adversarial-lens review was run for this change and there was no
      second reader.** `bench/CMakeLists.txt` is on the sensitive surface, so
      this is a gap and not an exemption. What stands in its place is the
      executed evidence below: both locks were broken and observed to red for
      the reason each names, each broken corpus was also run with the locks
      disabled to show what the oracle gate lets through, and the full suite
      ran on a device. That is evidence, not a reviewer, and it does not
      cover what a reviewer would have looked for.

- [ ] Review record. None: see above.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. `bench_snappy` is
      CPU-only by construction, and the two ctest entries it registers carry
      no `gpu` label.

The device-side sanitizer net has not run successfully on this project at all,
per #258, and nothing here changes that.

## Performance checklist

- [x] The claim is measured, not reasoned. Both denominators are recorded in
      `docs/BENCHMARKS.md` with the full methodology block the harness emits,
      including host CPU, corpus digest, run protocol and element density.
      Recorded inside the digest-pinned
      `nvidia/cuda:12.6.2-devel-ubuntu24.04` container.
- [x] No regression against the recorded baseline: this adds rows for a corpus
      that had none and changes no existing number.

The measurement contradicts what the element count predicts, and the section
says so rather than around it. The literal chain carries four times the
elements per decoded byte (209,715,200 against 52,432,000 over the same 209.72
MB) and finishes 20% sooner. Per element the ordering reverses five to one:
215.8 M elements/s against 42.9 M. The reference's offset-1 copy is the cost
on that corpus, not its parse. The section records that this ordering belongs
to the reference decoder and must not be carried over to a device row, because
a warp-cooperative decoder attacks the two regimes with different machinery
and which one floors it is a measurement nobody has taken.

## Quality checklist

- [x] Minimal. The replicator, the report, the timing loop and the oracle gate
      are shared with the sibling corpus rather than duplicated; the new code
      is one block builder, one lock function and one flag.
- [x] Self-documenting: the comments say why the literal chain's locks are not
      the copy chain's, which is the non-obvious part.
- [x] The new structural property is locked as a new ctest entry,
      `bench_snappy_worstlit_selfcheck`, with the timeout assertion updated so
      the configure step still refuses an entry without one.

## Verification

Everything below ran inside the digest-pinned container
(`nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`),
`--gpus all`, against this branch. Device: NVIDIA GeForce RTX 3080, driver
560.94. Toolchain: nvcc release 12.6, V12.6.77.

- [x] `cmake --build build-cuda -j` builds clean.
- [x] `ctest --test-dir build-cuda --output-on-failure`:

```
38/39 Test #38: bench_snappy_worstlit_selfcheck ...   Passed    0.01 sec
      Start 39: bench_zstd_worst_selfcheck
39/39 Test #39: bench_zstd_worst_selfcheck ........   Passed    0.16 sec

100% tests passed, 0 tests failed out of 39

Label Time Summary:
gpu    =   4.79 sec*proc (8 tests)
```

- [x] Prettier over `**/*.{md,yml,yaml}`: `All matched files use Prettier code
      style!`
- [x] Docs synced: `docs/BENCHMARKS.md` gains the section. No README or
      MASTERPLAN change is owed, since no behaviour, API or status row moves.

### The locks, proven by breaking them

Each mutation was applied to the generator, built, run, and reverted. Each was
then run a second time with both locks disabled, to show what the oracle gate
alone accepts.

**The element-rate floor.** The drift it names is a generator whose literals
grew longer. Length-2 literals instead of length-1:

```
--- locks in force ---
the parse-bound corpus carries 0.3333 elements per compressed byte, below the 0.49 floor: its elements cost more than the two-byte length-1 literal
exit=1
--- the identical bytes, both locks disabled ---
- element density: 131072 elements, 0.3333 per compressed byte, 2.0000 decoded bytes each
exit=0
```

The second run is the point: the stream is a valid Snappy stream, the pinned
oracle accepts every one of them and every one round-trips, so the run goes
green and prints "max parse work per output byte" over a corpus carrying a
third of the element rate it claims.

**The decoded-bytes-per-element ceiling.** The drift it names is a generator
that reverted to the copy chain:

```
--- locks in force ---
the parse-bound corpus produces 3.9998 decoded bytes per element, above the 1.02 ceiling: its elements are no longer one output byte each, so the parse work per reported byte is not the worst case it reports
exit=1
--- the identical bytes, both locks disabled ---
- element density: 65540 elements, 0.4999 per compressed byte, 3.9998 decoded bytes each
exit=0
```

That run is also why one lock is not enough. 0.4999 elements per compressed
byte clears the floor comfortably, so the floor never fires on this drift, and
the corpus would have been reported as parse-bound while measuring the copy
chain.

### The refusals

```
$ bench_snappy --worst --worstlit
--worst and --worstlit are separate corpora and separate reports; run one at a time
exit=2
$ bench_snappy --worstlit --chunked
--worstlit builds its own corpus and has one shape; it takes no files and no shape flag
exit=2
$ bench_snappy --worstlit /etc/hostname
--worstlit builds its own corpus and has one shape; it takes no files and no shape flag
exit=2
```

## Notes

What this does not do, and where it went instead. #119 was opened as the whole
M3 bench rung and is superseded on every other part of that: the Silesia path
and CPU denominator, the copy-chain corpus, and the first recorded GPU
baselines all have their own owners, and the recorded GPU row for these
corpora belongs to #167 and waits on the Snappy kernel. The literal chain was
the one thing #119 uniquely carried, and it is what landed here.

The comparator row for the copy-chain corpus is recorded alongside rather than
in its own change. That corpus landed without a number, and a parse-bound
denominator with nothing to compare against does not carry the claim the
section is about.
