### PR TITLE
Add the Silesia Zstd corpus path and CPU denominator to the bench harness

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -124,8 +124,11 @@ add_test(NAME bench_snappy_worst_selfcheck COMMAND bench_snappy --worst
 # link the linker rightly refuses.
 add_executable(bench_zstd bench_zstd.cpp ../tests/zstd_corpus.cpp)
 target_link_libraries(bench_zstd PRIVATE zstd_full)
-target_include_directories(bench_zstd
-                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../tests)
+# ../src for the corpus digest, which reads src/xxhash64.h - the hash already
+# in the tree rather than a new dependency for a bench.
+target_include_directories(
+  bench_zstd PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../tests
+                     ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 set_target_properties(bench_zstd PROPERTIES CXX_STANDARD 17
                                             CXX_STANDARD_REQUIRED ON)
 # -O2 unconditionally for the reason bench_lz4 gives above: the documented
@@ -141,6 +144,23 @@ target_compile_options(bench_zstd PRIVATE -Wall -Wextra -Werror -O2)
 add_test(NAME bench_zstd_worst_selfcheck COMMAND bench_zstd --worst
                                                  --selfcheck)
 
+# The standard Zstd corpus path (issue #227). The recorded run reads the
+# fetched Silesia files, which the CI runner does not have, so the selfcheck
+# runs the identical grid - both granularity endpoints, the whole level set -
+# over a source generated from a fixed PRNG, and asserts the digest of each
+# cell. That is what makes it a rot check rather than a run: a moved
+# compressor pin, a changed granularity or a generator that lost its noise
+# source all move a digest, and none of them would stop the frames
+# round-tripping. CPU-only, so it runs on the GPU-less runner.
+add_test(NAME bench_zstd_selfcheck COMMAND bench_zstd --selfcheck)
+
+# The forced-mode corpus as a coverage run (issue #227). It consumes the
+# fixture generator tests/ pins rather than building a second one, and it
+# reports which decode surfaces were reached instead of a throughput number -
+# fixtures sized to reach a surface each cannot carry one. CPU-only.
+add_test(NAME bench_zstd_coverage_selfcheck COMMAND bench_zstd --coverage
+                                                    --selfcheck)
+
 # Every ctest entry carries a finite TIMEOUT (issue #72): the self-checks run
 # the same corpus construction and CPU decode the decoder is held to, so a
 # non-terminating decode must red them rather than stall the run. The
@@ -148,7 +168,8 @@ add_test(NAME bench_zstd_worst_selfcheck COMMAND bench_zstd --worst
 # one.
 set_tests_properties(
   bench_selfcheck bench_worst4b_selfcheck bench_longmatch_selfcheck
-  bench_assetlike_selfcheck bench_zstd_worst_selfcheck bench_frame_selfcheck
-  bench_snappy_selfcheck bench_snappy_worst_selfcheck
+  bench_assetlike_selfcheck bench_zstd_worst_selfcheck bench_zstd_selfcheck
+  bench_zstd_coverage_selfcheck bench_frame_selfcheck bench_snappy_selfcheck
+  bench_snappy_worst_selfcheck
   PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 cudec_assert_test_timeouts()

--- a/bench/bench_zstd.cpp
+++ b/bench/bench_zstd.cpp
@@ -1,7 +1,25 @@
-/* The Zstd worst-case bench corpus (issue #229): a hand-constructed frame
- * family that is adversarial on all three axes the M5 design named, gated by
- * libzstd for validity and locked on shape, plus the libzstd CPU decode of
- * that corpus.
+/* The Zstd benchmark harness. Two corpora live here, and they are separate
+ * because they rot differently.
+ *
+ * THE STANDARD PATH (issue #227) builds the fetched corpora as independent
+ * frames at production granularity across a recorded level set, and times the
+ * reference decoder over them. That is the CPU denominator every later GPU
+ * number is read against. There is no Zstd kernel yet, so this measures the
+ * reference alone and says so in its own report rather than leaving a reader
+ * to infer it (docs/MASTERPLAN.md section 5, honest numbers). It rots on
+ * corpus shape and digests.
+ *
+ * THE WORST-CASE PATH (issue #229) is a hand-constructed frame family that is
+ * adversarial on all three axes the M5 design named, gated by libzstd for
+ * validity and locked on shape. It rots on adversariality, which a digest
+ * would not notice.
+ *
+ * Neither path builds its own compressor. The frames both consume come from
+ * the corpus generator in tests/zstd_corpus.h, which is compiled in here
+ * exactly as the tests compile it - this directory links and consumes what
+ * tests/ defines and modifies none of it.
+ *
+ * Everything below the next paragraph is the worst-case path.
  *
  * WHY IT IS HAND-CONSTRUCTED. The reference compressor never emits this
  * shape. Its match finder extends a run into one long match, picks whatever
@@ -50,12 +68,15 @@
 #include <zstd.h>
 
 #include "zstd_corpus.h"
+#include "xxhash64.h"
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -653,31 +674,548 @@ void PrintReport(const ZstdCorpus& corpus, const SequenceCensus& census,
                 GbpsFromMs(gb, p99 * 1e3));
 }
 
+/* ------------------------------------------------------------------------
+ * The standard corpus path (issue #227): the CPU denominator.
+ * ---------------------------------------------------------------------- */
+
+constexpr size_t kMaxRuns = 1000000;
+
+/* The frame granularity range the M5 batch model names (docs/MASTERPLAN.md,
+ * the Zstd chunk model): 64 KiB to 512 KiB, every frame independent, which is
+ * the geometry cudec_zstd_decompress_batch will consume. Both ENDPOINTS are
+ * recorded rather than one figure, because the two ends of the range are not
+ * one measurement: at 64 KiB the per-frame envelope and table builds are paid
+ * eight times as often over the same bytes, and a denominator taken at one end
+ * does not transfer to the other.
+ *
+ * A GRANULARITY ADDED HERE MUST STAY UNDER THE ORACLE'S OUTPUT CEILING.
+ * ZstdOracleDecodes bounds its destination at 4 MiB, deliberately, so a
+ * mutated content-size field cannot drive an allocation; a frame declaring
+ * more comes back refused. Both sizes below are far under it, but a future
+ * entry above 4 MiB would fail as "the oracle refuses frame 0" rather than as
+ * the size mistake it is. */
+constexpr size_t kFrameSizes[] = {65536, 524288};
+
+/* Fast, default, and the high-search family. Level 19 is not optional: it is
+ * where the reference's own search changes shape, and the interop defects the
+ * M4/M5 dossiers record were in that family rather than in the fast one. */
+constexpr int kLevels[] = {1, 3, 19};
+
+/* The selfcheck source. Several frames long at the 512 KiB rung, compressible
+ * enough that the frames are not all raw blocks, and from a fixed PRNG so a
+ * failure reproduces byte for byte. */
+constexpr size_t kSelfcheckBytes = 3u << 20;
+
+/* The corpus lock, on the model bench_snappy.cpp records in full: a fold of
+ * each frame's length and XXH64 in corpus order, hashed again. What it has to
+ * catch is drift - a compressor pin that moved, a chunking rule that changed,
+ * an input file that is not the one the report names - and all three change
+ * the produced frames, so the digest runs over those. The fetched inputs are
+ * already pinned by the manifest bench/get-corpora.sh writes, and a second
+ * input lock here would be two authorities on one fact.
+ *
+ * XXH64 and not SHA-256, said plainly so nobody reads more into it: this is a
+ * drift detector over data the harness just built, not a defence against a
+ * chosen collision, and it is the hash already in the tree. */
+void AppendLe64(uint64_t value, std::vector<unsigned char>* out) {
+    for (unsigned i = 0; i < 8; i++) {
+        out->push_back(static_cast<unsigned char>(value >> (i * 8)));
+    }
+}
+
+uint64_t CorpusDigest(const ZstdCorpus& corpus) {
+    std::vector<unsigned char> fold;
+    fold.reserve(corpus.compressed.size() * 16);
+    for (const auto& frame : corpus.compressed) {
+        AppendLe64(frame.size(), &fold);
+        AppendLe64(cudec_detail::Xxh64(frame.data(), frame.size()), &fold);
+    }
+    return cudec_detail::Xxh64(fold.data(), fold.size());
+}
+
+/* Reads one corpus file onto the end of `source`. Fails closed on I/O trouble
+ * and on a file that contributed nothing, per FILE rather than over the
+ * accumulated source: the accumulated test goes vacuous from the second
+ * argument on, and a file that contributed no bytes must never end up attested
+ * in the methodology block. */
+bool AppendFile(const std::string& path, std::vector<unsigned char>* source) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        std::fprintf(stderr, "cannot open corpus file: %s\n", path.c_str());
+        return false;
+    }
+    const size_t before = source->size();
+    char buffer[1 << 16];
+    while (in.read(buffer, sizeof(buffer)) || in.gcount() > 0) {
+        source->insert(source->end(), buffer, buffer + in.gcount());
+    }
+    if (in.bad()) {
+        std::fprintf(stderr, "read error in corpus file: %s\n", path.c_str());
+        return false;
+    }
+    if (source->size() == before) {
+        std::fprintf(stderr, "corpus file contributed no data: %s\n",
+                     path.c_str());
+        return false;
+    }
+    return true;
+}
+
+std::vector<unsigned char> MakeSelfcheckSource(size_t bytes) {
+    std::vector<unsigned char> out(bytes);
+    uint64_t state = 0x9E3779B97F4A7C15ull;
+    for (size_t i = 0; i < bytes; i++) {
+        state = state * 6364136223846793005ull + 1442695040888963407ull;
+        /* Runs of a repeating alphabet with occasional noise: matches for the
+         * decoder to execute, without collapsing into one long match. */
+        out[i] = (i % 61 == 0) ? static_cast<unsigned char>(state >> 56)
+                               : static_cast<unsigned char>('a' + (i / 7) % 26);
+    }
+    return out;
+}
+
+/* Cuts the source into independent frames through the corpus generator and
+ * fills in the decoded side by decoding what came back.
+ *
+ * The originals are DECODED rather than re-sliced from the source on purpose.
+ * Re-slicing would restate the generator's chunking rule here, and the two
+ * copies would then have to be kept in agreement by hand; decoding asks the
+ * reference what the frames actually contain, and the identity check below
+ * turns that into a proof that the frame set reconstructs the corpus exactly.
+ * A chunking rule that changed would fail that check rather than pass a
+ * matching pair of mistakes. */
+bool BuildStandardCorpus(const std::vector<unsigned char>& source,
+                         size_t frame_bytes, int level, ZstdCorpus* corpus) {
+    corpus->compressed = MakeZstdBatchFrames(source, frame_bytes, level);
+    if (corpus->compressed.empty()) {
+        std::fprintf(stderr,
+                     "the corpus generator produced no frames at %zu bytes, "
+                     "level %d\n",
+                     frame_bytes, level);
+        return false;
+    }
+    for (size_t i = 0; i < corpus->compressed.size(); i++) {
+        std::vector<unsigned char> decoded;
+        if (!ZstdOracleDecodes(corpus->compressed[i], &decoded)) {
+            std::fprintf(stderr, "the oracle refuses frame %zu of %s\n", i,
+                         corpus->name.c_str());
+            return false;
+        }
+        corpus->originals.push_back(std::move(decoded));
+    }
+    corpus->original_bytes = 0;
+    corpus->compressed_bytes = 0;
+    for (size_t i = 0; i < corpus->originals.size(); i++) {
+        corpus->original_bytes += corpus->originals[i].size();
+        corpus->compressed_bytes += corpus->compressed[i].size();
+    }
+    return true;
+}
+
+/* The identity check: the frames, decoded in order and concatenated, must be
+ * the source byte for byte. A number taken on a frame set that dropped,
+ * reordered or truncated part of the corpus is a number about a different
+ * corpus, and the ratio it reports would still look plausible. */
+bool StandardCorpusReconstructs(const std::vector<unsigned char>& source,
+                                const ZstdCorpus& corpus) {
+    if (corpus.original_bytes != source.size()) {
+        std::fprintf(stderr,
+                     "the frames decode to %zu bytes but the source is %zu - "
+                     "the corpus is not the one the report would name\n",
+                     corpus.original_bytes, source.size());
+        return false;
+    }
+    size_t at = 0;
+    for (size_t i = 0; i < corpus.originals.size(); i++) {
+        const std::vector<unsigned char>& frame = corpus.originals[i];
+        if (std::memcmp(source.data() + at, frame.data(), frame.size()) != 0) {
+            std::fprintf(stderr, "frame %zu does not round-trip\n", i);
+            return false;
+        }
+        at += frame.size();
+    }
+    return true;
+}
+
+/* Destination buffers, allocated outside the timed region so the number is the
+ * decoder's and not the allocator's. */
+std::vector<std::vector<unsigned char>> MakeStandardBuffers(
+    const ZstdCorpus& corpus) {
+    std::vector<std::vector<unsigned char>> buffers;
+    buffers.reserve(corpus.originals.size());
+    for (const auto& original : corpus.originals) {
+        buffers.push_back(std::vector<unsigned char>(original.size()));
+    }
+    return buffers;
+}
+
+/* One timed pass. The timed region is ZSTD_decompress alone. Returns a
+ * negative duration if any frame fails, so a broken decode can never be
+ * reported as a fast one. */
+double DecodeStandardSeconds(const ZstdCorpus& corpus,
+                             std::vector<std::vector<unsigned char>>* buffers) {
+    const auto start = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        const size_t rc = ZSTD_decompress(
+            (*buffers)[i].data(), (*buffers)[i].size(),
+            corpus.compressed[i].data(), corpus.compressed[i].size());
+        if (ZSTD_isError(rc)) {
+            return -1.0;
+        }
+    }
+    const auto end = std::chrono::steady_clock::now();
+    return std::chrono::duration<double>(end - start).count();
+}
+
+void PrintStandardReport(const ZstdCorpus& corpus, size_t frame_bytes,
+                         int level, const std::vector<double>& sorted,
+                         size_t warmup, size_t runs) {
+    std::vector<size_t> sizes;
+    sizes.reserve(corpus.originals.size());
+    for (const auto& original : corpus.originals) {
+        sizes.push_back(original.size());
+    }
+    std::sort(sizes.begin(), sizes.end());
+    const double gb = static_cast<double>(corpus.original_bytes) / 1e9;
+
+    std::printf("## bench_zstd report\n");
+    std::printf("- decoder: CPU oracle, ZSTD_decompress (libzstd %s), single "
+                "thread. cudec has no Zstd kernel yet, so this report is the "
+                "denominator and carries no cudec number\n",
+                ZSTD_versionString());
+    std::printf("- host CPU: %s\n", cudec_bench::HostCpuName().c_str());
+    std::printf("- corpus: %s, %zu frames, %.2f MB original, %.2f MB "
+                "compressed (ratio %.4f), %s\n",
+                corpus.name.c_str(), corpus.originals.size(),
+                static_cast<double>(corpus.original_bytes) / 1e6,
+                static_cast<double>(corpus.compressed_bytes) / 1e6,
+                static_cast<double>(corpus.compressed_bytes) /
+                    static_cast<double>(corpus.original_bytes),
+                corpus.provenance.c_str());
+    std::printf("- granularity: %zu KiB frames, compression level %d\n",
+                frame_bytes / 1024, level);
+    std::printf("- corpus digest: %016llx (XXH64 over per-frame length and "
+                "XXH64, little-endian, in corpus order)\n",
+                static_cast<unsigned long long>(CorpusDigest(corpus)));
+    std::printf("- frame sizes: min %zu / median %zu / max %zu bytes "
+                "uncompressed\n",
+                sizes.front(), sizes[sizes.size() / 2], sizes.back());
+    std::printf("- method: %zu warmup + %zu measured runs, wall clock per "
+                "whole-corpus decode; the timed region is ZSTD_decompress "
+                "only (destinations allocated outside it); every frame "
+                "round-trip-verified and the concatenation compared against "
+                "the source once before timing; percentiles are "
+                "nearest-rank\n",
+                warmup, runs);
+    const double p50 = Percentile(sorted, 50);
+    const double p90 = Percentile(sorted, 90);
+    const double p99 = Percentile(sorted, 99);
+    std::printf("- wall per run: p50 %.3f ms / p90 %.3f ms / p99 %.3f ms\n",
+                p50 * 1e3, p90 * 1e3, p99 * 1e3);
+    std::printf("- decode throughput: p50 %.3f GB/s / p90 %.3f GB/s / p99 "
+                "%.3f GB/s\n",
+                GbpsFromMs(gb, p50 * 1e3), GbpsFromMs(gb, p90 * 1e3),
+                GbpsFromMs(gb, p99 * 1e3));
+}
+
+/* The selfcheck's corpus is generated from a fixed PRNG and compressed by the
+ * pinned reference, so every frame set is reproducible byte for byte and its
+ * digest is a constant. Asserting them is what makes this a rot check rather
+ * than a run: a compressor pin that moved, a granularity that changed, or a
+ * generator that lost its noise source all move a digest, and none of them
+ * would stop the corpus round-tripping.
+ *
+ * One digest per (granularity, level) cell, in the order the loop walks them.
+ * Measured on the run recorded in docs/BENCHMARKS.md; a cell that moves is
+ * either a pin that moved or a generator that changed, and both are the thing
+ * this is for. */
+constexpr uint64_t kSelfcheckDigests[2][3] = {
+    /* 64 KiB frames, levels 1 / 3 / 19 */
+    {0x24921f467ca2abc6ull, 0xf42c518918be1546ull, 0x525b593d46eb3753ull},
+    /* 512 KiB frames, levels 1 / 3 / 19 */
+    {0xd3ed77175094c5d4ull, 0xf7667d9a0a862a2cull, 0x9f5f7a972eb54828ull},
+};
+
+/* The grid and the pin table are indexed by the same two loop variables, so a
+ * granularity or a level added to one and not the other reads off the end of
+ * this array. Refused at compile time rather than left to the run, because the
+ * read would be in the selfcheck - the one place a wrong answer looks like a
+ * verdict. */
+static_assert(sizeof(kSelfcheckDigests) / sizeof(kSelfcheckDigests[0]) ==
+                  sizeof(kFrameSizes) / sizeof(kFrameSizes[0]),
+              "one digest row per frame granularity");
+static_assert(sizeof(kSelfcheckDigests[0]) / sizeof(kSelfcheckDigests[0][0]) ==
+                  sizeof(kLevels) / sizeof(kLevels[0]),
+              "one digest column per compression level");
+
+bool CheckDigest(uint64_t actual, size_t frame_bytes, int level,
+                 uint64_t expected) {
+    if (actual == expected) {
+        return true;
+    }
+    std::fprintf(stderr,
+                 "the selfcheck corpus digest moved at %zu KiB frames, level "
+                 "%d: expected %016llx, built %016llx - the corpus this "
+                 "harness constructs is not the one its numbers were recorded "
+                 "on\n",
+                 frame_bytes / 1024, level,
+                 static_cast<unsigned long long>(expected),
+                 static_cast<unsigned long long>(actual));
+    return false;
+}
+
+/* Reports the digest of the corpus it built through `digest_out` rather than
+ * judging it here, so the caller can walk every cell of the grid and name all
+ * of the ones that moved. Stopping at the first would report one drifted cell
+ * and leave the rest unexamined, which reads as "only that one moved". */
+bool RunStandardCorpus(const std::vector<unsigned char>& source,
+                       const std::string& name, size_t frame_bytes, int level,
+                       size_t warmup, size_t runs, uint64_t* digest_out) {
+    ZstdCorpus corpus;
+    corpus.name = name;
+    corpus.provenance =
+        "cut into independent frames and compressed by the pinned libzstd "
+        "through the corpus generator in tests/zstd_corpus.h; every frame "
+        "decoded back by the reference and the concatenation compared "
+        "against the source before timing";
+    if (!BuildStandardCorpus(source, frame_bytes, level, &corpus)) {
+        return false;
+    }
+    if (!StandardCorpusReconstructs(source, corpus)) {
+        return false;
+    }
+
+    std::vector<std::vector<unsigned char>> buffers =
+        MakeStandardBuffers(corpus);
+    for (size_t i = 0; i < warmup; i++) {
+        if (DecodeStandardSeconds(corpus, &buffers) < 0) {
+            std::fprintf(stderr, "a warmup decode failed\n");
+            return false;
+        }
+    }
+    std::vector<double> times;
+    for (size_t i = 0; i < runs; i++) {
+        const double seconds = DecodeStandardSeconds(corpus, &buffers);
+        if (seconds < 0) {
+            std::fprintf(stderr, "a measured decode failed\n");
+            return false;
+        }
+        times.push_back(seconds);
+    }
+    std::sort(times.begin(), times.end());
+    PrintStandardReport(corpus, frame_bytes, level, times, warmup, runs);
+    std::printf("\n");
+    *digest_out = CorpusDigest(corpus);
+    return true;
+}
+
+/* The forced-mode corpora, run as COVERAGE rather than as a number. Each
+ * fixture exists to reach one decode surface - a literals class, a table mode,
+ * an envelope shape - and they are tiny and wildly unequal in size, so a
+ * throughput figure over them measures the fixture list and nothing else. What
+ * this reports is which surfaces were reached and that the reference decodes
+ * every one of them, and it says so in the same breath so no reader lifts a
+ * number out of it.
+ *
+ * The generator is consumed, never duplicated: these are the same fixtures
+ * tests/zstd_corpus_selfproof.cpp pins. */
+bool RunForcedModeCoverage() {
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    if (fixtures.empty()) {
+        std::fprintf(stderr, "the forced-mode corpus generator produced "
+                             "nothing\n");
+        return false;
+    }
+    size_t original_bytes = 0;
+    size_t compressed_bytes = 0;
+    std::vector<std::string> families;
+    for (const ZstdFixture& fixture : fixtures) {
+        std::vector<unsigned char> decoded;
+        if (!ZstdOracleDecodes(fixture.compressed, &decoded) ||
+            decoded != fixture.original) {
+            std::fprintf(stderr,
+                         "forced-mode fixture %s does not round-trip through "
+                         "the reference\n",
+                         fixture.name.c_str());
+            return false;
+        }
+        std::string why;
+        ZstdFrameShape shape;
+        if (!ParseZstdFrameShape(fixture.compressed, &shape, &why) ||
+            !ZstdShapeSatisfies(shape, fixture.demand, &why)) {
+            std::fprintf(stderr,
+                         "forced-mode fixture %s did not get the shape it "
+                         "asked for: %s\n",
+                         fixture.name.c_str(), why.c_str());
+            return false;
+        }
+        original_bytes += fixture.original.size();
+        compressed_bytes += fixture.compressed.size();
+        if (std::find(families.begin(), families.end(), fixture.family) ==
+            families.end()) {
+            families.push_back(fixture.family);
+        }
+    }
+    std::printf("## bench_zstd coverage run\n");
+    std::printf("- forced-mode corpus: %zu fixtures over %zu families, %.3f "
+                "MB original, %.3f MB compressed (ratio %.4f)\n",
+                fixtures.size(), families.size(),
+                static_cast<double>(original_bytes) / 1e6,
+                static_cast<double>(compressed_bytes) / 1e6,
+                static_cast<double>(compressed_bytes) /
+                    static_cast<double>(original_bytes));
+    std::printf("- families:");
+    for (size_t i = 0; i < families.size(); i++) {
+        std::printf("%s %s", i == 0 ? "" : ",", families[i].c_str());
+    }
+    std::printf("\n");
+    std::printf("- NOT A THROUGHPUT MEASUREMENT: these fixtures are sized to "
+                "reach a decode surface each, not to be timed. Every one was "
+                "decoded by the reference and checked against the shape it "
+                "was built to demand; no number here is a denominator\n\n");
+    return true;
+}
+
+bool ParseCount(const char* text, size_t low, size_t high, size_t* out) {
+    char* end = nullptr;
+    const unsigned long long value = std::strtoull(text, &end, 10);
+    if (end == text || *end != '\0' || value < low || value > high) {
+        return false;
+    }
+    *out = static_cast<size_t>(value);
+    return true;
+}
+
+void Usage(const char* argv0) {
+    std::fprintf(stderr,
+                 "usage: %s [--runs N] [--warmup N] [--worst] [--coverage] "
+                 "[--selfcheck] [corpus files...]\n"
+                 "  no flag and files given: the standard corpus path over "
+                 "the recorded granularity and level set\n",
+                 argv0);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
     bool worst = false;
+    bool coverage = false;
     bool selfcheck = false;
     size_t warmup = 3;
     size_t runs = 30;
+    std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
         if (arg == "--worst") {
             worst = true;
+        } else if (arg == "--coverage") {
+            coverage = true;
         } else if (arg == "--selfcheck") {
             selfcheck = true;
+        } else if (arg == "--runs" && i + 1 < argc) {
+            if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
+                std::fprintf(stderr, "--runs must be in [1, %zu]\n", kMaxRuns);
+                return 2;
+            }
+        } else if (arg == "--warmup" && i + 1 < argc) {
+            if (!ParseCount(argv[++i], 0, kMaxRuns, &warmup)) {
+                std::fprintf(stderr, "--warmup must be in [0, %zu]\n",
+                             kMaxRuns);
+                return 2;
+            }
+        } else if (arg == "--runs" || arg == "--warmup") {
+            std::fprintf(stderr, "%s needs a value\n", arg.c_str());
+            return 2;
+        } else if (!arg.empty() && arg[0] == '-') {
+            Usage(argv[0]);
+            return 2;
         } else {
-            std::fprintf(stderr, "usage: %s --worst [--selfcheck]\n", argv[0]);
-            return 1;
+            files.push_back(arg);
         }
     }
-    if (!worst) {
-        std::fprintf(stderr, "usage: %s --worst [--selfcheck]\n", argv[0]);
-        return 1;
+    if (worst && coverage) {
+        std::fprintf(stderr, "--worst and --coverage are separate runs\n");
+        return 2;
     }
+
+    if (coverage) {
+        if (!files.empty()) {
+            std::fprintf(stderr, "--coverage builds its own fixtures and takes "
+                                 "no files\n");
+            return 2;
+        }
+        if (!RunForcedModeCoverage()) {
+            return 1;
+        }
+        if (selfcheck) {
+            std::printf("PASS: selfcheck complete\n");
+        }
+        return 0;
+    }
+
+    if (!worst) {
+        /* The standard path. The recorded run walks both granularity
+         * endpoints across the whole level set; the selfcheck walks the same
+         * grid over a generated source, so the construction under test is the
+         * one the recorded numbers came from rather than a reduced stand-in. */
+        if (files.empty() && !selfcheck) {
+            std::fprintf(stderr,
+                         "bench_zstd needs corpus files (the recorded run "
+                         "uses bench/corpora/silesia/*); --selfcheck runs it "
+                         "on a generated source instead\n");
+            return 2;
+        }
+        std::vector<unsigned char> source;
+        std::string name;
+        if (selfcheck) {
+            warmup = 0;
+            runs = 1;
+            source = MakeSelfcheckSource(kSelfcheckBytes);
+            name = "generated (selfcheck)";
+        } else {
+            for (const std::string& path : files) {
+                if (!AppendFile(path, &source)) {
+                    return 1;
+                }
+                const size_t slash = path.find_last_of("/\\");
+                name += (name.empty() ? "" : "+") +
+                        path.substr(slash == std::string::npos ? 0
+                                                               : slash + 1);
+            }
+        }
+        bool digests_hold = true;
+        for (size_t f = 0; f < sizeof(kFrameSizes) / sizeof(kFrameSizes[0]);
+             f++) {
+            for (size_t l = 0; l < sizeof(kLevels) / sizeof(kLevels[0]); l++) {
+                uint64_t digest = 0;
+                if (!RunStandardCorpus(source, name, kFrameSizes[f], kLevels[l],
+                                       warmup, runs, &digest)) {
+                    return 1;
+                }
+                if (selfcheck && !CheckDigest(digest, kFrameSizes[f],
+                                              kLevels[l],
+                                              kSelfcheckDigests[f][l])) {
+                    digests_hold = false;
+                }
+            }
+        }
+        if (!digests_hold) {
+            return 1;
+        }
+        if (selfcheck) {
+            std::printf("PASS: selfcheck complete\n");
+        }
+        return 0;
+    }
+
     if (selfcheck) {
         warmup = 0;
         runs = 1;
+    }
+    if (!files.empty()) {
+        std::fprintf(stderr,
+                     "--worst builds its own corpus and takes no files\n");
+        return 2;
     }
 
     ZstdCorpus corpus;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1005,6 +1005,169 @@ same host with the timed region held to the decode call alone, so the
 comparison is between the two references and says nothing about either GPU
 path.
 
+## M5: the Zstd CPU denominator (issue #227)
+
+There is no Zstd kernel yet. This entry is the denominator a later device
+number will be read against, and the harness says so in its own report rather
+than leaving a reader to infer it from the absence of a GPU row.
+
+Six cells, because the M5 batch model has two axes and a denominator taken at
+one point on them does not transfer to another. The frame granularity is the
+range that model names, 64 KiB to 512 KiB with every frame independent, and
+both endpoints are recorded. The level set is fast, default and the high-search
+family: level 19 is not optional here, because it is where the reference's own
+search changes shape.
+
+Every cell is cut from the same Silesia bytes by the pinned libzstd 1.5.7
+through the corpus generator in `tests/zstd_corpus.h`, which the harness
+consumes rather than duplicating. Before anything is timed, every frame is
+decoded back by the reference and the concatenation of the decoded frames is
+compared against the source, so a frame set that dropped, reordered or
+truncated part of the corpus fails instead of reporting a plausible ratio over
+different bytes.
+
+Each report carries a digest of the corpus that was actually built, folded over
+the produced frames rather than over the inputs (the inputs are already pinned
+by the manifest `bench/get-corpora.sh` writes). It is order-sensitive, so the
+digests below belong to the file order listed in the corpus line. Recorded
+2026-08-11 inside the digest-pinned `nvidia/cuda:12.6.2-devel-ubuntu24.04`
+container, on the host CPU named in the blocks. Reproduce with
+`bench_zstd --warmup 3 --runs 30 bench/corpora/silesia/*`.
+
+| granularity | level | compressed | ratio  | p50 decode | corpus digest      |
+| ----------- | ----- | ---------- | ------ | ---------- | ------------------ |
+| 64 KiB      | 1     | 76.70 MB   | 0.3619 | 1.281 GB/s | `f95ac5fe65483030` |
+| 64 KiB      | 3     | 73.52 MB   | 0.3469 | 1.301 GB/s | `c7171e665a1888c6` |
+| 64 KiB      | 19    | 65.04 MB   | 0.3069 | 1.086 GB/s | `748220fb33f7ee01` |
+| 512 KiB     | 1     | 73.95 MB   | 0.3489 | 1.510 GB/s | `ed6b1bc51f66d81f` |
+| 512 KiB     | 3     | 68.23 MB   | 0.3219 | 1.404 GB/s | `4983cbc86cd8255b` |
+| 512 KiB     | 19    | 58.65 MB   | 0.2767 | 1.262 GB/s | `4242734974b3b0d5` |
+
+The table is a reading aid. The six blocks below are the record, and each one
+carries the methodology its own numbers were taken under.
+
+```
+## bench_zstd report
+- decoder: CPU oracle, ZSTD_decompress (libzstd 1.5.7), single thread. cudec has no Zstd kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 frames, 211.94 MB original, 76.70 MB compressed (ratio 0.3619), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before timing
+- granularity: 64 KiB frames, compression level 1
+- corpus digest: f95ac5fe65483030 (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- frame sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is ZSTD_decompress only (destinations allocated outside it); every frame round-trip-verified and the concatenation compared against the source once before timing; percentiles are nearest-rank
+- wall per run: p50 165.439 ms / p90 175.127 ms / p99 187.601 ms
+- decode throughput: p50 1.281 GB/s / p90 1.210 GB/s / p99 1.130 GB/s
+```
+
+```
+## bench_zstd report
+- decoder: CPU oracle, ZSTD_decompress (libzstd 1.5.7), single thread. cudec has no Zstd kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 frames, 211.94 MB original, 73.52 MB compressed (ratio 0.3469), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before timing
+- granularity: 64 KiB frames, compression level 3
+- corpus digest: c7171e665a1888c6 (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- frame sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is ZSTD_decompress only (destinations allocated outside it); every frame round-trip-verified and the concatenation compared against the source once before timing; percentiles are nearest-rank
+- wall per run: p50 162.906 ms / p90 180.539 ms / p99 184.608 ms
+- decode throughput: p50 1.301 GB/s / p90 1.174 GB/s / p99 1.148 GB/s
+```
+
+```
+## bench_zstd report
+- decoder: CPU oracle, ZSTD_decompress (libzstd 1.5.7), single thread. cudec has no Zstd kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 frames, 211.94 MB original, 65.04 MB compressed (ratio 0.3069), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before timing
+- granularity: 64 KiB frames, compression level 19
+- corpus digest: 748220fb33f7ee01 (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- frame sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is ZSTD_decompress only (destinations allocated outside it); every frame round-trip-verified and the concatenation compared against the source once before timing; percentiles are nearest-rank
+- wall per run: p50 195.213 ms / p90 199.905 ms / p99 204.529 ms
+- decode throughput: p50 1.086 GB/s / p90 1.060 GB/s / p99 1.036 GB/s
+```
+
+```
+## bench_zstd report
+- decoder: CPU oracle, ZSTD_decompress (libzstd 1.5.7), single thread. cudec has no Zstd kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 405 frames, 211.94 MB original, 73.95 MB compressed (ratio 0.3489), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before timing
+- granularity: 512 KiB frames, compression level 1
+- corpus digest: ed6b1bc51f66d81f (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- frame sizes: min 126228 / median 524288 / max 524288 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is ZSTD_decompress only (destinations allocated outside it); every frame round-trip-verified and the concatenation compared against the source once before timing; percentiles are nearest-rank
+- wall per run: p50 140.329 ms / p90 145.805 ms / p99 161.570 ms
+- decode throughput: p50 1.510 GB/s / p90 1.454 GB/s / p99 1.312 GB/s
+```
+
+```
+## bench_zstd report
+- decoder: CPU oracle, ZSTD_decompress (libzstd 1.5.7), single thread. cudec has no Zstd kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 405 frames, 211.94 MB original, 68.23 MB compressed (ratio 0.3219), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before timing
+- granularity: 512 KiB frames, compression level 3
+- corpus digest: 4983cbc86cd8255b (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- frame sizes: min 126228 / median 524288 / max 524288 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is ZSTD_decompress only (destinations allocated outside it); every frame round-trip-verified and the concatenation compared against the source once before timing; percentiles are nearest-rank
+- wall per run: p50 150.955 ms / p90 159.339 ms / p99 167.337 ms
+- decode throughput: p50 1.404 GB/s / p90 1.330 GB/s / p99 1.267 GB/s
+```
+
+```
+## bench_zstd report
+- decoder: CPU oracle, ZSTD_decompress (libzstd 1.5.7), single thread. cudec has no Zstd kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 405 frames, 211.94 MB original, 58.65 MB compressed (ratio 0.2767), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before timing
+- granularity: 512 KiB frames, compression level 19
+- corpus digest: 4242734974b3b0d5 (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- frame sizes: min 126228 / median 524288 / max 524288 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is ZSTD_decompress only (destinations allocated outside it); every frame round-trip-verified and the concatenation compared against the source once before timing; percentiles are nearest-rank
+- wall per run: p50 167.914 ms / p90 174.506 ms / p99 181.758 ms
+- decode throughput: p50 1.262 GB/s / p90 1.215 GB/s / p99 1.166 GB/s
+```
+
+**Cutting the corpus to 64 KiB frames costs the reference decoder 8 to 14
+percent, and that is the opposite of what the Snappy entry above found.** At
+level 1 the same bytes decode at 1.510 GB/s in 512 KiB frames and 1.281 GB/s in
+64 KiB ones; at level 3, 1.404 against 1.301; at level 19, 1.262 against 1.086.
+Each gap is several times the p50-to-p99 spread of either row, where the Snappy
+whole-versus-chunked pair differed by 0.18% and sat inside it. Zstd carries a
+frame envelope and per-block entropy tables that Snappy has no equivalent of,
+and cutting the corpus eight times finer pays for them eight times as often;
+this measurement does not separate those two costs from each other, and no
+claim is made here about which dominates.
+
+What that means for later device numbers is a rule rather than an observation:
+**a GPU figure must be quoted against the denominator at its own granularity.**
+Reading a 64 KiB batch decode against the 512 KiB CPU row would credit the
+device with a difference that is the corpus shape.
+
+**Level 19 is the slowest cell at both granularities while compressing the
+best.** 1.086 GB/s against 1.281 at 64 KiB, 1.262 against 1.510 at 512 KiB,
+with the ratio moving 0.3619 to 0.3069 and 0.3489 to 0.2767. The ratio and the
+decode cost move in opposite directions across the level set, so the
+high-search family is where a device decoder has both the most to gain and the
+most work per output byte. Why decode slows is not measured here; the per-phase
+entropy-versus-execution split that would answer it is a separate entry.
+
+**As a sanity check only**, the whole range 1.086 to 1.510 GB/s brackets the
+order of magnitude zstd's own README suggests for single-thread decode. That
+figure is not quoted as a number and nothing above is derived from it; these
+rows were measured locally and stand on their own.
+
+**Against the other two references on the same bytes and the same host**, at 64
+KiB frames: liblz4 3.410 GB/s at ratio 0.483, snappy 1.197 GB/s at 0.478, and
+libzstd 1.281 GB/s at 0.3619. Zstd is the only one of the three that is both
+faster than snappy and substantially smaller. All three are single-thread wall
+clock with the timed region held to the decode call alone, so this compares the
+three references and says nothing about any GPU path.
+
+**The forced-mode corpus is run as coverage and carries no number.** Nineteen
+fixtures over five families (envelope, block, literals, tables, level) are
+decoded by the reference and checked against the shape each was built to
+demand, on every run of `bench_zstd --coverage`. They are sized to reach one
+decode surface each, so a throughput figure over them would measure the fixture
+list; the harness prints that in place of a number rather than leaving it to be
+inferred.
+
 ## Community AMD results
 
 **No community results yet.** Nothing in this section is a measurement; it


### PR DESCRIPTION
Closes #227.

`bench_zstd` could only build its hand-constructed worst case. The standard corpora had no path through it, so the M5 record carried no ratio and no CPU denominator, and a later device number would have had nothing to be read against.

## What this adds

A standard corpus path that cuts a fetched corpus into independent frames at both endpoints of the 64 KiB to 512 KiB granularity range the batch model names, across levels 1, 3 and 19, and times single-thread `ZSTD_decompress` over each of the six cells. It consumes `MakeZstdBatchFrames` from `tests/zstd_corpus.h` rather than adding a second generator, which is what the issue asks for.

The forced-mode fixtures are run by `bench_zstd --coverage`. They report which decode surfaces were reached and state in their own output that they carry no number, because fixtures sized to reach one surface each cannot carry a throughput figure.

## Recorded numbers

Measured in the digest-pinned `nvidia/cuda:12.6.2-devel-ubuntu24.04` container on an AMD Ryzen 9 5950X, libzstd 1.5.7, over the twelve Silesia files at 211.94 MB. Reproduce with `bench_zstd --warmup 3 --runs 30 bench/corpora/silesia/*`.

| granularity | level | compressed | ratio  | p50 decode |
| ----------- | ----- | ---------- | ------ | ---------- |
| 64 KiB      | 1     | 76.70 MB   | 0.3619 | 1.281 GB/s |
| 64 KiB      | 3     | 73.52 MB   | 0.3469 | 1.301 GB/s |
| 64 KiB      | 19    | 65.04 MB   | 0.3069 | 1.086 GB/s |
| 512 KiB     | 1     | 73.95 MB   | 0.3489 | 1.510 GB/s |
| 512 KiB     | 3     | 68.23 MB   | 0.3219 | 1.404 GB/s |
| 512 KiB     | 19    | 58.65 MB   | 0.2767 | 1.262 GB/s |

`docs/BENCHMARKS.md` carries all six blocks with their full methodology rather than this table alone.

The reading worth carrying forward is that this disagrees with the Snappy entry above it. Cutting to 64 KiB frames costs libzstd 8 to 14 percent, where the same cut cost snappy 0.18 percent and sat inside its own run-to-run spread. So a device figure has to be quoted against the denominator at its own granularity; reading a 64 KiB batch decode against the 512 KiB row would credit the device with a difference that is the corpus shape.

## The two guards, and the proof that each bites

A corpus can stop being the recorded one in two ways that both still round-trip, so there are two guards and both were checked by breaking them.

The frames are decoded back and their concatenation compared against the source before anything is timed. Dropping one frame from every built corpus:

```
the frames decode to 3080192 bytes but the source is 3145728 - the corpus is not the one the report would name
exit=1
```

Each cell's corpus digest is pinned in the selfcheck. Moving the selfcheck source from 3 MiB to 2 MiB:

```
6
the selfcheck corpus digest moved at 64 KiB frames, level 1: expected 24921f467ca2abc6, built 6bc8b18068e83092 - the corpus this harness constructs is not the one its numbers were recorded on
exit=1
```

All six cells red, not one, because the grid reports every digest before judging any of them. Reverting both mutations returns the selfcheck to `exit=0`.

The pin table and the run grid are indexed by the same two loop variables. A level added to one and not the other is now refused at compile time by a `static_assert` rather than read off the end of the array inside the selfcheck, which is the one place a wrong answer would look like a verdict.

## Gate

Full build and `ctest` in the digest-pinned container against the local RTX 3080, driver 560.94, CUDA 12.6.2:

```
100% tests passed, 0 tests failed out of 40
```

40 rather than the previous 38: `bench_zstd_selfcheck` and `bench_zstd_coverage_selfcheck`. Both are CPU-only so they run on the GPU-less runner, and both carry the finite `TIMEOUT` that `cudec_assert_test_timeouts()` requires.

`npx prettier@3 --check "**/*.{md,yml,yaml}"` reports all matched files use Prettier code style.

## What this does not claim

No second reader has looked at this change. What stands in place of one is the evidence above: the two guards were each mutated and watched to fail, the numbers carry the commands that produced them, and the gate output is quoted rather than summarised.

The compute-sanitizer net did not run over this change and nothing here asserts it is clean under those tools. That gate cannot attach to a device on this route, which is recorded on #258, and this change adds no device code.

No claim is made about why level 19 decodes slowest while compressing best. The per-phase split that would answer it is a separate entry.
