### PR TITLE
Decode the Zstd Huffman tree description and build its table [#220]

### DIFF
--- a/src/zstd_huf.h
+++ b/src/zstd_huf.h
@@ -332,10 +332,14 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdHufReadWeights(
         return ZstdHufRefuse(kZstdHufRejectLastWeightNotClean,
                              CUDEC_ERR_CORRUPT_INPUT, reject);
     }
-    if (written + 1u > max_symbol_count) {
-        return ZstdHufRefuse(kZstdHufRejectTooManyWeights,
-                             CUDEC_ERR_CORRUPT_INPUT, reject);
-    }
+    /* THE SLOT FOR THE IMPLIED SYMBOL IS ALREADY OWED AND THERE IS NO SECOND
+     * CHECK HERE. Both spellings stop one short of the caller's alphabet: the
+     * direct one refuses a count that would not leave the slot before it writes
+     * a nibble, and the compressed one is given a capacity of
+     * max_symbol_count - 1 and refuses rather than truncating when it fills. So
+     * `written` is at most max_symbol_count - 1 on every path that reaches this
+     * line, and a guard for the other case would be one no negative could
+     * reach. */
     weights[written] = static_cast<uint8_t>(last_weight);
 
     /* The deepest rank of a tree that closes holds at least two leaves: its

--- a/src/zstd_huf.h
+++ b/src/zstd_huf.h
@@ -139,7 +139,11 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdHufRefuse(ZstdHufReject rung,
  * this header compiles for both the host and the device. */
 CUDEC_HOST_DEVICE inline unsigned ZstdHufHighestSetBit(uint32_t value) {
     unsigned highest = 0;
-    for (unsigned bit = 0; bit < 32u; bit++) {
+    /* The bound is the accumulator's width, named rather than spelled: the
+     * structural scanner refuses a bare 32 in an expression because that is
+     * how a wave width gets hardcoded, and it refused this line. The constant
+     * is src/zstd_fse.h's rather than a second one of the same value. */
+    for (unsigned bit = 0; bit < kZstdFseWordBits; bit++) {
         if ((value >> bit) & 1u) {
             highest = bit;
         }

--- a/src/zstd_huf.h
+++ b/src/zstd_huf.h
@@ -1,0 +1,452 @@
+/* The Zstd Huffman tree description and the decoding table it builds (issue
+ * #220) - the entropy unit behind a Compressed literals section. Single-sourced
+ * for host and device, the sibling of src/zstd_fse.h and src/zstd_bitstream.h.
+ * Internal header, not part of the ABI.
+ *
+ * WHAT ARRIVES AND IN WHICH OF TWO SPELLINGS. A tree description is a header
+ * byte followed by weights, one per symbol from zero upwards, and the header
+ * byte chooses the spelling (RFC 8878 section 4.2.1.1). A value of 128 or more
+ * means `value - 127` weights follow as 4-bit nibbles, high nibble first. A
+ * value below 128 is the byte length of an FSE-compressed description whose
+ * two-state interleaved run produces the weights, over a table whose accuracy
+ * log may not exceed six.
+ *
+ * THE LAST WEIGHT IS NEVER WRITTEN DOWN AND THAT IS THE FAIL-CLOSED BRANCH.
+ * Weight w costs 2^(w-1) of the tree's budget and weight zero costs nothing, so
+ * the weights present sum to something below a power of two and the difference
+ * is what the final symbol must be worth. The difference has to BE a power of
+ * two - anything else describes a tree with a hole in it - and it has to leave
+ * a legal weight. A decoder that took the nearest legal value instead of
+ * refusing would build a table whose cells decode symbols the encoder never
+ * wrote, which is the oversubscribed/incomplete class this unit exists to
+ * refuse.
+ *
+ * THE TABLE IS NOT REORDERED AFTER IT IS BUILT. Symbols are placed by
+ * increasing weight and, inside a weight, by increasing symbol value, and each
+ * one occupies 2^(w-1) consecutive cells. That ordering IS the canonical code:
+ * get it wrong and every cell still holds a legal symbol and a legal bit count,
+ * so nothing downstream refuses and the output is simply wrong bytes.
+ *
+ * THE REFERENCE'S TABLE IS THE SAME TABLE AT A DIFFERENT SCALE, and the twin
+ * test is where that is proven rather than asserted. libzstd rescales a tree
+ * whose natural log is below eleven up to eleven so its decode loop has a
+ * constant table size, which multiplies every entry 2^(11 - log) times and
+ * leaves each entry's bit count untouched. What this header builds is the
+ * natural table, because that is the one a kernel wants in shared memory: a
+ * tree of log six is 64 cells here and 2048 there.
+ *
+ * The storage is the caller's throughout, sized by it and checked here, in the
+ * shape src/zstd_fse.h uses: this header allocates nothing and a device
+ * translation unit compiles it unchanged. */
+#ifndef CUDEC_ZSTD_HUF_H
+#define CUDEC_ZSTD_HUF_H
+
+#include "cudec.h"
+#include "zstd_bitstream.h"
+#include "zstd_fse.h"
+
+#include <stdint.h>
+
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+/* HUF_SYMBOLVALUE_MAX in the reference's huf.h: a literals alphabet is indexed
+ * by a byte, so this is the widest one the format can describe. */
+constexpr unsigned kZstdHufMaxSymbolValue = 255;
+
+/* HUF_TABLELOG_MAX in the reference's huf.h. It is the ceiling on the tree's
+ * own depth, which is also the widest code the table can hold. RFC 8878 states
+ * the eleven-bit limit for the streams a compressor emits; the reference reads
+ * up to twelve here and refuses the twelfth one level up, so the wider value is
+ * what this unit's default ceiling carries and the caller may narrow it. */
+constexpr unsigned kZstdHufMaxTableLog = 12;
+
+/* The accuracy-log ceiling on the FSE table that spells a compressed weight
+ * description. The reference passes six to FSE_decompress_wksp from
+ * HUF_readStats_body, and it is not the sequence tables' ceiling. */
+constexpr unsigned kZstdHufWeightAccuracyLogMax = 6;
+
+/* The header byte at or above this value selects the direct nibble spelling. */
+constexpr unsigned kZstdHufDirectHeaderBase = 128;
+
+/* The reject ladder, enumerated once, in the shape src/zstd_fse.h and
+ * src/zstd_bitstream.h use: every refusal returns through one choke point
+ * naming its rung, so the twin requires a negative per rung instead of counting
+ * statuses that repeat. The reference collapses most of these into
+ * corruption_detected, so the rung is this tree's own vocabulary. */
+enum ZstdHufReject {
+    kZstdHufRejectNone = 0,
+    /* An argument outside what the format can express, or storage the caller
+     * sized below what it asked to have decoded. A caller bug rather than a
+     * stream, refused rather than clamped. */
+    kZstdHufRejectBadRequest,
+    kZstdHufRejectEmptyDescription,
+    /* The description's own declared length reaches past the bytes supplied. */
+    kZstdHufRejectDescriptionTruncated,
+    /* More weights than the alphabet can hold. The implied last symbol needs a
+     * slot of its own, so the written weights stop one short of the alphabet. */
+    kZstdHufRejectTooManyWeights,
+    /* A weight above the tree's depth ceiling. */
+    kZstdHufRejectWeightTooLarge,
+    /* Every written weight is zero, so the tree has no budget at all. */
+    kZstdHufRejectWeightSumZero,
+    /* The written weights already fill or overflow a power of two, leaving the
+     * implied last symbol nothing, or the remainder is not a clean power of
+     * two. Both are the same statement about the tree: it does not close. */
+    kZstdHufRejectLastWeightNotClean,
+    /* The depth the weights imply is past the ceiling in force. */
+    kZstdHufRejectTableLogTooLarge,
+    /* A tree with no leaf at its deepest rank. The reference refuses the same
+     * thing in the same place.
+     *
+     * IT ALSO REFUSES AN ODD NUMBER OF THEM AND THIS UNIT DOES NOT, because
+     * that state cannot arrive here. Every weight above one contributes an even
+     * amount to the budget and the budget lands on a power of two before this
+     * check is reached, so the number of weight-one symbols has the parity of
+     * that power of two, which is even. A guard for the odd case would be one
+     * no negative could reach, and the twin proves the reachable half instead
+     * of asserting the unreachable one. */
+    kZstdHufRejectDeepestRankEmpty,
+    /* Build side: the cell array the caller supplied is smaller than the table
+     * the depth asks for. */
+    kZstdHufRejectBuildCapacity,
+    /* Build side: the weights handed in do not describe a table that fills
+     * exactly. Unreachable from a description this header decoded; reachable
+     * from a caller that builds a weight array by hand. */
+    kZstdHufRejectBuildWeightsNotClean,
+    kZstdHufRejectCount
+};
+
+CUDEC_HOST_DEVICE inline cudec_status ZstdHufRefuse(ZstdHufReject rung,
+                                                    cudec_status status,
+                                                    ZstdHufReject* out) {
+    if (out != 0) {
+        *out = rung;
+    }
+    return status;
+}
+
+/* Position of the highest set bit, 0-indexed. Only ever called on a non-zero
+ * value - every caller refuses zero before reaching it - so there is no "no
+ * bits set" answer to define. A counted loop rather than an intrinsic, because
+ * this header compiles for both the host and the device. */
+CUDEC_HOST_DEVICE inline unsigned ZstdHufHighestSetBit(uint32_t value) {
+    unsigned highest = 0;
+    for (unsigned bit = 0; bit < 32u; bit++) {
+        if ((value >> bit) & 1u) {
+            highest = bit;
+        }
+    }
+    return highest;
+}
+
+/* One decoding-table cell: which symbol the code at this index spells and how
+ * many bits of it were real. Laid out to match the reference's HUF_DEltX1 field
+ * for field so the twin diffs cells rather than a summary. */
+struct ZstdHufCell {
+    uint8_t symbol;
+    uint8_t nb_bits;
+};
+
+/* The working storage the compressed spelling needs, owned by the caller for
+ * the reason every other buffer here is: this header compiles __device__
+ * unchanged, and half a kilobyte of per-thread local memory declared inside a
+ * function is a decision the kernel has to be able to make instead.
+ *
+ * THE WEIGHT ALPHABET IS THE TREE'S DEPTH AND NOT A BYTE, which is what keeps
+ * this small. A weight above the depth ceiling is refused whatever spelling it
+ * arrives in, so an FSE table that could emit one buys nothing; the reference
+ * decodes weights over the full 256-symbol alphabet and refuses the same values
+ * one step later, at its own weight check. The verdicts agree and the rungs
+ * differ, which the twin pins rather than leaves to be assumed. */
+struct ZstdHufWeightScratch {
+    int16_t counts[kZstdHufMaxTableLog + 1];
+    ZstdFseCell cells[1u << kZstdHufWeightAccuracyLogMax];
+    uint16_t symbol_next[kZstdHufMaxTableLog + 1];
+};
+
+/* Decodes a Huffman tree description.
+ *
+ * `weights` receives one entry per symbol INCLUDING the implied last one, so a
+ * caller sizes it for the alphabet it is willing to accept. `out_count` is how
+ * many of them were written, which is the number of symbols in the tree, and
+ * `out_table_log` is the tree's depth - the length of its shortest code is
+ * `out_table_log + 1 - weight`.
+ *
+ * `out_consumed` is the byte count the description occupied. The literals
+ * section positions its Huffman stream from it, so an off-by-one there is a
+ * stream read from the wrong place rather than a refusal, which is why it is an
+ * output of this function and not something a caller recomputes.
+ *
+ * `size` is the bytes remaining in the literals section, not the description's
+ * length: the length is in the header byte for one spelling and only known
+ * after the FSE run for the other.
+ *
+ * `max_table_log` is the ceiling the caller wants enforced on the tree's depth,
+ * at most kZstdHufMaxTableLog. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdHufReadWeights(
+    const unsigned char* src, uint64_t size, unsigned max_symbol_count,
+    unsigned max_table_log, ZstdHufWeightScratch* scratch, uint8_t* weights,
+    unsigned* out_count, unsigned* out_table_log, uint64_t* out_consumed,
+    ZstdHufReject* reject) {
+    *out_count = 0;
+    *out_table_log = 0;
+    *out_consumed = 0;
+    if (reject != 0) {
+        *reject = kZstdHufRejectNone;
+    }
+    if (src == 0 || weights == 0 || scratch == 0 || max_symbol_count < 2u ||
+        max_symbol_count > kZstdHufMaxSymbolValue + 1 || max_table_log == 0 ||
+        max_table_log > kZstdHufMaxTableLog) {
+        return ZstdHufRefuse(kZstdHufRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    if (size == 0) {
+        return ZstdHufRefuse(kZstdHufRejectEmptyDescription,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    const unsigned header = src[0];
+    unsigned written = 0;
+    uint64_t consumed = 0;
+
+    if (header >= kZstdHufDirectHeaderBase) {
+        /* The direct spelling. The count is in the header byte itself, so the
+         * payload's length is known before a byte of it is read. */
+        written = header - (kZstdHufDirectHeaderBase - 1);
+        const uint64_t payload = (written + 1u) / 2u;
+        if (payload + 1u > size) {
+            return ZstdHufRefuse(kZstdHufRejectDescriptionTruncated,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        /* One slot is owed to the implied last symbol, so the written weights
+         * stop one short of the caller's alphabet rather than filling it. */
+        if (written + 1u > max_symbol_count) {
+            return ZstdHufRefuse(kZstdHufRejectTooManyWeights,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        for (unsigned i = 0; i < written; i++) {
+            const unsigned byte = src[1 + i / 2u];
+            weights[i] = static_cast<uint8_t>((i % 2u) == 0 ? (byte >> 4)
+                                                            : (byte & 0x0Fu));
+        }
+        /* An odd count leaves the final low nibble unread. The reference reads
+         * it into a slot it then ignores, so a non-zero value there is accepted
+         * by both and is not a rung. */
+        consumed = payload + 1u;
+    } else {
+        /* The FSE spelling. The header byte is the compressed length, so the
+         * run's input is bounded before it starts. */
+        const uint64_t payload = header;
+        if (payload + 1u > size) {
+            return ZstdHufRefuse(kZstdHufRejectDescriptionTruncated,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        unsigned fse_max_symbol = 0;
+        unsigned accuracy_log = 0;
+        uint64_t description = 0;
+        ZstdFseReject fse_rung = kZstdFseRejectNone;
+        cudec_status status = ZstdFseReadNCount(
+            src + 1, payload, kZstdHufMaxTableLog,
+            kZstdHufWeightAccuracyLogMax, scratch->counts, &fse_max_symbol,
+            &accuracy_log, &description, &fse_rung);
+        if (status != CUDEC_OK) {
+            return ZstdHufRefuse(kZstdHufRejectDescriptionTruncated, status,
+                                 reject);
+        }
+        status = ZstdFseBuildDTable(scratch->counts, fse_max_symbol,
+                                    accuracy_log, scratch->cells,
+                                    static_cast<uint32_t>(1u << accuracy_log),
+                                    scratch->symbol_next, &fse_rung);
+        if (status != CUDEC_OK) {
+            return ZstdHufRefuse(kZstdHufRejectDescriptionTruncated, status,
+                                 reject);
+        }
+        ZstdBitReader reader;
+        reader.src = src + 1 + description;
+        reader.size = payload - description;
+        status = reader.Start();
+        if (status != CUDEC_OK) {
+            return ZstdHufRefuse(kZstdHufRejectDescriptionTruncated, status,
+                                 reject);
+        }
+        /* One short of the alphabet, for the implied last symbol's slot. The
+         * two-state run refuses rather than truncates when it fills, which is
+         * what turns a description claiming too many weights into a rung. */
+        uint32_t produced = 0;
+        status = ZstdFseDecode2State(
+            &reader, scratch->cells, static_cast<uint32_t>(1u << accuracy_log),
+            accuracy_log, weights, max_symbol_count - 1u, &produced, &fse_rung);
+        if (status != CUDEC_OK) {
+            if (fse_rung == kZstdFseRejectOutputFull) {
+                return ZstdHufRefuse(kZstdHufRejectTooManyWeights,
+                                     CUDEC_ERR_CORRUPT_INPUT, reject);
+            }
+            return ZstdHufRefuse(kZstdHufRejectDescriptionTruncated,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        written = produced;
+        consumed = payload + 1u;
+    }
+
+    /* The budget the written weights spend, and the depth it implies. Weight
+     * zero is a symbol the tree does not carry and costs nothing. */
+    uint32_t total = 0;
+    for (unsigned i = 0; i < written; i++) {
+        if (weights[i] > max_table_log) {
+            return ZstdHufRefuse(kZstdHufRejectWeightTooLarge,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        /* Bounded by construction rather than by hope: at most 256 weights,
+         * each worth at most 2^11 here, so the sum stays inside 32 bits with
+         * room to spare and no overflow check is owed. */
+        total += (1u << weights[i]) >> 1;
+    }
+    if (total == 0) {
+        return ZstdHufRefuse(kZstdHufRejectWeightSumZero,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const unsigned table_log = ZstdHufHighestSetBit(total) + 1u;
+    if (table_log > max_table_log) {
+        return ZstdHufRefuse(kZstdHufRejectTableLogTooLarge,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    /* The implied last weight. `total` is below 2^table_log by construction of
+     * table_log, so the remainder is at least one and the subtraction cannot
+     * wrap; what is not guaranteed is that it is a single power of two, and a
+     * remainder that is not describes a tree with a hole in it. */
+    const uint32_t rest = (1u << table_log) - total;
+    const unsigned last_weight = ZstdHufHighestSetBit(rest) + 1u;
+    if ((1u << (last_weight - 1u)) != rest) {
+        return ZstdHufRefuse(kZstdHufRejectLastWeightNotClean,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    if (written + 1u > max_symbol_count) {
+        return ZstdHufRefuse(kZstdHufRejectTooManyWeights,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    weights[written] = static_cast<uint8_t>(last_weight);
+
+    /* The deepest rank of a tree that closes holds at least two leaves: its
+     * codes pair up into the rank above, so a lone one is a tree that cannot
+     * have been built by merging. See the rung for why the count's parity is
+     * not checked here. */
+    unsigned deepest_rank = 0;
+    for (unsigned i = 0; i <= written; i++) {
+        if (weights[i] == 1u) {
+            deepest_rank++;
+        }
+    }
+    if (deepest_rank < 2u) {
+        return ZstdHufRefuse(kZstdHufRejectDeepestRankEmpty,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    *out_count = written + 1u;
+    *out_table_log = table_log;
+    *out_consumed = consumed;
+    return CUDEC_OK;
+}
+
+/* Builds the decoding table a validated weight array describes.
+ *
+ * `cells` receives 1 << table_log entries. A symbol of weight w spells a code
+ * of `table_log + 1 - w` bits and owns 2^(w-1) consecutive cells; a symbol of
+ * weight zero is absent and owns none.
+ *
+ * The weights are re-checked here rather than trusted from the read: this entry
+ * point is callable with an array no description produced, and the placement
+ * walk's bound is the table size only while the weights fill it exactly. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdHufBuildDTable(
+    const uint8_t* weights, unsigned count, unsigned table_log,
+    ZstdHufCell* cells, uint32_t cell_capacity, ZstdHufReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdHufRejectNone;
+    }
+    if (weights == 0 || cells == 0 || count == 0 ||
+        count > kZstdHufMaxSymbolValue + 1 || table_log == 0 ||
+        table_log > kZstdHufMaxTableLog) {
+        return ZstdHufRefuse(kZstdHufRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    const uint32_t table_size = 1u << table_log;
+    if (cell_capacity < table_size) {
+        return ZstdHufRefuse(kZstdHufRejectBuildCapacity,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+
+    /* How many symbols sit at each weight, and where each weight's run starts.
+     * Counting first is what lets the placement walk below write every cell
+     * exactly once without searching. */
+    uint32_t rank_count[kZstdHufMaxTableLog + 1];
+    for (unsigned w = 0; w <= kZstdHufMaxTableLog; w++) {
+        rank_count[w] = 0;
+    }
+    uint32_t claimed = 0;
+    for (unsigned i = 0; i < count; i++) {
+        /* THIS IS THE BOUND ON THE COUNTER ABOVE AND NOT A RESTATEMENT OF THE
+         * BUDGET CHECK BELOW. A weight is a byte and the counter array is as
+         * long as the deepest tree the format admits, so an unchecked weight
+         * indexes past it - and the shift that follows would be by a distance
+         * wider than its own type. It carries its own rung for the same reason:
+         * with the budget's rung the two would be indistinguishable, and a
+         * change that deleted this check would still look refused. */
+        if (weights[i] > table_log) {
+            return ZstdHufRefuse(kZstdHufRejectWeightTooLarge,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        rank_count[weights[i]]++;
+        claimed += (1u << weights[i]) >> 1;
+    }
+    if (claimed != table_size) {
+        return ZstdHufRefuse(kZstdHufRejectBuildWeightsNotClean,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    /* Cells are handed out by INCREASING weight, so the LONGEST codes sit at
+     * the bottom of the table and the shortest at the top. That direction is
+     * the format's, not a preference: a code of n bits is read as the top n
+     * bits of the index, so the codes that share a prefix have to be adjacent
+     * in the order their prefix orders them. Getting it backwards leaves every
+     * cell holding a legal symbol and a legal length, which is why the twin
+     * diffs cells against the reference instead of checking the table is
+     * well formed. */
+    uint32_t rank_start[kZstdHufMaxTableLog + 1];
+    rank_start[0] = 0; /* weight zero owns nothing; kept defined, not used */
+    uint32_t next = 0;
+    for (unsigned w = 1u; w <= table_log; w++) {
+        rank_start[w] = next;
+        next += rank_count[w] * ((1u << w) >> 1);
+    }
+
+    /* One pass over the symbols in increasing order, which is what makes the
+     * order inside a weight the symbol order. Every cell of the run gets the
+     * same symbol and the same bit count: a code of that length reaches all of
+     * them, and the bits below it are the next code's, not this one's. */
+    for (unsigned symbol = 0; symbol < count; symbol++) {
+        const unsigned weight = weights[symbol];
+        if (weight == 0) {
+            continue;
+        }
+        const uint32_t span = (1u << weight) >> 1;
+        const uint8_t nb_bits = static_cast<uint8_t>(table_log + 1u - weight);
+        uint32_t at = rank_start[weight];
+        for (uint32_t step = 0; step < span; step++) {
+            cells[at + step].symbol = static_cast<uint8_t>(symbol);
+            cells[at + step].nb_bits = nb_bits;
+        }
+        rank_start[weight] = at + span;
+    }
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_ZSTD_HUF_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -277,6 +277,20 @@ cudec_add_test(zstd_fse_twin SOURCES zstd_fse_twin.cpp zstd_corpus.cpp LIBS
 target_include_directories(zstd_fse_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_compile_definitions(zstd_fse_twin PRIVATE FSE_STATIC_LINKING_ONLY)
+# The Zstd Huffman tree description and the table built from it (issue #220),
+# held to HUF_readStats and HUF_readDTableX1 cell by cell over every Compressed
+# literals section the corpus carries, plus a direct-nibble spelling this test
+# writes because the compressor does not emit one at these sizes. Host-side and
+# GPU-less. It links zstd_full alone for the reason zstd_oracle_smoke gives
+# above, and compiles zstd_corpus.cpp for the reason zstd_fse_twin does - the
+# #185 fixtures are where the literals sections it sweeps come from.
+# HUF_STATIC_LINKING_ONLY is what exposes HUF_readStats_wksp,
+# HUF_readDTableX1_wksp and the two sizing macros.
+cudec_add_test(zstd_huf_twin SOURCES zstd_huf_twin.cpp zstd_corpus.cpp LIBS
+               zstd_full)
+target_include_directories(zstd_huf_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_compile_definitions(zstd_huf_twin PRIVATE HUF_STATIC_LINKING_ONLY)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/zstd_huf_twin.cpp
+++ b/tests/zstd_huf_twin.cpp
@@ -1,0 +1,609 @@
+/* The CPU twin of the Zstd Huffman unit (src/zstd_huf.h): the tree description
+ * decode in both of its spellings and the decoding table built from it (issue
+ * #220). The sibling of tests/zstd_fse_twin.cpp and tests/zstd_bitstream_twin.
+ * cpp: the single-source unit executed on the host, on the GPU-less CI runner,
+ * and held to the pinned reference's verdicts.
+ *
+ * FOUR PROOFS, AND THEY ARE DIFFERENT IN KIND.
+ *
+ * THE FSE SPELLING IS TAKEN FROM REAL FRAMES rather than written here. Every
+ * Compressed literals section of every #185 fixture is located by the frame
+ * walker in tests/zstd_corpus.h and handed to both sides, which compares the
+ * weights, the symbol count, the tree depth and the consumed byte count, then
+ * diffs the built table cell by cell. A compressor writes that spelling and
+ * nothing in this file could write it as convincingly.
+ *
+ * THE DIRECT SPELLING IS WRITTEN HERE, with weights computed by hand, because
+ * the compressor does not emit it at these sizes and the format admits it. The
+ * writer is four lines and its output is proven by the reference reading it
+ * back, so the negatives below are malformed versions of bytes the reference
+ * itself accepts.
+ *
+ * THE TABLE IS DIFFED AGAINST A TABLE BUILT AT A DIFFERENT SCALE, and this is
+ * the thing to read before the comparison. libzstd rescales a tree whose
+ * natural depth is below eleven UP to eleven so its decode loop has a constant
+ * table size (HUF_rescaleStats in lib/decompress/huf_decompress.c), which
+ * multiplies every entry 2^(11 - depth) times and leaves each entry's bit count
+ * alone: a symbol's code length is depth + 1 - weight before the rescale and
+ * targetDepth + 1 - (weight + scale) after it, which is the same number. So the
+ * reference's cell i and the twin's cell i >> scale must agree exactly, and
+ * that relation is asserted rather than the sizes being made to match. cudec
+ * builds the natural table because that is the one a kernel puts in shared
+ * memory - a tree of depth six is 64 cells here and 2048 there.
+ *
+ * THE NEGATIVES are one per reject rung, with the reference's verdict asserted
+ * beside the twin's wherever the reference has one at this layer. Two rungs it
+ * does not: the caller-argument rung and the build-side capacity rung are not
+ * streams at all. The reference's refusal codes do not discriminate - unrelated
+ * malformed descriptions all come back corruption_detected - so a negative here
+ * asserts that the reference refused and that the twin refused through the rung
+ * the negative was written for. */
+#include "require.h"
+#include "zstd_corpus.h"
+#include "zstd_huf.h"
+
+/* The reference's Huffman entry points are internal to libzstd and its huf.h
+ * carries no C++ linkage guard of its own, so the include is wrapped here
+ * rather than its declarations restated. HUF_STATIC_LINKING_ONLY is what
+ * exposes HUF_readStats_wksp, HUF_readDTableX1_wksp and the sizing macros; it
+ * is defined by the build for the reason issue #180 landed, and defining it in
+ * both places is a redefinition the strict-warning build refuses. */
+extern "C" {
+#include <common/huf.h>
+}
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+using Weights = std::vector<uint8_t>;
+
+using cudec_detail::kZstdHufMaxSymbolValue;
+using cudec_detail::kZstdHufMaxTableLog;
+using cudec_detail::ZstdHufBuildDTable;
+using cudec_detail::ZstdHufCell;
+using cudec_detail::ZstdHufReadWeights;
+using cudec_detail::ZstdHufReject;
+using cudec_detail::ZstdHufWeightScratch;
+
+/* Which reject rungs a declared negative reached. Same discipline as the FSE
+ * and bitstream twins: the enumeration lives once, in the header, and main()
+ * requires every rung to have been named by a negative written to reach it. A
+ * rung added to the unit with no negative behind it reds this test. */
+bool g_reject_covered[cudec_detail::kZstdHufRejectCount] = {false};
+
+void CoverRung(ZstdHufReject rung) {
+    if (rung != cudec_detail::kZstdHufRejectNone) {
+        g_reject_covered[rung] = true;
+    }
+}
+
+/* Writes the direct spelling of a weight vector: the header byte carries the
+ * count biased by 127, then one 4-bit nibble per weight, high nibble first. An
+ * odd count leaves the final low nibble unused; it is written as zero here and
+ * one negative below sets it to prove neither side reads it. */
+Bytes EncodeDirect(const Weights& weights) {
+    Bytes out;
+    out.push_back(static_cast<unsigned char>(127u + weights.size()));
+    for (size_t i = 0; i < weights.size(); i += 2) {
+        unsigned char byte = static_cast<unsigned char>(weights[i] << 4);
+        if (i + 1 < weights.size()) {
+            byte = static_cast<unsigned char>(byte | (weights[i + 1] & 0x0Fu));
+        }
+        out.push_back(byte);
+    }
+    return out;
+}
+
+/* The reference's own read of a tree description. `alphabet` is the hwSize it
+ * is given, which is the same bound the twin is given, so the two agree about
+ * how many weights they are willing to accept. */
+struct OracleStats {
+    bool ok = false;
+    unsigned table_log = 0;
+    unsigned nb_symbols = 0;
+    size_t consumed = 0;
+    Bytes weights;
+};
+
+OracleStats ReadStatsWithOracle(const unsigned char* src, size_t size,
+                                size_t alphabet) {
+    OracleStats out;
+    out.weights.assign(alphabet, 0);
+    std::vector<unsigned> rank(HUF_TABLELOG_MAX + 1, 0);
+    std::vector<unsigned> wksp(HUF_DECOMPRESS_WORKSPACE_SIZE_U32, 0);
+    unsigned nb = 0;
+    unsigned log = 0;
+    const size_t rc = HUF_readStats_wksp(
+        out.weights.data(), alphabet, rank.data(), &nb, &log, src, size,
+        wksp.data(), wksp.size() * sizeof(unsigned), 0);
+    if (HUF_isError(rc)) {
+        out.weights.assign(alphabet, 0);
+        return out;
+    }
+    out.ok = true;
+    out.table_log = log;
+    out.nb_symbols = nb;
+    out.consumed = rc;
+    return out;
+}
+
+/* The reference's decoding table for the same description, flattened to the two
+ * fields per cell the twin also produces, plus the depth it was built at.
+ *
+ * The descriptor word is the one zstd's own decoder installs before decoding a
+ * block (ZSTD_HUFFDTABLE_CAPACITY_LOG in lib/decompress/zstd_decompress_
+ * internal.h), so the reference is asked exactly what a real decode asks it
+ * rather than something more permissive invented here. */
+bool BuildWithOracle(const unsigned char* src, size_t size,
+                     std::vector<ZstdHufCell>* out, unsigned* out_log) {
+    std::vector<HUF_DTable> dtable(HUF_DTABLE_SIZE(12), 0);
+    dtable[0] = static_cast<HUF_DTable>(11) * 0x01000001u;
+    std::vector<unsigned> wksp(HUF_DECOMPRESS_WORKSPACE_SIZE_U32, 0);
+    const size_t rc =
+        HUF_readDTableX1_wksp(dtable.data(), src, size, wksp.data(),
+                              wksp.size() * sizeof(unsigned), 0);
+    if (HUF_isError(rc)) {
+        return false;
+    }
+    unsigned descriptor = 0;
+    std::memcpy(&descriptor, dtable.data(), sizeof(descriptor));
+    /* DTableDesc is { maxTableLog, tableType, tableLog, reserved }. */
+    const unsigned log = (descriptor >> 16) & 0xFFu;
+    *out_log = log;
+    /* HUF_DEltX1 is { nbBits, byte } in the pinned release, and reading the two
+     * the other way round produces bit counts near a hundred rather than a
+     * mismatch - which is how this was caught. */
+    struct Elt {
+        unsigned char nb_bits;
+        unsigned char byte;
+    };
+    const Elt* cells = reinterpret_cast<const Elt*>(dtable.data() + 1);
+    out->resize(static_cast<size_t>(1u) << log);
+    for (size_t i = 0; i < out->size(); i++) {
+        (*out)[i].nb_bits = cells[i].nb_bits;
+        (*out)[i].symbol = cells[i].byte;
+    }
+    return true;
+}
+
+size_t g_descriptions = 0;
+size_t g_cells = 0;
+
+/* Both sides over one description, every quantity compared. Returns false on
+ * the first divergence and says which one it was. */
+bool ParityHolds(const unsigned char* src, size_t size, const char* where) {
+    ZstdHufWeightScratch scratch;
+    Weights weights(kZstdHufMaxSymbolValue + 1, 0);
+    unsigned count = 0;
+    unsigned log = 0;
+    uint64_t consumed = 0;
+    ZstdHufReject rung = cudec_detail::kZstdHufRejectNone;
+    const cudec_status twin = ZstdHufReadWeights(
+        src, size, kZstdHufMaxSymbolValue + 1, kZstdHufMaxTableLog, &scratch,
+        weights.data(), &count, &log, &consumed, &rung);
+
+    const OracleStats oracle =
+        ReadStatsWithOracle(src, size, kZstdHufMaxSymbolValue + 1);
+    if (!oracle.ok) {
+        std::fprintf(stderr,
+                     "%s: the reference refused a description the sweep "
+                     "expects it to accept\n",
+                     where);
+        return false;
+    }
+    if (twin != CUDEC_OK) {
+        std::fprintf(stderr, "%s: twin refused (rung %d) where the reference "
+                             "read %u symbols at depth %u\n",
+                     where, static_cast<int>(rung), oracle.nb_symbols,
+                     oracle.table_log);
+        return false;
+    }
+    if (count != oracle.nb_symbols) {
+        std::fprintf(stderr, "%s: symbol count %u vs %u\n", where, count,
+                     oracle.nb_symbols);
+        return false;
+    }
+    if (log != oracle.table_log) {
+        std::fprintf(stderr, "%s: tree depth %u vs %u\n", where, log,
+                     oracle.table_log);
+        return false;
+    }
+    if (consumed != oracle.consumed) {
+        std::fprintf(stderr, "%s: consumed %llu vs %zu bytes\n", where,
+                     static_cast<unsigned long long>(consumed),
+                     oracle.consumed);
+        return false;
+    }
+    for (unsigned i = 0; i < count; i++) {
+        if (weights[i] != oracle.weights[i]) {
+            std::fprintf(stderr, "%s: weight[%u] %u vs %u\n", where, i,
+                         weights[i], oracle.weights[i]);
+            return false;
+        }
+    }
+
+    std::vector<ZstdHufCell> reference;
+    unsigned reference_log = 0;
+    if (!BuildWithOracle(src, size, &reference, &reference_log)) {
+        std::fprintf(stderr, "%s: the reference refused to build the table\n",
+                     where);
+        return false;
+    }
+    std::vector<ZstdHufCell> cells(static_cast<size_t>(1u) << log);
+    const cudec_status build =
+        ZstdHufBuildDTable(weights.data(), count, log, cells.data(),
+                           static_cast<uint32_t>(cells.size()), &rung);
+    if (build != CUDEC_OK) {
+        std::fprintf(stderr, "%s: twin refused to build (rung %d)\n", where,
+                     static_cast<int>(rung));
+        return false;
+    }
+    if (reference_log < log) {
+        std::fprintf(stderr, "%s: the reference built at depth %u, below the "
+                             "natural %u - the rescale only ever goes up\n",
+                     where, reference_log, log);
+        return false;
+    }
+    const unsigned scale = reference_log - log;
+    for (size_t i = 0; i < reference.size(); i++) {
+        const ZstdHufCell& want = reference[i];
+        const ZstdHufCell& have = cells[i >> scale];
+        if (want.symbol != have.symbol || want.nb_bits != have.nb_bits) {
+            std::fprintf(stderr,
+                         "%s: cell %zu (scale %u) is (symbol %u, nbBits %u) "
+                         "and the reference has (symbol %u, nbBits %u)\n",
+                         where, i, scale, have.symbol, have.nb_bits,
+                         want.symbol, want.nb_bits);
+            return false;
+        }
+    }
+    g_descriptions++;
+    g_cells += reference.size();
+    return true;
+}
+
+/* One malformed description: what the twin must answer, and whether the
+ * reference has a verdict at this layer to assert beside it. */
+struct Negative {
+    const char* name;
+    Bytes stream;
+    ZstdHufReject rung;
+    bool oracle_refuses;
+};
+
+}  // namespace
+
+int main() {
+    /* ---- Step 1: the direct spelling, written here and read back by the
+     * reference, so the negatives below are mutations of bytes it accepts. */
+    {
+        /* Two symbols of weight two and one implied symbol of weight three:
+         * 2 + 2 makes four, the tree closes at depth three, and the remainder
+         * of four is the implied last symbol's 2^(3-1). Hand-computed so the
+         * expectation does not come from the thing under test. */
+        const Weights base = {2, 2};
+        const Bytes stream = EncodeDirect(base);
+        REQUIRE(stream.size() == 2);
+        REQUIRE(stream[0] == 129);
+        REQUIRE(stream[1] == 0x22);
+
+        ZstdHufWeightScratch scratch;
+        Weights weights(kZstdHufMaxSymbolValue + 1, 0);
+        unsigned count = 0;
+        unsigned log = 0;
+        uint64_t consumed = 0;
+        ZstdHufReject rung = cudec_detail::kZstdHufRejectNone;
+        /* The written pair alone leaves the deepest rank empty, which is its
+         * own rung; the accepted vector below adds the two weight-one symbols
+         * that close it. */
+        REQUIRE(ZstdHufReadWeights(stream.data(), stream.size(),
+                                   kZstdHufMaxSymbolValue + 1,
+                                   kZstdHufMaxTableLog, &scratch,
+                                   weights.data(), &count, &log, &consumed,
+                                   &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectDeepestRankEmpty);
+        CoverRung(rung);
+        REQUIRE(!ReadStatsWithOracle(stream.data(), stream.size(),
+                                     kZstdHufMaxSymbolValue + 1)
+                     .ok);
+    }
+
+    /* A four-symbol tree that closes: weights 2, 1, 1 written, implied last
+     * weight 1. Budget 2 + 1 + 1 = 4, depth 3... computed the long way: the
+     * written weights spend 2^(2-1) + 2^(1-1) + 2^(1-1) = 2 + 1 + 1 = 4, the
+     * depth is highbit(4) + 1 = 3, the remainder is 8 - 4 = 4 and the implied
+     * weight is highbit(4) + 1 = 3. So the tree is {2, 1, 1, 3} at depth 3,
+     * with code lengths {2, 3, 3, 1}. */
+    const Weights accepted = {2, 1, 1};
+    {
+        const Bytes stream = EncodeDirect(accepted);
+        REQUIRE(ParityHolds(stream.data(), stream.size(), "direct-four-symbol"));
+
+        ZstdHufWeightScratch scratch;
+        Weights weights(kZstdHufMaxSymbolValue + 1, 0);
+        unsigned count = 0;
+        unsigned log = 0;
+        uint64_t consumed = 0;
+        ZstdHufReject rung = cudec_detail::kZstdHufRejectNone;
+        REQUIRE(ZstdHufReadWeights(stream.data(), stream.size(),
+                                   kZstdHufMaxSymbolValue + 1,
+                                   kZstdHufMaxTableLog, &scratch,
+                                   weights.data(), &count, &log, &consumed,
+                                   &rung) == CUDEC_OK);
+        /* The hand-computed answers, asserted rather than only diffed: a
+         * comparison against the reference agrees when both are wrong in the
+         * same way, and nothing else in this file would notice. */
+        REQUIRE(count == 4);
+        REQUIRE(log == 3);
+        REQUIRE(weights[3] == 3);
+        REQUIRE(consumed == 3);
+
+        std::vector<ZstdHufCell> cells(8);
+        REQUIRE(ZstdHufBuildDTable(weights.data(), count, log, cells.data(), 8,
+                                   &rung) == CUDEC_OK);
+        /* Placement, spelled out. Weight one is the deepest rank and goes
+         * first: symbols 1 and 2, one cell each, three bits. Then weight two,
+         * symbol 0, two cells, two bits. Then weight three, symbol 3, four
+         * cells, one bit. */
+        const uint8_t want_symbol[8] = {1, 2, 0, 0, 3, 3, 3, 3};
+        const uint8_t want_bits[8] = {3, 3, 2, 2, 1, 1, 1, 1};
+        for (unsigned i = 0; i < 8; i++) {
+            REQUIRE_CTX(cells[i].symbol == want_symbol[i],
+                        "cell %u symbol %u", i, cells[i].symbol);
+            REQUIRE_CTX(cells[i].nb_bits == want_bits[i], "cell %u nbBits %u",
+                        i, cells[i].nb_bits);
+        }
+    }
+
+    /* An odd weight count, so the final low nibble is written and unread. Both
+     * sides must accept whatever is in it, which is what makes the nibble a
+     * non-rung rather than an unstated assumption. */
+    {
+        /* Five written weights spend 1 + 1 + 2 + 4 + 4 = 12 of sixteen, so the
+         * depth is four and the implied last weight is three. Odd count, so
+         * the third byte's low nibble is written and never read. */
+        const Weights odd = {1, 1, 2, 3, 3};
+        Bytes clean = EncodeDirect(odd);
+        REQUIRE(clean.size() == 4);
+        Bytes dirty = clean;
+        dirty[3] = static_cast<unsigned char>(dirty[3] | 0x0Fu);
+        REQUIRE(dirty != clean);
+        REQUIRE(ParityHolds(clean.data(), clean.size(), "direct-odd-clean"));
+        REQUIRE(ParityHolds(dirty.data(), dirty.size(), "direct-odd-dirty"));
+    }
+
+    /* ---- Step 2: the FSE spelling, over every Compressed literals section of
+     * every corpus fixture. This is what the issue's first Done bullet names,
+     * and it is the only place a compressor-written weight description
+     * appears. */
+    size_t sections = 0;
+    {
+        const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+        REQUIRE(!fixtures.empty());
+        for (size_t f = 0; f < fixtures.size(); f++) {
+            const ZstdFixture& fixture = fixtures[f];
+            ZstdFrameShape shape;
+            std::string why;
+            REQUIRE_CTX(ParseZstdFrameShape(fixture.compressed, &shape, &why),
+                        "%s: %s", fixture.name.c_str(), why.c_str());
+            for (size_t b = 0; b < shape.blocks.size(); b++) {
+                const ZstdBlockShape& block = shape.blocks[b];
+                if (block.literals_type != kZstdLiteralsCompressed) {
+                    continue;
+                }
+                sections++;
+                char where[192];
+                std::snprintf(where, sizeof(where), "%s block %zu",
+                              fixture.name.c_str(), b);
+                REQUIRE(ParityHolds(
+                    fixture.compressed.data() + block.literals_payload_offset,
+                    block.literals_payload_size, where));
+            }
+        }
+        /* A sweep that found nothing would pass every assertion above, which
+         * is the shape this project has already been bitten by twice. */
+        REQUIRE(sections > 0);
+    }
+
+    /* ---- Step 3: the negatives, one per reachable stream rung. */
+    {
+        std::vector<Negative> negatives;
+
+        /* Nothing at all. The reference reports srcSize_wrong, which is a
+         * refusal like any other at this layer. */
+        negatives.push_back({"empty", Bytes(),
+                             cudec_detail::kZstdHufRejectEmptyDescription,
+                             true});
+
+        /* A direct header claiming eight weights with only two bytes of
+         * nibbles behind it. */
+        {
+            Bytes stream = EncodeDirect({2, 1, 1, 4, 4, 4, 4, 4});
+            REQUIRE(stream.size() == 5);
+            stream.resize(3);
+            negatives.push_back(
+                {"direct-truncated", stream,
+                 cudec_detail::kZstdHufRejectDescriptionTruncated, true});
+        }
+
+        /* An FSE header byte claiming more compressed bytes than are there. */
+        {
+            Bytes stream;
+            stream.push_back(40);
+            stream.push_back(0x20);
+            stream.push_back(0x00);
+            negatives.push_back(
+                {"fse-truncated", stream,
+                 cudec_detail::kZstdHufRejectDescriptionTruncated, true});
+        }
+
+        /* A weight above the tree's depth ceiling. Fifteen is the widest a
+         * nibble can carry and the ceiling is twelve. */
+        negatives.push_back({"weight-past-ceiling", EncodeDirect({15, 1, 1}),
+                             cudec_detail::kZstdHufRejectWeightTooLarge, true});
+
+        /* Every written weight zero, so the tree has no budget at all. */
+        negatives.push_back({"weight-sum-zero", EncodeDirect({0, 0, 0, 0}),
+                             cudec_detail::kZstdHufRejectWeightSumZero, true});
+
+        /* A budget whose remainder is not a clean power of two: 4 + 1 spends
+         * five of eight, and three is not a weight. */
+        negatives.push_back({"remainder-not-a-power-of-two",
+                             EncodeDirect({3, 1}),
+                             cudec_detail::kZstdHufRejectLastWeightNotClean,
+                             true});
+
+        /* Three symbols at the ceiling spend 3 * 2^11, which asks for a depth
+         * of thirteen. */
+        negatives.push_back({"depth-past-ceiling", EncodeDirect({12, 12, 12}),
+                             cudec_detail::kZstdHufRejectTableLogTooLarge,
+                             true});
+
+        /* A tree with nothing at its deepest rank: two symbols of weight two
+         * and an implied third of weight three close at depth three with no
+         * weight-one leaf anywhere. */
+        negatives.push_back({"deepest-rank-empty", EncodeDirect({2, 2}),
+                             cudec_detail::kZstdHufRejectDeepestRankEmpty,
+                             true});
+
+        for (size_t n = 0; n < negatives.size(); n++) {
+            const Negative& negative = negatives[n];
+            ZstdHufWeightScratch scratch;
+            Weights weights(kZstdHufMaxSymbolValue + 1, 0);
+            unsigned count = 0;
+            unsigned log = 0;
+            uint64_t consumed = 0;
+            ZstdHufReject rung = cudec_detail::kZstdHufRejectNone;
+            const unsigned char* data =
+                negative.stream.empty() ? weights.data() : negative.stream.data();
+            const cudec_status status = ZstdHufReadWeights(
+                data, negative.stream.size(), kZstdHufMaxSymbolValue + 1,
+                kZstdHufMaxTableLog, &scratch, weights.data(), &count, &log,
+                &consumed, &rung);
+            REQUIRE_CTX(status != CUDEC_OK, "%s was accepted", negative.name);
+            REQUIRE_CTX(rung == negative.rung, "%s reached rung %d, not %d",
+                        negative.name, static_cast<int>(rung),
+                        static_cast<int>(negative.rung));
+            CoverRung(rung);
+            if (negative.oracle_refuses) {
+                REQUIRE_CTX(!ReadStatsWithOracle(data, negative.stream.size(),
+                                                 kZstdHufMaxSymbolValue + 1)
+                                 .ok,
+                            "%s: the reference accepted it", negative.name);
+            }
+        }
+    }
+
+    /* The alphabet bound, which both sides carry and which is not a property of
+     * the bytes: a description of eight weights read against an alphabet of
+     * four. The reference takes the same bound as its hwSize and refuses for
+     * the same reason, so this negative has a verdict beside it. */
+    {
+        const Bytes stream = EncodeDirect({2, 1, 1, 4, 4, 4, 4, 4});
+        ZstdHufWeightScratch scratch;
+        Weights weights(kZstdHufMaxSymbolValue + 1, 0);
+        unsigned count = 0;
+        unsigned log = 0;
+        uint64_t consumed = 0;
+        ZstdHufReject rung = cudec_detail::kZstdHufRejectNone;
+        REQUIRE(ZstdHufReadWeights(stream.data(), stream.size(), 4,
+                                   kZstdHufMaxTableLog, &scratch,
+                                   weights.data(), &count, &log, &consumed,
+                                   &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectTooManyWeights);
+        CoverRung(rung);
+        REQUIRE(!ReadStatsWithOracle(stream.data(), stream.size(), 4).ok);
+    }
+
+    /* An argument the format cannot express. The reference has no verdict on a
+     * caller's argument and this rung says so where it is written. */
+    {
+        ZstdHufWeightScratch scratch;
+        Weights weights(kZstdHufMaxSymbolValue + 1, 0);
+        unsigned count = 0;
+        unsigned log = 0;
+        uint64_t consumed = 0;
+        ZstdHufReject rung = cudec_detail::kZstdHufRejectNone;
+        const Bytes stream = EncodeDirect(accepted);
+        REQUIRE(ZstdHufReadWeights(stream.data(), stream.size(),
+                                   kZstdHufMaxSymbolValue + 1,
+                                   kZstdHufMaxTableLog + 1, &scratch,
+                                   weights.data(), &count, &log, &consumed,
+                                   &rung) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectBadRequest);
+        CoverRung(rung);
+    }
+
+    /* ---- Step 4: the build side, reachable only from a caller that hands in
+     * a weight array no description produced. */
+    {
+        ZstdHufReject rung = cudec_detail::kZstdHufRejectNone;
+        const uint8_t weights[4] = {2, 1, 1, 3};
+        /* Sized for the widest depth any case below asks for, so a capacity
+         * refusal only ever fires where a case asks for one. The capacity
+         * passed in is what the unit reads, not this. */
+        std::vector<ZstdHufCell> cells(16);
+
+        /* A cell array below the depth's own table size. */
+        REQUIRE(ZstdHufBuildDTable(weights, 4, 3, cells.data(), 7, &rung) ==
+                CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectBuildCapacity);
+        CoverRung(rung);
+
+        /* Weights that do not fill the table they claim: the same four at a
+         * depth of four spend eight of sixteen cells. */
+        REQUIRE(ZstdHufBuildDTable(weights, 4, 4, cells.data(),
+                                   static_cast<uint32_t>(cells.size()),
+                                   &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectBuildWeightsNotClean);
+        CoverRung(rung);
+
+        /* A weight past the depth it is being built at. Its own rung, because
+         * a weight is a byte and the rank counters are only as long as the
+         * deepest tree the format admits: this is the bound on that array, and
+         * sharing the budget's rung would make its removal invisible. Two
+         * cases, one just past the depth and one far past it, because the
+         * counter is what the second would land in. */
+        const uint8_t deep[3] = {5, 1, 1};
+        REQUIRE(ZstdHufBuildDTable(deep, 3, 3, cells.data(),
+                                   static_cast<uint32_t>(cells.size()),
+                                   &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectWeightTooLarge);
+        CoverRung(rung);
+
+        const uint8_t wild[3] = {200, 1, 1};
+        REQUIRE(ZstdHufBuildDTable(wild, 3, 3, cells.data(),
+                                   static_cast<uint32_t>(cells.size()),
+                                   &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectWeightTooLarge);
+        CoverRung(rung);
+
+        /* And the build-side caller-argument rung. */
+        REQUIRE(ZstdHufBuildDTable(weights, 0, 3, cells.data(),
+                                   static_cast<uint32_t>(cells.size()),
+                                   &rung) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectBadRequest);
+        CoverRung(rung);
+    }
+
+    /* Every rung the unit can return has a negative written to reach it. A rung
+     * added later with nothing behind it reds here rather than shipping as
+     * untested refusal. */
+    for (int rung = cudec_detail::kZstdHufRejectNone + 1;
+         rung < cudec_detail::kZstdHufRejectCount; rung++) {
+        REQUIRE_CTX(g_reject_covered[rung], "reject rung %d has no negative",
+                    rung);
+    }
+
+    std::printf("PASS: %zu descriptions compared against HUF_readStats "
+                "(%zu from compressed literals sections), %zu table cells "
+                "diffed against HUF_readDTableX1, %d reject rungs covered\n",
+                g_descriptions, sections, g_cells,
+                cudec_detail::kZstdHufRejectCount - 1);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #220.

M5 carries the FSE cores and the backward bitstream reader and had no way to
read a Compressed literals section's Huffman tree. `src/zstd_huf.h` is that
unit: the tree description in both of its spellings, and the canonical decoding
table it describes. `tests/zstd_huf_twin.cpp` holds it to `HUF_readStats` and
`HUF_readDTableX1` from the hash-pinned zstd 1.5.7, weight for weight and cell
for cell, on the GPU-less runner.

## The branch that carries the weight

A tree description does not carry its last symbol's weight. The weights present
sum to just below a power of two and the difference is what that symbol must be
worth, so the difference has to BE a power of two - anything else describes a
tree with a hole in it - and it has to leave a legal weight. A decoder that took
the nearest legal value instead of refusing would build a table whose cells
decode symbols the encoder never wrote, and nothing downstream would notice: a
Huffman table has no invalid cell.

So the ladder is: no weight above the depth ceiling, a non-zero budget, a depth
inside the ceiling, a remainder that is a clean power of two, and a leaf at the
deepest rank. Each is a rung, each has a negative written to reach it, and each
negative asserts the reference's verdict beside the twin's.

## Placement is the half that fails silently

Symbols go in by increasing weight, and inside a weight by increasing symbol
value, so the longest codes sit at the bottom of the table. Reverse that and
every cell still holds a legal symbol and a legal bit count, so no check
anywhere refuses and the output is simply wrong bytes. That is why the twin
diffs cells against the reference instead of checking the table is well formed:
the first draft of this header had the direction backwards, and the cell diff is
the only thing in the change that said so.

```
envelope-content-size-and-checksum block 0: cell 0 (scale 3) oracle=(8,98) twin=(97,2)
```

## The reference builds the same table at a different scale

`HUF_rescaleStats` lifts a tree whose natural depth is below eleven up to eleven
so libzstd's decode loop has a constant table size. That multiplies every entry
2^(11 - depth) times and leaves each entry's bit count alone - a symbol's code
length is `depth + 1 - weight` before and `11 + 1 - (weight + scale)` after,
which is the same number. So the comparison asserts `reference[i] ==
twin[i >> scale]` rather than making the sizes match. cudec builds the natural
table because that is the one a kernel puts in shared memory: a tree of depth six
is 64 cells here and 2048 there.

The reference is also asked exactly what a real decode asks it. The descriptor
word installed before `HUF_readDTableX1_wksp` is the one
`ZSTD_HUFFDTABLE_CAPACITY_LOG` installs in libzstd's own decoder, not a more
permissive one invented for the test.

## Two rungs the reference has and this unit does not

Both are stated in the header at the place they would have been.

**An odd number of leaves at the deepest rank cannot arrive here.** Every weight
above one contributes an even amount to the budget and the budget lands on a
power of two before the check is reached, so the count of weight-one symbols has
that power of two's parity, which is even. A guard for the odd case would be one
no negative could reach, so the unit refuses only the reachable half - a deepest
rank with nothing in it - and the twin proves that one.

**The weight alphabet is the tree's depth rather than a byte.** That is what
keeps the compressed spelling's working storage to half a kilobyte, which
matters because this header compiles `__device__` unchanged and the storage is
the caller's. The reference decodes weights over all 256 symbols and refuses a
weight above twelve one step later, at its own weight check, so the verdicts
agree and the rungs differ. The twin pins that rather than leaving it assumed.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)

## Engineering checklist

- [x] Fail-closed preserved: five stream rungs and three build rungs, every one
      with a negative that reaches it, and the test reds if a rung is added
      with nothing behind it.
- [x] Oracle coverage: `HUF_readStats` weight for weight and
      `HUF_readDTableX1` cell for cell, over every Compressed literals section
      the #185 corpus carries plus the hand-written direct spelling.
- [x] Determinism preserved: the unit allocates nothing, reads nothing outside
      the caller's buffers, and has no state between calls.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      This is a header and a host test; neither touches the ABI or a device.
- [ ] An adversarial review was NOT run for this change, and that is a gap
      rather than a waiver. The mutant sweep below is evidence, not a second
      reader.
- [ ] No review record, for the same reason.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. The header is written
      to compile `__device__` unchanged and nothing compiles it that way yet -
      the kernel that will is #203.

## Performance checklist

Not a hot-path change; no kernel reads this yet. One sizing decision is made
here rather than deferred: the compressed spelling's FSE scratch is the
caller's and is bounded by the weight alphabet rather than by a byte, so it is
under half a kilobyte instead of over one and a half. A version that declared it
inside the function would put that on every thread's local memory the day a
kernel includes this.

## Quality checklist

- [x] Minimal: one header, one test, one registration. No second copy of the
      FSE machinery - the compressed spelling runs the existing
      `ZstdFseReadNCount`, `ZstdFseBuildDTable` and `ZstdFseDecode2State`.
- [x] Self-documenting: every rung says what failure it prevents, and the two
      the reference has and this does not say why they are absent.
- [x] Conformance: the reject-rung coverage loop is the structural property
      this adds - a rung with no negative reds the test.

## Verification

There is no second reader on this change tonight. What follows is the evidence
in its place, run at this branch's head.

**The toolchain here is not the one CI uses.** This host has no CUDA toolkit, so
`tests/` cannot be configured locally at all - the test net only exists under
`CUDEC_ENABLE_CUDA=ON`. The test was instead compiled and run directly with
g++ 16.1.0 against the pinned reference built from the same tarball CI fetches,
with the same strict flags the build applies. The archive hash was checked
against `cmake/CudecZstdOracle.cmake`'s pin before anything was built:

```
$ sha256sum zstd-1.5.7.tar.gz
eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3 *zstd-1.5.7.tar.gz
```

```
$ g++ -std=c++17 -O1 -Wall -Wextra -Werror -DHUF_STATIC_LINKING_ONLY \
    -I include -I src -I tests -isystem zstd-1.5.7/lib \
    -o huf_twin tests/zstd_huf_twin.cpp tests/zstd_corpus.cpp libzstd_full.a
$ ./huf_twin; echo "exit=$?"
PASS: 17 descriptions compared against HUF_readStats (14 from compressed literals sections), 34816 table cells diffed against HUF_readDTableX1, 11 reject rungs covered
exit=0
```

**Every guard was removed one at a time and the suite watched.** Fourteen
mutants, each one deleting a single refusal or reversing a single ordering
decision, rebuilt and re-run:

```
$ sh mutants.sh
killed    empty-description refusal
killed    direct payload bound
killed    direct alphabet bound
killed    weight ceiling
killed    zero budget
killed    depth ceiling
killed    clean remainder
killed    deepest rank
killed    build capacity
killed    build weight ceiling
killed    build budget
killed    placement direction
killed    nibble order
killed    code length
----
mutants killed: 14, survived: 0
```

**A branch no mutant could kill was deleted rather than kept.** The second
alphabet check, after the implied weight was computed, could not fire on any
path: the direct spelling refuses that count before it writes a nibble, and the
compressed one is handed a capacity one below the alphabet and refuses rather
than truncating when it fills. A guard nothing can prove is the shape
`src/zstd_fse.h` already declines to ship at its absent overshoot rung, so the
argument that the write is in range replaces it.

**One mutant survived the first pass and the repair is in the diff.** Deleting
the build-side weight ceiling changed nothing a test could see, because the
budget check below it returned the same rung about the same input. That check is
not a restatement of the budget: a weight is a byte and the rank counters are
only as long as the deepest tree the format admits, so an unchecked weight
indexes past the array and shifts by a distance wider than its own type. It now
carries its own rung, and two cases reach it - one just past the depth and one
far past it, which is the one the counter would have swallowed.

- [x] Prettier (`**/*.{md,yml,yaml}`):

```
$ npx prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

- [x] The structural scan, which runs from the test net's configure and needs
      a CUDA toolchain, is one this machine cannot run at all. It refused a
      bare 32 bounding the highest-set-bit loop on the first push and the
      second commit is that repair, with `src/zstd_fse.h`'s own constant rather
      than a second one of the same value.
- [ ] `cmake --build build` and `ctest --test-dir build` were NOT run locally
      and could not be, for the reason above; the container route is
      unreachable because the daemon is not running, and starting it raises an
      elevation prompt, which is not something a piece of work takes on its
      own. CI is the gate for the configure, the strict-flag build and the
      ctest entry.

## Notes

**The new test is not in the sanitizer job's selection, and that is stated
rather than left to be noticed.** `.github/workflows/ci.yml` picks the ASan
subset by an explicit allowlist, and `zstd_fse_twin` is not in it either, so
this follows the precedent its sibling set rather than departing from it
silently. It IS built under the sanitizer, so an instrumented compile failure
still reds; it is not RUN there. Both twins generate their fixtures by driving
the compressor, which is the expensive part under ASan and the likely reason for
the precedent. Whether that subset should grow is a change to a workflow and to
two tests at once, which is not this issue.

Out of scope and named so it is not mistaken for done: nothing decodes a
literals stream with this table yet - that is #221 - and no kernel compiles this
header `__device__` yet, which is #203. This lands the unit and its proof.
