### PR TITLE
Four passages stop describing themselves and describe their subject

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -13,9 +13,8 @@ cudec distributes none of the sources below. They are fetched at configure
 time by the test build, the way the LZ4, Snappy and Zstd references already
 are, and the no-vendored-binaries rule keeps them out of this tree. Neither
 upstream ships a NOTICE file, so Apache-2.0 section 4(d) has nothing to
-propagate here; this section exists because recording where the verification
-apparatus came from is worth doing on its own terms, and it is what
-`docs/MASTERPLAN.md` section 11.9 decided to carry.
+propagate here. The provenance below is recorded anyway, and
+`docs/MASTERPLAN.md` section 11.9 is where that was decided.
 
 **The NVIDIA fork of libdeflate, branch `gdeflate`**, pinned at commit
 `8ba9502fb30d2bf728592d121f0d402e40c8cb05`. It is the reference GDeflate

--- a/docs/BENCHMARK-METHODOLOGY.md
+++ b/docs/BENCHMARK-METHODOLOGY.md
@@ -129,19 +129,19 @@ is covered in [The design rationale](#the-design-rationale-single-pass).
 The worst case matters because it is the security-posture number: it is what
 an attacker who fully controls a valid input can force. The honest findings:
 
-- **The degradation is uniform and bounded, ~2.2–2.3× across every path** -
-  CPU, GPU decode, and GPU parse-only all slow by the same factor. That factor
-  is the sequence density (one sequence per 4 decoded bytes here, versus
-  Silesia's longer average matches): the cost is linear in the number of
-  sequences, exactly the redundant parse the design accepts. There is no
-  super-linear blow-up, and this is below the ~4× the issue pessimistically
-  estimated.
+- The degradation is uniform and bounded at roughly 2.2–2.3× across every
+  path. CPU, GPU decode, and GPU parse-only all slow by the same factor. That
+  factor is the sequence density, one sequence per 4 decoded bytes here
+  against Silesia's longer average matches: the cost is linear in the number
+  of sequences, which is the redundant parse the design accepts. There is no
+  super-linear blow-up, and the measured factor is below the ~4× the issue
+  pessimistically estimated.
 - **No size amplification.** The block barely compresses (ratio 0.750,
   ~1.33× expansion) and each chunk decodes to exactly 65536 bytes, capped by
-  the caller's destination capacity. The throughput worst case and a
-  decompression bomb are mutually exclusive for LZ4 - a bomb is one long
-  match (a single fast sequence), the opposite shape - and cudec's fixed
-  per-chunk output cap fail-closes the size axis regardless.
+  the caller's destination capacity. For LZ4 the throughput worst case and a
+  decompression bomb are mutually exclusive, because a bomb is one long match
+  and therefore a single fast sequence, which is the opposite shape. cudec's
+  fixed per-chunk output cap fail-closes the size axis regardless.
 - **The GPU advantage holds under the worst input:** 8.1 GB/s worst-case GPU
   is still ~5.4× the CPU worst case and ~2.3× the CPU's Silesia _average_.
 

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -810,9 +810,8 @@ none of them is a call that needs the release gate.
 
 What GDeflate is, sourced, so that the kernel design panel and the
 table/parse core work from one record instead of each re-reading a draft.
-This section states facts and provenance only. It takes no design decision,
-and it does not settle the legal posture, which is its own maintainer-gated
-issue.
+Facts and provenance only. No design decision is taken below, and the legal
+posture is settled in its own maintainer-gated issue.
 
 ### 11.1 Provenance: three artifacts, no single specification
 


### PR DESCRIPTION
# What & why

Four passages in three documents described themselves rather than their
subject. `NOTICE.md` said its provenance section exists because recording
provenance is worth doing on its own terms; `docs/MASTERPLAN.md` section 11
opened by saying what the section states; and two bullets in
`docs/BENCHMARK-METHODOLOGY.md` used a dash pair where a subordinate clause
belongs, in the sentences that carry the security-posture claim about a
decompression bomb.

No claim moves. The degradation factor stays 2.2-2.3x, the mutual exclusivity
of the throughput worst case and a bomb stays, the GDeflate provenance stays,
and section 11 still takes no design decision.

Closes #348

## Type of change

- [x] Docs

## Engineering checklist

Not applicable. No decode path, no device code, no API surface and no build
input is touched; the diff is three Markdown files.

- [x] An adversarial review was not run, and this line says so rather than
      being ticked. This change reaches no kernel, no format parsing, no C-ABI
      boundary, no build tooling and no workflow, which is the set that
      requires one.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

## Performance checklist

Not applicable: nothing on the hot path is touched, and `docs/BENCHMARKS.md`
is not among the changed files.

## Quality checklist

- [x] Minimal: three files, 15 lines added and 17 removed.
- [x] Self-documenting: the rewrites are shorter than what they replace and
      keep every number.
- [ ] No new structural property is established, so there is nothing to lock
      in as a conformance test.

## Verification

The build and test boxes are NOT ticked and the reason is stated rather than
implied: no C++ toolchain run was made for this change, because the diff
reaches no source, no header, no CMake input and no test. CI is the authority
here and its `build` and `format` contexts are what the ruleset requires.

- [ ] `cmake --build build` - not run, see above.
- [ ] `ctest --test-dir build` - not run, see above.
- [x] Prettier clean on the three changed files, run locally at the head
      commit:

```
$ npx --yes prettier@3 --check "NOTICE.md" "docs/MASTERPLAN.md" "docs/BENCHMARK-METHODOLOGY.md"
Checking formatting...
All matched files use Prettier code style!
```

- [x] Docs synced: no behaviour, API or performance change to reflect.

## Notes

The 21 en dashes in this tree are number ranges and are deliberately left
alone. Before and after the change:

```
$ git grep -oP '\x{2013}' -- '*.md' | wc -l
21
```

The `docs/BENCHMARK-METHODOLOGY.md` bullet list keeps two of its bold openers,
on the "No size amplification" and "The GPU advantage holds" items. Only the
first bullet lost its bold label, because that bullet's label ran into a dash
and then into the sentence, which is the construction the issue names. Making
the whole list consistent one way or the other is a larger judgement about that
document's voice and is not taken here.

There is no second reader on this change. The reasoning above and the commands
it quotes stand in place of one.


## Correction, after the merge, to the number in the Notes above

The Notes section quoted

```
$ git grep -oP '\x{2013}' -- '*.md' | wc -l
21
```

and that command does not return 21. It returns 24, at the base commit and at
the merge commit alike:

```
$ git grep -oP '\x{2013}' 1294267 -- '*.md' | wc -l
24
$ git grep -oP '\x{2013}' f38b542 -- '*.md' | wc -l
24
```

21 is the number of LINES carrying an en dash, which is what a per-file count
returns and what #348 counted:

```
$ git grep -cP '\x{2013}' f38b542 -- '*.md'
docs/BENCHMARK-METHODOLOGY.md:2
docs/BENCHMARKS.md:11
docs/MASTERPLAN.md:8
```

2 plus 11 plus 8 is 21. So the figure was right about the tree and wrong about
the command that was pasted beside it, which is the pairing a reader checks.
The claim it supports is unchanged and is now measured with the command that
produces it: the en-dash count does not move across this change, 24 before and
24 after. #348's body carries the same wrong pairing and this is the correction
for both.
