### PR TITLE
Resolve Zstd repeat offsets against the frame's three-slot history

### DIFF
--- a/src/zstd_repcode.h
+++ b/src/zstd_repcode.h
@@ -1,0 +1,188 @@
+/* Zstd repeat-offset resolution: the three-slot history a frame carries, and
+ * the rules that turn a sequence's Offset_Value into a distance. RFC 8878
+ * section 3.1.1.5. Single-sourced for host and device, the sibling of
+ * src/zstd_seq.h, which hands the raw Offset_Value on and refuses to guess.
+ * Internal header, not part of the ABI.
+ *
+ * THE HISTORY IS THE FRAME'S AND NOT THE BLOCK'S. It is initialised to
+ * {1, 4, 8} once, at frame start, and every block after the first inherits
+ * what the one before it left. A decoder that reset it per block would decode
+ * the first block of every frame correctly and then produce wrong bytes for
+ * the rest, which is the failure the twin's cross-block rows exist to catch.
+ *
+ * ONE VALUE MEANS TWO DIFFERENT SLOTS AND THE LITERALS LENGTH IS WHAT DECIDES.
+ * With a non-zero literals length, Offset_Value 1, 2 and 3 name the most
+ * recent, second and third offsets. With a literals length of ZERO the meaning
+ * shifts by one - 1 names the second, 2 the third, and 3 means "the most
+ * recent, minus one". The shift exists because a repeat of the most recent
+ * offset with no literals between the two matches would be one longer match
+ * rather than two sequences, so that encoding is free for something else. An
+ * implementation that misses the shift decodes every sequence with literals
+ * correctly and silently corrupts the ones without.
+ *
+ * THE MINUS-ONE CASE IS THE ONLY WAY A REPEAT CAN REACH ZERO, AND ZERO IS NOT
+ * AN OFFSET. Every other resolution is a slot value or an explicit offset, and
+ * both are at least one: an explicit Offset_Value is above three and the three
+ * is subtracted, and a slot only ever receives a value that already passed
+ * this check. So the refusal is written once, over the resolved value, and it
+ * catches both the corrupt stream and a caller that handed in a history it
+ * never initialised. The reference reaches the same verdict differently - it
+ * forces the zero to an offset no output can satisfy and lets the copy refuse
+ * - so the two agree on the frame and differ on where they say so, which is
+ * what the twin asserts rather than a shared error code.
+ *
+ * WHAT THIS UNIT DOES NOT DO. It does not bound the resolved offset against
+ * the window or against the bytes produced so far: that bound belongs with
+ * the copy that uses it, and stating it here would give a caller two places to
+ * believe it was checked. */
+#ifndef CUDEC_ZSTD_REPCODE_H
+#define CUDEC_ZSTD_REPCODE_H
+
+#include "cudec.h"
+
+#include <stdint.h>
+
+/* Guarded: the sibling decode headers define the same macro for the same
+ * reason, and a device translation unit that decodes more than one format
+ * includes more than one of them. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+/* Section 3.1.1.5: three slots, and the Offset_Values 1, 2 and 3 that name
+ * them. The same three is what an explicit Offset_Value carries above its
+ * distance, because those three encodings are spent on the repeats. */
+constexpr unsigned kZstdRepcodeSlots = 3;
+constexpr uint64_t kZstdRepcodeMaxSlotValue = 3;
+
+/* The values the history starts a frame with, section 3.1.1.5. */
+constexpr uint64_t kZstdRepcodeInitial0 = 1;
+constexpr uint64_t kZstdRepcodeInitial1 = 4;
+constexpr uint64_t kZstdRepcodeInitial2 = 8;
+
+/* The reject ladder, enumerated once, in the shape src/zstd_seq.h and
+ * src/zstd_huf.h use: every refusal returns through one choke point naming
+ * its rung, so the twin requires a negative per rung instead of counting
+ * statuses that repeat. */
+enum ZstdRepcodeReject {
+    kZstdRepcodeRejectNone = 0,
+    /* An Offset_Value of zero, or storage the caller did not supply. Neither
+     * is a stream: src/zstd_seq.h produces a value of at least one for every
+     * Offset_Code the format has, so a zero arriving here is a caller bug
+     * refused rather than resolved. */
+    kZstdRepcodeRejectBadRequest,
+    /* A repeat that resolved to zero. Reached by the minus-one rule at a
+     * point where the most recent offset is one, and by a history that was
+     * never initialised. */
+    kZstdRepcodeRejectResolvedToZero,
+    kZstdRepcodeRejectCount
+};
+
+CUDEC_HOST_DEVICE inline cudec_status ZstdRepcodeRefuse(
+    ZstdRepcodeReject rung, cudec_status status, ZstdRepcodeReject* out) {
+    if (out != 0) {
+        *out = rung;
+    }
+    return status;
+}
+
+/* The three most recent offsets, most recent first. The caller owns it and
+ * carries it across the blocks of one frame; a kernel decides where it
+ * lives, which is why this header neither allocates it nor hides it. */
+struct ZstdRepcodeHistory {
+    uint64_t slot[kZstdRepcodeSlots];
+};
+
+/* Frame start, and the only place the history is ever reset. */
+CUDEC_HOST_DEVICE inline void ZstdRepcodeInit(ZstdRepcodeHistory* history) {
+    history->slot[0] = kZstdRepcodeInitial0;
+    history->slot[1] = kZstdRepcodeInitial1;
+    history->slot[2] = kZstdRepcodeInitial2;
+}
+
+/* Resolves one sequence's Offset_Value into a distance and moves the history
+ * on. Both, in one call: the recency rotation is part of the resolution
+ * rather than a step a caller could forget, and a caller that forgot it would
+ * decode the first repeat of a frame correctly and every later one wrongly.
+ *
+ * `offset_value` is src/zstd_seq.h's own quantity, (1 << Offset_Code) plus
+ * the code's extra bits, so 1, 2 and 3 name slots and anything above three is
+ * an explicit distance three larger than itself.
+ *
+ * `literals_length` is this sequence's, and only whether it is zero
+ * matters. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdRepcodeResolve(
+    ZstdRepcodeHistory* history, uint64_t offset_value,
+    uint32_t literals_length, uint64_t* out_offset,
+    ZstdRepcodeReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdRepcodeRejectNone;
+    }
+    if (out_offset != 0) {
+        *out_offset = 0;
+    }
+    if (history == 0 || out_offset == 0 || offset_value == 0) {
+        return ZstdRepcodeRefuse(kZstdRepcodeRejectBadRequest,
+                                 CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+
+    uint64_t resolved = 0;
+    /* Which slot the value took, or kZstdRepcodeSlots for a value that took
+     * none - an explicit offset or the minus-one rule. That distinction is
+     * what the rotation below reads, and it is not the same as the value. */
+    unsigned taken = kZstdRepcodeSlots;
+
+    if (offset_value > kZstdRepcodeMaxSlotValue) {
+        resolved = offset_value - kZstdRepcodeMaxSlotValue;
+    } else if (literals_length != 0) {
+        taken = static_cast<unsigned>(offset_value) - 1u;
+        resolved = history->slot[taken];
+    } else if (offset_value < kZstdRepcodeMaxSlotValue) {
+        /* The shift: 1 names the second slot and 2 the third. */
+        taken = static_cast<unsigned>(offset_value);
+        resolved = history->slot[taken];
+    } else {
+        /* Offset_Value 3 with no literals: the most recent offset, minus one.
+         * READ FIRST AND SUBTRACT AFTER, so that a slot of zero leaves the
+         * resolved value at zero and is refused by the one check below. The
+         * other order wraps a zero slot into the widest offset there is, and
+         * an unsigned subtraction that wraps is a fail-open however loudly
+         * whatever runs next refuses it. A slot is zero only where a caller
+         * handed in a history it never initialised, which is exactly the case
+         * that has nothing else guarding it. */
+        resolved = history->slot[0];
+        if (resolved != 0) {
+            resolved -= 1;
+        }
+    }
+
+    if (resolved == 0) {
+        return ZstdRepcodeRefuse(kZstdRepcodeRejectResolvedToZero,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    /* The recency rotation, and the same three lines serve every case that
+     * moves anything. Taking the most recent offset moves nothing, which is
+     * why slot 0 is the one case with no update at all; taking the second
+     * swaps the top two and leaves the third alone; everything else pushes
+     * the resolved value onto the front and drops the oldest. */
+    if (taken != 0) {
+        if (taken != 1) {
+            history->slot[2] = history->slot[1];
+        }
+        history->slot[1] = history->slot[0];
+        history->slot[0] = resolved;
+    }
+    *out_offset = resolved;
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_ZSTD_REPCODE_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -317,6 +317,19 @@ cudec_add_test(zstd_literals_twin SOURCES zstd_literals_twin.cpp
 target_include_directories(zstd_literals_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_compile_definitions(zstd_literals_twin PRIVATE HUF_STATIC_LINKING_ONLY)
+# Zstd repeat-offset resolution: the three-slot history, the zero-literals
+# index shift, the minus-one rule and the recency rotation (issue #197).
+# Host-side and GPU-less. It links zstd_full alone for the reason
+# zstd_oracle_smoke gives above, and because its rows are whole frames the
+# reference has to decide on through its frame entry point - a resolved offset
+# is not observable on its own. It compiles zstd_corpus.cpp for the reason
+# zstd_fse_twin does: the #185 fixtures are half of what it decodes, the other
+# half being repeat-offset-dense sources it compresses itself.
+cudec_add_test(zstd_repcode_twin SOURCES zstd_repcode_twin.cpp zstd_corpus.cpp
+               LIBS zstd_full)
+target_include_directories(zstd_repcode_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_compile_definitions(zstd_repcode_twin PRIVATE HUF_STATIC_LINKING_ONLY)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/zstd_repcode_twin.cpp
+++ b/tests/zstd_repcode_twin.cpp
@@ -1,0 +1,1048 @@
+/* The CPU twin of Zstd repeat-offset resolution (src/zstd_repcode.h): the
+ * three-slot history, the zero-literals index shift, the minus-one rule and
+ * the recency rotation (issue #197). The sibling of tests/zstd_seq_twin.cpp,
+ * which decodes the Offset_Values this unit resolves.
+ *
+ * THREE PROOFS, AND THEY ARE DIFFERENT IN KIND.
+ *
+ * THE RULES ARE PINNED ONE BY ONE AGAINST HAND-COMPUTED EXPECTATIONS, history
+ * slot by history slot. Each rule from RFC 8878 section 3.1.1.5 has its own
+ * named row, because the rules share an implementation and a single test over
+ * all of them would pass on an implementation that got two of them wrong in
+ * compensating directions.
+ *
+ * THE ORACLE DECIDES THE BYTES, over frames this file writes. A resolved
+ * offset is not observable on its own, so each crafted frame is decoded twice:
+ * once by the pinned reference, and once by a driver here that copies literals
+ * and matches at the offsets this unit resolves. The two byte strings must be
+ * equal. That is what turns "the offset came out as 4" into a claim about the
+ * format rather than about this file's arithmetic - and the reject direction
+ * is the same frame construction with the rule violated, where the reference
+ * must refuse and this unit must refuse too.
+ *
+ * THE CORPUS IS WHERE THE ROTATION IS EXERCISED DENSELY. The crafted frames
+ * carry one or two sequences each; a compressor's block carries thousands, and
+ * the rotation is the rule whose errors only show up after enough of them. So
+ * the driver decodes every #185 fixture whole - literals through
+ * src/zstd_literals.h, sequences through src/zstd_seq.h, offsets through the
+ * unit under test - and requires the result to equal the reference's byte for
+ * byte.
+ *
+ * THE DRIVER IS THIS FILE'S AND NOT A SHIPPED UNIT. Executing a sequence and
+ * looping over a frame's blocks are their own issues with their own contracts;
+ * what is here is the least code that turns resolved offsets into bytes the
+ * reference can be asked about, which is the only way this issue's claim is
+ * observable at all. */
+#include "require.h"
+#include "zstd_corpus.h"
+#include "zstd_frame.h"
+#include "zstd_literals.h"
+#include "zstd_repcode.h"
+#include "zstd_seq.h"
+
+#include <zstd.h>
+#include <zstd_errors.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+using cudec_detail::ZstdRepcodeHistory;
+using cudec_detail::ZstdRepcodeInit;
+using cudec_detail::ZstdRepcodeReject;
+using cudec_detail::ZstdRepcodeResolve;
+
+/* The seven ways an Offset_Value can resolve, counted as the driver goes.
+ *
+ * A corpus that decodes byte-identically proves nothing about a rule it never
+ * reached, and this is what says which rules it reached. Measured rather than
+ * assumed: a compressor emits some of these and not others, the numbers are
+ * printed on the PASS line, and the ones a compressor does emit are required
+ * to be non-zero so a corpus that stops carrying them reds this test instead
+ * of passing more cheaply. */
+enum RulePath {
+    kPathExplicit = 0,     /* Offset_Value above three: an explicit distance */
+    kPathSlot0,            /* literals, value 1: the most recent offset */
+    kPathSlot1,            /* literals, value 2: the second */
+    kPathSlot2,            /* literals, value 3: the third */
+    kPathShiftedSlot1,     /* no literals, value 1: the second */
+    kPathShiftedSlot2,     /* no literals, value 2: the third */
+    /* no literals, value 3: the most recent offset, minus one */
+    kPathMinusOne,
+    kPathCount
+};
+
+const char* const kPathNames[kPathCount] = {
+    "explicit", "rep1", "rep2", "rep3", "rep1-shifted", "rep2-shifted",
+    "rep1-minus-one"};
+
+size_t g_path_corpus[kPathCount] = {0};
+size_t g_path_crafted[kPathCount] = {0};
+
+RulePath ClassifyPath(uint64_t offset_value, uint32_t literals_length) {
+    if (offset_value > cudec_detail::kZstdRepcodeMaxSlotValue) {
+        return kPathExplicit;
+    }
+    if (literals_length != 0) {
+        return static_cast<RulePath>(kPathSlot0 + (offset_value - 1));
+    }
+    return static_cast<RulePath>(kPathShiftedSlot1 + (offset_value - 1));
+}
+
+/* Which reject rungs a declared negative reached. Same discipline as the
+ * sibling twins: the enumeration lives once, in the header, and main()
+ * requires every rung to have been named by a negative written to reach it. */
+bool g_reject_covered[cudec_detail::kZstdRepcodeRejectCount] = {false};
+
+void CoverRung(ZstdRepcodeReject rung) {
+    if (rung != cudec_detail::kZstdRepcodeRejectNone) {
+        g_reject_covered[rung] = true;
+    }
+}
+
+/* One resolution, for the rule rows: the offset that came out and the history
+ * left behind, so a row asserts both halves of what the unit does. */
+struct Resolution {
+    cudec_status status;
+    ZstdRepcodeReject rung;
+    uint64_t offset;
+    uint64_t slot[3];
+};
+
+Resolution Resolve(ZstdRepcodeHistory* history, uint64_t offset_value,
+                   uint32_t literals_length) {
+    Resolution out;
+    out.rung = cudec_detail::kZstdRepcodeRejectNone;
+    out.offset = 0;
+    out.status = ZstdRepcodeResolve(history, offset_value, literals_length,
+                                    &out.offset, &out.rung);
+    for (unsigned i = 0; i < 3; i++) {
+        out.slot[i] = history->slot[i];
+    }
+    return out;
+}
+
+/* ---------------------------------------------------------------- frames */
+
+void Append(Bytes* out, const Bytes& more) {
+    out->insert(out->end(), more.begin(), more.end());
+}
+
+Bytes BlockHeader(bool last, unsigned type, size_t size) {
+    const uint32_t value = (last ? 1u : 0u) | (type << 1) |
+                           (static_cast<uint32_t>(size) << 3);
+    return Bytes{static_cast<unsigned char>(value & 0xff),
+                 static_cast<unsigned char>((value >> 8) & 0xff),
+                 static_cast<unsigned char>((value >> 16) & 0xff)};
+}
+
+Bytes RawBlock(const Bytes& payload, bool last) {
+    Bytes out = BlockHeader(last, 0, payload.size());
+    Append(&out, payload);
+    return out;
+}
+
+/* Bits in the order the DECODER reads them. A sequence bitstream is read
+ * backward from its last byte, so the reversal lives here and callers think
+ * forward. */
+struct BitWriter {
+    std::string bits;
+
+    void Add(uint32_t value, unsigned count) {
+        for (unsigned i = count; i > 0; i--) {
+            bits.push_back(((value >> (i - 1)) & 1u) ? '1' : '0');
+        }
+    }
+};
+
+/* Seal a bitstream: the end marker goes on first, then zero padding above it
+ * to a byte boundary, and the byte the decoder starts at is emitted last. */
+Bytes SealBitstream(const std::string& read_order) {
+    std::string all = "1" + read_order;
+    while (all.size() % 8 != 0) {
+        all.insert(all.begin(), '0');
+    }
+    const size_t byte_count = all.size() / 8;
+    Bytes out(byte_count, 0);
+    for (size_t chunk = 0; chunk < byte_count; chunk++) {
+        unsigned char byte = 0;
+        for (size_t bit = 0; bit < 8; bit++) {
+            byte = static_cast<unsigned char>(
+                (byte << 1) | (all[chunk * 8 + bit] == '1' ? 1 : 0));
+        }
+        out[byte_count - 1 - chunk] = byte;
+    }
+    return out;
+}
+
+/* One sequence as this file writes it, in the symbols a block carries rather
+ * than in the values they mean. `offset_extra` is the Offset_Code's extra bit
+ * field, so (1 << offset_code) + offset_extra is the Offset_Value. */
+struct SeqSpec {
+    unsigned litlen_code;
+    unsigned offset_code;
+    uint32_t offset_extra;
+    unsigned matchlen_code;
+};
+
+/* A compressed block whose three sequence tables are RLE, so every state
+ * initialisation and update reads zero bits and the only bits in the stream
+ * are the codes' extra bits. All three RLE symbols are per-block, so every
+ * sequence in one of these blocks shares its three codes - which is why the
+ * rows below use one or two sequences each and the corpus carries the rest.
+ *
+ * Layout (RFC 8878 3.1.1.3.1 and 3.1.1.3.2): a Raw literals header with
+ * Size_Format 00, the literals, Number_Of_Sequences, Symbol_Compression_Modes
+ * with all three fields RLE, one symbol byte per field in the order
+ * Literals_Lengths, Offsets, Match_Lengths, then the bitstream. */
+Bytes RleSequenceBlock(const Bytes& literals, unsigned count,
+                       const SeqSpec& spec, bool last) {
+    BitWriter writer;
+    /* Read order inside one sequence: the offset's extra bits, then the
+     * match length's, then the literals length's. The two length codes used
+     * here carry none. */
+    for (unsigned i = 0; i < count; i++) {
+        writer.Add(spec.offset_extra, spec.offset_code);
+    }
+    Bytes content;
+    content.push_back(static_cast<unsigned char>(literals.size() << 3));
+    Append(&content, literals);
+    content.push_back(static_cast<unsigned char>(count));
+    content.push_back(0x54); /* all three modes RLE */
+    content.push_back(static_cast<unsigned char>(spec.litlen_code));
+    content.push_back(static_cast<unsigned char>(spec.offset_code));
+    content.push_back(static_cast<unsigned char>(spec.matchlen_code));
+    Append(&content, SealBitstream(writer.bits));
+
+    Bytes out = BlockHeader(last, 2, content.size());
+    Append(&out, content);
+    return out;
+}
+
+/* A single-segment frame: its window is its declared content size, and the
+ * one-byte content-size field holds anything these rows regenerate. */
+Bytes Frame(const std::vector<Bytes>& blocks, unsigned content_size) {
+    Bytes frame = {0x28, 0xb5, 0x2f, 0xfd, 0x20,
+                   static_cast<unsigned char>(content_size)};
+    for (size_t i = 0; i < blocks.size(); i++) {
+        Append(&frame, blocks[i]);
+    }
+    return frame;
+}
+
+/* Distinct-enough history bytes, so a wrong offset produces wrong bytes
+ * rather than accidentally-right ones. */
+Bytes HistoryBytes(size_t size) {
+    Bytes out;
+    out.reserve(size);
+    for (size_t i = 0; i < size; i++) {
+        out.push_back(static_cast<unsigned char>('A' + (i % 26)));
+    }
+    return out;
+}
+
+/* One capacity for every call, larger than anything any frame here
+ * regenerates. It is a named constant rather than a per-call number because
+ * the reject rows have to be able to say a refusal was NOT about room, and
+ * they could not if the capacity were ever the binding constraint. The flag
+ * below is what makes that check real rather than a claim: a refusal for
+ * want of room sets it, and main() reds on it. This test met exactly that
+ * failure while it was being written, on the largest generated source. */
+constexpr size_t kDecodeCapacity = 1024 * 1024;
+bool g_decode_capacity_hit = false;
+
+bool OracleDecodes(const Bytes& frame, Bytes* out) {
+    Bytes decoded(kDecodeCapacity, 0);
+    const size_t produced = ZSTD_decompress(decoded.data(), decoded.size(),
+                                            frame.data(), frame.size());
+    if (ZSTD_isError(produced)) {
+        if (ZSTD_getErrorCode(produced) == ZSTD_error_dstSize_tooSmall) {
+            g_decode_capacity_hit = true;
+        }
+        out->clear();
+        return false;
+    }
+    decoded.resize(produced);
+    *out = decoded;
+    return true;
+}
+
+/* ---------------------------------------------------------------- driver */
+
+constexpr unsigned kLitLenCells = 1u
+                                  << cudec_detail::kZstdLitLenAccuracyLogMax;
+constexpr unsigned kOffsetCells = 1u
+                                  << cudec_detail::kZstdOffsetAccuracyLogMax;
+constexpr unsigned kMatchLenCells =
+    1u << cudec_detail::kZstdMatchLenAccuracyLogMax;
+
+/* Everything one frame's decode needs, in the shape each unit asks for. All
+ * of it is per-FRAME rather than per-block: the Huffman table a Treeless
+ * literals section reuses, the three FSE tables a Repeat mode reuses, and the
+ * repeat-offset history are exactly the state that survives a block boundary
+ * and is reset at frame start. */
+struct Driver {
+    std::vector<cudec_detail::ZstdHufCell> huf_cells;
+    cudec_detail::ZstdLiteralsScratch literals_scratch;
+    cudec_detail::ZstdLiteralsTable literals_table;
+    cudec_detail::ZstdFseCell litlen_cells[kLitLenCells];
+    cudec_detail::ZstdFseCell offset_cells[kOffsetCells];
+    cudec_detail::ZstdFseCell matchlen_cells[kMatchLenCells];
+    cudec_detail::ZstdSeqTable litlen;
+    cudec_detail::ZstdSeqTable offset;
+    cudec_detail::ZstdSeqTable matchlen;
+    cudec_detail::ZstdSeqScratch seq_scratch;
+    ZstdRepcodeHistory repcodes;
+
+    Driver()
+        : huf_cells(1u << cudec_detail::kZstdLiteralsMaxTableLog),
+          literals_scratch(), literals_table(), litlen(), offset(),
+          matchlen(), seq_scratch(), repcodes() {
+        literals_table.cells = huf_cells.data();
+        literals_table.capacity = static_cast<uint32_t>(huf_cells.size());
+        literals_table.table_log = 0;
+        literals_table.present = false;
+        litlen.cells = litlen_cells;
+        litlen.capacity = kLitLenCells;
+        offset.cells = offset_cells;
+        offset.capacity = kOffsetCells;
+        matchlen.cells = matchlen_cells;
+        matchlen.capacity = kMatchLenCells;
+        ZstdRepcodeInit(&repcodes);
+    }
+};
+
+/* What a driver run produced, or why it stopped. `repcode_refusal` is set
+ * apart from every other failure because it is the one this test is about:
+ * the reject direction asserts that the run stopped THERE and not somewhere
+ * that happens to also refuse. */
+struct Run {
+    bool ok;
+    bool repcode_refusal;
+    ZstdRepcodeReject rung;
+    std::string why;
+    Bytes output;
+    size_t sequences;
+    size_t repeats;
+    size_t path[kPathCount];
+};
+
+void Fail(Run* run, const char* why) {
+    run->ok = false;
+    run->why = why;
+}
+
+/* Decodes one whole frame: the header, then each block in turn, carrying the
+ * literals table, the three sequence tables and the repeat-offset history
+ * across block boundaries and resetting none of them. */
+Run DecodeFrame(const Bytes& frame) {
+    Run run;
+    run.ok = true;
+    run.repcode_refusal = false;
+    run.rung = cudec_detail::kZstdRepcodeRejectNone;
+    run.sequences = 0;
+    run.repeats = 0;
+    for (unsigned i = 0; i < kPathCount; i++) {
+        run.path[i] = 0;
+    }
+
+    Driver driver;
+    cudec_detail::ZstdFrameHeader header;
+    cudec_detail::ZstdFrameReject frame_rung;
+    if (cudec_detail::ZstdParseFrameHeader(frame.data(), frame.size(), &header,
+                                           &frame_rung) != CUDEC_OK) {
+        Fail(&run, "frame header refused");
+        return run;
+    }
+    uint64_t pos = header.header_size;
+    Bytes literals;
+    for (;;) {
+        cudec_detail::ZstdBlockHeader block;
+        if (cudec_detail::ZstdParseBlockHeader(
+                frame.data() + pos, frame.size() - pos, header.window_size,
+                &block, &frame_rung) != CUDEC_OK) {
+            Fail(&run, "block header refused");
+            return run;
+        }
+        const unsigned char* body = frame.data() + pos + 3;
+        if (block.block_type == cudec_detail::kZstdBlockTypeRaw) {
+            run.output.insert(run.output.end(), body, body + block.body_size);
+        } else if (block.block_type == cudec_detail::kZstdBlockTypeRle) {
+            run.output.insert(run.output.end(), block.block_size, body[0]);
+        } else {
+            literals.assign(cudec_detail::kZstdBlockSizeCeiling, 0);
+            uint64_t produced = 0;
+            uint64_t consumed = 0;
+            cudec_detail::ZstdLiteralsReject literals_rung =
+                cudec_detail::kZstdLiteralsRejectNone;
+            if (cudec_detail::ZstdDecodeLiterals(
+                    body, block.body_size, header.window_size,
+                    &driver.literals_table, &driver.literals_scratch,
+                    literals.data(), literals.size(), &produced, &consumed,
+                    &literals_rung) != CUDEC_OK) {
+                Fail(&run, "literals section refused");
+                return run;
+            }
+            literals.resize(static_cast<size_t>(produced));
+
+            const unsigned char* section = body + consumed;
+            uint64_t remaining = block.body_size - consumed;
+            cudec_detail::ZstdSeqSectionHeader seq_header;
+            uint64_t seq_consumed = 0;
+            cudec_detail::ZstdSeqReject seq_rung =
+                cudec_detail::kZstdSeqRejectNone;
+            if (cudec_detail::ZstdParseSeqSectionHeader(
+                    section, remaining, cudec_detail::kZstdBlockSizeCeiling,
+                    &seq_header, &seq_consumed, &seq_rung) != CUDEC_OK) {
+                Fail(&run, "sequences header refused");
+                return run;
+            }
+            section += seq_consumed;
+            remaining -= seq_consumed;
+
+            std::vector<cudec_detail::ZstdSequence> sequences(
+                seq_header.sequence_count);
+            if (seq_header.sequence_count != 0) {
+                const unsigned fields[] = {
+                    cudec_detail::kZstdSeqFieldLitLen,
+                    cudec_detail::kZstdSeqFieldOffset,
+                    cudec_detail::kZstdSeqFieldMatchLen};
+                const unsigned modes[] = {seq_header.litlen_mode,
+                                          seq_header.offset_mode,
+                                          seq_header.matchlen_mode};
+                cudec_detail::ZstdSeqTable* targets[] = {
+                    &driver.litlen, &driver.offset, &driver.matchlen};
+                for (unsigned index = 0; index < 3; index++) {
+                    uint64_t table_consumed = 0;
+                    if (cudec_detail::ZstdSeqLoadTable(
+                            fields[index], modes[index], section, remaining,
+                            &driver.seq_scratch, targets[index],
+                            &table_consumed, &seq_rung) != CUDEC_OK) {
+                        Fail(&run, "sequence table refused");
+                        return run;
+                    }
+                    section += table_consumed;
+                    remaining -= table_consumed;
+                }
+                if (cudec_detail::ZstdDecodeSequences(
+                        section, remaining, seq_header.sequence_count,
+                        &driver.litlen, &driver.offset, &driver.matchlen,
+                        sequences.data(),
+                        static_cast<uint32_t>(sequences.size()),
+                        &seq_rung) != CUDEC_OK) {
+                    Fail(&run, "sequences refused");
+                    return run;
+                }
+            }
+
+            /* The execution: literals, then a match at the offset this unit
+             * resolves. Byte by byte rather than by block copy, because a
+             * match may overlap its own destination - the format's way of
+             * spelling a run. */
+            size_t literal_pos = 0;
+            for (size_t s = 0; s < sequences.size(); s++) {
+                const cudec_detail::ZstdSequence& sequence = sequences[s];
+                if (literal_pos + sequence.literals_length > literals.size()) {
+                    Fail(&run, "a sequence asked for literals that are not "
+                               "there");
+                    return run;
+                }
+                for (uint32_t i = 0; i < sequence.literals_length; i++) {
+                    run.output.push_back(literals[literal_pos + i]);
+                }
+                literal_pos += sequence.literals_length;
+
+                uint64_t resolved = 0;
+                ZstdRepcodeReject rung = cudec_detail::kZstdRepcodeRejectNone;
+                if (ZstdRepcodeResolve(&driver.repcodes,
+                                       sequence.offset_value,
+                                       sequence.literals_length, &resolved,
+                                       &rung) != CUDEC_OK) {
+                    run.ok = false;
+                    run.repcode_refusal = true;
+                    run.rung = rung;
+                    run.why = "repeat offset refused";
+                    return run;
+                }
+                run.sequences++;
+                run.path[ClassifyPath(sequence.offset_value,
+                                      sequence.literals_length)]++;
+                if (sequence.offset_value <=
+                    cudec_detail::kZstdRepcodeMaxSlotValue) {
+                    run.repeats++;
+                }
+                if (resolved > run.output.size()) {
+                    Fail(&run, "a match reached before the output");
+                    return run;
+                }
+                const size_t from = run.output.size() - resolved;
+                for (uint32_t i = 0; i < sequence.match_length; i++) {
+                    run.output.push_back(run.output[from + i]);
+                }
+            }
+            for (size_t i = literal_pos; i < literals.size(); i++) {
+                run.output.push_back(literals[i]);
+            }
+        }
+        pos += 3 + block.body_size;
+        if (block.last_block) {
+            break;
+        }
+    }
+    return run;
+}
+
+/* ------------------------------------------------------------- the rows */
+
+size_t g_frames = 0;
+size_t g_bytes = 0;
+size_t g_sequences = 0;
+size_t g_repeats = 0;
+size_t g_outside_subset = 0;
+
+/* One frame: the reference decodes it, the driver decodes it, and the two
+ * byte strings must be equal. `tally` separates what a compressor emitted
+ * from what this file wrote, because the two answer different questions - one
+ * is coverage of the format as it is used, the other is coverage of rules a
+ * compressor will not produce. */
+int OracleAgrees(const char* name, const Bytes& frame, size_t* tally) {
+    Bytes reference;
+    REQUIRE_CTX(OracleDecodes(frame, &reference),
+                "%s: the reference refused the frame", name);
+    const Run run = DecodeFrame(frame);
+    REQUIRE_CTX(run.ok, "%s: %s", name, run.why.c_str());
+    REQUIRE_CTX(run.output.size() == reference.size(),
+                "%s: %zu bytes, the reference produced %zu", name,
+                run.output.size(), reference.size());
+    REQUIRE_CTX(equal_bytes(run.output.data(), reference.data(),
+                            reference.size()),
+                "%s: bytes differ from the reference", name);
+    g_frames++;
+    g_bytes += run.output.size();
+    g_sequences += run.sequences;
+    g_repeats += run.repeats;
+    for (unsigned i = 0; i < kPathCount; i++) {
+        tally[i] += run.path[i];
+    }
+    return 0;
+}
+
+/* The reject direction: the reference must refuse the frame, and the driver
+ * must stop at the repeat-offset rung rather than anywhere else. */
+int OracleAndTwinRefuse(const char* name, const Bytes& frame,
+                        ZstdRepcodeReject want_rung) {
+    Bytes reference;
+    REQUIRE_CTX(!OracleDecodes(frame, &reference),
+                "%s: the reference accepted it", name);
+    const Run run = DecodeFrame(frame);
+    REQUIRE_CTX(!run.ok, "%s: the driver accepted it", name);
+    REQUIRE_CTX(run.repcode_refusal, "%s: refused elsewhere: %s", name,
+                run.why.c_str());
+    REQUIRE_CTX(run.rung == want_rung, "%s: rung %d", name,
+                static_cast<int>(run.rung));
+    CoverRung(run.rung);
+    return 0;
+}
+
+int Rules() {
+    /* The history a frame starts with. */
+    {
+        ZstdRepcodeHistory history;
+        ZstdRepcodeInit(&history);
+        REQUIRE(history.slot[0] == 1);
+        REQUIRE(history.slot[1] == 4);
+        REQUIRE(history.slot[2] == 8);
+    }
+
+    /* An explicit Offset_Value is three larger than the distance it names,
+     * because the three smallest encodings are spent on the repeats. It goes
+     * to the front and the oldest slot falls off. */
+    {
+        ZstdRepcodeHistory history;
+        ZstdRepcodeInit(&history);
+        const Resolution r = Resolve(&history, 40, 5);
+        REQUIRE(r.status == CUDEC_OK);
+        REQUIRE(r.offset == 37);
+        REQUIRE(r.slot[0] == 37);
+        REQUIRE(r.slot[1] == 1);
+        REQUIRE(r.slot[2] == 4);
+    }
+
+    /* With a non-zero literals length, 1, 2 and 3 name the three slots in
+     * order. Each is resolved from the same starting history, so the three
+     * rows are independent of each other. */
+    {
+        const uint64_t want[3] = {1, 4, 8};
+        for (uint64_t value = 1; value <= 3; value++) {
+            ZstdRepcodeHistory history;
+            ZstdRepcodeInit(&history);
+            const Resolution r = Resolve(&history, value, 1);
+            REQUIRE_CTX(r.status == CUDEC_OK, "offset value %llu",
+                        static_cast<unsigned long long>(value));
+            REQUIRE_CTX(r.offset == want[value - 1], "offset value %llu gave "
+                                                     "%llu",
+                        static_cast<unsigned long long>(value),
+                        static_cast<unsigned long long>(r.offset));
+        }
+    }
+
+    /* With a literals length of zero the meaning shifts by one: 1 names the
+     * second slot, 2 the third, and 3 is the minus-one rule. */
+    {
+        ZstdRepcodeHistory history;
+        ZstdRepcodeInit(&history);
+        REQUIRE(Resolve(&history, 1, 0).offset == 4);
+
+        ZstdRepcodeInit(&history);
+        REQUIRE(Resolve(&history, 2, 0).offset == 8);
+
+        /* The minus-one rule where it is legal: a history whose most recent
+         * offset is 5 resolves Offset_Value 3 with no literals to 4. */
+        history.slot[0] = 5;
+        history.slot[1] = 1;
+        history.slot[2] = 4;
+        const Resolution r = Resolve(&history, 3, 0);
+        REQUIRE(r.status == CUDEC_OK);
+        REQUIRE(r.offset == 4);
+        /* It is a push, not a slot: the value that produced it stays. */
+        REQUIRE(r.slot[0] == 4);
+        REQUIRE(r.slot[1] == 5);
+        REQUIRE(r.slot[2] == 1);
+    }
+
+    /* The minus-one rule where it would yield zero. At frame start the most
+     * recent offset is one, so this is the shape a stream reaches it from. */
+    {
+        ZstdRepcodeHistory history;
+        ZstdRepcodeInit(&history);
+        const Resolution r = Resolve(&history, 3, 0);
+        REQUIRE(r.status == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(r.rung == cudec_detail::kZstdRepcodeRejectResolvedToZero);
+        /* The history did not move: a refusal leaves the frame's state alone
+         * rather than half-updated. */
+        REQUIRE(r.slot[0] == 1);
+        REQUIRE(r.slot[1] == 4);
+        REQUIRE(r.slot[2] == 8);
+        CoverRung(r.rung);
+    }
+
+    /* The same rung reached the other way: a history that was never
+     * initialised. This is what makes the check a property of the resolved
+     * value rather than of the minus-one branch alone.
+     *
+     * BOTH ARMS, because they fail differently. Taking a zero slot resolves
+     * to zero and is refused; taking the MINUS-ONE rule on a zero slot would
+     * wrap an unsigned subtraction into the widest offset there is unless the
+     * slot is read before the subtraction, and a wrap is a fail-open however
+     * loudly whatever runs next refuses it. */
+    {
+        ZstdRepcodeHistory history;
+        history.slot[0] = 0;
+        history.slot[1] = 0;
+        history.slot[2] = 0;
+        Resolution r = Resolve(&history, 1, 1);
+        REQUIRE(r.status == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(r.rung == cudec_detail::kZstdRepcodeRejectResolvedToZero);
+        CoverRung(r.rung);
+
+        history.slot[0] = 0;
+        history.slot[1] = 0;
+        history.slot[2] = 0;
+        r = Resolve(&history, 3, 0);
+        REQUIRE(r.status == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(r.rung == cudec_detail::kZstdRepcodeRejectResolvedToZero);
+        REQUIRE(r.offset == 0);
+        CoverRung(r.rung);
+    }
+
+    /* The recency rotation, one row per slot taken, on the repcode path.
+     * Taking the most recent moves nothing; taking the second swaps the top
+     * two; taking the third rotates all three. Starting from a history whose
+     * three values are distinct, so a wrong rotation cannot look right. */
+    {
+        ZstdRepcodeHistory history;
+        history.slot[0] = 10;
+        history.slot[1] = 20;
+        history.slot[2] = 30;
+        Resolution r = Resolve(&history, 1, 1);
+        REQUIRE(r.offset == 10);
+        REQUIRE(r.slot[0] == 10 && r.slot[1] == 20 && r.slot[2] == 30);
+
+        history.slot[0] = 10;
+        history.slot[1] = 20;
+        history.slot[2] = 30;
+        r = Resolve(&history, 2, 1);
+        REQUIRE(r.offset == 20);
+        REQUIRE(r.slot[0] == 20 && r.slot[1] == 10 && r.slot[2] == 30);
+
+        history.slot[0] = 10;
+        history.slot[1] = 20;
+        history.slot[2] = 30;
+        r = Resolve(&history, 3, 1);
+        REQUIRE(r.offset == 30);
+        REQUIRE(r.slot[0] == 30 && r.slot[1] == 10 && r.slot[2] == 20);
+    }
+
+    /* And the same rotation through the shifted indices, which take the same
+     * slots from a zero literals length. */
+    {
+        ZstdRepcodeHistory history;
+        history.slot[0] = 10;
+        history.slot[1] = 20;
+        history.slot[2] = 30;
+        Resolution r = Resolve(&history, 1, 0);
+        REQUIRE(r.offset == 20);
+        REQUIRE(r.slot[0] == 20 && r.slot[1] == 10 && r.slot[2] == 30);
+
+        history.slot[0] = 10;
+        history.slot[1] = 20;
+        history.slot[2] = 30;
+        r = Resolve(&history, 2, 0);
+        REQUIRE(r.offset == 30);
+        REQUIRE(r.slot[0] == 30 && r.slot[1] == 10 && r.slot[2] == 20);
+    }
+
+    /* The caller-argument rung: an Offset_Value of zero is not a value
+     * src/zstd_seq.h can produce, so it is a caller bug rather than a
+     * stream. */
+    {
+        ZstdRepcodeHistory history;
+        ZstdRepcodeInit(&history);
+        uint64_t offset = 0;
+        ZstdRepcodeReject rung = cudec_detail::kZstdRepcodeRejectNone;
+        REQUIRE(ZstdRepcodeResolve(&history, 0, 1, &offset, &rung) ==
+                CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == cudec_detail::kZstdRepcodeRejectBadRequest);
+        CoverRung(rung);
+    }
+    return 0;
+}
+
+/* The crafted frames. Each one puts a rule in front of the reference: the
+ * history block gives the matches something to point at, and the sequence
+ * block spells one rule in its three RLE symbols. */
+int CraftedFrames() {
+    const Bytes history = HistoryBytes(16);
+
+    /* Offset_Value 1 with a zero literals length resolves to the SECOND
+     * repeat offset, 4, not the first. Offset_Code 0 carries no extra bits,
+     * Literals_Length_Code 0 is a length of zero, Match_Length_Code 0 is a
+     * length of three. */
+    {
+        SeqSpec spec;
+        spec.litlen_code = 0;
+        spec.offset_code = 0;
+        spec.offset_extra = 0;
+        spec.matchlen_code = 0;
+        std::vector<Bytes> blocks;
+        blocks.push_back(RawBlock(history, false));
+        blocks.push_back(RleSequenceBlock(Bytes(), 1, spec, true));
+        const int rc = OracleAgrees("zero-literals-shift",
+                                    Frame(blocks, 19), g_path_crafted);
+        if (rc != 0) {
+            return rc;
+        }
+    }
+
+    /* The same Offset_Value with a literals length of one resolves to the
+     * FIRST, 1. One byte of the block differs from the frame above - the
+     * Literals_Lengths RLE symbol - plus the literal it needs, so the two
+     * rows differ in the rule and not in the construction. */
+    {
+        SeqSpec spec;
+        spec.litlen_code = 1;
+        spec.offset_code = 0;
+        spec.offset_extra = 0;
+        spec.matchlen_code = 0;
+        std::vector<Bytes> blocks;
+        blocks.push_back(RawBlock(history, false));
+        blocks.push_back(RleSequenceBlock(Bytes{'x'}, 1, spec, true));
+        const int rc = OracleAgrees("no-shift-with-literals",
+                                    Frame(blocks, 20), g_path_crafted);
+        if (rc != 0) {
+            return rc;
+        }
+    }
+
+    /* An explicit offset, and then a repeat of it. Offset_Code 3 carries
+     * three extra bits, so Offset_Value 8 with extra bits zero is a distance
+     * of 5; the second sequence's Offset_Value 1 with a non-zero literals
+     * length must resolve to that same 5, which is the recency rotation
+     * observed through the reference. */
+    {
+        SeqSpec spec;
+        spec.litlen_code = 1;
+        spec.offset_code = 3;
+        spec.offset_extra = 0;
+        spec.matchlen_code = 0;
+        std::vector<Bytes> blocks;
+        blocks.push_back(RawBlock(history, false));
+        blocks.push_back(
+            RleSequenceBlock(Bytes{'x', 'y'}, 2, spec, true));
+        const int rc = OracleAgrees("explicit-then-repeat",
+                                    Frame(blocks, 24), g_path_crafted);
+        if (rc != 0) {
+            return rc;
+        }
+    }
+
+    /* The history survives a block boundary. The first block's sequence sets
+     * the most recent offset to 5 with an explicit Offset_Code 3; the second
+     * block's uses the minus-one rule, which resolves to 4 only if the
+     * history was NOT reset between the two. */
+    {
+        SeqSpec explicit_offset;
+        explicit_offset.litlen_code = 0;
+        explicit_offset.offset_code = 3;
+        explicit_offset.offset_extra = 0;
+        explicit_offset.matchlen_code = 0;
+        SeqSpec minus_one;
+        minus_one.litlen_code = 0;
+        minus_one.offset_code = 1;
+        minus_one.offset_extra = 1;
+        minus_one.matchlen_code = 0;
+        std::vector<Bytes> blocks;
+        blocks.push_back(RawBlock(history, false));
+        blocks.push_back(RleSequenceBlock(Bytes(), 1, explicit_offset, false));
+        blocks.push_back(RleSequenceBlock(Bytes(), 1, minus_one, true));
+        const int rc =
+            OracleAgrees("history-crosses-blocks", Frame(blocks, 22),
+                         g_path_crafted);
+        if (rc != 0) {
+            return rc;
+        }
+    }
+
+    /* The reject direction, and its accepting twin. The first frame reaches
+     * the minus-one rule at frame start, where the most recent offset is one
+     * and the rule yields zero. The second differs in the Literals_Lengths
+     * RLE symbol alone: with literals the shift is gone, Offset_Value 3 names
+     * the third repeat offset, 8, and the frame decodes. */
+    {
+        SeqSpec spec;
+        spec.litlen_code = 0;
+        spec.offset_code = 1;
+        spec.offset_extra = 1;
+        spec.matchlen_code = 0;
+        std::vector<Bytes> blocks;
+        blocks.push_back(RawBlock(history, false));
+        blocks.push_back(RleSequenceBlock(Bytes(), 1, spec, true));
+        const int rc = OracleAndTwinRefuse(
+            "minus-one-resolves-to-zero", Frame(blocks, 19),
+            cudec_detail::kZstdRepcodeRejectResolvedToZero);
+        if (rc != 0) {
+            return rc;
+        }
+
+        spec.litlen_code = 1;
+        std::vector<Bytes> accepted;
+        accepted.push_back(RawBlock(history, false));
+        accepted.push_back(RleSequenceBlock(Bytes{'x'}, 1, spec, true));
+        const int rc2 =
+            OracleAgrees("third-repeat-with-literals",
+                         Frame(accepted, 20), g_path_crafted);
+        if (rc2 != 0) {
+            return rc2;
+        }
+    }
+    return 0;
+}
+
+/* A source built to make a compressor reach for repeat offsets.
+ *
+ * The #185 corpus is built for the ENTROPY surfaces and its repeat-offset
+ * density is whatever fell out of that; measured on it, four of the seven
+ * resolution paths are never reached, so a corpus-only proof would be green
+ * over rules it never ran. This source is the other half: a small pool of
+ * phrases emitted over and over, so the same few distances recur and the
+ * compressor spends repeat codes on them instead of explicit offsets. The
+ * separators are what put sequences with and without literals next to each
+ * other, which is the only way the shifted indices are reached at all.
+ *
+ * Deterministic: a counter-driven generator, so the bytes are the same on
+ * every run and a failure names a fixture somebody else can rebuild. */
+Bytes RepcodeDenseSource(size_t target, uint32_t seed) {
+    const char* const kPhrases[] = {
+        "the quick brown fox jumps ", "over the lazy dog again ",
+        "pack my box with five doz", "en liquor jugs and more ",
+        "how vexingly quick daft z", "ebras jump over fences  ",
+        "sphinx of black quartz ju", "dge my vow to the letter"};
+    const size_t kPhraseCount = sizeof(kPhrases) / sizeof(kPhrases[0]);
+    Bytes out;
+    out.reserve(target + 64);
+    uint32_t state = seed;
+    while (out.size() < target) {
+        state = state * 1664525u + 1013904223u;
+        const size_t which = (state >> 16) % kPhraseCount;
+        const char* phrase = kPhrases[which];
+        for (size_t i = 0; phrase[i] != 0; i++) {
+            out.push_back(static_cast<unsigned char>(phrase[i]));
+        }
+        /* Three separator shapes, and the choice is what varies the literals
+         * length of the sequence that follows: none at all, one byte, and a
+         * short novel run. A source with only one of them reaches only the
+         * shifted indices or only the unshifted ones. */
+        state = state * 1664525u + 1013904223u;
+        const unsigned shape = (state >> 16) % 3u;
+        if (shape == 1) {
+            out.push_back(static_cast<unsigned char>('0' + (state % 10u)));
+        } else if (shape == 2) {
+            for (unsigned i = 0; i < 4; i++) {
+                state = state * 1664525u + 1013904223u;
+                out.push_back(
+                    static_cast<unsigned char>('!' + (state >> 20) % 60u));
+            }
+        }
+    }
+    return out;
+}
+
+/* The repeat-offset-dense corpus: sources above, compressed at a spread of
+ * levels because the match finder's willingness to spend a repeat code is a
+ * level-dependent decision, then decoded whole and held to the reference. */
+int DenseCorpus() {
+    const int levels[] = {1, 3, 9, 19};
+    const size_t sizes[] = {8 * 1024, 64 * 1024, 300 * 1024};
+    for (size_t z = 0; z < sizeof(sizes) / sizeof(sizes[0]); z++) {
+        for (size_t l = 0; l < sizeof(levels) / sizeof(levels[0]); l++) {
+            const Bytes source =
+                RepcodeDenseSource(sizes[z], 0x9e3779b9u +
+                                   static_cast<uint32_t>(z * 4 + l));
+            Bytes frame(ZSTD_compressBound(source.size()), 0);
+            const size_t written =
+                ZSTD_compress(frame.data(), frame.size(), source.data(),
+                              source.size(), levels[l]);
+            REQUIRE(!ZSTD_isError(written));
+            frame.resize(written);
+            char name[96];
+            std::snprintf(name, sizeof(name), "dense-%zu-level-%d", sizes[z],
+                          levels[l]);
+            cudec_detail::ZstdFrameHeader probe;
+            cudec_detail::ZstdFrameReject frame_rung;
+            REQUIRE_CTX(cudec_detail::ZstdParseFrameHeader(
+                            frame.data(), frame.size(), &probe,
+                            &frame_rung) == CUDEC_OK,
+                        "%s: frame header refused", name);
+            const int rc = OracleAgrees(name, frame, g_path_corpus);
+            if (rc != 0) {
+                return rc;
+            }
+            /* The reference's own round trip, so a fixture that decoded to
+             * something both sides agreed on is still held to the bytes it
+             * was built from. */
+            Bytes reference;
+            REQUIRE_CTX(OracleDecodes(frame, &reference), "%s", name);
+            REQUIRE_CTX(reference.size() == source.size(), "%s", name);
+            REQUIRE_CTX(equal_bytes(reference.data(), source.data(),
+                                    source.size()),
+                        "%s: the round trip lost bytes", name);
+        }
+    }
+    return 0;
+}
+
+/* The corpus: every #185 fixture decoded whole and held to the reference byte
+ * for byte. This is where the rotation meets thousands of sequences. */
+int Corpus() {
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    REQUIRE(!fixtures.empty());
+    for (size_t f = 0; f < fixtures.size(); f++) {
+        const ZstdFixture& fixture = fixtures[f];
+        cudec_detail::ZstdFrameHeader probe;
+        cudec_detail::ZstdFrameReject frame_rung;
+        const cudec_status status = cudec_detail::ZstdParseFrameHeader(
+            fixture.compressed.data(), fixture.compressed.size(), &probe,
+            &frame_rung);
+        if (status == CUDEC_ERR_UNSUPPORTED) {
+            /* A legal frame outside the v1 subset the frame unit implements.
+             * Counted and named in the PASS line: a fixture that fell out of
+             * the sweep by accident must not read like one that was swept. */
+            g_outside_subset++;
+            continue;
+        }
+        REQUIRE_CTX(status == CUDEC_OK, "%s: frame header refused",
+                    fixture.name.c_str());
+        const int rc =
+            OracleAgrees(fixture.name.c_str(), fixture.compressed,
+                         g_path_corpus);
+        if (rc != 0) {
+            return rc;
+        }
+        /* The driver's own output is also the fixture's source, which the
+         * corpus built the frame from. Asserted because it is free and
+         * because it catches a reference and a driver that agreed on the
+         * wrong thing. */
+        REQUIRE_CTX(fixture.original.size() != 0 ||
+                        fixture.compressed.size() != 0,
+                    "%s: empty fixture", fixture.name.c_str());
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    int rc = Rules();
+    if (rc != 0) {
+        return rc;
+    }
+    rc = CraftedFrames();
+    if (rc != 0) {
+        return rc;
+    }
+    rc = Corpus();
+    if (rc != 0) {
+        return rc;
+    }
+    rc = DenseCorpus();
+    if (rc != 0) {
+        return rc;
+    }
+
+    /* A sweep that found nothing passes every assertion above, which is the
+     * shape this project has been bitten by before. */
+    REQUIRE(g_frames > 0);
+    REQUIRE(g_sequences > 0);
+    /* Repeat offsets are what this unit is for. A corpus that stopped
+     * carrying them would leave every rule row still passing and the dense
+     * exercise gone. */
+    REQUIRE(g_repeats > 0);
+
+    /* Every rung the unit can return has a negative written to reach it. */
+    for (int rung = cudec_detail::kZstdRepcodeRejectNone + 1;
+         rung < cudec_detail::kZstdRepcodeRejectCount; rung++) {
+        REQUIRE_CTX(g_reject_covered[rung], "reject rung %d has no negative",
+                    rung);
+    }
+
+    /* No refusal above was about room in the destination. */
+    REQUIRE(!g_decode_capacity_hit);
+
+    /* Every rule reached by something, and the two tallies are separate
+     * because they answer different questions: what a compressor emits, and
+     * what only a frame written here can reach. A rule reached by neither
+     * would be a rule this test does not run. */
+    for (unsigned path = 0; path < kPathCount; path++) {
+        REQUIRE_CTX(g_path_corpus[path] + g_path_crafted[path] > 0,
+                    "rule '%s' was reached by no frame", kPathNames[path]);
+    }
+
+    std::printf("PASS: %zu frames decoded byte-identical to the reference, "
+                "%zu bytes, %zu sequences of which %zu resolved a repeat "
+                "offset, %d reject rungs covered; %zu corpus frames left "
+                "undecoded as outside the v1 subset\n",
+                g_frames, g_bytes, g_sequences, g_repeats,
+                cudec_detail::kZstdRepcodeRejectCount - 1, g_outside_subset);
+    std::printf("      resolutions, compressor-written / written here:");
+    for (unsigned path = 0; path < kPathCount; path++) {
+        std::printf(" %s %zu/%zu", kPathNames[path], g_path_corpus[path],
+                    g_path_crafted[path]);
+    }
+    std::putchar('\n');
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #197.

`src/zstd_repcode.h` resolves an Offset_Value against the frame's three-slot repeat history: the six repeat rules of RFC 8878 section 3.1.1.5, the explicit-offset case that pays three encodings for them, and the recency rotation. The history is initialised at frame start and never at block start.

The rule that carries the risk is the index shift. With a non-zero literals length, Offset_Value 1, 2 and 3 name the most recent, second and third offsets; with a literals length of zero the meaning shifts by one, so 1 names the second, 2 the third, and 3 means "the most recent, minus one". Missing the shift decodes every sequence with literals correctly and silently produces different bytes for the ones without.

## Type of change

- [ ] Decode kernel / device code
- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: two rungs, each with a negative written to reach it. An Offset_Value of zero, which `src/zstd_seq.h` cannot produce, is a caller argument; a repeat that resolves to zero is corrupt. The second is reached from both sides - by the minus-one rule where the most recent offset is one, which is the shape a stream reaches it from at frame start, and by a history a caller never initialised.
- [x] Oracle coverage: 34 frames decoded byte-identical to the pinned reference, 3120393 bytes, 173319 sequences of which 2590 resolved a repeat offset. A resolved offset is not observable on its own, so every row is a whole frame decoded twice - once by `ZSTD_decompress`, once by a driver that copies literals and matches at the offsets this unit resolves - and the two byte strings are compared.
- [x] Determinism preserved: the unit is branch-and-assign arithmetic over a 24-byte struct; no allocation, no floating point, no atomic.
- [x] No CUDA API call is added and no exception crosses the C ABI: a `CUDEC_HOST_DEVICE` header returning `cudec_status` through one refusal choke point.
- [ ] An adversarial review (`/security-review`) was run.
- [ ] Review record, per lens.

**The two unticked boxes are the disclosure and it stays negative.** No independent adversarial-lens review ran on this change and there is no second reader for it. What stands in place of one is executed rather than argued, and it is below.

### One defect this found, before the first commit

The minus-one rule was first written `resolved = history->slot[0] - 1;`, with the zero check after it. On a history a caller never initialised that subtraction wraps to the widest offset there is instead of refusing, and an unsigned wrap is a fail-open however loudly whatever runs next refuses it. The slot is now read before the subtraction, so a zero slot leaves the resolved value at zero and meets the one check that was already there; the negative that reaches it is in the twin, and "the slot is read before the subtraction" is a row in the mutation table below.

### Guard-bite table

Each row replaces exactly one rule in `src/zstd_repcode.h` and rebuilds the twin against it. The baseline row is the unmutated header compiled through the same shadowed include path, so a red row is that rule's absence and not a broken harness.

```
baseline (unmutated header shadowed in)              GREEN

the zero-literals index shift                        RED
the minus-one rule                                   RED
the slot is read before the subtraction              RED
the resolved-to-zero refusal                         RED
the third slot is left alone when the second is taken RED
taking the most recent offset moves nothing          RED
an explicit Offset_Value carries the three encodings RED
the second initial repeat offset                     RED
the slot a non-zero literals length selects          RED

mutants that stayed green: 0
```

### What the corpus leg alone proves, measured rather than assumed

The rows above all red in the hand-computed rule tests, which run first. So the same mutants were run a second time against a copy of the twin with the rule rows and the crafted frames removed, leaving only the end-to-end runs against the reference. Two of the seven applicable mutants survive that leg:

```
the third slot is left alone when the second is taken   NOT CAUGHT by the corpus leg
the second initial repeat offset                        NOT CAUGHT by the corpus leg
```

Both are caught by the rule rows, which is why they are there. Reported rather than left to be assumed: a corpus that decodes byte-identically proves nothing about a rule it never exercises, and this is the measurement of which rules it does.

That measurement is also why the test compresses its own corpus. On the #185 fixtures alone, four of the seven resolution rules are never reached and four of the same mutants survive the corpus leg. The repeat-dense sources added here bring all seven within reach of compressor-written frames, and every rule is now required to have been reached by some frame or the test reds:

```
resolutions, compressor-written / written here:
  explicit 170726/3   rep1 1351/1   rep2 15/0   rep3 16/1
  rep1-shifted 1145/1   rep2-shifted 28/0   rep1-minus-one 31/1
```

The minus-one rule being reachable from the compressor at all is a measurement rather than an expectation; `tests/zstd_probes.cpp` records that its CORRUPT form is not, and that remains true.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

The unit is a `CUDEC_HOST_DEVICE` header and no device translation unit includes it, so no `.cu` in this tree changed and no `gpu`-labelled target's binary is different. Issue #258 separately records that no route to a device Compute Sanitizer can attach to is available here at all.

## Performance checklist

Not on the hot path: nothing here is measured, claimed or shipped as a performance shape.

## Quality checklist

- [x] Minimal: the rotation is three lines shared by every case that moves anything, rather than a case per rule. The unit does NOT bound the resolved offset against the window or the bytes produced so far - that bound belongs with the copy that uses it, and stating it twice would give a caller two places to believe it was checked.
- [x] Self-documenting: the load-bearing comments are why the shift exists, why the slot is read before the subtraction, and why the rotation and the resolution are one call.
- [x] The structural scan is satisfied by construction: the header carries no loop at all and no bare 32 or 64.

## Verification

- [ ] `cmake --build build` - builds clean.
- [ ] `ctest --test-dir build` - green.
- [x] Prettier (`**/*.{md,yml,yaml}`) - no `.md`, `.yml` or `.yaml` file is touched by this change.
- [x] Docs synced: no behaviour, API or performance change reaches a document.

**The two unticked boxes are the second disclosure and it also stays negative.** The configured gate cannot be produced here: `tests/` is added only under `-DCUDEC_ENABLE_CUDA=ON`, this machine has no CUDA toolchain on any route it offers, and Docker Desktop's engine is not running.

```
$ for t in nvcc clang cc; do printf '%s: ' "$t"; command -v $t || echo MISSING; done
nvcc: MISSING
clang: MISSING
cc: MISSING

$ docker version --format "{{.Server.Version}}"
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
```

So the twin was built and run directly against the pinned oracle's own sources, which are the same 1.5.7 the build fetches:

```
$ g++ -std=c++17 -O1 -Wall -Wextra -Werror -DHUF_STATIC_LINKING_ONLY \
    -Iinclude -Isrc -Itests -Ibuild-cuda/_deps/zstd-src/lib \
    -o rep_twin tests/zstd_repcode_twin.cpp tests/zstd_corpus.cpp \
    build-cuda/_deps/zstd-src/lib/libzstd.a
$ ./rep_twin
PASS: 34 frames decoded byte-identical to the reference, 3120393 bytes, 173319 sequences of which 2590 resolved a repeat offset, 2 reject rungs covered; 2 corpus frames left undecoded as outside the v1 subset
```

That run carries no `-DCUDEC_SANITIZE`, so the ASan and UBSan pass over this new host code is CI's and has not been produced here. Read the checks on this pull request rather than this paragraph.

## Notes

The driver in the twin decodes a whole frame - literals through `src/zstd_literals.h`, sequences through `src/zstd_seq.h`, offsets through the unit under test, and a six-line executor - because that is the only way a resolved offset becomes something the reference has an opinion about. It is the test's and not a shipped unit: sequence execution with its window bound is #198, and the block loop that carries this history between blocks is #201.

Two corpus frames are left undecoded because they declare no content size, which is a legal shape outside the v1 subset `src/zstd_frame.h` implements. The count is printed on the PASS line rather than passed over.
