### PR TITLE
Decode the Zstd sequences section and its three-state loop [#196]

### DIFF
--- a/src/zstd_seq.h
+++ b/src/zstd_seq.h
@@ -1,0 +1,676 @@
+/* The Zstd sequences section: the section header, the four table modes per
+ * field, and the three-state interleaved decode loop that turns the block's
+ * backward bitstream into (literals_length, match_length, offset_value)
+ * triples. RFC 8878 sections 3.1.1.3.2.1 and 4.2. Single-sourced for host and
+ * device, the sibling of src/zstd_fse.h and src/zstd_huf.h. Internal header,
+ * not part of the ABI.
+ *
+ * WHAT THIS UNIT PRODUCES IS NOT YET AN OFFSET. `offset_value` is the format's
+ * own quantity, (1 << Offset_Code) + extra bits, and the values 1, 2 and 3
+ * name repeat offsets rather than distances. Resolving those against the
+ * frame's three-entry repeat history is a separate unit with its own state, so
+ * this one hands the raw value on and refuses to guess. A caller that treats
+ * `offset_value` as a distance is off by three on every explicit offset and
+ * wrong in kind on every repeated one.
+ *
+ * THE BASELINES ARE DERIVED, NOT TABULATED. Every Literals_Length_Code and
+ * Match_Length_Code baseline is the running sum of the widths below it -
+ * base(c + 1) = base(c) + (1 << extra(c)) - which is a property of the
+ * format's own construction rather than a coincidence this file exploits. So
+ * only the extra-bit widths are written down, and the table a reader has to
+ * check against the RFC is a third of the size. The sum is recomputed per
+ * lookup: this is the correctness twin, and a resident baseline table is a
+ * performance shape that belongs with the kernel that needs it, exactly as the
+ * FSE cell layout does.
+ *
+ * WHAT THE FAIL-CLOSED CASES ARE HERE. A sequence count is bounded by what the
+ * block can regenerate before any bit is read, because every sequence emits at
+ * least a minimum-length match and a count the block cannot hold is a demand
+ * for output nobody will check later. A Repeat mode with no previously decoded
+ * table is refused rather than resolved against whatever the cell array
+ * happens to hold. And the bitstream must end exactly where the last sequence
+ * leaves it: bits left over mean the stream and the count disagree, which is
+ * the same fail-open the reference refuses with BIT_DStream_completed. */
+#ifndef CUDEC_ZSTD_SEQ_H
+#define CUDEC_ZSTD_SEQ_H
+
+#include "cudec.h"
+#include "zstd_bitstream.h"
+#include "zstd_fse.h"
+
+#include <stdint.h>
+
+/* Guarded: the sibling decode headers define the same macro for the same
+ * reason, and a device translation unit that decodes more than one format
+ * includes more than one of them. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+/* The three fields, in the order their table descriptions appear in the
+ * section - which is not the order their states are initialised in, and not
+ * the order their extra bits are read in either. All three orders are the
+ * format's; none of them is this file's choice. */
+constexpr unsigned kZstdSeqFieldLitLen = 0;
+constexpr unsigned kZstdSeqFieldOffset = 1;
+constexpr unsigned kZstdSeqFieldMatchLen = 2;
+
+/* Symbol_Compression_Mode, RFC 8878 section 3.1.1.3.2.1.1. */
+constexpr unsigned kZstdSeqModePredefined = 0;
+constexpr unsigned kZstdSeqModeRle = 1;
+constexpr unsigned kZstdSeqModeCompressed = 2;
+constexpr unsigned kZstdSeqModeRepeat = 3;
+
+/* Alphabet sizes: 36 literals-length codes, 53 match-length codes, and 32
+ * offset codes of which the predefined distribution reaches 29. */
+constexpr unsigned kZstdSeqLitLenSymbolCount = 36;
+constexpr unsigned kZstdSeqMatchLenSymbolCount = 53;
+constexpr unsigned kZstdSeqOffsetSymbolCount = 32;
+constexpr unsigned kZstdSeqOffsetPredefinedCount = 29;
+/* The widest of the three, which is what a caller's scratch must hold. */
+constexpr unsigned kZstdSeqMaxAlphabet = 53;
+
+/* Accuracy logs of the three predefined distributions. */
+constexpr unsigned kZstdSeqLitLenPredefinedLog = 6;
+constexpr unsigned kZstdSeqOffsetPredefinedLog = 5;
+constexpr unsigned kZstdSeqMatchLenPredefinedLog = 6;
+
+/* The shortest match a sequence can express, which is what bounds the number
+ * of sequences a block of a given regenerated size can hold. */
+constexpr unsigned kZstdSeqMinMatchLength = 3;
+
+/* Number_of_Sequences, RFC 8878 section 3.1.1.3.2.1: one byte below this, two
+ * below the escape, three at it. */
+constexpr unsigned kZstdSeqCountTwoByteMin = 128;
+constexpr unsigned kZstdSeqCountThreeByteMark = 255;
+constexpr uint32_t kZstdSeqCountThreeByteBias = 0x7F00u;
+
+/* Codes below these carry no extra bits: a literals length is its own code up
+ * to fifteen, and a match length is its code plus the minimum up to
+ * thirty-one. */
+constexpr unsigned kZstdSeqLitLenDirectCodes = 16;
+constexpr unsigned kZstdSeqMatchLenDirectCodes = 32;
+
+/* The reject ladder, in the shape src/zstd_fse.h uses: every refusal returns
+ * through one choke point naming its rung, so the twin requires a negative per
+ * rung instead of counting statuses that repeat. The reference collapses all
+ * of these into corruption_detected, so the rung is this tree's vocabulary. */
+enum ZstdSeqReject {
+    kZstdSeqRejectNone = 0,
+    /* An argument outside what the format can express, or a caller's buffer
+     * that is null or too small. A caller bug rather than a stream. */
+    kZstdSeqRejectBadRequest,
+    /* The section ended inside the Number_of_Sequences varint. */
+    kZstdSeqRejectCountTruncated,
+    /* More sequences than the block's regenerated size can hold. */
+    kZstdSeqRejectCountTooLarge,
+    /* No Symbol_Compression_Modes byte after the count. */
+    kZstdSeqRejectModesTruncated,
+    /* The mode byte's low two bits are reserved and must be zero. */
+    kZstdSeqRejectModesReserved,
+    /* An RLE table description with no byte left to carry its symbol. */
+    kZstdSeqRejectRleTruncated,
+    /* A description naming a symbol outside the field's alphabet: an RLE byte
+     * carrying one, or an FSE description reaching one. */
+    kZstdSeqRejectSymbolPastMax,
+    /* A code outside the field's alphabet coming OUT of a table. Separate from
+     * the rung above because it refuses a different thing: no description this
+     * unit accepts can produce one, so this is the cell array a caller built
+     * elsewhere, and collapsing the two would leave whichever guard was
+     * removed covered by the other one's negative. */
+    kZstdSeqRejectDecodedSymbolPastMax,
+    /* A Set_Compressed description this section could not decode, or a table
+     * that could not be built from it. The FSE unit's own rung is where the
+     * reason is; this one says which field carried it. */
+    kZstdSeqRejectTableDescription,
+    /* Repeat_Mode with no table decoded for that field yet. */
+    kZstdSeqRejectRepeatWithoutTable,
+    /* The section ended with no bytes left for the bitstream, or the
+     * bitstream's final byte carries no start marker. */
+    kZstdSeqRejectBitstreamMissing,
+    /* The stream held fewer bits than the three initial states need. */
+    kZstdSeqRejectStateInitTruncated,
+    /* A state landed outside its table. Well-formed tables cannot produce one;
+     * this refuses a cell array that came from somewhere else. */
+    kZstdSeqRejectStateOutOfTable,
+    /* The bits ran out inside a sequence: an extra-bit field or a state update
+     * the stream could not pay for. */
+    kZstdSeqRejectSequenceTruncated,
+    /* Bits left over after the last sequence. The count and the stream
+     * disagree, and which of the two is lying is not decidable here. */
+    kZstdSeqRejectBitstreamNotConsumed,
+    /* A table claiming more cells than its array holds. Its own rung rather
+     * than the caller-argument one, because it is the bound every cell read
+     * below rests on: a state is checked against `table_size` and nothing else
+     * checks `table_size` against the allocation. */
+    kZstdSeqRejectTableCapacity,
+    kZstdSeqRejectCount
+};
+
+CUDEC_HOST_DEVICE inline cudec_status ZstdSeqRefuse(ZstdSeqReject rung,
+                                                    cudec_status status,
+                                                    ZstdSeqReject* out) {
+    if (out != 0) {
+        *out = rung;
+    }
+    return status;
+}
+
+/* The highest symbol each field's alphabet reaches. */
+CUDEC_HOST_DEVICE inline unsigned ZstdSeqFieldSymbolMax(unsigned field) {
+    if (field == kZstdSeqFieldLitLen) {
+        return kZstdSeqLitLenSymbolCount - 1;
+    }
+    if (field == kZstdSeqFieldOffset) {
+        return kZstdSeqOffsetSymbolCount - 1;
+    }
+    return kZstdSeqMatchLenSymbolCount - 1;
+}
+
+/* The per-field accuracy-log ceiling. Tighter than the FSE unit's own bound,
+ * and the reference refuses a description above it one level up from where the
+ * description is read - so it is checked here, where the field is known. */
+CUDEC_HOST_DEVICE inline unsigned ZstdSeqFieldAccuracyLogMax(unsigned field) {
+    if (field == kZstdSeqFieldLitLen) {
+        return kZstdLitLenAccuracyLogMax;
+    }
+    if (field == kZstdSeqFieldOffset) {
+        return kZstdOffsetAccuracyLogMax;
+    }
+    return kZstdMatchLenAccuracyLogMax;
+}
+
+/* Extra-bit widths, RFC 8878 section 3.1.1.3.2.1.1. Written as the format
+ * states them: a run of codes carrying none, a short irregular middle, and a
+ * tail whose width is the code's own index shifted by a constant. */
+CUDEC_HOST_DEVICE inline unsigned ZstdSeqLitLenExtraBits(unsigned code) {
+    constexpr unsigned kTailBias = 19;
+    const unsigned middle[] = {1, 1, 1, 1, 2, 2, 3, 3, 4};
+    const unsigned middle_count = sizeof(middle) / sizeof(middle[0]);
+    if (code < kZstdSeqLitLenDirectCodes) {
+        return 0;
+    }
+    if (code >= kZstdSeqLitLenDirectCodes + middle_count) {
+        return code - kTailBias;
+    }
+    return middle[code - kZstdSeqLitLenDirectCodes];
+}
+
+CUDEC_HOST_DEVICE inline unsigned ZstdSeqMatchLenExtraBits(unsigned code) {
+    constexpr unsigned kTailBias = 36;
+    const unsigned middle[] = {1, 1, 1, 1, 2, 2, 3, 3, 4, 4, 5};
+    const unsigned middle_count = sizeof(middle) / sizeof(middle[0]);
+    if (code < kZstdSeqMatchLenDirectCodes) {
+        return 0;
+    }
+    if (code >= kZstdSeqMatchLenDirectCodes + middle_count) {
+        return code - kTailBias;
+    }
+    return middle[code - kZstdSeqMatchLenDirectCodes];
+}
+
+/* Baselines as the running sum of the widths below them. The loops are counted
+ * over the alphabet, so their trip counts are compile-time bounded and no lane
+ * can be held here by a hostile stream. */
+CUDEC_HOST_DEVICE inline uint32_t ZstdSeqLitLenBaseline(unsigned code) {
+    uint32_t base = 0;
+    for (unsigned below = 0; below < code; below++) {
+        base += 1u << ZstdSeqLitLenExtraBits(below);
+    }
+    return base;
+}
+
+CUDEC_HOST_DEVICE inline uint32_t ZstdSeqMatchLenBaseline(unsigned code) {
+    uint32_t base = kZstdSeqMinMatchLength;
+    for (unsigned below = 0; below < code; below++) {
+        base += 1u << ZstdSeqMatchLenExtraBits(below);
+    }
+    return base;
+}
+
+/* One field's decoding table, plus the fact of it existing. `present` is what
+ * Repeat_Mode reads, and it is deliberately not the same question as
+ * `cells != 0`: a caller hands the same cell array to every block of a frame,
+ * and a Repeat in the first block must be refused over an array that is
+ * allocated and stale. */
+struct ZstdSeqTable {
+    ZstdFseCell* cells;
+    uint32_t capacity;
+    uint32_t table_size;
+    /* Zero for an RLE table, which has one cell and reads no state bits. */
+    unsigned accuracy_log;
+    bool present;
+};
+
+/* The working memory a table description needs, the caller's for the reason
+ * the FSE and Huffman units give: the kernel places it, and a header that
+ * allocated would decide that placement. */
+struct ZstdSeqScratch {
+    int16_t counts[kZstdSeqMaxAlphabet];
+    uint16_t symbol_next[kZstdSeqMaxAlphabet];
+};
+
+/* The three predefined distributions, RFC 8878 section 3.1.1.3.2.2, written
+ * into the caller's count vector. Local rather than resident: they are read
+ * once per Predefined field, and a namespace-scope array would have this
+ * header decide where the device holds them instead of the kernel. */
+CUDEC_HOST_DEVICE inline void ZstdSeqPredefinedCounts(unsigned field,
+                                                      int16_t* counts,
+                                                      unsigned* out_symbol_max,
+                                                      unsigned* out_log) {
+    if (field == kZstdSeqFieldLitLen) {
+        const int16_t litlen[kZstdSeqLitLenSymbolCount] = {
+            4, 3, 2, 2, 2, 2, 2, 2, 2,  2,  2,  2,  2, 1, 1, 1, 2, 2,
+            2, 2, 2, 2, 2, 2, 2, 3, 2, 1, 1, 1, 1, 1, -1, -1, -1, -1};
+        for (unsigned symbol = 0; symbol < kZstdSeqLitLenSymbolCount;
+             symbol++) {
+            counts[symbol] = litlen[symbol];
+        }
+        *out_symbol_max = kZstdSeqLitLenSymbolCount - 1;
+        *out_log = kZstdSeqLitLenPredefinedLog;
+        return;
+    }
+    if (field == kZstdSeqFieldOffset) {
+        const int16_t offset[kZstdSeqOffsetPredefinedCount] = {
+            1, 1, 1, 1, 1, 1, 2, 2, 2, 1,  1,  1,  1,  1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1};
+        for (unsigned symbol = 0; symbol < kZstdSeqOffsetPredefinedCount;
+             symbol++) {
+            counts[symbol] = offset[symbol];
+        }
+        *out_symbol_max = kZstdSeqOffsetPredefinedCount - 1;
+        *out_log = kZstdSeqOffsetPredefinedLog;
+        return;
+    }
+    const int16_t matchlen[kZstdSeqMatchLenSymbolCount] = {
+        1,  4,  3,  2,  2,  2,  2,  2,  2,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  -1, -1, -1, -1, -1, -1, -1};
+    for (unsigned symbol = 0; symbol < kZstdSeqMatchLenSymbolCount; symbol++) {
+        counts[symbol] = matchlen[symbol];
+    }
+    *out_symbol_max = kZstdSeqMatchLenSymbolCount - 1;
+    *out_log = kZstdSeqMatchLenPredefinedLog;
+}
+
+/* What the section header declares. Where `sequence_count` is zero the section
+ * ends at the count byte and the three modes are absent, so they are left at
+ * Predefined and a caller must not read them. */
+struct ZstdSeqSectionHeader {
+    uint32_t sequence_count;
+    unsigned litlen_mode;
+    unsigned offset_mode;
+    unsigned matchlen_mode;
+};
+
+/* Number_of_Sequences and the Symbol_Compression_Modes byte.
+ *
+ * `block_size_max` is the number of bytes this block may regenerate, and it is
+ * the bound the declared count is checked against BEFORE any table is read.
+ * Every sequence emits at least a minimum-length match, so a block of that
+ * size holds at most that many sequences, and a larger count is a demand this
+ * section cannot be describing. Checked here rather than downstream because
+ * downstream is a per-sequence loop whose trip count this number is. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdParseSeqSectionHeader(
+    const unsigned char* src, uint64_t size, uint64_t block_size_max,
+    ZstdSeqSectionHeader* out, uint64_t* out_consumed, ZstdSeqReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdSeqRejectNone;
+    }
+    if (src == 0 || out == 0 || out_consumed == 0) {
+        return ZstdSeqRefuse(kZstdSeqRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    out->sequence_count = 0;
+    out->litlen_mode = kZstdSeqModePredefined;
+    out->offset_mode = kZstdSeqModePredefined;
+    out->matchlen_mode = kZstdSeqModePredefined;
+    *out_consumed = 0;
+    if (size == 0) {
+        return ZstdSeqRefuse(kZstdSeqRejectCountTruncated,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const unsigned first = src[0];
+    uint32_t count = 0;
+    uint64_t consumed = 1;
+    if (first < kZstdSeqCountTwoByteMin) {
+        count = first;
+    } else if (first < kZstdSeqCountThreeByteMark) {
+        if (size < 2) {
+            return ZstdSeqRefuse(kZstdSeqRejectCountTruncated,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        count = ((static_cast<uint32_t>(first) - kZstdSeqCountTwoByteMin)
+                 << kZstdBitsPerByte) +
+                src[1];
+        consumed = 2;
+    } else {
+        if (size < 3) {
+            return ZstdSeqRefuse(kZstdSeqRejectCountTruncated,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        count = static_cast<uint32_t>(src[1]) +
+                (static_cast<uint32_t>(src[2]) << kZstdBitsPerByte) +
+                kZstdSeqCountThreeByteBias;
+        consumed = 3;
+    }
+    /* Zero sequences ends the section: no mode byte, no tables, no bitstream.
+     * The block is its literals and nothing else. */
+    if (count == 0) {
+        *out_consumed = consumed;
+        return CUDEC_OK;
+    }
+    if (count > block_size_max / kZstdSeqMinMatchLength) {
+        return ZstdSeqRefuse(kZstdSeqRejectCountTooLarge,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    if (size <= consumed) {
+        return ZstdSeqRefuse(kZstdSeqRejectModesTruncated,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const unsigned modes = src[consumed];
+    consumed++;
+    constexpr unsigned kModeMask = 3u;
+    constexpr unsigned kLitLenModeShift = 6;
+    constexpr unsigned kOffsetModeShift = 4;
+    constexpr unsigned kMatchLenModeShift = 2;
+    if ((modes & kModeMask) != 0) {
+        /* Reserved, and the reference refuses rather than ignoring them: bits
+         * with no meaning today are how a future field arrives, and a decoder
+         * that skipped them would read tomorrow's stream as today's. */
+        return ZstdSeqRefuse(kZstdSeqRejectModesReserved,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    out->sequence_count = count;
+    out->litlen_mode = (modes >> kLitLenModeShift) & kModeMask;
+    out->offset_mode = (modes >> kOffsetModeShift) & kModeMask;
+    out->matchlen_mode = (modes >> kMatchLenModeShift) & kModeMask;
+    *out_consumed = consumed;
+    return CUDEC_OK;
+}
+
+/* Brings one field's table into being for this block, whichever of the four
+ * modes the header named, and reports how many bytes of description it read.
+ * A Repeat reads none and leaves the table exactly as the previous block left
+ * it, which is why the table is in/out rather than out. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdSeqLoadTable(
+    unsigned field, unsigned mode, const unsigned char* src, uint64_t size,
+    ZstdSeqScratch* scratch, ZstdSeqTable* table, uint64_t* out_consumed,
+    ZstdSeqReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdSeqRejectNone;
+    }
+    if (src == 0 || scratch == 0 || table == 0 || table->cells == 0 ||
+        out_consumed == 0 || field > kZstdSeqFieldMatchLen ||
+        mode > kZstdSeqModeRepeat) {
+        return ZstdSeqRefuse(kZstdSeqRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    *out_consumed = 0;
+    const unsigned symbol_max = ZstdSeqFieldSymbolMax(field);
+
+    if (mode == kZstdSeqModeRepeat) {
+        if (!table->present) {
+            return ZstdSeqRefuse(kZstdSeqRejectRepeatWithoutTable,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        return CUDEC_OK;
+    }
+
+    if (mode == kZstdSeqModeRle) {
+        if (size == 0) {
+            return ZstdSeqRefuse(kZstdSeqRejectRleTruncated,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        if (table->capacity == 0) {
+            return ZstdSeqRefuse(kZstdSeqRejectBadRequest,
+                                 CUDEC_ERR_INVALID_ARGUMENT, reject);
+        }
+        const unsigned symbol = src[0];
+        if (symbol > symbol_max) {
+            return ZstdSeqRefuse(kZstdSeqRejectSymbolPastMax,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        /* One cell, zero state bits: every sequence in the block takes this
+         * symbol and the state never moves. An accuracy log of zero is what
+         * makes the state initialisation below read no bits for this field. */
+        table->cells[0].new_state = 0;
+        table->cells[0].symbol = static_cast<uint8_t>(symbol);
+        table->cells[0].nb_bits = 0;
+        table->table_size = 1;
+        table->accuracy_log = 0;
+        table->present = true;
+        *out_consumed = 1;
+        return CUDEC_OK;
+    }
+
+    unsigned description_symbol_max = 0;
+    unsigned accuracy_log = 0;
+    if (mode == kZstdSeqModePredefined) {
+        ZstdSeqPredefinedCounts(field, scratch->counts,
+                                &description_symbol_max, &accuracy_log);
+    } else {
+        ZstdFseReject fse_reject = kZstdFseRejectNone;
+        uint64_t consumed = 0;
+        const cudec_status status = ZstdFseReadNCount(
+            src, size, symbol_max, ZstdSeqFieldAccuracyLogMax(field),
+            scratch->counts, &description_symbol_max, &accuracy_log, &consumed,
+            &fse_reject);
+        if (status != CUDEC_OK) {
+            /* The FSE unit refuses a description reaching past the field's
+             * alphabet through its own rung; reported here as the field-level
+             * one, so a caller sees which field the section lost. */
+            const ZstdSeqReject rung =
+                fse_reject == kZstdFseRejectSymbolPastMax
+                    ? kZstdSeqRejectSymbolPastMax
+                    : kZstdSeqRejectTableDescription;
+            return ZstdSeqRefuse(rung, status, reject);
+        }
+        *out_consumed = consumed;
+    }
+
+    ZstdFseReject build_reject = kZstdFseRejectNone;
+    const cudec_status status = ZstdFseBuildDTable(
+        scratch->counts, description_symbol_max, accuracy_log, table->cells,
+        table->capacity, scratch->symbol_next, &build_reject);
+    if (status != CUDEC_OK) {
+        *out_consumed = 0;
+        return ZstdSeqRefuse(kZstdSeqRejectTableDescription, status, reject);
+    }
+    table->table_size = 1u << accuracy_log;
+    table->accuracy_log = accuracy_log;
+    table->present = true;
+    return CUDEC_OK;
+}
+
+/* One decoded sequence, in the format's own quantities. `offset_value` is not
+ * a distance; see the note at the top of this file. */
+struct ZstdSequence {
+    uint32_t literals_length;
+    uint32_t match_length;
+    uint64_t offset_value;
+};
+
+/* Reads the symbol a state names, without moving it.
+ *
+ * ZstdFseNextSymbol is not reused here, and the reason is the loop's shape
+ * rather than taste: it emits and updates in one call, and the sequences loop
+ * has to read three fields' extra bits BETWEEN the emit and the update, and
+ * must not update at all after the last sequence. Splitting the two halves is
+ * what the format asks for; keeping them fused would mean telling the fused
+ * function which half to skip. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdSeqPeekSymbol(
+    const ZstdSeqTable* table, const ZstdFseState* state, unsigned* out_symbol,
+    ZstdSeqReject* reject) {
+    if (state->value >= table->table_size) {
+        return ZstdSeqRefuse(kZstdSeqRejectStateOutOfTable,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    *out_symbol = table->cells[state->value].symbol;
+    return CUDEC_OK;
+}
+
+/* Moves a state on by the bits its current cell asks for. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdSeqUpdateState(
+    ZstdBitReader* reader, const ZstdSeqTable* table, ZstdFseState* state,
+    ZstdSeqReject* reject) {
+    if (state->value >= table->table_size) {
+        return ZstdSeqRefuse(kZstdSeqRejectStateOutOfTable,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const ZstdFseCell cell = table->cells[state->value];
+    uint64_t bits = 0;
+    if (reader->ReadBits(cell.nb_bits, &bits) != CUDEC_OK) {
+        return ZstdSeqRefuse(kZstdSeqRejectSequenceTruncated,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    state->value = cell.new_state + static_cast<uint32_t>(bits);
+    return CUDEC_OK;
+}
+
+/* The three-state interleaved loop over one backward bitstream.
+ *
+ * Three orders, all the format's and no two of them the same: the states are
+ * initialised literals-length, offset, match-length; the extra bits are read
+ * offset, match-length, literals-length; and the states are updated
+ * literals-length, match-length, offset. An implementation that gets any one
+ * of them wrong still decodes the first field of the first sequence
+ * correctly, which is why the corpus sweep asserts exact consumption rather
+ * than only the count.
+ *
+ * `src`/`size` are the bitstream alone: the section header and the table
+ * descriptions have already been stepped over by the caller. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeSequences(
+    const unsigned char* src, uint64_t size, uint32_t sequence_count,
+    const ZstdSeqTable* litlen, const ZstdSeqTable* offset,
+    const ZstdSeqTable* matchlen, ZstdSequence* out, uint32_t out_capacity,
+    ZstdSeqReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdSeqRejectNone;
+    }
+    if (src == 0 || litlen == 0 || offset == 0 || matchlen == 0 || out == 0 ||
+        sequence_count == 0 || out_capacity < sequence_count ||
+        litlen->cells == 0 || offset->cells == 0 || matchlen->cells == 0 ||
+        !litlen->present || !offset->present || !matchlen->present) {
+        return ZstdSeqRefuse(kZstdSeqRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    /* Every cell read below is bounded by `table_size`, and nothing so far has
+     * bounded `table_size` by the array it indexes. A table this unit built
+     * cannot fail this - the FSE builder refuses a table larger than the
+     * capacity it was given - so what it refuses is a table assembled
+     * somewhere else. */
+    if (litlen->table_size > litlen->capacity ||
+        offset->table_size > offset->capacity ||
+        matchlen->table_size > matchlen->capacity) {
+        return ZstdSeqRefuse(kZstdSeqRejectTableCapacity,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    if (size == 0) {
+        return ZstdSeqRefuse(kZstdSeqRejectBitstreamMissing,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    ZstdBitReader reader{src, size};
+    if (reader.Start() != CUDEC_OK) {
+        return ZstdSeqRefuse(kZstdSeqRejectBitstreamMissing,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    ZstdFseState litlen_state;
+    ZstdFseState offset_state;
+    ZstdFseState matchlen_state;
+    ZstdFseReject fse_reject = kZstdFseRejectNone;
+    if (ZstdFseInitState(&reader, litlen->accuracy_log, &litlen_state,
+                         &fse_reject) != CUDEC_OK ||
+        ZstdFseInitState(&reader, offset->accuracy_log, &offset_state,
+                         &fse_reject) != CUDEC_OK ||
+        ZstdFseInitState(&reader, matchlen->accuracy_log, &matchlen_state,
+                         &fse_reject) != CUDEC_OK) {
+        return ZstdSeqRefuse(kZstdSeqRejectStateInitTruncated,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    for (uint32_t index = 0; index < sequence_count; index++) {
+        unsigned litlen_code = 0;
+        unsigned offset_code = 0;
+        unsigned matchlen_code = 0;
+        cudec_status status =
+            ZstdSeqPeekSymbol(litlen, &litlen_state, &litlen_code, reject);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+        status = ZstdSeqPeekSymbol(offset, &offset_state, &offset_code,
+                                   reject);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+        status = ZstdSeqPeekSymbol(matchlen, &matchlen_state, &matchlen_code,
+                                   reject);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+        /* A code past the alphabet can only arrive from a table built
+         * elsewhere - every description this unit accepts is bounded by the
+         * field's maximum - and the reads below are indexed by it, so it is
+         * refused before it is used. */
+        if (litlen_code > ZstdSeqFieldSymbolMax(kZstdSeqFieldLitLen) ||
+            offset_code > ZstdSeqFieldSymbolMax(kZstdSeqFieldOffset) ||
+            matchlen_code > ZstdSeqFieldSymbolMax(kZstdSeqFieldMatchLen)) {
+            return ZstdSeqRefuse(kZstdSeqRejectDecodedSymbolPastMax,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+
+        uint64_t offset_extra = 0;
+        uint64_t matchlen_extra = 0;
+        uint64_t litlen_extra = 0;
+        if (reader.ReadBits(offset_code, &offset_extra) != CUDEC_OK ||
+            reader.ReadBits(ZstdSeqMatchLenExtraBits(matchlen_code),
+                            &matchlen_extra) != CUDEC_OK ||
+            reader.ReadBits(ZstdSeqLitLenExtraBits(litlen_code),
+                            &litlen_extra) != CUDEC_OK) {
+            return ZstdSeqRefuse(kZstdSeqRejectSequenceTruncated,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+
+        out[index].offset_value = (1ull << offset_code) + offset_extra;
+        out[index].match_length = ZstdSeqMatchLenBaseline(matchlen_code) +
+                                  static_cast<uint32_t>(matchlen_extra);
+        out[index].literals_length = ZstdSeqLitLenBaseline(litlen_code) +
+                                     static_cast<uint32_t>(litlen_extra);
+
+        /* The last sequence consumes its states without updating them, which
+         * is what makes the stream end exactly here. */
+        if (index + 1 == sequence_count) {
+            continue;
+        }
+        status = ZstdSeqUpdateState(&reader, litlen, &litlen_state, reject);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+        status = ZstdSeqUpdateState(&reader, matchlen, &matchlen_state,
+                                    reject);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+        status = ZstdSeqUpdateState(&reader, offset, &offset_state, reject);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+    }
+
+    if (!reader.AtEnd()) {
+        return ZstdSeqRefuse(kZstdSeqRejectBitstreamNotConsumed,
+                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_ZSTD_SEQ_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -291,6 +291,18 @@ cudec_add_test(zstd_huf_twin SOURCES zstd_huf_twin.cpp zstd_corpus.cpp LIBS
 target_include_directories(zstd_huf_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_compile_definitions(zstd_huf_twin PRIVATE HUF_STATIC_LINKING_ONLY)
+# The Zstd sequences section: the Number_of_Sequences varint, the four table
+# modes on each of the three fields, and the three-state interleaved decode
+# loop (issue #196). Host-side and GPU-less. It links zstd_full alone for the
+# reason zstd_oracle_smoke gives above, and because its negatives are one-byte
+# mutations of a whole frame the reference has to accept first - which needs
+# the frame entry point rather than a block one. It compiles zstd_corpus.cpp
+# for the reason zstd_fse_twin does: the #185 fixtures are where the
+# compressor-written sequences sections it sweeps over come from.
+cudec_add_test(zstd_seq_twin SOURCES zstd_seq_twin.cpp zstd_corpus.cpp LIBS
+               zstd_full)
+target_include_directories(zstd_seq_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/zstd_seq_twin.cpp
+++ b/tests/zstd_seq_twin.cpp
@@ -1,0 +1,896 @@
+/* The CPU twin of the Zstd sequences section (src/zstd_seq.h): the section
+ * header, the four table modes on each of the three fields, and the
+ * three-state interleaved decode loop (issue #196). The sibling of
+ * tests/zstd_fse_twin.cpp and tests/zstd_huf_twin.cpp - the single-source unit
+ * executed on the host, on the GPU-less CI runner, and held to the pinned
+ * reference's verdicts.
+ *
+ * FIVE PROOFS, AND THEY ARE DIFFERENT IN KIND.
+ *
+ * THE FRAME WRITER IS PROVEN BEFORE ANYTHING USES IT. Every negative below is
+ * a one-byte mutation of one accepted frame, and that frame is first handed to
+ * the reference and required to decode to bytes this file computed by hand.
+ * Without that step a hand-built negative would only prove that the twin
+ * agrees with a writer nobody checked; with it, each malformed stream is a
+ * malformed version of bytes the reference itself accepts.
+ *
+ * THE HAND-BUILT TRACE isolates the three orders from every table builder.
+ * Three tables written cell by cell in this file, two sequences, and a bit
+ * string laid out bit by bit in the comment beside it: the states are
+ * initialised literals-length, offset, match-length, the extra bits are read
+ * offset, match-length, literals-length, and the states are updated
+ * literals-length, match-length, offset. Each field's update reads a different
+ * number of bits, so any other update order hands the wrong bits to the wrong
+ * state and the second sequence's symbols move. That is the one proof here
+ * that does not depend on the FSE table builder being right.
+ *
+ * THE VARINT AND MODE BRANCHES are read off hand-written headers, one per
+ * encoding and one per mode on each field, with the expected count and the
+ * expected three modes written down rather than derived.
+ *
+ * THE CORPUS SWEEP is the only place a compressor-written sequences section
+ * appears. Every compressed block of every #185 fixture that carries sequences
+ * is positioned from tests/zstd_corpus.h, its three tables are loaded through
+ * the twin from the section's own bytes, and its bitstream is decoded. Two
+ * things are asserted: the sequence count agrees with the frame walker's, and
+ * the bitstream is consumed EXACTLY. The second is what covers the state
+ * update order over real FSE tables - a wrong order advances the wrong state,
+ * the next symbol's cell asks for a different number of bits, and the stream
+ * stops landing on its last bit.
+ *
+ * THE NEGATIVES are one per reject rung, with the reference's verdict asserted
+ * beside the twin's wherever the negative is a whole frame. Eight of them are
+ * not: a caller-argument rung, a section fragment and a table handed in from
+ * outside are not streams the reference has an opinion about, and each says so
+ * where it is written. The reference's refusal codes do not discriminate -
+ * unrelated malformed sections all come back corruption_detected - so a
+ * negative asserts that the reference refused and that the twin refused
+ * through the rung the negative was written for.
+ *
+ * WHAT IS NOT PROVEN HERE, because it is not this unit's claim: repcode
+ * resolution (offset values 1, 2 and 3 are handed on raw), and executing the
+ * tuples against the literals. Both are separate sub-issues. */
+#include "require.h"
+#include "zstd_corpus.h"
+#include "zstd_frame.h"
+#include "zstd_seq.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* Every declared rung must be reached by a declared negative; the check is at
+ * the bottom of main. */
+bool g_reject_covered[cudec_detail::kZstdSeqRejectCount] = {false};
+
+void CoverRung(cudec_detail::ZstdSeqReject rung) {
+    if (rung != cudec_detail::kZstdSeqRejectNone) {
+        g_reject_covered[rung] = true;
+    }
+}
+
+/* Cell storage for the three fields, sized by each one's accuracy-log
+ * ceiling, plus the tables that point at it. One object per block, which is
+ * also what makes a Repeat across two calls testable: the same object carries
+ * the previous block's table, a fresh one carries none. */
+constexpr unsigned kLitLenCells = 1u
+                                  << cudec_detail::kZstdLitLenAccuracyLogMax;
+constexpr unsigned kOffsetCells = 1u
+                                  << cudec_detail::kZstdOffsetAccuracyLogMax;
+constexpr unsigned kMatchLenCells =
+    1u << cudec_detail::kZstdMatchLenAccuracyLogMax;
+
+struct SeqTables {
+    cudec_detail::ZstdFseCell litlen_cells[kLitLenCells];
+    cudec_detail::ZstdFseCell offset_cells[kOffsetCells];
+    cudec_detail::ZstdFseCell matchlen_cells[kMatchLenCells];
+    cudec_detail::ZstdSeqTable litlen;
+    cudec_detail::ZstdSeqTable offset;
+    cudec_detail::ZstdSeqTable matchlen;
+    cudec_detail::ZstdSeqScratch scratch;
+
+    SeqTables() {
+        litlen.cells = litlen_cells;
+        litlen.capacity = kLitLenCells;
+        litlen.table_size = 0;
+        litlen.accuracy_log = 0;
+        litlen.present = false;
+        offset.cells = offset_cells;
+        offset.capacity = kOffsetCells;
+        offset.table_size = 0;
+        offset.accuracy_log = 0;
+        offset.present = false;
+        matchlen.cells = matchlen_cells;
+        matchlen.capacity = kMatchLenCells;
+        matchlen.table_size = 0;
+        matchlen.accuracy_log = 0;
+        matchlen.present = false;
+    }
+};
+
+/* What one whole sequences section decoded to, or the rung it was refused
+ * through. The rung is what a negative asserts on: it names where the section
+ * died, which a bare status cannot - every refusal here returns the same two
+ * status codes. */
+struct SectionResult {
+    cudec_status status = CUDEC_OK;
+    cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+    cudec_detail::ZstdSeqSectionHeader header;
+    std::vector<cudec_detail::ZstdSequence> sequences;
+};
+
+/* Header, three table descriptions, bitstream - the whole section, in the
+ * order the format writes them. This is the caller the block loop will be, and
+ * it is written here rather than in the unit for the reason the sub-issue
+ * gives: the block loop is a separate claim. */
+SectionResult DecodeSection(const unsigned char* section, size_t size,
+                            uint64_t block_size_max, SeqTables* tables) {
+    SectionResult result;
+    uint64_t consumed = 0;
+    result.status = cudec_detail::ZstdParseSeqSectionHeader(
+        section, size, block_size_max, &result.header, &consumed,
+        &result.rung);
+    if (result.status != CUDEC_OK) {
+        return result;
+    }
+    size_t position = static_cast<size_t>(consumed);
+    if (result.header.sequence_count == 0) {
+        return result;
+    }
+
+    const unsigned fields[] = {cudec_detail::kZstdSeqFieldLitLen,
+                               cudec_detail::kZstdSeqFieldOffset,
+                               cudec_detail::kZstdSeqFieldMatchLen};
+    const unsigned modes[] = {result.header.litlen_mode,
+                              result.header.offset_mode,
+                              result.header.matchlen_mode};
+    cudec_detail::ZstdSeqTable* targets[] = {
+        &tables->litlen, &tables->offset, &tables->matchlen};
+    for (unsigned index = 0; index < 3; index++) {
+        result.status = cudec_detail::ZstdSeqLoadTable(
+            fields[index], modes[index], section + position, size - position,
+            &tables->scratch, targets[index], &consumed, &result.rung);
+        if (result.status != CUDEC_OK) {
+            return result;
+        }
+        position += static_cast<size_t>(consumed);
+        if (position > size) {
+            /* Unreachable through the unit - every description is bounded by
+             * the size handed to it - and asserted rather than assumed,
+             * because the arithmetic below would wrap. */
+            result.status = CUDEC_ERR_CORRUPT_INPUT;
+            return result;
+        }
+    }
+
+    result.sequences.resize(result.header.sequence_count);
+    result.status = cudec_detail::ZstdDecodeSequences(
+        section + position, size - position, result.header.sequence_count,
+        &tables->litlen, &tables->offset, &tables->matchlen,
+        result.sequences.data(),
+        static_cast<uint32_t>(result.sequences.size()), &result.rung);
+    return result;
+}
+
+/* ---- The frame writer. Small on purpose: one compressed block, raw
+ * literals, and whatever sequences section the caller hands in. Every field
+ * below is RFC 8878 section 3.1.1, and the sizes it can express are the ones
+ * these tests need rather than the ones the format allows. */
+
+constexpr unsigned kRawLiteralsMaxSize = 31;
+
+Bytes RawLiteralsSection(const Bytes& literals) {
+    /* Size_Format 00: a one-byte header carrying the type in the low two bits
+     * and a five-bit regenerated size above them. */
+    Bytes section;
+    section.push_back(static_cast<unsigned char>(literals.size() << 3));
+    section.insert(section.end(), literals.begin(), literals.end());
+    return section;
+}
+
+Bytes BuildFrame(const Bytes& literals, const Bytes& sequences,
+                 unsigned content_size) {
+    Bytes frame;
+    /* Magic, little-endian. */
+    frame.push_back(0x28);
+    frame.push_back(0xB5);
+    frame.push_back(0x2F);
+    frame.push_back(0xFD);
+    /* Frame_Header_Descriptor: Single_Segment_flag alone, so the window is the
+     * content size and the frame carries no window byte. With
+     * Frame_Content_Size_flag zero and Single_Segment set, the content size is
+     * one byte and is not biased. */
+    frame.push_back(0x20);
+    frame.push_back(static_cast<unsigned char>(content_size));
+
+    Bytes block = RawLiteralsSection(literals);
+    block.insert(block.end(), sequences.begin(), sequences.end());
+    /* Block_Header: Last_Block, then a two-bit type, then the size. */
+    const uint32_t header =
+        (static_cast<uint32_t>(block.size()) << 3) | (2u << 1) | 1u;
+    frame.push_back(static_cast<unsigned char>(header & 0xFFu));
+    frame.push_back(static_cast<unsigned char>((header >> 8) & 0xFFu));
+    frame.push_back(static_cast<unsigned char>((header >> 16) & 0xFFu));
+    frame.insert(frame.end(), block.begin(), block.end());
+    return frame;
+}
+
+/* The one accepted frame every negative is a mutation of.
+ *
+ * Eight raw literals and one sequence, all three fields in RLE mode:
+ * literals-length code 8 (baseline 8, no extra bits), offset code 2 (baseline
+ * 4, two extra bits, both zero, so Offset_Value 4 and a distance of 1) and
+ * match-length code 5 (baseline 8, no extra bits). The block therefore
+ * regenerates "abcdefgh" followed by eight copies of 'h'.
+ *
+ * THE SIZES ARE NOT ARBITRARY. A single-segment frame's window is its content
+ * size, and the reference bounds a block's COMPRESSED size by that window - so
+ * a frame declaring seven bytes of content cannot carry an eleven-byte block,
+ * whatever the block decodes to. Sixteen bytes of content against a fifteen-
+ * byte block is the smallest shape of this kind that clears it.
+ *
+ * The bitstream is one byte. An RLE table has one cell and an accuracy log of
+ * zero, so the three state initialisations read nothing and the only bits in
+ * the stream are the offset's two extra bits. 0x04 is the start marker at bit
+ * 2 with two zero bits below it. */
+constexpr unsigned kAcceptedModesByte = 0x54;
+constexpr unsigned kAcceptedContentSize = 16;
+
+Bytes AcceptedSequencesSection() {
+    Bytes section;
+    section.push_back(0x01); /* Number_of_Sequences */
+    section.push_back(kAcceptedModesByte);
+    section.push_back(0x08); /* Literals_Lengths_Mode RLE symbol */
+    section.push_back(0x02); /* Offsets_Mode RLE symbol */
+    section.push_back(0x05); /* Match_Lengths_Mode RLE symbol */
+    section.push_back(0x04); /* the bitstream */
+    return section;
+}
+
+Bytes AcceptedLiterals() {
+    return Bytes{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
+}
+
+Bytes AcceptedFrame() {
+    return BuildFrame(AcceptedLiterals(), AcceptedSequencesSection(),
+                      kAcceptedContentSize);
+}
+
+/* Where the sequences section starts inside the accepted frame: four magic
+ * bytes, the descriptor, the content size, three block-header bytes, and the
+ * literals section's header plus its eight bytes. */
+constexpr size_t kSectionOffsetInFrame = 4 + 1 + 1 + 3 + 1 + 8;
+
+/* One mutated frame, its expected rung, and whether the reference has a
+ * verdict on it at all. */
+struct Negative {
+    const char* name;
+    Bytes section;
+    Bytes frame;
+    bool frame_is_real;
+    cudec_detail::ZstdSeqReject rung;
+};
+
+Negative MutatedFrameNegative(const char* name, size_t index,
+                              unsigned char value,
+                              cudec_detail::ZstdSeqReject rung) {
+    Negative negative;
+    negative.name = name;
+    negative.section = AcceptedSequencesSection();
+    negative.section[index] = value;
+    negative.frame = BuildFrame(AcceptedLiterals(), negative.section,
+                                kAcceptedContentSize);
+    negative.frame_is_real = true;
+    negative.rung = rung;
+    return negative;
+}
+
+Negative SectionOnlyNegative(const char* name, const Bytes& section,
+                             cudec_detail::ZstdSeqReject rung) {
+    Negative negative;
+    negative.name = name;
+    negative.section = section;
+    negative.frame_is_real = false;
+    negative.rung = rung;
+    return negative;
+}
+
+void PrintHex(const char* label, const Bytes& bytes) {
+    std::fprintf(stderr, "%s:", label);
+    for (size_t i = 0; i < bytes.size(); i++) {
+        std::fprintf(stderr, " %02x", bytes[i]);
+    }
+    std::fputc('\n', stderr);
+}
+
+}  // namespace
+
+int main() {
+    /* ---- Step 0: the writer's own proof. The accepted frame decodes through
+     * the reference to bytes computed by hand here, and through the twin to
+     * the one tuple that produces them. Everything below is a mutation of
+     * these bytes, so this is the step that makes the mutations mean
+     * something. */
+    {
+        const Bytes frame = AcceptedFrame();
+        Bytes decoded;
+        if (!ZstdOracleDecodes(frame, &decoded)) {
+            PrintHex("frame", frame);
+        }
+        REQUIRE(ZstdOracleDecodes(frame, &decoded));
+        const Bytes expected{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+                             'h', 'h', 'h', 'h', 'h', 'h', 'h', 'h'};
+        REQUIRE(decoded.size() == expected.size());
+        REQUIRE(equal_bytes(decoded.data(), expected.data(), expected.size()));
+
+        const Bytes section = AcceptedSequencesSection();
+        SeqTables tables;
+        const SectionResult result = DecodeSection(
+            section.data(), section.size(), kAcceptedContentSize, &tables);
+        REQUIRE(result.status == CUDEC_OK);
+        REQUIRE(result.header.sequence_count == 1);
+        REQUIRE(result.header.litlen_mode == cudec_detail::kZstdSeqModeRle);
+        REQUIRE(result.header.offset_mode == cudec_detail::kZstdSeqModeRle);
+        REQUIRE(result.header.matchlen_mode == cudec_detail::kZstdSeqModeRle);
+        REQUIRE(result.sequences.size() == 1);
+        REQUIRE(result.sequences[0].literals_length == 8);
+        REQUIRE(result.sequences[0].match_length == 8);
+        REQUIRE(result.sequences[0].offset_value == 4);
+        /* The section really does start where the mutations index it. */
+        REQUIRE(frame.size() == kSectionOffsetInFrame + section.size());
+        REQUIRE(equal_bytes(frame.data() + kSectionOffsetInFrame,
+                            section.data(), section.size()));
+    }
+
+    /* ---- Step 1: the extra-bit widths and the baselines they sum to, pinned
+     * at every boundary RFC 8878 section 3.1.1.3.2.1.1 names. The tail rule
+     * and the irregular middle meet at codes 24/25 and 42/43, and the direct
+     * runs end at 15 and 31, so those are where an off-by-one lands. */
+    {
+        REQUIRE(cudec_detail::ZstdSeqLitLenExtraBits(0) == 0);
+        REQUIRE(cudec_detail::ZstdSeqLitLenExtraBits(15) == 0);
+        REQUIRE(cudec_detail::ZstdSeqLitLenExtraBits(16) == 1);
+        REQUIRE(cudec_detail::ZstdSeqLitLenExtraBits(19) == 1);
+        REQUIRE(cudec_detail::ZstdSeqLitLenExtraBits(20) == 2);
+        REQUIRE(cudec_detail::ZstdSeqLitLenExtraBits(24) == 4);
+        REQUIRE(cudec_detail::ZstdSeqLitLenExtraBits(25) == 6);
+        REQUIRE(cudec_detail::ZstdSeqLitLenExtraBits(35) == 16);
+        REQUIRE(cudec_detail::ZstdSeqLitLenBaseline(0) == 0);
+        REQUIRE(cudec_detail::ZstdSeqLitLenBaseline(15) == 15);
+        REQUIRE(cudec_detail::ZstdSeqLitLenBaseline(16) == 16);
+        REQUIRE(cudec_detail::ZstdSeqLitLenBaseline(20) == 24);
+        REQUIRE(cudec_detail::ZstdSeqLitLenBaseline(24) == 48);
+        REQUIRE(cudec_detail::ZstdSeqLitLenBaseline(25) == 64);
+        REQUIRE(cudec_detail::ZstdSeqLitLenBaseline(35) == 65536);
+
+        REQUIRE(cudec_detail::ZstdSeqMatchLenExtraBits(0) == 0);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenExtraBits(31) == 0);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenExtraBits(32) == 1);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenExtraBits(36) == 2);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenExtraBits(42) == 5);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenExtraBits(43) == 7);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenExtraBits(52) == 16);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenBaseline(0) == 3);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenBaseline(31) == 34);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenBaseline(32) == 35);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenBaseline(36) == 43);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenBaseline(42) == 99);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenBaseline(43) == 131);
+        REQUIRE(cudec_detail::ZstdSeqMatchLenBaseline(52) == 65539);
+    }
+
+    /* ---- Step 2: the Number_of_Sequences varint, all three encodings plus
+     * the zero that ends the section. The expected counts are the format's
+     * arithmetic written out rather than recomputed from the code. */
+    {
+        struct VarintCase {
+            const char* name;
+            Bytes bytes;
+            uint32_t count;
+            uint64_t consumed;
+        };
+        const VarintCase cases[] = {
+            /* One byte, below the escape. */
+            {"one-byte", Bytes{0x7F, kAcceptedModesByte}, 127, 2},
+            /* Two bytes: ((0x80 - 128) << 8) + 0x2A. */
+            {"two-byte-low", Bytes{0x80, 0x2A, kAcceptedModesByte}, 42, 3},
+            /* Two bytes at the top of the form: ((0xFE - 128) << 8) + 0xFF. */
+            {"two-byte-high", Bytes{0xFE, 0xFF, kAcceptedModesByte}, 32511, 3},
+            /* Three bytes: 0x0201 + 0x7F00. */
+            {"three-byte", Bytes{0xFF, 0x01, 0x02, kAcceptedModesByte}, 33025,
+             4},
+        };
+        for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+            cudec_detail::ZstdSeqSectionHeader header;
+            uint64_t consumed = 0;
+            cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+            const cudec_status status =
+                cudec_detail::ZstdParseSeqSectionHeader(
+                    cases[i].bytes.data(), cases[i].bytes.size(),
+                    cudec_detail::kZstdSeqMinMatchLength * 100000, &header,
+                    &consumed, &rung);
+            REQUIRE_CTX(status == CUDEC_OK, "%s", cases[i].name);
+            REQUIRE_CTX(header.sequence_count == cases[i].count,
+                        "%s: got %u want %u", cases[i].name,
+                        header.sequence_count, cases[i].count);
+            REQUIRE_CTX(consumed == cases[i].consumed, "%s", cases[i].name);
+        }
+
+        /* Zero sequences: the section is that one byte and nothing else, and
+         * the modes are absent rather than defaulted from a byte that is not
+         * there. */
+        const Bytes empty{0x00};
+        cudec_detail::ZstdSeqSectionHeader header;
+        uint64_t consumed = 0;
+        cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+        REQUIRE(cudec_detail::ZstdParseSeqSectionHeader(
+                    empty.data(), empty.size(), 1024, &header, &consumed,
+                    &rung) == CUDEC_OK);
+        REQUIRE(header.sequence_count == 0);
+        REQUIRE(consumed == 1);
+    }
+
+    /* ---- Step 3: the Symbol_Compression_Modes byte, every mode on every
+     * field. The byte carries literals-length in the top two bits, offsets
+     * next, match-lengths next, and two reserved bits at the bottom. */
+    {
+        for (unsigned litlen = 0; litlen < 4; litlen++) {
+            for (unsigned offset = 0; offset < 4; offset++) {
+                for (unsigned matchlen = 0; matchlen < 4; matchlen++) {
+                    const Bytes bytes{
+                        0x01, static_cast<unsigned char>(
+                                  (litlen << 6) | (offset << 4) |
+                                  (matchlen << 2))};
+                    cudec_detail::ZstdSeqSectionHeader header;
+                    uint64_t consumed = 0;
+                    cudec_detail::ZstdSeqReject rung =
+                        cudec_detail::kZstdSeqRejectNone;
+                    REQUIRE(cudec_detail::ZstdParseSeqSectionHeader(
+                                bytes.data(), bytes.size(), 1024, &header,
+                                &consumed, &rung) == CUDEC_OK);
+                    REQUIRE_CTX(header.litlen_mode == litlen, "%u/%u/%u",
+                                litlen, offset, matchlen);
+                    REQUIRE_CTX(header.offset_mode == offset, "%u/%u/%u",
+                                litlen, offset, matchlen);
+                    REQUIRE_CTX(header.matchlen_mode == matchlen, "%u/%u/%u",
+                                litlen, offset, matchlen);
+                    REQUIRE(consumed == 2);
+                }
+            }
+        }
+    }
+
+    /* ---- Step 4: the hand-built trace. Three tables written cell by cell
+     * here, so the symbol sequence is what the bit string spells and nothing
+     * depends on the FSE table builder.
+     *
+     * The bit string, in consumption order, is
+     *
+     *     00 01 10 | 11 | 1 011 10 | 101 1
+     *
+     * and it reads: three state initialisations of two bits each, which is
+     * literals-length 0, offset 1, match-length 2; the first sequence's offset
+     * extra bits; the first sequence's three state updates, one bit for
+     * literals-length, three for match-length and two for offset; and the last
+     * sequence's offset and match-length extra bits. Eighteen bits, packed
+     * into three bytes with the start marker at bit 2 of the last one.
+     *
+     * THE UPDATE WIDTHS ARE ALL DIFFERENT ON PURPOSE. Update the states in any
+     * other order and the 1, 3 and 2 bits go to the wrong states, so the
+     * second sequence reads different cells and its tuple moves. The same
+     * holds for the extra-bit order: offset takes two bits here and
+     * match-length and literals-length take none, so reading them in any other
+     * order changes the offset. */
+    {
+        SeqTables tables;
+        for (unsigned cell = 0; cell < 4; cell++) {
+            tables.litlen_cells[cell] = {0, 0, 0};
+            tables.offset_cells[cell] = {0, 0, 0};
+            tables.matchlen_cells[cell] = {0, 0, 0};
+        }
+        /* {new_state, symbol, nb_bits} */
+        tables.litlen_cells[0] = {1, 0, 1};
+        tables.litlen_cells[2] = {0, 4, 0};
+        tables.offset_cells[1] = {0, 2, 2};
+        tables.offset_cells[2] = {0, 3, 0};
+        tables.matchlen_cells[2] = {0, 0, 3};
+        tables.matchlen_cells[3] = {0, 32, 0};
+        tables.litlen.table_size = 4;
+        tables.litlen.accuracy_log = 2;
+        tables.litlen.present = true;
+        tables.offset.table_size = 4;
+        tables.offset.accuracy_log = 2;
+        tables.offset.present = true;
+        tables.matchlen.table_size = 4;
+        tables.matchlen.accuracy_log = 2;
+        tables.matchlen.present = true;
+
+        const Bytes stream{0xEB, 0x6E, 0x04};
+        cudec_detail::ZstdSequence decoded[2];
+        cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+        REQUIRE(cudec_detail::ZstdDecodeSequences(
+                    stream.data(), stream.size(), 2, &tables.litlen,
+                    &tables.offset, &tables.matchlen, decoded, 2,
+                    &rung) == CUDEC_OK);
+        /* Sequence one: literals-length code 0, match-length code 0, offset
+         * code 2 with both extra bits set. */
+        REQUIRE(decoded[0].literals_length == 0);
+        REQUIRE(decoded[0].match_length == 3);
+        REQUIRE(decoded[0].offset_value == 7);
+        /* Sequence two, after the updates: literals-length code 4,
+         * match-length code 32 with one extra bit set, offset code 3 with
+         * extra bits 101. */
+        REQUIRE(decoded[1].literals_length == 4);
+        REQUIRE(decoded[1].match_length == 36);
+        REQUIRE(decoded[1].offset_value == 13);
+    }
+
+    /* ---- Step 5: the corpus sweep. Every compressed block of every fixture
+     * that carries sequences, positioned by the frame walker, its three tables
+     * loaded from the section's own bytes and its bitstream decoded. */
+    size_t corpus_blocks = 0;
+    size_t corpus_sequences = 0;
+    size_t corpus_headers = 0;
+    unsigned mode_seen[4] = {0, 0, 0, 0};
+    {
+        const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+        REQUIRE(!fixtures.empty());
+        for (size_t f = 0; f < fixtures.size(); f++) {
+            const ZstdFixture& fixture = fixtures[f];
+            ZstdFrameShape shape;
+            std::string why;
+            REQUIRE_CTX(ParseZstdFrameShape(fixture.compressed, &shape, &why),
+                        "%s: %s", fixture.name.c_str(), why.c_str());
+            /* One set of tables per FRAME, not per block: Repeat_Mode names
+             * the table the previous block of this frame left behind, and a
+             * fresh set per block would refuse every Repeat the corpus
+             * carries. A new frame starts with none, which is what makes the
+             * Repeat-without-a-table negative below reachable. */
+            SeqTables tables;
+            for (size_t b = 0; b < shape.blocks.size(); b++) {
+                const ZstdBlockShape& block = shape.blocks[b];
+                if (block.block_type != kZstdBlockCompressed ||
+                    block.sequence_count == 0) {
+                    continue;
+                }
+                corpus_blocks++;
+                corpus_sequences += block.sequence_count;
+                mode_seen[block.ll_mode]++;
+                mode_seen[block.of_mode]++;
+                mode_seen[block.ml_mode]++;
+                char where[192];
+                std::snprintf(where, sizeof(where), "%s block %zu",
+                              fixture.name.c_str(), b);
+
+                /* The walker stands on the first table description, so the
+                 * section header sits just above it. Its length is one mode
+                 * byte plus a varint of one, two or three bytes, and which of
+                 * the three it is, is not derivable from the count alone - an
+                 * encoder may spell a small count in a long form. So each
+                 * start is tried and the one that reproduces the walker's
+                 * count and its three modes, landing exactly on the first
+                 * description, is the section header. */
+                bool header_agreed = false;
+                for (size_t length = 1; length <= 3 && !header_agreed;
+                     length++) {
+                    if (block.tables_offset < length + 1) {
+                        continue;
+                    }
+                    const size_t start = block.tables_offset - length - 1;
+                    cudec_detail::ZstdSeqSectionHeader header;
+                    uint64_t consumed = 0;
+                    cudec_detail::ZstdSeqReject rung =
+                        cudec_detail::kZstdSeqRejectNone;
+                    if (cudec_detail::ZstdParseSeqSectionHeader(
+                            fixture.compressed.data() + start,
+                            block.block_end - start,
+                            cudec_detail::kZstdBlockSizeCeiling, &header,
+                            &consumed, &rung) != CUDEC_OK) {
+                        continue;
+                    }
+                    header_agreed =
+                        consumed == length + 1 &&
+                        header.sequence_count == block.sequence_count &&
+                        header.litlen_mode == block.ll_mode &&
+                        header.offset_mode == block.of_mode &&
+                        header.matchlen_mode == block.ml_mode;
+                }
+                REQUIRE_CTX(header_agreed,
+                            "%s: no section header start reproduces the "
+                            "walker's count and modes",
+                            where);
+                corpus_headers++;
+
+                /* The tables and the bitstream. The three modes come from the
+                 * walker so this leg tests the loader and the loop rather than
+                 * the header parse, which the leg above covered. */
+                size_t position = block.tables_offset;
+                const unsigned fields[] = {
+                    cudec_detail::kZstdSeqFieldLitLen,
+                    cudec_detail::kZstdSeqFieldOffset,
+                    cudec_detail::kZstdSeqFieldMatchLen};
+                const unsigned modes[] = {block.ll_mode, block.of_mode,
+                                          block.ml_mode};
+                cudec_detail::ZstdSeqTable* targets[] = {
+                    &tables.litlen, &tables.offset, &tables.matchlen};
+                for (unsigned index = 0; index < 3; index++) {
+                    uint64_t consumed = 0;
+                    cudec_detail::ZstdSeqReject rung =
+                        cudec_detail::kZstdSeqRejectNone;
+                    REQUIRE_CTX(
+                        cudec_detail::ZstdSeqLoadTable(
+                            fields[index], modes[index],
+                            fixture.compressed.data() + position,
+                            block.block_end - position, &tables.scratch,
+                            targets[index], &consumed, &rung) == CUDEC_OK,
+                        "%s: field %u mode %u refused through rung %d", where,
+                        index, modes[index], static_cast<int>(rung));
+                    position += static_cast<size_t>(consumed);
+                    REQUIRE_CTX(position <= block.block_end, "%s", where);
+                }
+
+                std::vector<cudec_detail::ZstdSequence> sequences(
+                    block.sequence_count);
+                cudec_detail::ZstdSeqReject rung =
+                    cudec_detail::kZstdSeqRejectNone;
+                REQUIRE_CTX(
+                    cudec_detail::ZstdDecodeSequences(
+                        fixture.compressed.data() + position,
+                        block.block_end - position, block.sequence_count,
+                        &tables.litlen, &tables.offset, &tables.matchlen,
+                        sequences.data(),
+                        static_cast<uint32_t>(sequences.size()),
+                        &rung) == CUDEC_OK,
+                    "%s: %u sequences refused through rung %d", where,
+                    block.sequence_count, static_cast<int>(rung));
+                for (size_t s = 0; s < sequences.size(); s++) {
+                    REQUIRE_CTX(sequences[s].match_length >=
+                                    cudec_detail::kZstdSeqMinMatchLength,
+                                "%s: sequence %zu", where, s);
+                    REQUIRE_CTX(sequences[s].offset_value >= 1, "%s", where);
+                }
+            }
+        }
+        /* A sweep that found nothing passes every assertion above, which is
+         * the shape this project has been bitten by before. */
+        REQUIRE(corpus_blocks > 0);
+        /* Predefined and Set_Compressed are what a compressor at these sizes
+         * emits; RLE and Repeat are not required to appear, and the hand-built
+         * sections above are where those two are covered. */
+        REQUIRE(mode_seen[kZstdTableBasic] > 0);
+        REQUIRE(mode_seen[kZstdTableCompressed] > 0);
+    }
+
+    /* ---- Step 6: the negatives, one per declared rung. */
+    {
+        std::vector<Negative> negatives;
+
+        /* Mutations of the accepted frame: the reference has a verdict on
+         * every one of these, and each differs from a frame it accepts by one
+         * byte. */
+        negatives.push_back(MutatedFrameNegative(
+            "modes-reserved-bits", 1, kAcceptedModesByte | 0x01,
+            cudec_detail::kZstdSeqRejectModesReserved));
+        negatives.push_back(MutatedFrameNegative(
+            "rle-symbol-past-max", 2,
+            cudec_detail::kZstdSeqLitLenSymbolCount,
+            cudec_detail::kZstdSeqRejectSymbolPastMax));
+        negatives.push_back(MutatedFrameNegative(
+            "repeat-without-table", 1,
+            (cudec_detail::kZstdSeqModeRepeat << 6) | (1u << 4) | (1u << 2),
+            cudec_detail::kZstdSeqRejectRepeatWithoutTable));
+        negatives.push_back(MutatedFrameNegative(
+            "bitstream-without-marker", 5, 0x00,
+            cudec_detail::kZstdSeqRejectBitstreamMissing));
+        negatives.push_back(MutatedFrameNegative(
+            "one-sequence-too-many", 0, 0x02,
+            cudec_detail::kZstdSeqRejectSequenceTruncated));
+        negatives.push_back(MutatedFrameNegative(
+            "bitstream-not-consumed", 5, 0x0C,
+            cudec_detail::kZstdSeqRejectBitstreamNotConsumed));
+
+        /* Section fragments. The reference decodes frames, not sections, and
+         * wrapping a fragment in a frame would change which field the block
+         * header declares - so these assert the twin's rung alone and say so
+         * rather than manufacturing a verdict. */
+        negatives.push_back(SectionOnlyNegative(
+            "count-two-byte-truncated", Bytes{0x80},
+            cudec_detail::kZstdSeqRejectCountTruncated));
+        negatives.push_back(SectionOnlyNegative(
+            "count-three-byte-truncated", Bytes{0xFF, 0x01},
+            cudec_detail::kZstdSeqRejectCountTruncated));
+        negatives.push_back(SectionOnlyNegative(
+            "modes-missing", Bytes{0x01},
+            cudec_detail::kZstdSeqRejectModesTruncated));
+        negatives.push_back(SectionOnlyNegative(
+            "rle-symbol-missing", Bytes{0x01, kAcceptedModesByte},
+            cudec_detail::kZstdSeqRejectRleTruncated));
+        /* A Set_Compressed description on every field with nothing behind the
+         * mode byte to read it from. */
+        negatives.push_back(SectionOnlyNegative(
+            "table-description-truncated",
+            Bytes{0x01, static_cast<unsigned char>(
+                            (cudec_detail::kZstdSeqModeCompressed << 6) |
+                            (cudec_detail::kZstdSeqModeCompressed << 4) |
+                            (cudec_detail::kZstdSeqModeCompressed << 2))},
+            cudec_detail::kZstdSeqRejectTableDescription));
+        /* Three Predefined tables want six, five and six bits of state before
+         * the first sequence; this stream carries three. */
+        negatives.push_back(SectionOnlyNegative(
+            "state-init-truncated", Bytes{0x01, 0x00, 0x08},
+            cudec_detail::kZstdSeqRejectStateInitTruncated));
+
+        for (size_t i = 0; i < negatives.size(); i++) {
+            const Negative& negative = negatives[i];
+            SeqTables tables;
+            const SectionResult result =
+                DecodeSection(negative.section.data(), negative.section.size(),
+                              kAcceptedContentSize, &tables);
+            REQUIRE_CTX(result.status != CUDEC_OK, "%s was accepted",
+                        negative.name);
+            REQUIRE_CTX(result.rung == negative.rung,
+                        "%s: refused through rung %d, want %d", negative.name,
+                        static_cast<int>(result.rung),
+                        static_cast<int>(negative.rung));
+            CoverRung(result.rung);
+            if (!negative.frame_is_real) {
+                continue;
+            }
+            Bytes decoded;
+            if (ZstdOracleDecodes(negative.frame, &decoded)) {
+                PrintHex(negative.name, negative.frame);
+            }
+            REQUIRE_CTX(!ZstdOracleDecodes(negative.frame, &decoded),
+                        "%s: the reference accepted it", negative.name);
+        }
+
+        /* The count bound. Not a mutation of the accepted frame: what it
+         * refuses is a count larger than the block's regenerated size can
+         * hold, and the accepted frame's block regenerates sixteen bytes, so
+         * the bound is five sequences. */
+        {
+            cudec_detail::ZstdSeqSectionHeader header;
+            uint64_t consumed = 0;
+            cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+            const Bytes bytes{0x06, kAcceptedModesByte};
+            REQUIRE(cudec_detail::ZstdParseSeqSectionHeader(
+                        bytes.data(), bytes.size(), kAcceptedContentSize,
+                        &header, &consumed, &rung) != CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdSeqRejectCountTooLarge);
+            CoverRung(rung);
+            /* One below the bound is accepted, so the refusal above is the
+             * bound rather than a blanket refusal. */
+            const Bytes allowed{0x05, kAcceptedModesByte};
+            REQUIRE(cudec_detail::ZstdParseSeqSectionHeader(
+                        allowed.data(), allowed.size(), kAcceptedContentSize,
+                        &header, &consumed, &rung) == CUDEC_OK);
+        }
+
+        /* A section of no bytes at all. Written against a real pointer with
+         * a zero length rather than an empty vector, whose data() may be null
+         * and would reach the caller-argument rung instead. */
+        {
+            const unsigned char anchor = 0;
+            cudec_detail::ZstdSeqSectionHeader header;
+            uint64_t consumed = 0;
+            cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+            REQUIRE(cudec_detail::ZstdParseSeqSectionHeader(
+                        &anchor, 0, 1024, &header, &consumed, &rung) !=
+                    CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdSeqRejectCountTruncated);
+            CoverRung(rung);
+        }
+
+        /* A caller argument rather than a stream: no buffer at all. */
+        {
+            cudec_detail::ZstdSeqSectionHeader header;
+            uint64_t consumed = 0;
+            cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+            REQUIRE(cudec_detail::ZstdParseSeqSectionHeader(
+                        0, 4, 1024, &header, &consumed, &rung) !=
+                    CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdSeqRejectBadRequest);
+            CoverRung(rung);
+        }
+
+        /* A table claiming four cells over an array of one. Nothing the unit
+         * builds can look like this, and the cell reads in the loop are
+         * bounded by the claim rather than by the array, so it is refused
+         * before the first read rather than trusted. */
+        {
+            cudec_detail::ZstdFseCell one_cell = {0, 0, 0};
+            cudec_detail::ZstdSeqTable narrow;
+            narrow.cells = &one_cell;
+            narrow.capacity = 1;
+            narrow.table_size = 4;
+            narrow.accuracy_log = 2;
+            narrow.present = true;
+            const Bytes stream{0x02};
+            cudec_detail::ZstdSequence decoded[1];
+            cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+            REQUIRE(cudec_detail::ZstdDecodeSequences(
+                        stream.data(), stream.size(), 1, &narrow, &narrow,
+                        &narrow, decoded, 1, &rung) != CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdSeqRejectTableCapacity);
+            CoverRung(rung);
+        }
+
+        /* A code out of a table rather than out of a description: a
+         * hand-built literals-length cell naming a symbol the alphabet does
+         * not have. No description this unit accepts produces one, which is
+         * why the description-side rung's negative cannot stand in for it. */
+        {
+            SeqTables tables;
+            tables.litlen_cells[0] = {0, 40, 0};
+            tables.offset_cells[0] = {0, 0, 0};
+            tables.matchlen_cells[0] = {0, 0, 0};
+            tables.litlen.table_size = 1;
+            tables.litlen.accuracy_log = 0;
+            tables.litlen.present = true;
+            tables.offset.table_size = 1;
+            tables.offset.accuracy_log = 0;
+            tables.offset.present = true;
+            tables.matchlen.table_size = 1;
+            tables.matchlen.accuracy_log = 0;
+            tables.matchlen.present = true;
+            const Bytes stream{0x02};
+            cudec_detail::ZstdSequence decoded[1];
+            cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+            REQUIRE(cudec_detail::ZstdDecodeSequences(
+                        stream.data(), stream.size(), 1, &tables.litlen,
+                        &tables.offset, &tables.matchlen, decoded, 1,
+                        &rung) != CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdSeqRejectDecodedSymbolPastMax);
+            CoverRung(rung);
+        }
+
+        /* A cell array that came from somewhere else: a table declaring four
+         * cells' worth of state bits over a table of one. No description this
+         * unit accepts produces one, and the reference has no verdict on a
+         * table rather than a stream. */
+        {
+            SeqTables tables;
+            tables.litlen_cells[0] = {0, 0, 0};
+            tables.offset_cells[0] = {0, 0, 0};
+            tables.matchlen_cells[0] = {0, 0, 0};
+            tables.litlen.table_size = 1;
+            tables.litlen.accuracy_log = 2;
+            tables.litlen.present = true;
+            tables.offset.table_size = 1;
+            tables.offset.accuracy_log = 0;
+            tables.offset.present = true;
+            tables.matchlen.table_size = 1;
+            tables.matchlen.accuracy_log = 0;
+            tables.matchlen.present = true;
+            const Bytes stream{0x1F};
+            cudec_detail::ZstdSequence decoded[1];
+            cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+            REQUIRE(cudec_detail::ZstdDecodeSequences(
+                        stream.data(), stream.size(), 1, &tables.litlen,
+                        &tables.offset, &tables.matchlen, decoded, 1,
+                        &rung) != CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdSeqRejectStateOutOfTable);
+            CoverRung(rung);
+        }
+    }
+
+    for (int declared = cudec_detail::kZstdSeqRejectNone + 1;
+         declared < cudec_detail::kZstdSeqRejectCount; declared++) {
+        REQUIRE_CTX(g_reject_covered[declared],
+                    "reject rung %d has no declared negative that reaches it "
+                    "- add one, or the rung is untested",
+                    declared);
+    }
+
+    std::printf("PASS: %zu sequences decoded across %zu corpus blocks, %zu "
+                "section headers reproduced against the frame walker, %d of "
+                "%d reject rungs covered by a declared negative\n",
+                corpus_sequences, corpus_blocks, corpus_headers,
+                static_cast<int>(cudec_detail::kZstdSeqRejectCount) - 1,
+                static_cast<int>(cudec_detail::kZstdSeqRejectCount) - 1);
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #196.

The sequences section is where a Zstd block says what to copy and from where.
Three orders govern it and no two of them are the same: the states are
initialised literals-length, offset, match-length; the extra bits are read
offset, match-length, literals-length; and the states are updated
literals-length, match-length, offset. Getting any one of them wrong still
decodes the first field of the first sequence correctly and then produces a
different stream in silence, so this lands with a proof against that rather
than an argument.

`src/zstd_seq.h` holds the unit: the `Number_of_Sequences` varint in all three
encodings, the `Symbol_Compression_Modes` byte, the four table modes on each of
the three fields, and the loop. It adds no second copy of the FSE core -
Predefined and Set_Compressed tables are built through `ZstdFseBuildDTable`,
and the two halves of a state step are split only because the format reads
three fields' extra bits between them, which the comment at that split says.

Baselines are derived rather than tabulated. Every literals-length and
match-length baseline is the running sum of the widths below it, so the only
table a reader has to check against RFC 8878 is the extra-bit vector.

Repcode resolution and sequence execution are not here; an offset value of 1, 2
or 3 is handed on raw rather than guessed at. That is the issue's own scope
line, and the header says so where a caller will read it.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)

## Engineering checklist

- [x] Fail-closed preserved: sixteen reject rungs, each with a negative that
      reaches it, and the run prints `16 of 16 reject rungs covered by a
      declared negative` or fails. The bounds that are not obvious are argued
      where they sit: a sequence count is refused against what the block can
      regenerate before a bit is read, a Repeat with no previously decoded
      table is refused rather than resolved against a stale cell array, a table
      claiming more cells than its array holds is refused before the first cell
      read, and the bitstream has to end exactly where the last sequence leaves
      it.
- [x] Oracle coverage: the frame the negatives are mutations of is decoded by
      the pinned libzstd 1.5.7 first and required to produce bytes computed by
      hand; each of the six frame negatives is one byte away from it and the
      reference is required to refuse it. The reference's codes do not
      discriminate between malformed sections, so a negative asserts that it
      refused, and the rung comes from this tree's own ladder.
- [x] Determinism preserved: no floating point, no atomics, no allocation; the
      unit is a pure function of its input bytes and the caller's storage.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      No CUDA call and no device code is added here.
- [ ] An adversarial review (`/security-review`) was run.

  **NOT RUN, and nothing here should be read as a second reader having seen
  this.** No lens ran over this diff and no review record exists for it. What
  stands in its place is executed rather than asserted, and it is below: a
  mutant table where every guard was removed one at a time and the suite
  watched, and a sweep over every compressed block the corpus carries.

- [ ] Review record: none, per the line above.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

`src/zstd_seq.h` is `__host__ __device__` and compiles for both, but nothing in
this change launches a kernel or is reachable from one yet - the sequences unit
has no caller on the device until the M5 kernel lands. There was also no route
to a device the sanitizer could attach to from here:

```
$ docker version --format {{.Server.Version}}
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
$ nvcc --version
nvcc: command not found
```

## Performance checklist

Not on the hot path and no number is claimed. The baselines are recomputed per
lookup on purpose: this is the correctness twin, and a resident baseline table
is a performance shape that belongs with the kernel that needs it, exactly as
the FSE cell layout does. The header says so where the derivation is written.

## Quality checklist

- [x] Minimal: no second FSE core, no second bit reader, no baseline tables.
      The one place a reader may expect reuse and does not find it -
      `ZstdFseNextSymbol` is not called from the sequence loop - carries the
      reason at the split.
- [x] Self-documenting.
- [x] The new structural property is locked by the test rather than by prose:
      every declared rung must be reached by a declared negative, checked in a
      loop over the enum, so a rung added later without one reds the run.

## Verification

The container gate could not be run: the Docker daemon is not reachable from
here (the command and its output are in the sanitizer block above), and this
host carries no CUDA toolchain, so `ctest` could not be run through the
project's own build. **CI is the gate for this change** - its build job
configures with `CUDEC_ENABLE_CUDA=ON` and runs `ctest -LE gpu`, which is where
`zstd_seq_twin` sits.

What was run here instead, and it is a different thing rather than the same
thing by another route: libzstd 1.5.7 was built from the archive this
repository already pins, and the twin was compiled and run against it directly.

```
$ curl -sSL -o zstd-1.5.7.tar.gz \
    https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz
$ sha256sum zstd-1.5.7.tar.gz
eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3
```

which is byte for byte the pin in `cmake/CudecZstdOracle.cmake`.

```
$ g++ -std=c++17 -O1 -Wall -Wextra -Werror -Iinclude -Isrc -Itests \
    -Izstd-1.5.7/lib -Izstd-1.5.7/lib/common \
    tests/zstd_seq_twin.cpp tests/zstd_corpus.cpp src/version.c \
    zstd-1.5.7/libzstd.a -o zstd_seq_twin
$ ./zstd_seq_twin
PASS: 125067 sequences decoded across 332 corpus blocks, 332 section headers
reproduced against the frame walker, 16 of 16 reject rungs covered by a
declared negative
```

- [x] `cmake -B build && cmake --build build` - builds clean (host-only, which
      is what this host can configure).
- [ ] `ctest --test-dir build` - not run here; see above.
- [x] Prettier - no `.md`, `.yml` or `.yaml` file is touched by this change.
- [x] Docs synced: nothing in MASTERPLAN, README or BENCHMARKS describes this
      unit yet, and no behaviour, API or number moves.

## The mutant table

Every guard removed one at a time, the suite rebuilt and run, and the check it
died on recorded. Fifteen mutants, no survivors.

| mutant | result |
| --- | --- |
| init order: offset state before literals-length | red, the hand-built trace |
| extra-bit order: match-length before offset | red, `decoded[1].offset_value == 13` |
| update order: offset before match-length | red, the hand-built trace |
| the last sequence updates its states too | red, the corpus sweep |
| the exact-consumption check is gone | red, `bitstream-not-consumed was accepted` |
| the reserved mode bits are ignored | red, `modes-reserved-bits was accepted` |
| the sequence-count bound is gone | red, the count-bound negative |
| an RLE symbol past the field alphabet is accepted | red, the rung the negative names |
| Repeat with no previous table is accepted | red, the rung the negative names |
| the literals-length baseline sums one width too many | red, the accepted frame's tuple |
| the match-length extra-bit tail is off by one | red, the RFC boundary pins |
| a decoded code past the field alphabet is not refused | red, the hand-built-table negative |
| an RLE table claims one bit of state | red, the accepted frame |
| the predefined literals-length accuracy log is one too high | red, the corpus sweep |
| the table-capacity guard is gone | red, the narrow-table negative |

**Two of them survived the first pass, and both were the same shape.** Removing
the RLE symbol bound left the section still refused, by the per-sequence code
bound one layer down and through the same rung, so the negative could not tell
the two guards apart; and the per-sequence bound then had no negative of its
own that a description could reach at all. Both were repaired by separating the
rungs - a description naming a symbol past the alphabet and a code coming out
of a table are different refusals - and by writing the second negative against
a hand-built table. The table-capacity rung came out of the same reading: a
state is checked against `table_size`, and nothing was checking `table_size`
against the allocation.

## Notes

The corpus sweep asserts exact bitstream consumption rather than a tuple
comparison, because the reference exposes no sequence stream to compare against
at this layer. What that buys is stated rather than assumed: a wrong
state-update order advances the wrong state, the next symbol's cell asks for a
different number of bits, and the stream stops landing on its last bit - which
is what the fourth and fourteenth mutants above demonstrate over 332 real
blocks.

One set of tables is held per frame in the sweep, not per block, because
Repeat_Mode names the table the previous block of that frame left behind.
