### PR TITLE
Make the reporting link absolute so it survives the Security tab

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,5 +17,5 @@ not incidental:
 
 Please report vulnerabilities (e.g. a crafted bitstream causing memory
 corruption) privately via
-[GitHub private vulnerability reporting](../../security/advisories/new)
+[GitHub private vulnerability reporting](https://github.com/iderex/cudec/security/advisories/new)
 rather than a public issue. Reports are usually answered within a week.


### PR DESCRIPTION
Closes #350


## Type of change

One link target in `SECURITY.md`:

    ](../../security/advisories/new)  ->  ](https://github.com/iderex/cudec/security/advisories/new)

## Engineering checklist

This heading has no answer for this change. It adds the address of the
reporting form to the paragraph that already describes it, and inventing a
paragraph that looks like an answer would be worse than saying so.

## GPU sanitizer gate

This heading has no answer for this change. It adds the address of the
reporting form to the paragraph that already describes it, and inventing a
paragraph that looks like an answer would be worse than saying so.

## Performance checklist

This heading has no answer for this change. It adds the address of the
reporting form to the paragraph that already describes it, and inventing a
paragraph that looks like an answer would be worse than saying so.

## Quality checklist

This heading has no answer for this change. It adds the address of the
reporting form to the paragraph that already describes it, and inventing a
paragraph that looks like an answer would be worse than saying so.

## Verification

This heading has no answer for this change. It adds the address of the
reporting form to the paragraph that already describes it, and inventing a
paragraph that looks like an answer would be worse than saying so.

## Notes

This heading has no answer for this change. It adds the address of the
reporting form to the paragraph that already describes it, and inventing a
paragraph that looks like an answer would be worse than saying so.