### PR TITLE
Add the GDeflate round/refill schedule and its CPU twin [#178]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,7 @@ jobs:
           grep -E ': bench_worst4b_selfcheck$' host-selected.txt &&
           grep -E ': oracle_gdeflate$' host-selected.txt &&
           grep -E ': gdeflate_probes$' host-selected.txt &&
+          grep -E ': gdeflate_schedule_twin$' host-selected.txt &&
           echo "Deferred to the local GPU gate:" &&
           ctest --test-dir build-cuda -L gpu -N | tee gpu-deferred.txt &&
           grep -E ': smoke$' gpu-deferred.txt &&
@@ -435,6 +436,7 @@ jobs:
           test -x build-san/tests/snappy_parser_twin &&
           test -x build-san/tests/frame_host_negative &&
           test -x build-san/tests/tilestream_host_negative &&
+          test -x build-san/tests/gdeflate_schedule_twin &&
           test -x build-san/tests/termination
 
       # Prove the sanitizer runtimes are actually linked: a dropped or renamed
@@ -456,7 +458,7 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|zstd_frame_twin|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|zstd_frame_twin|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
@@ -467,6 +469,7 @@ jobs:
           grep -E ': snappy_upstream_negatives$' san-selected.txt &&
           grep -E ': frame_host_negative$' san-selected.txt &&
           grep -E ': tilestream_host_negative$' san-selected.txt &&
+          grep -E ': gdeflate_schedule_twin$' san-selected.txt &&
           grep -E ': zstd_frame_twin$' san-selected.txt &&
           grep -E ': termination$' san-selected.txt
 

--- a/src/gdeflate_schedule.h
+++ b/src/gdeflate_schedule.h
@@ -75,15 +75,24 @@ constexpr uint32_t kGDeflateNumStreams = 32;
 constexpr uint32_t kGDeflateBitsPerPacket = 32;
 constexpr uint32_t kGDeflateLowWatermarkBits = 32;
 
-/* The bit buffer is 64-bit and a refill only fires below the watermark, so a
- * lane holds at most (watermark - 1) + packet bits at any instant. This is the
- * bound the shift in the refill is safe under: shifting a 32-bit packet left
- * by up to 31 places touches bit 62 at the highest. */
+/* The width of one lane's bit buffer, named rather than left as the width of
+ * whatever type the struct below happens to use: every shift in this header is
+ * safe because of this number, so it is the thing the assertions compare
+ * against. */
+constexpr uint32_t kGDeflateLaneBufferBits = 64;
+
+/* A refill only fires below the watermark, so a lane holds at most
+ * (watermark - 1) + packet bits at any instant. That is the bound the shift in
+ * the refill is safe under: shifting one packet left by up to a watermark less
+ * one place stays inside the buffer. */
 constexpr uint32_t kGDeflateMaxLaneBits =
     kGDeflateLowWatermarkBits - 1 + kGDeflateBitsPerPacket;
-static_assert(kGDeflateMaxLaneBits < 64,
-              "the lane bit buffer is 64-bit; a refill at the watermark must "
-              "not shift a packet off the top of it");
+static_assert(kGDeflateMaxLaneBits < kGDeflateLaneBufferBits,
+              "a refill at the watermark must not shift a packet off the top "
+              "of the lane bit buffer");
+static_assert(sizeof(uint64_t) * 8 == kGDeflateLaneBufferBits,
+              "the lane bit buffer type must be as wide as the constant the "
+              "shift bounds are argued against");
 
 /* The widest single read the format asks for is the 16-bit stored-block LEN
  * (dossier 11.3). The ceiling here is not that number: it is the watermark,

--- a/src/gdeflate_schedule.h
+++ b/src/gdeflate_schedule.h
@@ -1,0 +1,263 @@
+/* The GDeflate round/refill schedule (issue #178): which of the 32 lanes
+ * consumes which 32-bit word of a page, in which round. Single-sourced for
+ * host and device, the sibling of src/lz4_block.h, src/snappy_block.h and
+ * src/zstd_frame.h. It decodes no symbol and builds no table; it owns the bit
+ * cursor and nothing else.
+ *
+ * WHY THIS IS A SEPARATE THING FROM THE DECODER. GDeflate carries no checksum
+ * anywhere (MASTERPLAN section 11.4) and its 32 substreams have no markers: a
+ * boundary is not self-delimiting, and the only thing that says where lane 7's
+ * next word is, is the schedule that put it there. So an off-by-one here is
+ * not a crash, it is silent corruption that no downstream check catches.
+ * Isolating the schedule is what makes it testable before a table or a kernel
+ * exists, which is the reason the M4 rungs are cut in this order (#178, then
+ * #176, then #182).
+ *
+ * WHAT A ROUND IS. One shared word cursor walks the page's 32-bit words in
+ * increasing order. Advance is the only thing that moves the lane index, and
+ * it refills the CURRENT lane before rotating, not after - so lane L's refill
+ * is the word that sits at the cursor at the moment lane L is current, and the
+ * lane order is 0, 1, ... 31, 0, 1, ... with no exception anywhere in the
+ * format. Reset returns to lane 0 without consuming a word: every block header
+ * rides lane 0 (dossier 11.2), and the header round is that reset.
+ *
+ * THE PRIMING ROUND IS PART OF THE FORMAT, NOT AN IMPLEMENTATION CHOICE. A
+ * page opens with one full pass that loads a word into each of the 32 lanes in
+ * lane order, which is why a valid GDeflate stream cannot be smaller than
+ * 4 * 32 = 128 bytes (draft section 5.3, pinned in tests/gdeflate_probes.cpp).
+ * GDeflateInit performs it, and a page too short to carry it is refused there
+ * rather than half-primed.
+ *
+ * FAIL-CLOSED, AND STRICTER THAN THE REFERENCE IN TWO PLACES THAT ARE STATED
+ * RATHER THAN LEFT TO BE FOUND. The reference refills without checking that a
+ * word is present and pops without checking that bits are present, because the
+ * format's own watermark discipline makes both true on a well-formed page.
+ * Hostile input is the expected case here, so a refill past the last word and
+ * a pop wider than the lane holds each set the sticky failure flag and consume
+ * nothing. Both are refusals a valid page cannot reach: after the priming
+ * round every lane holds exactly 32 bits, and every Advance restores any lane
+ * that fell below the 32-bit watermark, so a page that trips either one is
+ * malformed. Nothing here ever sizes anything from the stream.
+ *
+ * THE HOST SHAPE AND THE DEVICE SHAPE ARE THE SAME FUNCTION, NOT THE SAME
+ * LAYOUT. This struct holds all 32 lane buffers because the CPU twin runs the
+ * lanes sequentially in one thread. In the warp kernel each lane owns its own
+ * bit buffer and occupancy in registers while the lane index and the cursor
+ * are warp-uniform, so the kernel instantiates the same arithmetic over a
+ * different residency. What must not fork is the schedule itself, which is why
+ * it lives in one place. The cursor is 64-bit for the reason the other parsers
+ * give: the caller's sizes are size_t, and mixing widths in a bound comparison
+ * is where an overflow hides. */
+#ifndef CUDEC_GDEFLATE_SCHEDULE_H
+#define CUDEC_GDEFLATE_SCHEDULE_H
+
+#include <stdint.h>
+
+/* Guarded: the other single-sourced parsers define the same macro for the same
+ * reason, and a device translation unit that decodes two formats includes two
+ * of these headers. The definitions are identical, so an unguarded second one
+ * is legal rather than an error - which is exactly why it would go unnoticed
+ * if they ever stopped being identical. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+/* All three are the reference's own constants (deflate_constants.h in the
+ * pinned NVIDIA/libdeflate fork), restated here because this header is the
+ * thing that has to agree with them. */
+constexpr uint32_t kGDeflateNumStreams = 32;
+constexpr uint32_t kGDeflateBitsPerPacket = 32;
+constexpr uint32_t kGDeflateLowWatermarkBits = 32;
+
+/* The bit buffer is 64-bit and a refill only fires below the watermark, so a
+ * lane holds at most (watermark - 1) + packet bits at any instant. This is the
+ * bound the shift in the refill is safe under: shifting a 32-bit packet left
+ * by up to 31 places touches bit 62 at the highest. */
+constexpr uint32_t kGDeflateMaxLaneBits =
+    kGDeflateLowWatermarkBits - 1 + kGDeflateBitsPerPacket;
+static_assert(kGDeflateMaxLaneBits < 64,
+              "the lane bit buffer is 64-bit; a refill at the watermark must "
+              "not shift a packet off the top of it");
+
+/* The widest single read the format asks for is the 16-bit stored-block LEN
+ * (dossier 11.3). The ceiling here is not that number: it is the watermark,
+ * because a read wider than a lane sitting exactly at the watermark could not
+ * be satisfied on a well-formed page, which would make it a caller bug rather
+ * than bad input. */
+constexpr uint32_t kGDeflateMaxPopBits = kGDeflateLowWatermarkBits;
+
+/* The 32 lane bit buffers, the current lane, and the one shared word cursor.
+ * The failure flag is sticky: once set, every operation is a no-op, so a
+ * caller that checks it once at the end reads the same verdict as one that
+ * checks after every call. */
+struct GDeflateSchedule {
+    uint64_t bitbuf[kGDeflateNumStreams];
+    uint32_t bitsleft[kGDeflateNumStreams];
+    uint32_t idx;
+    uint64_t cursor;
+    uint64_t word_count;
+    bool failed;
+};
+
+/* Little-endian, byte by byte, for the reason every other parser in this tree
+ * reads its integers this way: the page is a byte buffer with no alignment
+ * guarantee, and a cast through a uint32_t pointer would be undefined on the
+ * host and differently undefined on the device. */
+CUDEC_HOST_DEVICE inline uint32_t GDeflateWordAt(const unsigned char* page,
+                                                 uint64_t word_index) {
+    const unsigned char* p = page + word_index * 4u;
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) |
+           (static_cast<uint32_t>(p[3]) << 24);
+}
+
+/* Refill the CURRENT lane if it has fallen below the watermark. Consumes at
+ * most one word and never runs past the page. */
+CUDEC_HOST_DEVICE inline void GDeflateEnsure(GDeflateSchedule& s,
+                                             const unsigned char* page) {
+    if (s.failed) {
+        return;
+    }
+    if (s.bitsleft[s.idx] >= kGDeflateLowWatermarkBits) {
+        return;
+    }
+    if (s.cursor >= s.word_count) {
+        /* The page has no word left to give this lane. A well-formed page
+         * cannot reach here, so this is a refusal and not a tail case: a
+         * decoder that carried on with a short buffer would be reading the
+         * lane's stale bits as if the stream had supplied them. */
+        s.failed = true;
+        return;
+    }
+    s.bitbuf[s.idx] |= static_cast<uint64_t>(GDeflateWordAt(page, s.cursor))
+                       << s.bitsleft[s.idx];
+    s.cursor += 1;
+    s.bitsleft[s.idx] += kGDeflateBitsPerPacket;
+}
+
+/* Ensure the current lane, then rotate. This order IS the schedule: the word a
+ * lane takes is the one at the cursor while that lane is still current. */
+CUDEC_HOST_DEVICE inline void GDeflateAdvance(GDeflateSchedule& s,
+                                              const unsigned char* page) {
+    if (s.failed) {
+        return;
+    }
+    GDeflateEnsure(s, page);
+    if (s.failed) {
+        return;
+    }
+    s.idx = (s.idx + 1u) % kGDeflateNumStreams;
+}
+
+/* Back to lane 0 without consuming anything. Every block header rides lane 0,
+ * so this is what starts a block rather than a round of its own. Guarded like
+ * everything else, so "once failed, nothing moves" is literally true rather
+ * than true of the parts a caller happens to look at. */
+CUDEC_HOST_DEVICE inline void GDeflateReset(GDeflateSchedule& s) {
+    if (s.failed) {
+        return;
+    }
+    s.idx = 0;
+}
+
+/* The priming round: one word into each lane, in lane order, leaving the
+ * cursor at word 32 and the current lane back at 0. Returns false and leaves
+ * the schedule failed if the page cannot carry it. */
+CUDEC_HOST_DEVICE inline bool GDeflateInit(GDeflateSchedule& s,
+                                           const unsigned char* page,
+                                           uint64_t page_bytes) {
+    for (uint32_t n = 0; n < kGDeflateNumStreams; ++n) {
+        s.bitbuf[n] = 0;
+        s.bitsleft[n] = 0;
+    }
+    s.idx = 0;
+    s.cursor = 0;
+    s.failed = false;
+    s.word_count = page_bytes / 4u;
+    /* Whole words only. A trailing partial word is not a word this schedule
+     * could hand a lane, and rounding down would leave those bytes reachable
+     * by nothing while the page still claimed them. */
+    if (page_bytes % 4u != 0u) {
+        s.failed = true;
+        return false;
+    }
+    if (s.word_count < kGDeflateNumStreams) {
+        /* Draft section 5.3: the first round always loads 32 consecutive
+         * words, so a stream below 128 bytes cannot be valid. Refused here
+         * rather than discovered part-way through the priming round. */
+        s.failed = true;
+        return false;
+    }
+    for (uint32_t n = 0; n < kGDeflateNumStreams; ++n) {
+        GDeflateAdvance(s, page);
+    }
+    return !s.failed;
+}
+
+/* Read n bits from the current lane without removing them. The width bound is
+ * not a policy: a shift of 64 or more is undefined, and this is a const read
+ * with no failure flag to set, so the only fail-closed answer available here
+ * is to hand back nothing. A caller reaching this is asking for a width the
+ * format has no field for, and the Remove that follows a peek carries the
+ * refusal that stops it going further. */
+CUDEC_HOST_DEVICE inline uint32_t GDeflatePeek(const GDeflateSchedule& s,
+                                               uint32_t n) {
+    if (n == 0 || n > kGDeflateMaxPopBits) {
+        return 0;
+    }
+    return static_cast<uint32_t>(s.bitbuf[s.idx] &
+                                 ((static_cast<uint64_t>(1) << n) - 1));
+}
+
+/* Remove n bits from the current lane. Refuses rather than underflowing: the
+ * occupancy is unsigned, so an unchecked subtraction would wrap to a lane that
+ * appears to hold four billion bits. */
+CUDEC_HOST_DEVICE inline void GDeflateRemove(GDeflateSchedule& s, uint32_t n) {
+    if (s.failed) {
+        return;
+    }
+    if (n > s.bitsleft[s.idx]) {
+        s.failed = true;
+        return;
+    }
+    s.bitbuf[s.idx] >>= n;
+    s.bitsleft[s.idx] -= n;
+}
+
+/* Peek and remove. No refill: refills belong to Advance, and a read that
+ * quietly topped a lane up would move a word at a point the format does not,
+ * which is precisely the off-by-one this header exists to prevent. */
+CUDEC_HOST_DEVICE inline uint32_t GDeflatePop(GDeflateSchedule& s, uint32_t n) {
+    if (s.failed) {
+        return 0;
+    }
+    if (n > kGDeflateMaxPopBits || n > s.bitsleft[s.idx]) {
+        s.failed = true;
+        return 0;
+    }
+    const uint32_t value = GDeflatePeek(s, n);
+    GDeflateRemove(s, n);
+    return value;
+}
+
+/* The sum of every lane's occupancy. The reference computes exactly this to
+ * bound a stored block's declared length against the bytes still reachable, so
+ * it is part of the schedule's surface rather than a test helper. */
+CUDEC_HOST_DEVICE inline uint64_t GDeflateBufferedBits(
+    const GDeflateSchedule& s) {
+    uint64_t total = 0;
+    for (uint32_t n = 0; n < kGDeflateNumStreams; ++n) {
+        total += s.bitsleft[n];
+    }
+    return total;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_GDEFLATE_SCHEDULE_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -261,6 +261,15 @@ cudec_add_test(oracle_gdeflate SOURCES oracle_gdeflate.cpp LIBS
 # device.
 cudec_add_test(gdeflate_probes SOURCES gdeflate_probes.cpp LIBS
                gdeflate_oracle)
+# The GDeflate round/refill schedule (issue #178), the first rung of the M4
+# substream machine. GPU-less because the schedule is pure arithmetic over a
+# byte range and the CPU twin is the only place it is testable before a kernel
+# exists; it links gdeflate_oracle alone for the reason oracle_gdeflate gives
+# above, and it reaches src/ for the header under test.
+cudec_add_test(gdeflate_schedule_twin SOURCES gdeflate_schedule_twin.cpp LIBS
+               gdeflate_oracle)
+target_include_directories(gdeflate_schedule_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 # The reference's own decode behaviours, executed rather than read (issue
 # #155). Host-side and GPU-less on purpose: it is the oracle answering, and
 # the answers are what the M3 fail-closed matrix is allowed to lock against.

--- a/tests/gdeflate_schedule_twin.cpp
+++ b/tests/gdeflate_schedule_twin.cpp
@@ -1,0 +1,636 @@
+/* The GDeflate round/refill schedule under test (issue #178). Three things
+ * are asked of src/gdeflate_schedule.h and each has its own section below:
+ * that the priming round loads one word into each of the 32 lanes in lane
+ * order, that the three off-by-one traps around a refill are answered the way
+ * the format answers them, and that a real page emitted by the reference is
+ * walked word for word with nothing skipped and nothing taken twice.
+ *
+ * WHY A STORED-BLOCK CORPUS IS THE TRACE, AND WHAT THAT DOES AND DOES NOT
+ * REACH. A GDeflate stored block is the one block type whose whole body is
+ * readable through the schedule alone - a 16-bit length and then one 8-bit
+ * literal per round, with no Huffman table anywhere (dossier 11.3). So a page
+ * of stored blocks can be decoded here end to end, byte-compared against the
+ * reference's own output, and checked to land exactly on the page's last word.
+ * That is a full trace of the cursor over a real corpus, and it is a corpus of
+ * one block type. Dynamic and static pages are walked only as far as their
+ * header round, because reading further needs the code-length decode (#176)
+ * and the symbol tables (#182); the byte parity that covers them is #182's
+ * acceptance test, and it fails exactly when this schedule is wrong.
+ *
+ * The reference is the pinned NVIDIA/libdeflate fork, reached through its
+ * public API only - nothing here reads its internals, and no claim below rests
+ * on its source. */
+#include "gdeflate_schedule.h"
+#include "require.h"
+
+#include <libdeflate.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+using cudec_detail::GDeflateAdvance;
+using cudec_detail::GDeflateBufferedBits;
+using cudec_detail::GDeflateEnsure;
+using cudec_detail::GDeflateInit;
+using cudec_detail::GDeflatePop;
+using cudec_detail::GDeflateReset;
+using cudec_detail::GDeflateSchedule;
+using cudec_detail::kGDeflateBitsPerPacket;
+using cudec_detail::kGDeflateLowWatermarkBits;
+using cudec_detail::kGDeflateNumStreams;
+
+constexpr uint32_t kMinStreamBytes = kGDeflateNumStreams * 4;
+
+/* A deterministic byte source. Not std::rand: every claim below is a
+ * comparison against the reference, and a comparison is only evidence if the
+ * bytes are the same on every machine and every run. */
+class Lcg {
+  public:
+    explicit Lcg(uint32_t seed) : state_(seed) {}
+    uint32_t Next() {
+        state_ = state_ * 1103515245u + 12345u;
+        return state_ >> 8;
+    }
+    unsigned char NextByte() { return static_cast<unsigned char>(Next()); }
+
+  private:
+    uint32_t state_;
+};
+
+/* A word buffer whose contents identify their own index, so a lane holding
+ * the wrong word says which one it took. */
+std::vector<unsigned char> IndexedWords(uint32_t count) {
+    std::vector<unsigned char> bytes(static_cast<size_t>(count) * 4);
+    for (uint32_t i = 0; i < count; ++i) {
+        const uint32_t w = 0xA5000000u | i;
+        bytes[i * 4 + 0] = static_cast<unsigned char>(w);
+        bytes[i * 4 + 1] = static_cast<unsigned char>(w >> 8);
+        bytes[i * 4 + 2] = static_cast<unsigned char>(w >> 16);
+        bytes[i * 4 + 3] = static_cast<unsigned char>(w >> 24);
+    }
+    return bytes;
+}
+
+/* ---- 1. The priming round ---- */
+
+int PrimingRound() {
+    const std::vector<unsigned char> page = IndexedWords(64);
+    GDeflateSchedule s;
+    REQUIRE(GDeflateInit(s, page.data(), page.size()));
+
+    /* One word each, in lane order, and the cursor left immediately after
+     * them. This is the whole of "lane order" as an executed statement: lane i
+     * holds word i and nothing else. */
+    REQUIRE(s.cursor == kGDeflateNumStreams);
+    REQUIRE(s.idx == 0);
+    for (uint32_t n = 0; n < kGDeflateNumStreams; ++n) {
+        REQUIRE_CTX(s.bitsleft[n] == kGDeflateBitsPerPacket, "lane %u", n);
+        REQUIRE_CTX(s.bitbuf[n] == (0xA5000000u | n), "lane %u holds %llx", n,
+                    static_cast<unsigned long long>(s.bitbuf[n]));
+    }
+    REQUIRE(GDeflateBufferedBits(s) ==
+            static_cast<uint64_t>(kGDeflateNumStreams) * kGDeflateBitsPerPacket);
+
+    /* Draft section 5.3: 128 bytes is the floor because the priming round
+     * needs 32 words. One word short is refused, and refused before any lane
+     * is primed rather than part-way through. */
+    const std::vector<unsigned char> short_page = IndexedWords(31);
+    GDeflateSchedule t;
+    REQUIRE(!GDeflateInit(t, short_page.data(), short_page.size()));
+    REQUIRE(t.failed);
+    REQUIRE(t.cursor == 0);
+
+    const std::vector<unsigned char> exact = IndexedWords(32);
+    REQUIRE(exact.size() == kMinStreamBytes);
+    GDeflateSchedule u;
+    REQUIRE(GDeflateInit(u, exact.data(), exact.size()));
+    REQUIRE(u.cursor == 32);
+
+    /* A trailing partial word is not a word any lane could be handed. */
+    GDeflateSchedule v;
+    REQUIRE(!GDeflateInit(v, page.data(), page.size() - 1));
+    REQUIRE(v.failed);
+    return 0;
+}
+
+/* ---- 2. The three off-by-one traps ---- */
+
+int TrapFirstRoundAfterTheHeader() {
+    /* A block header rides lane 0 and consumes bits without advancing, so the
+     * first refill of the page after the priming round lands on a lane that
+     * already holds a residue. The trap is where the incoming word is placed:
+     * it goes ABOVE the bits still there, not at bit 0. */
+    const std::vector<unsigned char> page = IndexedWords(64);
+    GDeflateSchedule s;
+    REQUIRE(GDeflateInit(s, page.data(), page.size()));
+    GDeflateReset(s);
+
+    const uint32_t bfinal_btype = GDeflatePop(s, 3);
+    REQUIRE(!s.failed);
+    REQUIRE(bfinal_btype == (0xA5000000u & 0x7u));
+    REQUIRE(s.bitsleft[0] == kGDeflateBitsPerPacket - 3);
+
+    GDeflateEnsure(s, page.data());
+    REQUIRE(!s.failed);
+    /* Word 32 is the next unconsumed one, and it is lane 0 that takes it. */
+    REQUIRE(s.cursor == 33);
+    REQUIRE(s.bitsleft[0] == kGDeflateBitsPerPacket - 3 + kGDeflateBitsPerPacket);
+    const uint64_t residue = (0xA5000000u | 0u) >> 3;
+    const uint64_t refilled = static_cast<uint64_t>(0xA5000000u | 32u) << 29;
+    REQUIRE_CTX(s.bitbuf[0] == (residue | refilled), "have %llx want %llx",
+                static_cast<unsigned long long>(s.bitbuf[0]),
+                static_cast<unsigned long long>(residue | refilled));
+    return 0;
+}
+
+int TrapRefillOnAWordBoundary() {
+    /* The watermark is a floor, not a strict one: a lane sitting at exactly 32
+     * bits is satisfied and must NOT take a word. One bit lower and it must.
+     * A `>` where the format has `>=` moves every subsequent word by one and
+     * is invisible in any single round. */
+    const std::vector<unsigned char> page = IndexedWords(64);
+
+    GDeflateSchedule at;
+    REQUIRE(GDeflateInit(at, page.data(), page.size()));
+    REQUIRE(at.bitsleft[0] == kGDeflateLowWatermarkBits);
+    const uint64_t before = at.cursor;
+    GDeflateEnsure(at, page.data());
+    REQUIRE(!at.failed);
+    REQUIRE_CTX(at.cursor == before, "a lane at the watermark took a word");
+
+    GDeflateSchedule below;
+    REQUIRE(GDeflateInit(below, page.data(), page.size()));
+    (void)GDeflatePop(below, 1);
+    REQUIRE(below.bitsleft[0] == kGDeflateLowWatermarkBits - 1);
+    GDeflateEnsure(below, page.data());
+    REQUIRE(!below.failed);
+    REQUIRE_CTX(below.cursor == before + 1,
+                "a lane one bit below the watermark took no word");
+    return 0;
+}
+
+int TrapTheLastWordOfTheStream() {
+    /* The page ends. The refusal is on the refill that has no word left, the
+     * cursor does not move past the end, and the failure is sticky - a caller
+     * that keeps going gets no further consumption and no further bits. */
+    const uint32_t words = 40;
+    const std::vector<unsigned char> page = IndexedWords(words);
+    GDeflateSchedule s;
+    REQUIRE(GDeflateInit(s, page.data(), page.size()));
+
+    /* Drain lane by lane until the page is out of words. Each lane needs four
+     * 8-bit reads before it drops under the watermark, so this walks rounds
+     * rather than jumping to the end. */
+    uint64_t guard = 0;
+    while (!s.failed && guard < 100000) {
+        (void)GDeflatePop(s, 8);
+        GDeflateAdvance(s, page.data());
+        ++guard;
+    }
+    REQUIRE(s.failed);
+    REQUIRE_CTX(s.cursor == words, "stopped at word %llu of %u",
+                static_cast<unsigned long long>(s.cursor), words);
+
+    const uint64_t frozen = s.cursor;
+    GDeflateAdvance(s, page.data());
+    GDeflateEnsure(s, page.data());
+    REQUIRE(GDeflatePop(s, 8) == 0);
+    REQUIRE(s.cursor == frozen);
+    return 0;
+}
+
+int PeekAndRemoveRefuseSeparately() {
+    /* A Huffman codeword is read as peek-then-remove rather than as one read
+     * of a known width, because the width is what the peek decides (#176,
+     * #182). So the remove is reached directly, with a count that came out of
+     * a decode table, and its own guard is the one standing between a table
+     * entry and an occupancy that wraps to four billion bits. */
+    const std::vector<unsigned char> page = IndexedWords(64);
+    GDeflateSchedule s;
+    REQUIRE(GDeflateInit(s, page.data(), page.size()));
+
+    REQUIRE(cudec_detail::GDeflatePeek(s, 0) == 0);
+    REQUIRE(cudec_detail::GDeflatePeek(s, 8) == (0xA5000000u & 0xFFu));
+    cudec_detail::GDeflateRemove(s, 8);
+    REQUIRE(!s.failed);
+    REQUIRE(s.bitsleft[0] == kGDeflateBitsPerPacket - 8);
+
+    const uint32_t held = s.bitsleft[0];
+    cudec_detail::GDeflateRemove(s, held + 1);
+    REQUIRE_CTX(s.failed, "a remove wider than the lane was accepted");
+    REQUIRE_CTX(s.bitsleft[0] == held, "the occupancy moved on a refusal");
+
+    /* And a read wider than the watermark is refused as a caller error rather
+     * than served from a lane that happens to be full. The peek has no flag to
+     * set, so it answers with nothing; the pop refuses outright. */
+    GDeflateSchedule t;
+    REQUIRE(GDeflateInit(t, page.data(), page.size()));
+    REQUIRE(cudec_detail::GDeflatePeek(t, cudec_detail::kGDeflateMaxPopBits) !=
+            0);
+    REQUIRE(cudec_detail::GDeflatePeek(
+                t, cudec_detail::kGDeflateMaxPopBits + 1) == 0);
+    REQUIRE(cudec_detail::GDeflatePeek(t, 64) == 0);
+    REQUIRE(!t.failed);
+
+    /* The width bound has to be tested on a lane that COULD have served the
+     * read, or the occupancy check answers first and the bound is never
+     * reached. A lane past a refill holds up to 63 bits, and a 33-bit read out
+     * of it would come back through a 32-bit return value with its top bit
+     * silently gone - which is why the refusal is on the width and not only on
+     * the occupancy. */
+    (void)GDeflatePop(t, 3);
+    GDeflateEnsure(t, page.data());
+    REQUIRE(!t.failed);
+    REQUIRE(t.bitsleft[0] > cudec_detail::kGDeflateMaxPopBits);
+    REQUIRE(GDeflatePop(t, cudec_detail::kGDeflateMaxPopBits + 1) == 0);
+    REQUIRE_CTX(t.failed, "a read wider than the field bound was served");
+
+    /* Once failed, nothing moves - the lane index included, which is the one
+     * piece of state a caller could otherwise steer after a refusal. The lane
+     * is moved off zero first, or the assertion would hold whether or not the
+     * reset was guarded. */
+    GDeflateSchedule f;
+    REQUIRE(GDeflateInit(f, page.data(), page.size()));
+    GDeflateAdvance(f, page.data());
+    REQUIRE(f.idx == 1);
+    (void)GDeflatePop(f, kGDeflateLowWatermarkBits + 1);
+    REQUIRE(f.failed);
+    GDeflateReset(f);
+    REQUIRE_CTX(f.idx == 1, "the lane index moved after a refusal");
+    return 0;
+}
+
+int InitRefusesBeforeItReads() {
+    /* An empty candidate range is refused on its declared size, before a byte
+     * of it is touched: nothing here is ever sized from the stream, so a page
+     * that cannot carry the priming round is answered from the size alone. */
+    GDeflateSchedule s;
+    REQUIRE(!GDeflateInit(s, nullptr, 0));
+    REQUIRE(s.failed);
+    REQUIRE(s.cursor == 0);
+    return 0;
+}
+
+/* ---- 3. The property test ---- */
+
+/* Walk a randomised stream with randomised read widths and check the
+ * invariants after every single operation rather than at the end: the lane
+ * index cycles 0..31 in order, the cursor moves by at most one word per
+ * advance and never backwards, a lane never holds more than the buffer's
+ * bound, and no bit sits at or above the occupancy the lane reports. */
+int PropertyOverRandomStreams() {
+    for (uint32_t seed = 1; seed <= 64; ++seed) {
+        Lcg rng(seed);
+        const uint32_t words = kGDeflateNumStreams + (rng.Next() % 400);
+        std::vector<unsigned char> page(static_cast<size_t>(words) * 4);
+        for (size_t i = 0; i < page.size(); ++i) {
+            page[i] = rng.NextByte();
+        }
+
+        GDeflateSchedule s;
+        REQUIRE_CTX(GDeflateInit(s, page.data(), page.size()), "seed %u", seed);
+
+        /* One mark per word, so "consumed twice" and "skipped" are checked
+         * against the page rather than inferred from a counter. */
+        std::vector<unsigned char> taken(words, 0);
+        for (uint64_t w = 0; w < s.cursor; ++w) {
+            taken[static_cast<size_t>(w)] = 1;
+        }
+
+        uint32_t expected_idx = 0;
+        uint64_t steps = 0;
+        while (!s.failed && steps < 200000) {
+            const uint32_t width = 1 + (rng.Next() % kGDeflateLowWatermarkBits);
+            if (width <= s.bitsleft[s.idx]) {
+                (void)GDeflatePop(s, width);
+                REQUIRE_CTX(!s.failed, "seed %u: a satisfiable read refused",
+                            seed);
+            }
+            const uint64_t before = s.cursor;
+            const uint32_t lane = s.idx;
+            GDeflateAdvance(s, page.data());
+            if (s.failed) {
+                break;
+            }
+
+            REQUIRE_CTX(s.cursor >= before && s.cursor <= before + 1,
+                        "seed %u: the cursor moved %llu words in one round",
+                        seed,
+                        static_cast<unsigned long long>(s.cursor - before));
+            if (s.cursor == before + 1) {
+                const size_t w = static_cast<size_t>(before);
+                REQUIRE_CTX(!taken[w], "seed %u: word %zu taken twice", seed, w);
+                taken[w] = 1;
+                REQUIRE_CTX(s.bitsleft[lane] >= kGDeflateLowWatermarkBits,
+                            "seed %u: lane %u refilled and is still short",
+                            seed, lane);
+            } else {
+                REQUIRE_CTX(s.bitsleft[lane] >= kGDeflateLowWatermarkBits,
+                            "seed %u: lane %u took no word while short", seed,
+                            lane);
+            }
+            expected_idx = (expected_idx + 1) % kGDeflateNumStreams;
+            REQUIRE_CTX(s.idx == expected_idx, "seed %u: lane order broke",
+                        seed);
+
+            for (uint32_t n = 0; n < kGDeflateNumStreams; ++n) {
+                REQUIRE_CTX(s.bitsleft[n] <= cudec_detail::kGDeflateMaxLaneBits,
+                            "seed %u: lane %u holds %u bits", seed, n,
+                            s.bitsleft[n]);
+                const uint32_t held = s.bitsleft[n];
+                const uint64_t above =
+                    held >= 64 ? 0 : (s.bitbuf[n] >> held);
+                REQUIRE_CTX(above == 0,
+                            "seed %u: lane %u carries bits above its occupancy",
+                            seed, n);
+            }
+            ++steps;
+        }
+
+        /* The run ends when the page runs out, and the page runs out exactly
+         * once: every word is marked and the cursor is at the end. */
+        REQUIRE_CTX(s.failed, "seed %u: the walk never reached the end", seed);
+        REQUIRE_CTX(s.cursor == words, "seed %u: stopped at %llu of %u", seed,
+                    static_cast<unsigned long long>(s.cursor), words);
+        for (uint32_t w = 0; w < words; ++w) {
+            REQUIRE_CTX(taken[w], "seed %u: word %u was never consumed", seed,
+                        w);
+        }
+    }
+    return 0;
+}
+
+/* ---- 4. The oracle-anchored trace ---- */
+
+/* Perturbations of the schedule state, injected between operations rather than
+ * by reimplementing them. Each is a one-word or one-lane error of the kind the
+ * traps above are about, and the trace below has to catch every one of them -
+ * otherwise the trace is decoration. */
+enum class Defect { kNone, kSkipOneWord, kOneLaneAhead, kRefillEarly };
+
+/* Decode a stored-block page through the schedule alone and report the bytes.
+ * Returns false if the schedule refused or the page was not what it claimed. */
+bool WalkStoredPage(const unsigned char* page, size_t page_bytes,
+                    Defect defect, std::vector<unsigned char>& out,
+                    uint64_t& words_consumed) {
+    GDeflateSchedule s;
+    if (!GDeflateInit(s, page, page_bytes)) {
+        return false;
+    }
+    if (defect == Defect::kSkipOneWord) {
+        s.cursor += 1;
+    } else if (defect == Defect::kOneLaneAhead) {
+        s.idx = 1;
+    }
+
+    for (;;) {
+        GDeflateReset(s);
+        if (defect == Defect::kOneLaneAhead) {
+            s.idx = 1;
+        }
+        const uint32_t is_final = GDeflatePop(s, 1);
+        const uint32_t block_type = GDeflatePop(s, 2);
+        GDeflateEnsure(s, page);
+        if (s.failed || block_type != 0) {
+            return false;
+        }
+        const uint32_t len = GDeflatePop(s, 16);
+        if (s.failed) {
+            return false;
+        }
+        if (defect == Defect::kRefillEarly) {
+            s.bitsleft[s.idx] = kGDeflateLowWatermarkBits - 1;
+            GDeflateEnsure(s, page);
+        }
+        for (uint32_t i = 0; i < len; ++i) {
+            out.push_back(static_cast<unsigned char>(GDeflatePop(s, 8)));
+            GDeflateAdvance(s, page);
+            if (s.failed) {
+                return false;
+            }
+        }
+        /* The reference closes a block by walking all 32 lanes once, which is
+         * where the deferred copies are run. There are none in a stored block,
+         * but the round still happens and the words it takes are part of the
+         * page. */
+        for (uint32_t n = 0; n < kGDeflateNumStreams; ++n) {
+            GDeflateAdvance(s, page);
+            if (s.failed) {
+                return false;
+            }
+        }
+        if (is_final) {
+            break;
+        }
+    }
+    words_consumed = s.cursor;
+    return true;
+}
+
+struct Compressed {
+    std::vector<unsigned char> bytes;
+    std::vector<size_t> page_sizes;
+};
+
+bool CompressPages(int level, const std::vector<unsigned char>& in,
+                   Compressed& out) {
+    libdeflate_gdeflate_compressor* c = libdeflate_alloc_gdeflate_compressor(level);
+    if (c == nullptr) {
+        return false;
+    }
+    size_t npages = 0;
+    const size_t bound = libdeflate_gdeflate_compress_bound(c, in.size(), &npages);
+    if (npages == 0) {
+        libdeflate_free_gdeflate_compressor(c);
+        return false;
+    }
+    std::vector<unsigned char> buf(bound);
+    std::vector<libdeflate_gdeflate_out_page> pages(npages);
+    const size_t per = bound / npages;
+    for (size_t i = 0; i < npages; ++i) {
+        pages[i].data = buf.data() + i * per;
+        pages[i].nbytes = per;
+    }
+    const size_t total = libdeflate_gdeflate_compress(c, in.data(), in.size(),
+                                                      pages.data(), npages);
+    libdeflate_free_gdeflate_compressor(c);
+    if (total == 0) {
+        return false;
+    }
+    out.bytes.clear();
+    out.page_sizes.clear();
+    for (size_t i = 0; i < npages; ++i) {
+        const unsigned char* p = static_cast<const unsigned char*>(pages[i].data);
+        out.bytes.insert(out.bytes.end(), p, p + pages[i].nbytes);
+        out.page_sizes.push_back(pages[i].nbytes);
+    }
+    return true;
+}
+
+int TraceStoredPagesAgainstTheOracle() {
+    /* Level 0 forces stored blocks out of the reference compressor, which is
+     * the one block type the schedule can decode without a table. */
+    const size_t sizes[] = {1, 37, 1024, 4096, 65536, 70000};
+    for (size_t si = 0; si < sizeof(sizes) / sizeof(sizes[0]); ++si) {
+        Lcg rng(static_cast<uint32_t>(9000 + sizes[si]));
+        std::vector<unsigned char> in(sizes[si]);
+        for (size_t i = 0; i < in.size(); ++i) {
+            in[i] = rng.NextByte();
+        }
+
+        Compressed c;
+        REQUIRE_CTX(CompressPages(0, in, c), "size %zu did not compress",
+                    sizes[si]);
+
+        std::vector<unsigned char> decoded;
+        size_t off = 0;
+        for (size_t p = 0; p < c.page_sizes.size(); ++p) {
+            const unsigned char* page = c.bytes.data() + off;
+            const size_t bytes = c.page_sizes[p];
+            off += bytes;
+
+            uint64_t words = 0;
+            std::vector<unsigned char> page_out;
+            REQUIRE_CTX(WalkStoredPage(page, bytes, Defect::kNone, page_out,
+                                       words),
+                        "size %zu page %zu: the walk refused", sizes[si], p);
+            /* Nothing skipped and nothing left: the walk ends on the page's
+             * last word, which is the cursor claim this issue is about. */
+            REQUIRE_CTX(words == bytes / 4,
+                        "size %zu page %zu: consumed %llu of %zu words",
+                        sizes[si], p, static_cast<unsigned long long>(words),
+                        bytes / 4);
+            decoded.insert(decoded.end(), page_out.begin(), page_out.end());
+        }
+
+        REQUIRE_CTX(decoded.size() == in.size(), "size %zu: produced %zu bytes",
+                    sizes[si], decoded.size());
+        REQUIRE_CTX(equal_bytes(decoded.data(), in.data(), in.size()),
+                    "size %zu: byte divergence", sizes[si]);
+
+        /* And the reference agrees the stream is what it looks like, so the
+         * comparison above is against a page the oracle also accepts. */
+        libdeflate_gdeflate_decompressor* d =
+            libdeflate_alloc_gdeflate_decompressor();
+        REQUIRE(d != nullptr);
+        std::vector<libdeflate_gdeflate_in_page> in_pages(c.page_sizes.size());
+        off = 0;
+        for (size_t p = 0; p < c.page_sizes.size(); ++p) {
+            in_pages[p].data = c.bytes.data() + off;
+            in_pages[p].nbytes = c.page_sizes[p];
+            off += c.page_sizes[p];
+        }
+        std::vector<unsigned char> ref(in.size());
+        size_t got = 0;
+        const libdeflate_result r = libdeflate_gdeflate_decompress(
+            d, in_pages.data(), in_pages.size(), ref.data(), ref.size(), &got);
+        libdeflate_free_gdeflate_decompressor(d);
+        REQUIRE_CTX(r == LIBDEFLATE_SUCCESS, "size %zu: oracle refused",
+                    sizes[si]);
+        REQUIRE(got == in.size());
+        REQUIRE_CTX(equal_bytes(decoded.data(), ref.data(), ref.size()),
+                    "size %zu: divergence from the oracle", sizes[si]);
+    }
+    return 0;
+}
+
+int TheTraceBitesOnEveryPerturbation() {
+    Lcg rng(4242);
+    std::vector<unsigned char> in(8192);
+    for (size_t i = 0; i < in.size(); ++i) {
+        in[i] = rng.NextByte();
+    }
+    Compressed c;
+    REQUIRE(CompressPages(0, in, c));
+    REQUIRE(c.page_sizes.size() == 1);
+
+    const Defect defects[] = {Defect::kSkipOneWord, Defect::kOneLaneAhead,
+                              Defect::kRefillEarly};
+    for (size_t i = 0; i < sizeof(defects) / sizeof(defects[0]); ++i) {
+        uint64_t words = 0;
+        std::vector<unsigned char> out;
+        const bool walked = WalkStoredPage(c.bytes.data(), c.page_sizes[0],
+                                           defects[i], out, words);
+        const bool matches = walked && words == c.page_sizes[0] / 4 &&
+                             out.size() == in.size() &&
+                             std::memcmp(out.data(), in.data(), in.size()) == 0;
+        REQUIRE_CTX(!matches, "perturbation %zu produced the right answer",
+                    i);
+    }
+    return 0;
+}
+
+int TheHeaderRoundOnCompressedPages() {
+    /* Compressed pages cannot be walked past their header here, but the header
+     * itself rides lane 0 and is readable. BTYPE 3 is the reserved value the
+     * format never emits, so a page whose header round reads 3 is a page this
+     * schedule opened in the wrong place. */
+    for (int level = 1; level <= 12; ++level) {
+        Lcg rng(static_cast<uint32_t>(500 + level));
+        std::vector<unsigned char> in(60000);
+        for (size_t i = 0; i < in.size(); ++i) {
+            /* Compressible, so the compressor reaches for a Huffman block. */
+            in[i] = static_cast<unsigned char>(rng.NextByte() & 0x0Fu);
+        }
+        Compressed c;
+        REQUIRE_CTX(CompressPages(level, in, c), "level %d", level);
+
+        size_t off = 0;
+        for (size_t p = 0; p < c.page_sizes.size(); ++p) {
+            GDeflateSchedule s;
+            REQUIRE_CTX(
+                GDeflateInit(s, c.bytes.data() + off, c.page_sizes[p]),
+                "level %d page %zu", level, p);
+            off += c.page_sizes[p];
+            GDeflateReset(s);
+            (void)GDeflatePop(s, 1);
+            const uint32_t block_type = GDeflatePop(s, 2);
+            REQUIRE(!s.failed);
+            REQUIRE_CTX(block_type != 3,
+                        "level %d page %zu: header round read the reserved "
+                        "block type",
+                        level, p);
+        }
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    if (PrimingRound() != 0) {
+        return 1;
+    }
+    if (TrapFirstRoundAfterTheHeader() != 0) {
+        return 1;
+    }
+    if (TrapRefillOnAWordBoundary() != 0) {
+        return 1;
+    }
+    if (TrapTheLastWordOfTheStream() != 0) {
+        return 1;
+    }
+    if (PeekAndRemoveRefuseSeparately() != 0) {
+        return 1;
+    }
+    if (InitRefusesBeforeItReads() != 0) {
+        return 1;
+    }
+    if (PropertyOverRandomStreams() != 0) {
+        return 1;
+    }
+    if (TraceStoredPagesAgainstTheOracle() != 0) {
+        return 1;
+    }
+    if (TheTraceBitesOnEveryPerturbation() != 0) {
+        return 1;
+    }
+    if (TheHeaderRoundOnCompressedPages() != 0) {
+        return 1;
+    }
+    std::printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #178.

GDeflate's 32 substreams carry no markers, the boundaries are not
self-delimiting, and the format carries no checksum anywhere. The only thing
that says where a lane's next word is, is the schedule that put it there, so a
decoder that gets it wrong produces silent corruption rather than a refusal and
nothing downstream catches it. This states that schedule once, in
`src/gdeflate_schedule.h`, as a pure host/device function: the priming round,
the watermark refill, the refill-then-rotate order, and the reset to lane 0 that
starts every block.

Isolating it is what makes it testable before a table or a kernel exists, which
is the ordering the rest of the M4 rungs need: the code-length decode (#176) and
the page decode (#182) both read their bits through this.

Two behaviours are stricter than the reference and both are stated in the
header. A refill with no word left, and a read wider than the lane holds, are
refusals rather than reads of stale bits. Neither is reachable on a well-formed
page: the priming round leaves every lane at exactly the watermark, and every
advance restores any lane that fell below it, so a page that trips either one is
malformed.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Build / CI / supply chain (the new test is registered in both CI jobs)

## Engineering checklist

- [x] Fail-closed preserved. Every refusal in the header has a negative test:
      a stream under 128 bytes, a trailing partial word, an empty range, a
      refill past the last word, a remove wider than the lane, a read wider than
      the field bound, and the sticky-failure property that nothing moves after
      any of them.
- [x] Oracle coverage for the path this touches. The stored-block corpus is
      emitted by the pinned NVIDIA/libdeflate fork and walked end to end through
      the schedule alone, byte-compared both against the input and against the
      reference's own decompressed output.
- [x] Determinism preserved. The schedule is pure arithmetic over a byte range
      with no state outside the struct; the corpus generator is a fixed LCG
      rather than `std::rand`, so a failure reproduces on any machine.
- [ ] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      Not applicable: this change adds no CUDA call and touches no ABI symbol.
- [ ] An adversarial review was run. **It was not.** There was no second reader
      for this change, and the evidence below stands in place of one rather than
      the box being ticked.
- [ ] Review record. None, for the same reason. The mutation table is what this
      change offers instead, and it is weaker than a review in a specific way:
      it proves the tests bite on the defects I thought to write, and says
      nothing about the ones I did not.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. The header compiles
      `__host__ __device__` so a later kernel can include it, but nothing in
      this change is launched, and the new test is host-only and GPU-less.

```
```

The block is left empty rather than removed. Separately, and stated so it is not
read as a smaller thing: no route to a device the sanitizer can attach to was
available for this change either. The container is not reachable on this
machine right now -

```
$ (Get-Service com.docker.service).Status
Stopped
$ docker version --format '{{.Server.Version}}'
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
```

- and starting that service raises an elevation prompt, which is not something
this change takes on its own. #258 records the standing state of that route.

## Performance checklist

Not applicable. No number is claimed anywhere in this change, and none is
measured. The schedule is written for clarity, not for a shape; the layout
question for the device (all 32 lane buffers in one struct here, one per lane in
registers in the kernel) is named in the header and is a kernel-shape decision
this does not take.

## Quality checklist

- [x] Minimal. Eight functions and one struct. The two guards that turned out
      to be unreachable from any test were not deleted and not left unproven:
      each got the test that reaches it, because both are on the path the
      Huffman rungs will take (peek-then-remove with a width that came out of a
      decode table).
- [x] Self-documenting. The header says why the rotate happens after the refill
      and not before, why the watermark is a floor rather than a strict bound,
      and where the schedule is stricter than the reference.
- [x] The structural properties this establishes are locked as tests, not
      argued here.

## Verification

The GPU container is unreachable, so this was verified by building the test and
the pinned oracle by hand with the host toolchain. That is a different route
from `ctest` and is named as such rather than reported as one.

```
$ gcc --version | head -1
gcc.exe (MinGW-W64 x86_64-ucrt-posix-seh, built by Brecht Sanders, r3) 16.1.0

$ g++ -std=c++17 -Wall -Wextra -Werror -O2 \
    -I tests -I src -isystem <gdeflate-src> \
    -o sched tests/gdeflate_schedule_twin.cpp libgdeflate_oracle.a
$ ./sched; echo "exit=$?"
PASS
exit=0
```

- [ ] `cmake --build build` - not run here; there is no CUDA toolchain on this
      machine, and `tests/` is only added to the build under
      `CUDEC_ENABLE_CUDA=ON`. The build job is the gate for it.
- [ ] `ctest --test-dir build` - not run here, for the same reason.
- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.

```
$ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

- [x] Docs synced. Nothing in MASTERPLAN, README or BENCHMARKS describes this:
      no behaviour, API or number moves. The dossier facts this rests on are
      section 11 and are cited in the code rather than restated.

### The guards were proven by removing them

Fourteen one-change mutants of `src/gdeflate_schedule.h`, each built against the
unchanged test and run. A guard that survives is a guard nothing proves.

```
watermark-is-strict                exit=1
rotate-before-refill               exit=1
prime-31-lanes                     exit=1
remove-without-underflow-guard     exit=1
refill-past-the-last-word          exit=1
accept-a-stream-under-128-bytes    exit=1
accept-a-partial-trailing-word     exit=1
refill-placed-at-bit-zero          exit=1
cursor-skips-a-word                exit=1
occupancy-off-by-one               exit=1
reset-ignores-the-lane             exit=1
peek-without-the-width-bound       exit=1
reset-moves-after-a-refusal        exit=1
pop-without-the-width-bound        exit=1
--- clean:
PASS
exit=0
```

Two of those went green on the first pass and are the reason this section is
worth reading rather than skipping. `reset-moves-after-a-refusal` passed because
the assertion behind it compared the lane index against zero on a schedule whose
lane index was already zero, so it held whether or not the reset was guarded.
`pop-without-the-width-bound` passed because the occupancy check answered first:
a 33-bit read was refused for being wider than a 32-bit lane, never for being
wider than the field bound, and the bound it was supposed to prove was never
reached. Both tests were sharpened - the first moves the lane off zero before
failing the schedule, the second asks for 33 bits from a lane holding 61 - and
both mutants then red. A third mutant, masking the refill shift with `& 31`, is
equivalent rather than surviving: a refill only fires below 32, so the mask
cannot change a result, and it was dropped rather than counted.

## Notes

**What this covers and what it does not, stated plainly.** A stored block is the
one block type whose whole body is readable through the schedule alone, so the
trace is a full walk of a real page: every word consumed, none twice, the cursor
landing exactly on the last one, and the bytes matching the reference. That is a
corpus of one block type. Dynamic and static pages are walked only as far as
their header round, where the reserved block type is asserted never to appear,
because reading further needs the code-length decode and the symbol tables.
#178's done-condition asks for the trace over the corpus, so that issue keeps
the remaining half rather than closing on this - the second half arrives with
#182, whose byte parity over the generated corpus fails exactly when this
schedule is wrong.

**Why the cursor is not read out of the reference.** The reference exposes its
word cursor through no public symbol, and it is pinned by hash, so instrumenting
it to report one would mean editing a third-party source this project audits by
hash rather than by reading. The stored-block walk gets the same property from
the outside: the schedule has to consume the page exactly, or the byte
comparison and the end-of-page check disagree.

**The new test is registered in both CI jobs.** The `-LE gpu` selection would
have picked it up on its own; the identity greps are what red if it silently
drops out later, and the sanitize job's three lists are what put the new
untrusted-input arithmetic under ASan and UBSan. That instrumentation has not
run on this machine - MinGW ships no sanitizer runtime here - so CI is where it
first executes.
