### PR TITLE
Hold the whole Zstd entropy stage to libzstd over both corpora

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -330,6 +330,20 @@ cudec_add_test(zstd_repcode_twin SOURCES zstd_repcode_twin.cpp zstd_corpus.cpp
 target_include_directories(zstd_repcode_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_compile_definitions(zstd_repcode_twin PRIVATE HUF_STATIC_LINKING_ONLY)
+# The whole M5 entropy stage over both corpora, two-directionally (issue
+# #223). It is the only Zstd test that decodes a FRAME: the sibling twins each
+# prove one unit against the reference entry point that matches it, and none of
+# them can say whether the stage as a whole ever accepts what the reference
+# refuses. Host-side and GPU-less. It links zstd_full alone for the reason
+# zstd_oracle_smoke gives above, and compiles zstd_corpus.cpp for the reason
+# zstd_fse_twin does - the #185 fixtures and the #187 mutants are both behind
+# it. HUF_STATIC_LINKING_ONLY is what exposes the reference decoder it uses to
+# classify the one mutant on which libzstd disagrees with itself.
+cudec_add_test(zstd_entropy_twin SOURCES zstd_entropy_twin.cpp zstd_corpus.cpp
+               LIBS zstd_full)
+target_include_directories(zstd_entropy_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_compile_definitions(zstd_entropy_twin PRIVATE HUF_STATIC_LINKING_ONLY)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/zstd_entropy_twin.cpp
+++ b/tests/zstd_entropy_twin.cpp
@@ -1,0 +1,415 @@
+/* The corpus-level differential run over the whole M5 entropy stage (issue
+ * #223): every #185 fixture and every #187 mutant driven through the
+ * single-sourced units in src/ and held to the pinned reference in BOTH
+ * directions, on the GPU-less runner.
+ *
+ * WHAT THIS ADDS TO THE SIBLING TWINS, which is not more of the same. Each
+ * entropy unit's twin proves that unit against the reference's matching entry
+ * point and carries a crafted negative per reject rung. None of them decodes a
+ * FRAME, so none of them can say whether the stage as a whole ever accepts
+ * something the reference refuses - and that is the property a decompressor is
+ * judged on. This file asks exactly that question, over the two corpora built
+ * for it.
+ *
+ * TWO DIRECTIONS, AND THE SECOND ONE IS WHY THE DRIVER IS COMPLETE. Where the
+ * reference accepts, the bytes must be identical; where it refuses, the driver
+ * must refuse too. The second half is only worth something if the driver
+ * enforces everything the reference does, so tests/zstd_twin_driver.h carries
+ * the frame-level rules as well as the entropy ones: the declared content
+ * size, the content checksum, the window bound on a match, and bytes after the
+ * frame. A driver missing any of them would report the gap as a fail-open on
+ * every mutant that reached it.
+ *
+ * A FRAME THIS DECODER DECLINES IS NOT A FRAME IT REFUSES. The v1 subset
+ * (#102) leaves out frames with no declared content size, with a dictionary
+ * id, and with a window past 8 MB, and a mutation lands on those descriptor
+ * bits regularly. Those come back CUDEC_ERR_UNSUPPORTED and are counted under
+ * their own name; treating them as divergences would report the subset as a
+ * defect, and treating them as agreement would hide a real over-strictness
+ * among them.
+ *
+ * THE COUNT LOCK IS A STATIC ASSERTION AND IT IS DELIBERATELY BLUNT. Every
+ * reject rung across the Zstd ladder is counted at compile time and compared
+ * against one number written down here. A rung added anywhere moves the sum
+ * and reds the build until somebody looks - and what they have to do when they
+ * look is add the negative that reaches it, which that unit's own twin already
+ * refuses to pass without. The number is written down rather than derived
+ * because a lock derived from the thing it locks is not a lock. */
+#include "require.h"
+#include "zstd_corpus.h"
+#include "zstd_twin_driver.h"
+
+/* The reference's Huffman entry points are internal to libzstd and its huf.h
+ * carries no C++ linkage guard of its own, so the include is wrapped here
+ * rather than its declarations restated. HUF_STATIC_LINKING_ONLY is defined by
+ * the build, for the reason issue #180 landed. */
+extern "C" {
+#include <common/huf.h>
+}
+
+#include <zstd.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+using cudec_twin::Bytes;
+using cudec_twin::DecodeFrame;
+using cudec_twin::kStageNames;
+using cudec_twin::Run;
+
+/* ---- The count lock ----------------------------------------------------
+ *
+ * Every reject rung the Zstd surface can return, summed at compile time. The
+ * six ladders are the bitstream reader, the FSE table description, the
+ * Huffman tree description, the literals section, the sequences section and
+ * the repeat-offset history - the whole surface rather than the entropy
+ * subset, because a rung added to any of them is a refusal that arrives with
+ * no negative behind it unless somebody wrote one.
+ *
+ * Each ladder's `...RejectCount` counts kNone as well, so the sum below
+ * subtracts one per ladder and the number is the count of real rungs.
+ *
+ * WHEN THIS REDS, the repair is not to update the number. It is to write the
+ * negative that reaches the new rung, in the twin that owns that unit - which
+ * that twin's own coverage loop already refuses to pass without - and THEN to
+ * update the number here, deliberately, as the record that somebody looked. */
+constexpr int kZstdRejectRungs =
+    (cudec_detail::kZstdBitRejectCount - 1) +
+    (cudec_detail::kZstdFseRejectCount - 1) +
+    (cudec_detail::kZstdHufRejectCount - 1) +
+    (cudec_detail::kZstdLiteralsRejectCount - 1) +
+    (cudec_detail::kZstdSeqRejectCount - 1) +
+    (cudec_detail::kZstdRepcodeRejectCount - 1);
+
+constexpr int kExpectedZstdRejectRungs = 59;
+
+/* How many mutants land in the declared class below, measured on the pinned
+ * zstd 1.5.7 and the pinned mutation corpus. Written down rather than derived
+ * for the reason the count lock above is: a number that moves silently is not
+ * a record that anybody looked. */
+constexpr int kExpectedReferenceSelfDisagreements = 1;
+
+static_assert(kZstdRejectRungs == kExpectedZstdRejectRungs,
+              "a Zstd reject rung was added or removed: write the negative "
+              "that reaches it in that unit's twin, then update "
+              "kExpectedZstdRejectRungs here (issue #223)");
+
+/* ---- The runs ---------------------------------------------------------- */
+
+/* One capacity for every run, above anything either corpus regenerates, so a
+ * refusal is never about room. */
+constexpr uint64_t kCapacity = 8ull * 1024ull * 1024ull;
+
+size_t g_fixtures = 0;
+size_t g_fixture_bytes = 0;
+size_t g_fixtures_declined = 0;
+size_t g_mutants = 0;
+size_t g_mutants_oracle_refused = 0;
+size_t g_mutants_both_accepted = 0;
+size_t g_mutants_declined = 0;
+size_t g_stage_refusals[cudec_twin::kStageCount] = {0};
+size_t g_reference_disagrees_with_itself = 0;
+
+/* The first byte at which two strings differ, or the shorter length when one
+ * is a prefix of the other. Reported on a divergence because "the bytes
+ * differ" is not a repro key and an offset is. */
+size_t FirstDifference(const Bytes& a, const Bytes& b) {
+    const size_t shared = a.size() < b.size() ? a.size() : b.size();
+    for (size_t i = 0; i < shared; i++) {
+        if (a[i] != b[i]) {
+            return i;
+        }
+    }
+    return shared;
+}
+
+/* The accept direction over the forced-mode corpus. */
+int Fixtures() {
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    REQUIRE(!fixtures.empty());
+    for (size_t f = 0; f < fixtures.size(); f++) {
+        const ZstdFixture& fixture = fixtures[f];
+        const char* name = fixture.name.c_str();
+        Bytes reference;
+        REQUIRE_CTX(ZstdOracleDecodes(fixture.compressed, &reference),
+                    "%s: the reference refused a fixture", name);
+        const Run run = DecodeFrame(fixture.compressed, kCapacity);
+        if (!run.ok && run.status == CUDEC_ERR_UNSUPPORTED) {
+            /* A legal frame outside the v1 subset. Counted and named on the
+             * PASS line: a fixture that fell out of the sweep by accident
+             * must not read like one that was swept. */
+            g_fixtures_declined++;
+            continue;
+        }
+        REQUIRE_CTX(run.ok, "%s: refused at the %s stage, rung %d: %s", name,
+                    kStageNames[run.stage], run.rung, run.why.c_str());
+        REQUIRE_CTX(run.output.size() == reference.size(),
+                    "%s: %zu bytes, the reference produced %zu", name,
+                    run.output.size(), reference.size());
+        REQUIRE_CTX(equal_bytes(run.output.data(), reference.data(),
+                                reference.size()),
+                    "%s: bytes differ from the reference", name);
+        /* And against the source the corpus compressed, which is the third
+         * reader: the reference and the driver agreeing on wrong bytes would
+         * pass the comparison above. */
+        REQUIRE_CTX(run.output.size() == fixture.original.size() &&
+                        equal_bytes(run.output.data(),
+                                    fixture.original.data(),
+                                    fixture.original.size()),
+                    "%s: the round trip lost bytes", name);
+        g_fixtures++;
+        g_fixture_bytes += run.output.size();
+    }
+    REQUIRE(g_fixtures > 0);
+    return 0;
+}
+
+/* Does the reference's OWN entropy entry point refuse this frame's literals?
+ *
+ * This exists for one measured case and it is not a shrug. libzstd's frame
+ * path accepted a mutant whose second block declares a four-stream literals
+ * section whose first stream is seventeen bytes and must regenerate three
+ * hundred and sixty-seven symbols - which no code of one bit or more can
+ * spell - and produced different bytes rather than refusing. Its own
+ * HUF_decompress4X_usingDTable, handed the same payload and the same table,
+ * refuses it. So the disagreement is inside the reference, and cudec siding
+ * with the stricter of its two answers is not an over-strictness of cudec's.
+ *
+ * What this asks is exactly that and nothing wider: walk the frame, hand each
+ * compressed block's literals payload to the reference's own Huffman decoder
+ * with the table the previous block left, and report whether any of them came
+ * back refused. A yes admits the mutant into the declared class below; a no
+ * fails the test, because then the reference agrees with itself and cudec is
+ * the odd one out.
+ *
+ * The walk uses cudec's own header parsers to find the payload, which the
+ * fixture rows above have already held to the reference byte for byte. */
+bool ReferenceEntropyRefusesALiteralsSection(const Bytes& frame) {
+    cudec_detail::ZstdFrameHeader header;
+    cudec_detail::ZstdFrameReject frame_rung =
+        cudec_detail::kZstdFrameRejectNone;
+    if (cudec_detail::ZstdParseFrameHeader(frame.data(), frame.size(), &header,
+                                           &frame_rung) != CUDEC_OK) {
+        return false;
+    }
+    HUF_CREATE_STATIC_DTABLEX1(reference_table, HUF_TABLELOG_MAX);
+    bool table_present = false;
+    std::vector<unsigned> workspace(HUF_DECOMPRESS_WORKSPACE_SIZE_U32, 0);
+    uint64_t pos = header.header_size;
+    for (;;) {
+        cudec_detail::ZstdBlockHeader block;
+        if (cudec_detail::ZstdParseBlockHeader(frame.data() + pos,
+                                               frame.size() - pos,
+                                               header.window_size, &block,
+                                               &frame_rung) != CUDEC_OK) {
+            return false;
+        }
+        const unsigned char* body = frame.data() + pos + 3;
+        if (block.block_type == cudec_detail::kZstdBlockTypeCompressed) {
+            cudec_detail::ZstdLiteralsHeader literals;
+            cudec_detail::ZstdLiteralsReject literals_rung =
+                cudec_detail::kZstdLiteralsRejectNone;
+            if (cudec_detail::ZstdParseLiteralsHeader(body, block.body_size,
+                                                      &literals,
+                                                      &literals_rung) !=
+                CUDEC_OK) {
+                return false;
+            }
+            const bool compressed =
+                literals.block_type ==
+                cudec_detail::kZstdLiteralsTypeCompressed;
+            const bool treeless =
+                literals.block_type ==
+                cudec_detail::kZstdLiteralsTypeTreeless;
+            if ((compressed || treeless) &&
+                literals.compressed_size <=
+                    block.body_size - literals.header_size &&
+                literals.regenerated_size != 0) {
+                if (treeless && !table_present) {
+                    return false;
+                }
+                const unsigned char* payload = body + literals.header_size;
+                Bytes out(static_cast<size_t>(literals.regenerated_size), 0);
+                size_t result;
+                if (compressed) {
+                    result =
+                        literals.stream_count == 1
+                            ? HUF_decompress1X1_DCtx_wksp(
+                                  reference_table, out.data(), out.size(),
+                                  payload,
+                                  static_cast<size_t>(
+                                      literals.compressed_size),
+                                  workspace.data(),
+                                  workspace.size() * sizeof(unsigned), 0)
+                            : HUF_decompress4X_hufOnly_wksp(
+                                  reference_table, out.data(), out.size(),
+                                  payload,
+                                  static_cast<size_t>(
+                                      literals.compressed_size),
+                                  workspace.data(),
+                                  workspace.size() * sizeof(unsigned), 0);
+                    if (!HUF_isError(result)) {
+                        table_present = true;
+                    }
+                } else {
+                    result = literals.stream_count == 1
+                                 ? HUF_decompress1X_usingDTable(
+                                       out.data(), out.size(), payload,
+                                       static_cast<size_t>(
+                                           literals.compressed_size),
+                                       reference_table, 0)
+                                 : HUF_decompress4X_usingDTable(
+                                       out.data(), out.size(), payload,
+                                       static_cast<size_t>(
+                                           literals.compressed_size),
+                                       reference_table, 0);
+                }
+                if (HUF_isError(result)) {
+                    return true;
+                }
+            }
+        }
+        pos += 3 + block.body_size;
+        if (block.last_block || pos >= frame.size()) {
+            return false;
+        }
+    }
+}
+
+/* Both directions over the mutation corpus. */
+int Mutants() {
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    REQUIRE(!fixtures.empty());
+    size_t fixtures_with_a_driver_refusal = 0;
+    for (size_t f = 0; f < fixtures.size(); f++) {
+        const ZstdFixture& fixture = fixtures[f];
+        const std::vector<ZstdMutant> mutants =
+            MutateZstdFrame(fixture.compressed, f + 1);
+        REQUIRE_CTX(!mutants.empty(), "%s: the mutation layer produced none",
+                    fixture.name.c_str());
+        bool driver_refused_one = false;
+        for (size_t m = 0; m < mutants.size(); m++) {
+            const ZstdMutant& mutant = mutants[m];
+            g_mutants++;
+            Bytes reference;
+            const bool oracle_ok = ZstdOracleDecodes(mutant.frame, &reference);
+            const Run run = DecodeFrame(mutant.frame, kCapacity);
+            if (!run.ok) {
+                driver_refused_one = true;
+                g_stage_refusals[run.stage]++;
+            }
+
+            if (!oracle_ok) {
+                g_mutants_oracle_refused++;
+                /* THE FAIL-OPEN DIRECTION. A mutant the reference refuses and
+                 * the driver accepts is the failure this whole file exists to
+                 * find, and it is reported with everything needed to rebuild
+                 * it: the fixture, the mutation's own description, and the
+                 * index inside that fixture's mutant list. */
+                REQUIRE_CTX(!run.ok,
+                            "FAIL-OPEN: %s mutant %zu (%s) was refused by "
+                            "libzstd and accepted by the driver, which "
+                            "produced %zu bytes",
+                            fixture.name.c_str(), m,
+                            mutant.description.c_str(), run.output.size());
+                continue;
+            }
+
+            if (!run.ok) {
+                if (run.status == CUDEC_ERR_UNSUPPORTED) {
+                    /* A legal frame this decoder declines rather than
+                     * refuses. Counted under its own name. */
+                    g_mutants_declined++;
+                    continue;
+                }
+                /* The one admitted class, and it is checked rather than
+                 * assumed: cudec refuses a literals section that the
+                 * reference's own Huffman decoder refuses too, while the
+                 * reference's frame path accepts it. */
+                REQUIRE_CTX(
+                    run.stage == cudec_twin::kStageLiterals &&
+                        ReferenceEntropyRefusesALiteralsSection(mutant.frame),
+                    "OVER-STRICT: %s mutant %zu (%s) was decoded by libzstd "
+                    "to %zu bytes and refused by the driver at the %s stage, "
+                    "rung %d: %s",
+                    fixture.name.c_str(), m, mutant.description.c_str(),
+                    reference.size(), kStageNames[run.stage], run.rung,
+                    run.why.c_str());
+                g_reference_disagrees_with_itself++;
+                continue;
+            }
+
+            g_mutants_both_accepted++;
+            REQUIRE_CTX(
+                run.output.size() == reference.size() &&
+                    FirstDifference(run.output, reference) == reference.size(),
+                "%s mutant %zu (%s): both accepted and the bytes differ at "
+                "offset %zu; driver produced %zu, libzstd %zu",
+                fixture.name.c_str(), m, mutant.description.c_str(),
+                FirstDifference(run.output, reference), run.output.size(),
+                reference.size());
+        }
+        if (driver_refused_one) {
+            fixtures_with_a_driver_refusal++;
+        }
+    }
+    REQUIRE(g_mutants > 0);
+    /* The mutations have to BITE on this side too. Every fixture yielding a
+     * mutant the reference refuses is what tests/zstd_mutants.cpp already
+     * establishes; that says nothing about whether the DRIVER ever refuses,
+     * and a driver that accepted everything would pass every assertion above
+     * except this one. */
+    const size_t swept = g_fixtures + g_fixtures_declined;
+    REQUIRE_CTX(fixtures_with_a_driver_refusal == swept,
+                "%zu of %zu fixtures produced no mutant the driver refused",
+                swept - fixtures_with_a_driver_refusal, swept);
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    int rc = Fixtures();
+    if (rc != 0) {
+        return rc;
+    }
+    rc = Mutants();
+    if (rc != 0) {
+        return rc;
+    }
+
+    std::printf("PASS: %zu fixtures decoded byte-identical to libzstd and to "
+                "their own sources (%zu bytes), %zu declined as outside the "
+                "v1 subset; %zu mutants, %zu refused by libzstd with 0 "
+                "fail-opens, %zu accepted by both with 0 byte divergences, "
+                "%zu declined as outside the subset; %d reject rungs locked\n",
+                g_fixtures, g_fixture_bytes, g_fixtures_declined, g_mutants,
+                g_mutants_oracle_refused, g_mutants_both_accepted,
+                g_mutants_declined, kZstdRejectRungs);
+    std::printf("      driver refusals by stage:");
+    for (unsigned stage = 1; stage < cudec_twin::kStageCount; stage++) {
+        if (g_stage_refusals[stage] != 0) {
+            std::printf(" %s %zu", kStageNames[stage],
+                        g_stage_refusals[stage]);
+        }
+    }
+    std::putchar('\n');
+
+    /* The class above is real and it is not empty, so its count is asserted
+     * both ways: a run in which it vanished would mean the reference changed
+     * its mind, and a run in which it grew would mean a second such case
+     * arrived unexamined. */
+    REQUIRE_CTX(g_reference_disagrees_with_itself ==
+                    kExpectedReferenceSelfDisagreements,
+                "%zu mutants where libzstd's frame path accepts what its own "
+                "Huffman decoder refuses; %d were recorded",
+                g_reference_disagrees_with_itself,
+                kExpectedReferenceSelfDisagreements);
+    std::printf("      %zu mutants where libzstd's frame path accepts a "
+                "literals section its own Huffman decoder refuses\n",
+                g_reference_disagrees_with_itself);
+    return 0;
+}

--- a/tests/zstd_repcode_twin.cpp
+++ b/tests/zstd_repcode_twin.cpp
@@ -35,10 +35,8 @@
  * observable at all. */
 #include "require.h"
 #include "zstd_corpus.h"
-#include "zstd_frame.h"
-#include "zstd_literals.h"
 #include "zstd_repcode.h"
-#include "zstd_seq.h"
+#include "zstd_twin_driver.h"
 
 #include <zstd.h>
 #include <zstd_errors.h>
@@ -50,49 +48,23 @@
 
 namespace {
 
-using Bytes = std::vector<unsigned char>;
+using Bytes = cudec_twin::Bytes;
 
 using cudec_detail::ZstdRepcodeHistory;
 using cudec_detail::ZstdRepcodeInit;
 using cudec_detail::ZstdRepcodeReject;
 using cudec_detail::ZstdRepcodeResolve;
 
-/* The seven ways an Offset_Value can resolve, counted as the driver goes.
- *
- * A corpus that decodes byte-identically proves nothing about a rule it never
- * reached, and this is what says which rules it reached. Measured rather than
- * assumed: a compressor emits some of these and not others, the numbers are
- * printed on the PASS line, and the ones a compressor does emit are required
- * to be non-zero so a corpus that stops carrying them reds this test instead
- * of passing more cheaply. */
-enum RulePath {
-    kPathExplicit = 0,     /* Offset_Value above three: an explicit distance */
-    kPathSlot0,            /* literals, value 1: the most recent offset */
-    kPathSlot1,            /* literals, value 2: the second */
-    kPathSlot2,            /* literals, value 3: the third */
-    kPathShiftedSlot1,     /* no literals, value 1: the second */
-    kPathShiftedSlot2,     /* no literals, value 2: the third */
-    /* no literals, value 3: the most recent offset, minus one */
-    kPathMinusOne,
-    kPathCount
-};
+using cudec_twin::DecodeFrame;
+using cudec_twin::kPathCount;
+using cudec_twin::kPathNames;
+using cudec_twin::Run;
 
-const char* const kPathNames[kPathCount] = {
-    "explicit", "rep1", "rep2", "rep3", "rep1-shifted", "rep2-shifted",
-    "rep1-minus-one"};
+/* One capacity for every driver run, larger than anything decoded here. */
+constexpr uint64_t kDriverCapacity = 8ull * 1024ull * 1024ull;
 
 size_t g_path_corpus[kPathCount] = {0};
 size_t g_path_crafted[kPathCount] = {0};
-
-RulePath ClassifyPath(uint64_t offset_value, uint32_t literals_length) {
-    if (offset_value > cudec_detail::kZstdRepcodeMaxSlotValue) {
-        return kPathExplicit;
-    }
-    if (literals_length != 0) {
-        return static_cast<RulePath>(kPathSlot0 + (offset_value - 1));
-    }
-    return static_cast<RulePath>(kPathShiftedSlot1 + (offset_value - 1));
-}
 
 /* Which reject rungs a declared negative reached. Same discipline as the
  * sibling twins: the enumeration lives once, in the header, and main()
@@ -272,231 +244,6 @@ bool OracleDecodes(const Bytes& frame, Bytes* out) {
     return true;
 }
 
-/* ---------------------------------------------------------------- driver */
-
-constexpr unsigned kLitLenCells = 1u
-                                  << cudec_detail::kZstdLitLenAccuracyLogMax;
-constexpr unsigned kOffsetCells = 1u
-                                  << cudec_detail::kZstdOffsetAccuracyLogMax;
-constexpr unsigned kMatchLenCells =
-    1u << cudec_detail::kZstdMatchLenAccuracyLogMax;
-
-/* Everything one frame's decode needs, in the shape each unit asks for. All
- * of it is per-FRAME rather than per-block: the Huffman table a Treeless
- * literals section reuses, the three FSE tables a Repeat mode reuses, and the
- * repeat-offset history are exactly the state that survives a block boundary
- * and is reset at frame start. */
-struct Driver {
-    std::vector<cudec_detail::ZstdHufCell> huf_cells;
-    cudec_detail::ZstdLiteralsScratch literals_scratch;
-    cudec_detail::ZstdLiteralsTable literals_table;
-    cudec_detail::ZstdFseCell litlen_cells[kLitLenCells];
-    cudec_detail::ZstdFseCell offset_cells[kOffsetCells];
-    cudec_detail::ZstdFseCell matchlen_cells[kMatchLenCells];
-    cudec_detail::ZstdSeqTable litlen;
-    cudec_detail::ZstdSeqTable offset;
-    cudec_detail::ZstdSeqTable matchlen;
-    cudec_detail::ZstdSeqScratch seq_scratch;
-    ZstdRepcodeHistory repcodes;
-
-    Driver()
-        : huf_cells(1u << cudec_detail::kZstdLiteralsMaxTableLog),
-          literals_scratch(), literals_table(), litlen(), offset(),
-          matchlen(), seq_scratch(), repcodes() {
-        literals_table.cells = huf_cells.data();
-        literals_table.capacity = static_cast<uint32_t>(huf_cells.size());
-        literals_table.table_log = 0;
-        literals_table.present = false;
-        litlen.cells = litlen_cells;
-        litlen.capacity = kLitLenCells;
-        offset.cells = offset_cells;
-        offset.capacity = kOffsetCells;
-        matchlen.cells = matchlen_cells;
-        matchlen.capacity = kMatchLenCells;
-        ZstdRepcodeInit(&repcodes);
-    }
-};
-
-/* What a driver run produced, or why it stopped. `repcode_refusal` is set
- * apart from every other failure because it is the one this test is about:
- * the reject direction asserts that the run stopped THERE and not somewhere
- * that happens to also refuse. */
-struct Run {
-    bool ok;
-    bool repcode_refusal;
-    ZstdRepcodeReject rung;
-    std::string why;
-    Bytes output;
-    size_t sequences;
-    size_t repeats;
-    size_t path[kPathCount];
-};
-
-void Fail(Run* run, const char* why) {
-    run->ok = false;
-    run->why = why;
-}
-
-/* Decodes one whole frame: the header, then each block in turn, carrying the
- * literals table, the three sequence tables and the repeat-offset history
- * across block boundaries and resetting none of them. */
-Run DecodeFrame(const Bytes& frame) {
-    Run run;
-    run.ok = true;
-    run.repcode_refusal = false;
-    run.rung = cudec_detail::kZstdRepcodeRejectNone;
-    run.sequences = 0;
-    run.repeats = 0;
-    for (unsigned i = 0; i < kPathCount; i++) {
-        run.path[i] = 0;
-    }
-
-    Driver driver;
-    cudec_detail::ZstdFrameHeader header;
-    cudec_detail::ZstdFrameReject frame_rung;
-    if (cudec_detail::ZstdParseFrameHeader(frame.data(), frame.size(), &header,
-                                           &frame_rung) != CUDEC_OK) {
-        Fail(&run, "frame header refused");
-        return run;
-    }
-    uint64_t pos = header.header_size;
-    Bytes literals;
-    for (;;) {
-        cudec_detail::ZstdBlockHeader block;
-        if (cudec_detail::ZstdParseBlockHeader(
-                frame.data() + pos, frame.size() - pos, header.window_size,
-                &block, &frame_rung) != CUDEC_OK) {
-            Fail(&run, "block header refused");
-            return run;
-        }
-        const unsigned char* body = frame.data() + pos + 3;
-        if (block.block_type == cudec_detail::kZstdBlockTypeRaw) {
-            run.output.insert(run.output.end(), body, body + block.body_size);
-        } else if (block.block_type == cudec_detail::kZstdBlockTypeRle) {
-            run.output.insert(run.output.end(), block.block_size, body[0]);
-        } else {
-            literals.assign(cudec_detail::kZstdBlockSizeCeiling, 0);
-            uint64_t produced = 0;
-            uint64_t consumed = 0;
-            cudec_detail::ZstdLiteralsReject literals_rung =
-                cudec_detail::kZstdLiteralsRejectNone;
-            if (cudec_detail::ZstdDecodeLiterals(
-                    body, block.body_size, header.window_size,
-                    &driver.literals_table, &driver.literals_scratch,
-                    literals.data(), literals.size(), &produced, &consumed,
-                    &literals_rung) != CUDEC_OK) {
-                Fail(&run, "literals section refused");
-                return run;
-            }
-            literals.resize(static_cast<size_t>(produced));
-
-            const unsigned char* section = body + consumed;
-            uint64_t remaining = block.body_size - consumed;
-            cudec_detail::ZstdSeqSectionHeader seq_header;
-            uint64_t seq_consumed = 0;
-            cudec_detail::ZstdSeqReject seq_rung =
-                cudec_detail::kZstdSeqRejectNone;
-            if (cudec_detail::ZstdParseSeqSectionHeader(
-                    section, remaining, cudec_detail::kZstdBlockSizeCeiling,
-                    &seq_header, &seq_consumed, &seq_rung) != CUDEC_OK) {
-                Fail(&run, "sequences header refused");
-                return run;
-            }
-            section += seq_consumed;
-            remaining -= seq_consumed;
-
-            std::vector<cudec_detail::ZstdSequence> sequences(
-                seq_header.sequence_count);
-            if (seq_header.sequence_count != 0) {
-                const unsigned fields[] = {
-                    cudec_detail::kZstdSeqFieldLitLen,
-                    cudec_detail::kZstdSeqFieldOffset,
-                    cudec_detail::kZstdSeqFieldMatchLen};
-                const unsigned modes[] = {seq_header.litlen_mode,
-                                          seq_header.offset_mode,
-                                          seq_header.matchlen_mode};
-                cudec_detail::ZstdSeqTable* targets[] = {
-                    &driver.litlen, &driver.offset, &driver.matchlen};
-                for (unsigned index = 0; index < 3; index++) {
-                    uint64_t table_consumed = 0;
-                    if (cudec_detail::ZstdSeqLoadTable(
-                            fields[index], modes[index], section, remaining,
-                            &driver.seq_scratch, targets[index],
-                            &table_consumed, &seq_rung) != CUDEC_OK) {
-                        Fail(&run, "sequence table refused");
-                        return run;
-                    }
-                    section += table_consumed;
-                    remaining -= table_consumed;
-                }
-                if (cudec_detail::ZstdDecodeSequences(
-                        section, remaining, seq_header.sequence_count,
-                        &driver.litlen, &driver.offset, &driver.matchlen,
-                        sequences.data(),
-                        static_cast<uint32_t>(sequences.size()),
-                        &seq_rung) != CUDEC_OK) {
-                    Fail(&run, "sequences refused");
-                    return run;
-                }
-            }
-
-            /* The execution: literals, then a match at the offset this unit
-             * resolves. Byte by byte rather than by block copy, because a
-             * match may overlap its own destination - the format's way of
-             * spelling a run. */
-            size_t literal_pos = 0;
-            for (size_t s = 0; s < sequences.size(); s++) {
-                const cudec_detail::ZstdSequence& sequence = sequences[s];
-                if (literal_pos + sequence.literals_length > literals.size()) {
-                    Fail(&run, "a sequence asked for literals that are not "
-                               "there");
-                    return run;
-                }
-                for (uint32_t i = 0; i < sequence.literals_length; i++) {
-                    run.output.push_back(literals[literal_pos + i]);
-                }
-                literal_pos += sequence.literals_length;
-
-                uint64_t resolved = 0;
-                ZstdRepcodeReject rung = cudec_detail::kZstdRepcodeRejectNone;
-                if (ZstdRepcodeResolve(&driver.repcodes,
-                                       sequence.offset_value,
-                                       sequence.literals_length, &resolved,
-                                       &rung) != CUDEC_OK) {
-                    run.ok = false;
-                    run.repcode_refusal = true;
-                    run.rung = rung;
-                    run.why = "repeat offset refused";
-                    return run;
-                }
-                run.sequences++;
-                run.path[ClassifyPath(sequence.offset_value,
-                                      sequence.literals_length)]++;
-                if (sequence.offset_value <=
-                    cudec_detail::kZstdRepcodeMaxSlotValue) {
-                    run.repeats++;
-                }
-                if (resolved > run.output.size()) {
-                    Fail(&run, "a match reached before the output");
-                    return run;
-                }
-                const size_t from = run.output.size() - resolved;
-                for (uint32_t i = 0; i < sequence.match_length; i++) {
-                    run.output.push_back(run.output[from + i]);
-                }
-            }
-            for (size_t i = literal_pos; i < literals.size(); i++) {
-                run.output.push_back(literals[i]);
-            }
-        }
-        pos += 3 + block.body_size;
-        if (block.last_block) {
-            break;
-        }
-    }
-    return run;
-}
-
 /* ------------------------------------------------------------- the rows */
 
 size_t g_frames = 0;
@@ -514,7 +261,7 @@ int OracleAgrees(const char* name, const Bytes& frame, size_t* tally) {
     Bytes reference;
     REQUIRE_CTX(OracleDecodes(frame, &reference),
                 "%s: the reference refused the frame", name);
-    const Run run = DecodeFrame(frame);
+    const Run run = DecodeFrame(frame, kDriverCapacity);
     REQUIRE_CTX(run.ok, "%s: %s", name, run.why.c_str());
     REQUIRE_CTX(run.output.size() == reference.size(),
                 "%s: %zu bytes, the reference produced %zu", name,
@@ -539,13 +286,14 @@ int OracleAndTwinRefuse(const char* name, const Bytes& frame,
     Bytes reference;
     REQUIRE_CTX(!OracleDecodes(frame, &reference),
                 "%s: the reference accepted it", name);
-    const Run run = DecodeFrame(frame);
+    const Run run = DecodeFrame(frame, kDriverCapacity);
     REQUIRE_CTX(!run.ok, "%s: the driver accepted it", name);
-    REQUIRE_CTX(run.repcode_refusal, "%s: refused elsewhere: %s", name,
-                run.why.c_str());
-    REQUIRE_CTX(run.rung == want_rung, "%s: rung %d", name,
-                static_cast<int>(run.rung));
-    CoverRung(run.rung);
+    REQUIRE_CTX(run.stage == cudec_twin::kStageRepcode,
+                "%s: refused at the %s stage: %s", name,
+                cudec_twin::kStageNames[run.stage], run.why.c_str());
+    REQUIRE_CTX(run.rung == static_cast<int>(want_rung), "%s: rung %d", name,
+                run.rung);
+    CoverRung(static_cast<ZstdRepcodeReject>(run.rung));
     return 0;
 }
 

--- a/tests/zstd_twin_driver.h
+++ b/tests/zstd_twin_driver.h
@@ -1,0 +1,394 @@
+/* The host driver that decodes a whole Zstd frame through the single-sourced
+ * units in src/, so a claim about one of them becomes bytes the pinned
+ * reference has an opinion about.
+ *
+ * WHY THIS IS A TEST FILE AND NOT A UNIT. Every stage it calls is shipped -
+ * the frame and block headers, the literals section, the FSE tables, the
+ * sequences loop, the repeat-offset history, the content checksum - and the
+ * two things it adds are not: the loop over a frame's blocks and the copy
+ * that executes one sequence. Those are their own issues with their own
+ * contracts, and a shipped decoder will make different choices about where
+ * the state lives and how the copy is laid out on a device. What is here is
+ * the least code that turns the stages into one byte string, so that
+ * "the offset resolved to four" and "this literals section decodes" become
+ * "the frame decodes to exactly what libzstd decodes it to".
+ *
+ * ALL OF THE STATE IS PER-FRAME AND NONE OF IT IS PER-BLOCK. The Huffman
+ * table a Treeless literals section reuses, the three FSE tables a Repeat
+ * mode reuses, and the repeat-offset history are exactly what survives a
+ * block boundary. A driver that reset any of them would decode the first
+ * block of every frame correctly and then produce wrong bytes, which is a
+ * failure mode the corpus rows exist to catch.
+ *
+ * WHERE A RUN STOPPED IS REPORTED, NOT JUST THAT IT DID. Reject parity over a
+ * mutation corpus is only worth something if a refusal can be attributed, so
+ * the stage is carried out alongside the verdict and a caller that cares
+ * asserts on it. */
+#ifndef CUDEC_TESTS_ZSTD_TWIN_DRIVER_H
+#define CUDEC_TESTS_ZSTD_TWIN_DRIVER_H
+
+#include "zstd_frame.h"
+#include "zstd_literals.h"
+#include "zstd_repcode.h"
+#include "zstd_seq.h"
+#include "xxhash64.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace cudec_twin {
+
+using Bytes = std::vector<unsigned char>;
+
+/* Cell storage for the three sequence fields, sized by each one's
+ * accuracy-log ceiling. */
+constexpr unsigned kLitLenCells = 1u
+                                  << cudec_detail::kZstdLitLenAccuracyLogMax;
+constexpr unsigned kOffsetCells = 1u
+                                  << cudec_detail::kZstdOffsetAccuracyLogMax;
+constexpr unsigned kMatchLenCells =
+    1u << cudec_detail::kZstdMatchLenAccuracyLogMax;
+
+/* Everything one frame's decode needs, in the shape each unit asks for. */
+struct Driver {
+    std::vector<cudec_detail::ZstdHufCell> huf_cells;
+    cudec_detail::ZstdLiteralsScratch literals_scratch;
+    cudec_detail::ZstdLiteralsTable literals_table;
+    cudec_detail::ZstdFseCell litlen_cells[kLitLenCells];
+    cudec_detail::ZstdFseCell offset_cells[kOffsetCells];
+    cudec_detail::ZstdFseCell matchlen_cells[kMatchLenCells];
+    cudec_detail::ZstdSeqTable litlen;
+    cudec_detail::ZstdSeqTable offset;
+    cudec_detail::ZstdSeqTable matchlen;
+    cudec_detail::ZstdSeqScratch seq_scratch;
+    cudec_detail::ZstdRepcodeHistory repcodes;
+
+    Driver()
+        : huf_cells(1u << cudec_detail::kZstdLiteralsMaxTableLog),
+          literals_scratch(), literals_table(), litlen(), offset(), matchlen(),
+          seq_scratch(), repcodes() {
+        literals_table.cells = huf_cells.data();
+        literals_table.capacity = static_cast<uint32_t>(huf_cells.size());
+        literals_table.table_log = 0;
+        literals_table.present = false;
+        litlen.cells = litlen_cells;
+        litlen.capacity = kLitLenCells;
+        offset.cells = offset_cells;
+        offset.capacity = kOffsetCells;
+        matchlen.cells = matchlen_cells;
+        matchlen.capacity = kMatchLenCells;
+        cudec_detail::ZstdRepcodeInit(&repcodes);
+    }
+};
+
+/* Where a run stopped. Named per STAGE rather than per rung: each stage's
+ * rungs are the business of that unit's own twin, and what a corpus-level run
+ * needs is which stage refused. */
+enum DriverStage {
+    kStageNone = 0,
+    kStageFrameHeader,
+    kStageBlockHeader,
+    kStageLiterals,
+    kStageSequenceHeader,
+    kStageSequenceTable,
+    kStageSequences,
+    kStageRepcode,
+    kStageExecute,
+    kStageContentSize,
+    kStageChecksum,
+    kStageTrailingBytes,
+    kStageCount
+};
+
+const char* const kStageNames[kStageCount] = {
+    "none",           "frame-header",  "block-header",   "literals",
+    "sequence-header", "sequence-table", "sequences",     "repcode",
+    "execute",        "content-size",  "checksum",       "trailing-bytes"};
+
+/* The seven ways an Offset_Value can resolve, counted as the driver goes. A
+ * corpus that decodes byte-identically proves nothing about a rule it never
+ * reached, and this is what says which rules it reached. */
+enum RulePath {
+    kPathExplicit = 0, /* Offset_Value above three: an explicit distance */
+    kPathSlot0,        /* literals, value 1: the most recent offset */
+    kPathSlot1,        /* literals, value 2: the second */
+    kPathSlot2,        /* literals, value 3: the third */
+    kPathShiftedSlot1, /* no literals, value 1: the second */
+    kPathShiftedSlot2, /* no literals, value 2: the third */
+    /* no literals, value 3: the most recent offset, minus one */
+    kPathMinusOne,
+    kPathCount
+};
+
+const char* const kPathNames[kPathCount] = {
+    "explicit", "rep1", "rep2", "rep3", "rep1-shifted", "rep2-shifted",
+    "rep1-minus-one"};
+
+inline RulePath ClassifyPath(uint64_t offset_value,
+                             uint32_t literals_length) {
+    if (offset_value > cudec_detail::kZstdRepcodeMaxSlotValue) {
+        return kPathExplicit;
+    }
+    if (literals_length != 0) {
+        return static_cast<RulePath>(kPathSlot0 + (offset_value - 1));
+    }
+    return static_cast<RulePath>(kPathShiftedSlot1 + (offset_value - 1));
+}
+
+/* What a driver run produced, or where and why it stopped. */
+struct Run {
+    bool ok = true;
+    /* The status the stage that stopped returned, which is not the same
+     * question as the stage: a frame this decoder DECLINES as outside the v1
+     * subset comes back CUDEC_ERR_UNSUPPORTED, and a corpus-level reject
+     * parity run has to separate that from a refusal. */
+    cudec_status status = CUDEC_OK;
+    DriverStage stage = kStageNone;
+    /* The rung the stage that stopped reported, as an int because each stage
+     * has its own enumeration and the caller that cares knows which. */
+    int rung = 0;
+    std::string why;
+    Bytes output;
+    size_t blocks = 0;
+    size_t sequences = 0;
+    size_t repeats = 0;
+    size_t path[kPathCount] = {0};
+};
+
+inline void Stop(Run* run, DriverStage stage, int rung, cudec_status status,
+                 const char* why) {
+    run->ok = false;
+    run->stage = stage;
+    run->rung = rung;
+    run->status = status;
+    run->why = why;
+}
+
+/* Decodes one whole frame inside the v1 subset (#102).
+ *
+ * The frame-level enforcement is here rather than left out, because a run
+ * that skipped it would ACCEPT frames the reference refuses and a reject
+ * parity claim over a mutation corpus would be measuring the gap instead of
+ * the decoder: the declared content size, the content checksum when the
+ * descriptor sets it, the window bound on a match, and bytes after the frame.
+ *
+ * `dst_capacity` bounds what the run will produce; a frame declaring more is
+ * refused rather than truncated. */
+inline Run DecodeFrame(const Bytes& frame, uint64_t dst_capacity) {
+    Run run;
+    Driver driver;
+    cudec_detail::ZstdFrameHeader header;
+    cudec_detail::ZstdFrameReject frame_rung =
+        cudec_detail::kZstdFrameRejectNone;
+    const cudec_status header_status = cudec_detail::ZstdParseFrameHeader(
+        frame.data(), frame.size(), &header, &frame_rung);
+    if (header_status != CUDEC_OK) {
+        Stop(&run, kStageFrameHeader, static_cast<int>(frame_rung),
+             header_status, "frame header refused");
+        return run;
+    }
+    if (header.frame_content_size > dst_capacity) {
+        Stop(&run, kStageContentSize, 0, CUDEC_ERR_OUTPUT_TOO_SMALL,
+             "the declared content size is past the destination");
+        return run;
+    }
+
+    uint64_t pos = header.header_size;
+    Bytes literals;
+    for (;;) {
+        cudec_detail::ZstdBlockHeader block;
+        const cudec_status block_status = cudec_detail::ZstdParseBlockHeader(
+            frame.data() + pos, frame.size() - pos, header.window_size, &block,
+            &frame_rung);
+        if (block_status != CUDEC_OK) {
+            Stop(&run, kStageBlockHeader, static_cast<int>(frame_rung),
+                 block_status, "block header refused");
+            return run;
+        }
+        run.blocks++;
+        const unsigned char* body = frame.data() + pos + 3;
+        if (block.block_type == cudec_detail::kZstdBlockTypeRaw) {
+            run.output.insert(run.output.end(), body, body + block.body_size);
+        } else if (block.block_type == cudec_detail::kZstdBlockTypeRle) {
+            run.output.insert(run.output.end(), block.block_size, body[0]);
+        } else {
+            /* A block may regenerate at most the block maximum, which is what
+             * sizes the literals buffer: the section's own bound is checked
+             * inside the unit against the same window. */
+            const uint64_t block_max =
+                cudec_detail::ZstdLiteralsBlockMaximum(header.window_size);
+            literals.assign(static_cast<size_t>(block_max), 0);
+            uint64_t produced = 0;
+            uint64_t consumed = 0;
+            cudec_detail::ZstdLiteralsReject literals_rung =
+                cudec_detail::kZstdLiteralsRejectNone;
+            if (cudec_detail::ZstdDecodeLiterals(
+                    body, block.body_size, header.window_size,
+                    &driver.literals_table, &driver.literals_scratch,
+                    literals.data(), literals.size(), &produced, &consumed,
+                    &literals_rung) != CUDEC_OK) {
+                Stop(&run, kStageLiterals, static_cast<int>(literals_rung),
+                     CUDEC_ERR_CORRUPT_INPUT, "literals section refused");
+                return run;
+            }
+            literals.resize(static_cast<size_t>(produced));
+
+            const unsigned char* section = body + consumed;
+            uint64_t remaining = block.body_size - consumed;
+            cudec_detail::ZstdSeqSectionHeader seq_header;
+            uint64_t seq_consumed = 0;
+            cudec_detail::ZstdSeqReject seq_rung =
+                cudec_detail::kZstdSeqRejectNone;
+            if (cudec_detail::ZstdParseSeqSectionHeader(
+                    section, remaining, block_max, &seq_header, &seq_consumed,
+                    &seq_rung) != CUDEC_OK) {
+                Stop(&run, kStageSequenceHeader, static_cast<int>(seq_rung),
+                     CUDEC_ERR_CORRUPT_INPUT, "sequences header refused");
+                return run;
+            }
+            section += seq_consumed;
+            remaining -= seq_consumed;
+
+            std::vector<cudec_detail::ZstdSequence> sequences(
+                seq_header.sequence_count);
+            if (seq_header.sequence_count != 0) {
+                const unsigned fields[] = {
+                    cudec_detail::kZstdSeqFieldLitLen,
+                    cudec_detail::kZstdSeqFieldOffset,
+                    cudec_detail::kZstdSeqFieldMatchLen};
+                const unsigned modes[] = {seq_header.litlen_mode,
+                                          seq_header.offset_mode,
+                                          seq_header.matchlen_mode};
+                cudec_detail::ZstdSeqTable* targets[] = {
+                    &driver.litlen, &driver.offset, &driver.matchlen};
+                for (unsigned index = 0; index < 3; index++) {
+                    uint64_t table_consumed = 0;
+                    if (cudec_detail::ZstdSeqLoadTable(
+                            fields[index], modes[index], section, remaining,
+                            &driver.seq_scratch, targets[index],
+                            &table_consumed, &seq_rung) != CUDEC_OK) {
+                        Stop(&run, kStageSequenceTable,
+                             static_cast<int>(seq_rung),
+                             CUDEC_ERR_CORRUPT_INPUT,
+                             "sequence table refused");
+                        return run;
+                    }
+                    section += table_consumed;
+                    remaining -= table_consumed;
+                }
+                if (cudec_detail::ZstdDecodeSequences(
+                        section, remaining, seq_header.sequence_count,
+                        &driver.litlen, &driver.offset, &driver.matchlen,
+                        sequences.data(),
+                        static_cast<uint32_t>(sequences.size()),
+                        &seq_rung) != CUDEC_OK) {
+                    Stop(&run, kStageSequences, static_cast<int>(seq_rung),
+                         CUDEC_ERR_CORRUPT_INPUT, "sequences refused");
+                    return run;
+                }
+            }
+
+            size_t literal_pos = 0;
+            for (size_t s = 0; s < sequences.size(); s++) {
+                const cudec_detail::ZstdSequence& sequence = sequences[s];
+                if (literal_pos + sequence.literals_length > literals.size()) {
+                    Stop(&run, kStageExecute, 0, CUDEC_ERR_CORRUPT_INPUT,
+                         "a sequence asked for literals that are not there");
+                    return run;
+                }
+                for (uint32_t i = 0; i < sequence.literals_length; i++) {
+                    run.output.push_back(literals[literal_pos + i]);
+                }
+                literal_pos += sequence.literals_length;
+
+                uint64_t resolved = 0;
+                cudec_detail::ZstdRepcodeReject repcode_rung =
+                    cudec_detail::kZstdRepcodeRejectNone;
+                if (cudec_detail::ZstdRepcodeResolve(
+                        &driver.repcodes, sequence.offset_value,
+                        sequence.literals_length, &resolved,
+                        &repcode_rung) != CUDEC_OK) {
+                    Stop(&run, kStageRepcode, static_cast<int>(repcode_rung),
+                         CUDEC_ERR_CORRUPT_INPUT, "repeat offset refused");
+                    return run;
+                }
+                run.sequences++;
+                run.path[ClassifyPath(sequence.offset_value,
+                                      sequence.literals_length)]++;
+                if (sequence.offset_value <=
+                    cudec_detail::kZstdRepcodeMaxSlotValue) {
+                    run.repeats++;
+                }
+                /* Two bounds, and they are different statements. A match may
+                 * not reach before the output, which is what makes the index
+                 * below defined; and it may not reach further back than the
+                 * window, which is what the format promises a decoder it will
+                 * never have to hold. */
+                if (resolved > run.output.size() ||
+                    resolved > header.window_size) {
+                    Stop(&run, kStageExecute, 0, CUDEC_ERR_CORRUPT_INPUT,
+                         "a match reached past the window or before the "
+                         "output");
+                    return run;
+                }
+                const size_t from = run.output.size() - resolved;
+                for (uint32_t i = 0; i < sequence.match_length; i++) {
+                    run.output.push_back(run.output[from + i]);
+                }
+                if (run.output.size() > dst_capacity) {
+                    Stop(&run, kStageContentSize, 0,
+                         CUDEC_ERR_OUTPUT_TOO_SMALL,
+                         "the frame regenerated more than the destination");
+                    return run;
+                }
+            }
+            for (size_t i = literal_pos; i < literals.size(); i++) {
+                run.output.push_back(literals[i]);
+            }
+        }
+        if (run.output.size() > dst_capacity) {
+            Stop(&run, kStageContentSize, 0, CUDEC_ERR_OUTPUT_TOO_SMALL,
+                 "the frame regenerated more than the destination");
+            return run;
+        }
+        pos += 3 + block.body_size;
+        if (block.last_block) {
+            break;
+        }
+    }
+
+    /* Section 3.1.1.1.1: where a content size is declared it is exact, and a
+     * frame in this subset always declares one. */
+    if (run.output.size() != header.frame_content_size) {
+        Stop(&run, kStageContentSize, 0, CUDEC_ERR_CORRUPT_INPUT,
+             "the frame produced other than its declared content size");
+        return run;
+    }
+
+    if (header.content_checksum) {
+        const uint64_t digest =
+            cudec_detail::Xxh64(run.output.data(), run.output.size());
+        if (cudec_detail::ZstdVerifyContentChecksum(
+                frame.data() + pos, frame.size() - pos, digest,
+                &frame_rung) != CUDEC_OK) {
+            Stop(&run, kStageChecksum, static_cast<int>(frame_rung),
+                 CUDEC_ERR_CORRUPT_INPUT, "content checksum refused");
+            return run;
+        }
+        pos += 4;
+    }
+
+    /* A chunk holding more than one frame is outside the subset (section
+     * 12.4), so bytes after the frame are refused rather than ignored. */
+    if (pos != frame.size()) {
+        Stop(&run, kStageTrailingBytes, 0, CUDEC_ERR_CORRUPT_INPUT,
+             "bytes follow the frame");
+        return run;
+    }
+    return run;
+}
+
+}  // namespace cudec_twin
+
+#endif /* CUDEC_TESTS_ZSTD_TWIN_DRIVER_H */


### PR DESCRIPTION
# What & why

Closes #223.

Each Zstd entropy unit's twin proves that unit against the reference entry point that matches it, and carries a crafted negative per reject rung. None of them decodes a frame, so none of them can answer the question a decompressor is judged on: does the stage as a whole ever accept something the reference refuses. `tests/zstd_entropy_twin.cpp` asks exactly that, over the #185 fixtures and the #187 mutants, in both directions.

`tests/zstd_twin_driver.h` is the driver, lifted out of `tests/zstd_repcode_twin.cpp` so there is one of it rather than two, and completed. Reject parity is only worth something if the driver enforces everything the reference does, so it now carries the frame-level rules alongside the entropy ones: the declared content size, the content checksum, the window bound on a match, and bytes after the frame.

```
PASS: 17 fixtures decoded byte-identical to libzstd and to their own sources
(1596416 bytes), 2 declined as outside the v1 subset; 784 mutants, 679 refused
by libzstd with 0 fail-opens, 98 accepted by both with 0 byte divergences, 6
declined as outside the subset; 59 reject rungs locked
      driver refusals by stage: frame-header 209 block-header 144 literals 48
      sequence-header 25 sequence-table 69 sequences 122 execute 1
      content-size 40 checksum 27 trailing-bytes 1
      1 mutants where libzstd's frame path accepts a literals section its own
      Huffman decoder refuses
```

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: nothing in `src/` changes. Zero fail-opens over 679 mutants libzstd refuses, and a fail-open is reported with the fixture, the mutation's own description and its index, which together rebuild the bytes.
- [x] Oracle coverage: the fixtures are held to libzstd AND to the sources the corpus compressed, which is a third reader - two decoders agreeing on wrong bytes would pass the first comparison on its own.
- [x] Determinism preserved: no `src/` change.
- [x] No CUDA API call is added and no exception crosses the C ABI.
- [ ] An adversarial review (`/security-review`) was run.
- [ ] Review record, per lens.

**The two unticked boxes are the disclosure and it stays negative.** No independent adversarial-lens review ran on this change and there is no second reader for it. What stands in place of one is below, and the second half of it is a bound on this very test rather than a claim for it.

### The count lock bites, and it bit while it was being written

The lock is a `static_assert` over every reject rung the Zstd surface carries - six ladders, fifty-nine rungs - compared against one number written down beside it. The first draft wrote 60 and the build refused it:

```
tests/zstd_entropy_twin.cpp:81:32: error: static assertion failed: a Zstd reject
rung was added or removed: write the negative that reaches it in that unit's
twin, then update kExpectedZstdRejectRungs here (issue #223)
note: the comparison reduces to '(59 == 60)'
```

A rung added anywhere now moves the sum and reds the build until somebody writes the negative that reaches it, which that unit's own twin already refuses to pass without.

### What this run detects, and what it does not - measured

Every guard below was deleted from its shipped unit, one at a time, and the corpus-level run was asked whether it noticed. It noticed one of eight:

```
baseline (unmutated header shadowed in)                       GREEN

zstd_literals.h  the literals stream must be fully consumed   RED
zstd_literals.h  the jump table may not overrun the payload   GREEN
zstd_literals.h  the regenerated size vs the block maximum    GREEN
zstd_seq.h       the sequence bitstream must be consumed      GREEN
zstd_huf.h       the implied last weight must close the tree  GREEN
zstd_fse.h       the accuracy log against the field ceiling   GREEN
zstd_frame.h     a block may not exceed the block maximum     GREEN
zstd_repcode.h   a repeat may not resolve to zero             GREEN
```

That is not a defect in this test, and it is the number to know before treating a green run here as coverage. The reject direction can only assert THAT the driver refused, never where: a mutant whose entropy guard is gone is still caught downstream by the declared content size or the content checksum, so the run stays green while the guard is missing. Per-guard detection is the sibling twins' job and they each enforce a negative per rung; what this run adds is the whole-stage two-directional agreement, which none of them can give.

The seven that survive are all caught by their own unit's twin. The measurement is reported rather than left to be assumed.

### The one over-strict mutant is classified by execution, not excused

libzstd's frame path accepts a mutant whose second block declares a four-stream literals section whose first stream is seventeen bytes and must regenerate three hundred and sixty-seven symbols. No code of one bit or more can spell that, and the reference produces different bytes rather than refusing - the mutant's output diverges from the original at offset 131107. Its own `HUF_decompress4X_usingDTable`, handed the same payload and the same table, refuses it:

```
mutant: block1-huffman-description-header-at-22032
byte 22032: parent 91 -> mutant 11
ZSTD_decompress: OK 262144 bytes, original 262144, first difference at 131107
block 0: type 2 regen 1805 csize 763 -> accepted by both
block 1: type 3 regen 1468 csize 598 -> cudec refuses (stream truncated)
  jump table: 17 147 145; payload 598; fourth 283
  reference HUF_decompress4X_usingDTable: Data corruption detected
```

So the test does not take that on trust. It re-runs the reference's own Huffman decoder over the same section, with the table the previous block left, and admits the mutant only because that answer came back refused - which is cudec siding with the stricter of the reference's two answers. The count of such mutants is pinned at one, so a second arriving unexamined reds the test, and a run in which it vanished would red too.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

Both new files are host test code. Issue #258 separately records that no route to a device Compute Sanitizer can attach to is available here at all.

## Performance checklist

Not on the hot path.

## Quality checklist

- [x] Minimal: the driver is extracted rather than copied - `tests/zstd_repcode_twin.cpp` loses 268 lines to `tests/zstd_twin_driver.h` and both tests now run the same one. No `src/` code is added.
- [x] Self-documenting: the driver header says why it is a test file and not a unit, and the test header says what this adds to the sibling twins and why a declined frame is not a refused one.
- [x] The new structural property - a rung added with no negative behind it - is locked in by the `static_assert` above.

## Verification

- [ ] `cmake --build build` - builds clean.
- [ ] `ctest --test-dir build` - green.
- [x] Prettier (`**/*.{md,yml,yaml}`) - clean, run locally; no file in that set is touched by this change.
- [x] Docs synced: no behaviour, API or performance change reaches a document.

**The two unticked boxes stay negative.** The configured gate cannot be produced here: `tests/` is added only under `-DCUDEC_ENABLE_CUDA=ON` and this machine has no CUDA toolchain on any route it offers. So every twin was built and run directly against the pinned oracle's own sources, which are the same 1.5.7 the build fetches, and all seven are green on this branch:

```
zstd_entropy_twin:  PASS (the block quoted at the top)
zstd_huf_twin:      PASS: 17 descriptions, 34816 table cells, 11 rungs
zstd_literals_twin: PASS: 333 sections, 42340 literal bytes, 14 rungs
zstd_repcode_twin:  PASS: 34 frames byte-identical, 173319 sequences, 2 rungs
zstd_seq_twin:      PASS: 125067 sequences across 332 blocks, 16 of 16 rungs
zstd_fse_twin:      PASS: 852 descriptions, 58624 table cells, 10 of 10 rungs
zstd_frame_twin:    PASS: 3 frames field for field, 18 checksums, 13 negatives
```

That run carries no `-DCUDEC_SANITIZE`, so the ASan and UBSan pass over the new host code is CI's and has not been produced here. Read the checks on this pull request rather than this paragraph.

## Notes

The issue asks that the driver be "recorded as a required check". It is registered through `cudec_add_test` without the `GPU` flag, so `ctest -LE gpu` on the GPU-less runner selects it and it runs inside the `build` job, which is already a required check. Making a further context required is branch-ruleset state rather than tree state, and nothing here changes repository settings.

Two corpus fixtures are declined rather than decoded: they declare no content size, which is a legal shape outside the v1 subset `src/zstd_frame.h` implements. Six mutants are declined for the same class of reason. Both counts are on the PASS line rather than passed over.
