### PR TITLE
M5 sequence execution: the prefix sum, the copies, and the two offset bounds [#198]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,6 +437,7 @@ jobs:
           test -x build-san/tests/frame_host_negative &&
           test -x build-san/tests/tilestream_host_negative &&
           test -x build-san/tests/gdeflate_schedule_twin &&
+          test -x build-san/tests/zstd_exec_twin &&
           test -x build-san/tests/termination
 
       # Prove the sanitizer runtimes are actually linked: a dropped or renamed
@@ -458,7 +459,7 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|zstd_frame_twin|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|zstd_frame_twin|zstd_exec_twin|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
@@ -471,6 +472,7 @@ jobs:
           grep -E ': tilestream_host_negative$' san-selected.txt &&
           grep -E ': gdeflate_schedule_twin$' san-selected.txt &&
           grep -E ': zstd_frame_twin$' san-selected.txt &&
+          grep -E ': zstd_exec_twin$' san-selected.txt &&
           grep -E ': termination$' san-selected.txt
 
   format:

--- a/src/zstd_exec.h
+++ b/src/zstd_exec.h
@@ -1,0 +1,347 @@
+/* Zstd sequence execution: the prefix sum that names where every sequence
+ * writes, and the literal and match copies that put the bytes there. RFC 8878
+ * section 3.1.1.3.2. Single-sourced for host and device, the sibling of
+ * src/zstd_seq.h, which produces the tuples, and of src/zstd_repcode.h, which
+ * turns an Offset_Value into a distance and says in its own header that
+ * bounding that distance belongs here.
+ *
+ * WHY THE PREFIX SUM IS ITS OWN FUNCTION AND NOT A CURSOR. A serial decoder
+ * would carry a running output position and never need one, and that is
+ * exactly why a serial decoder proves nothing about the copies a warp makes.
+ * Every sequence's destination is a pure function of the lengths before it, so
+ * the sum is computed once, up front, and every copy afterwards is independent
+ * of every other. On the device that sum is a scan and the copies fan out; on
+ * the host it is the loop below and the copies run in order. The two produce
+ * the same array, and the array is what the copies read - so an off-by-one in
+ * the scan cannot hide behind a cursor that happened to be right anyway.
+ *
+ * THE EXECUTION DOES NOT TRUST THE ARRAY IT IS HANDED. A caller that computes
+ * the destinations somewhere else - a warp scan, a second kernel - hands in an
+ * array this unit has no way to have produced. Trusting it would put every
+ * bound this unit checks behind an unchecked number, which is the fail-open
+ * shape the ladder exists to prevent, so each copy re-derives its own
+ * successor from its lengths and refuses a destination that disagrees. The
+ * check is one comparison per sequence and it is per-lane parallel, so it
+ * costs the device shape nothing it would not have paid anyway.
+ *
+ * TWO BOUNDS ON AN OFFSET, AND THEY ARE DIFFERENT STATEMENTS. A match may not
+ * reach further back than the window, which is what the format promises a
+ * decoder it will never have to hold; and it may not reach before the first
+ * byte the frame has produced, which is what makes the read defined at all. A
+ * decoder checking only the window reads outside its own output on a frame
+ * whose window is larger than what it has decoded so far, which is every frame
+ * near its start. Both are checked, separately, and each carries its own rung.
+ *
+ * THE OFFSET IS BOUNDED AGAINST THE FRAME AND NEVER AGAINST THE BLOCK. A match
+ * legitimately reaches back across a block boundary into what an earlier block
+ * produced - that is what makes the blocks of a frame sequential - so the
+ * bytes-produced-so-far this unit compares against are the frame's, and the
+ * destination buffer it copies inside is the frame's whole output. A unit
+ * bounding against the block would decode the first block of every frame
+ * correctly and refuse legal matches in every block after it.
+ *
+ * AN OVERLAPPING MATCH REPLICATES A PATTERN AND DOES NOT COPY A RANGE. Where
+ * the resolved offset is smaller than the match length the source runs into
+ * the bytes the match is itself writing, so the copy is byte by byte in
+ * increasing order - the same semantics src/lz4_block.h and src/snappy_block.h
+ * carry, and the run-fill an offset of one produces is the extreme case. The
+ * device form of the same statement is the closed-form modular gather
+ * src/lz4_decode.cuh already uses, dst[to + i] = dst[to - offset + (i mod
+ * offset)], which is defined for every i because an offset of zero is refused
+ * below. A vector copy of the range would produce different bytes, not a
+ * faster version of the same ones.
+ *
+ * WHAT THIS UNIT DOES NOT DO. It does not decode a block, loop over the blocks
+ * of a frame, or resolve an Offset_Value: the tuples, the literals and the
+ * resolved distances all arrive already produced, each from the unit that owns
+ * it. Where a block's regenerated size comes from is the caller's too - a
+ * compressed block does not declare one, so what this unit is given is the
+ * ceiling that block may not pass, and what it reports back is the size the
+ * sequences and the leftover literals actually add up to.
+ *
+ * Internal header, not part of the ABI. */
+#ifndef CUDEC_ZSTD_EXEC_H
+#define CUDEC_ZSTD_EXEC_H
+
+#include "cudec.h"
+#include "zstd_frame.h"
+#include "zstd_seq.h"
+
+#include <stdint.h>
+
+/* Guarded: the sibling decode headers define the same macro for the same
+ * reason, and a device translation unit that decodes more than one format
+ * includes more than one of them. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+/* The reject ladder, enumerated once, in the shape src/zstd_seq.h and
+ * src/zstd_repcode.h use: every refusal returns through one choke point naming
+ * its rung, so the twin requires a negative per rung instead of counting
+ * statuses that repeat. */
+enum ZstdExecReject {
+    kZstdExecRejectNone = 0,
+    /* Storage or a count the caller did not supply, or a destinations array
+     * with no room for the one-past-the-end entry. Not a stream: every one of
+     * these is a caller bug refused rather than decoded around. */
+    kZstdExecRejectBadRequest,
+    /* The sequences ask for more literal bytes than the literals section
+     * produced. The leftover tail is what is left after the last sequence, so
+     * this is the other side of the same accounting: over-consumption here and
+     * a shorter tail there. */
+    kZstdExecRejectLiteralsExhausted,
+    /* The block regenerates more than Block_Maximum_Size allows. A compressed
+     * block declares no regenerated size, so this ceiling is the only thing
+     * that bounds the sum before the copies run. */
+    kZstdExecRejectBlockTooLarge,
+    /* A destination that disagrees with the lengths of the sequence that
+     * writes there. Reached by a scan that is wrong, never by a stream. */
+    kZstdExecRejectPlanInconsistent,
+    /* A resolved offset of zero. src/zstd_repcode.h refuses one already, so
+     * this catches an offset array assembled some other way; zero is refused
+     * rather than treated as a copy of nothing, because it names a source that
+     * is the destination and no byte of it is defined. */
+    kZstdExecRejectOffsetZero,
+    /* A match reaching further back than the frame's window. */
+    kZstdExecRejectOffsetPastWindow,
+    /* A match reaching before the first byte the frame has produced. */
+    kZstdExecRejectOffsetBeforeOutput,
+    /* The frame's output plus this block does not fit the destination. Its
+     * status is OUTPUT_TOO_SMALL and not CORRUPT_INPUT: the bytes may be
+     * perfectly good and the buffer merely short, and a caller that cannot
+     * tell those apart cannot retry. */
+    kZstdExecRejectDestinationTooSmall,
+    kZstdExecRejectCount
+};
+
+CUDEC_HOST_DEVICE inline cudec_status ZstdExecRefuse(ZstdExecReject rung,
+                                                     cudec_status status,
+                                                     ZstdExecReject* out) {
+    if (out != 0) {
+        *out = rung;
+    }
+    return status;
+}
+
+/* What the prefix sum found out about one block, which is what the execution
+ * needs and the caller wants back. */
+struct ZstdExecPlan {
+    /* Bytes this block regenerates: everything the sequences write plus the
+     * literals left after the last one. */
+    uint64_t block_size;
+    /* Bytes of the literals buffer the sequences consume. The tail is
+     * `literals_size - literals_used` and starts exactly there. */
+    uint64_t literals_used;
+};
+
+/* The prefix sum over (Literal_Length + Match_Length), block-relative.
+ *
+ * `out_destinations` receives `sequence_count + 1` entries: entry `i` is where
+ * sequence `i` writes its literals, and the last entry is where the leftover
+ * literals begin. The one-past-the-end entry is not a convenience - it is what
+ * the execution compares each sequence's own arithmetic against, and it is
+ * what tells the tail where it starts without a second sum.
+ *
+ * `block_maximum` is Block_Maximum_Size for this frame (RFC 8878 section
+ * 3.1.1.2.4), the ceiling a compressed block's regenerated size may not pass.
+ * It is bounded here, before any copy, rather than discovered by a destination
+ * that overflows: the copies are independent of each other and one of them
+ * running past the end is not something the others would notice. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdExecPrefixSum(
+    const ZstdSequence* sequences, uint32_t sequence_count,
+    uint64_t literals_size, uint64_t block_maximum,
+    uint64_t* out_destinations, uint32_t destinations_capacity,
+    ZstdExecPlan* out_plan, ZstdExecReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdExecRejectNone;
+    }
+    if (out_plan != 0) {
+        out_plan->block_size = 0;
+        out_plan->literals_used = 0;
+    }
+    /* THE CEILING IS BOUNDED BEFORE IT IS USED, AND THAT IS WHAT MAKES EVERY
+     * SUM BELOW SAFE RATHER THAN LUCKY. Both of these are the caller's own
+     * quantities and both are already bounded where they are produced - the
+     * ceiling by section 3.1.1.2.4, the literals by the section that decoded
+     * them - so refusing them here costs a legal frame nothing. What it buys
+     * is that the running sum is compared against a ceiling of at most 128 KiB
+     * at every step and can never leave that range, so no addition in this
+     * file can wrap and no reject rung is needed for one. A rung for an
+     * overflow that 32-bit length fields cannot reach would be a guard no
+     * negative could ever red, which is worse than no guard: it reads as
+     * coverage. */
+    if (out_destinations == 0 || out_plan == 0 ||
+        (sequences == 0 && sequence_count != 0) ||
+        destinations_capacity < 1 ||
+        destinations_capacity - 1 < sequence_count ||
+        block_maximum > kZstdBlockSizeCeiling ||
+        literals_size > kZstdBlockSizeCeiling) {
+        return ZstdExecRefuse(kZstdExecRejectBadRequest,
+                              CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+
+    uint64_t at = 0;
+    uint64_t literals_used = 0;
+    for (uint32_t index = 0; index < sequence_count; index++) {
+        out_destinations[index] = at;
+        const uint64_t literals_length = sequences[index].literals_length;
+        const uint64_t match_length = sequences[index].match_length;
+        /* Checked as a subtraction against what is left of the ceiling, which
+         * never wraps, and refused at the sequence that passes it rather than
+         * after the whole sum: a block that has already exceeded its maximum
+         * does not become legal by what follows. */
+        const uint64_t span = literals_length + match_length;
+        if (span > block_maximum - at) {
+            return ZstdExecRefuse(kZstdExecRejectBlockTooLarge,
+                                  CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        at += span;
+        if (literals_length > literals_size - literals_used) {
+            return ZstdExecRefuse(kZstdExecRejectLiteralsExhausted,
+                                  CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        literals_used += literals_length;
+    }
+    out_destinations[sequence_count] = at;
+
+    const uint64_t tail = literals_size - literals_used;
+    if (tail > block_maximum - at) {
+        return ZstdExecRefuse(kZstdExecRejectBlockTooLarge,
+                              CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const uint64_t block_size = at + tail;
+    out_plan->block_size = block_size;
+    out_plan->literals_used = literals_used;
+    return CUDEC_OK;
+}
+
+/* Executes one block's sequences and its leftover literals into the frame's
+ * output.
+ *
+ * `offsets` holds one resolved distance per sequence, in the frame's own
+ * terms, as src/zstd_repcode.h produced them. Resolving is a serial chain over
+ * the frame's repeat-offset history and is that unit's business; what arrives
+ * here is the finished array, which is what lets every copy below be
+ * independent of every other.
+ *
+ * `dst` is the frame's whole output and `*produced` the bytes of it earlier
+ * blocks left, in and out: on success it advances by the block's size, and on
+ * any refusal it is left exactly where it was. Bytes may have been written
+ * past it before a later sequence refused - a partial write is not a partial
+ * success, and a caller that presented it as one would be reporting output it
+ * has no reason to believe. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdExecuteBlock(
+    const ZstdSequence* sequences, uint32_t sequence_count,
+    const uint64_t* destinations, const uint64_t* offsets,
+    const unsigned char* literals, uint64_t literals_size,
+    const ZstdExecPlan* plan, uint64_t window_size, unsigned char* dst,
+    uint64_t dst_capacity, uint64_t* produced, ZstdExecReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdExecRejectNone;
+    }
+    if (destinations == 0 || plan == 0 || produced == 0 || dst == 0 ||
+        (sequences == 0 && sequence_count != 0) ||
+        (offsets == 0 && sequence_count != 0) ||
+        (literals == 0 && literals_size != 0)) {
+        return ZstdExecRefuse(kZstdExecRejectBadRequest,
+                              CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+
+    const uint64_t base = *produced;
+    if (base > dst_capacity || plan->block_size > dst_capacity - base) {
+        return ZstdExecRefuse(kZstdExecRejectDestinationTooSmall,
+                              CUDEC_ERR_OUTPUT_TOO_SMALL, reject);
+    }
+
+    uint64_t literal_at = 0;
+    for (uint32_t index = 0; index < sequence_count; index++) {
+        const uint64_t literals_length = sequences[index].literals_length;
+        const uint64_t match_length = sequences[index].match_length;
+        const uint64_t at = destinations[index];
+        /* The array is re-derived rather than believed: this sequence's own
+         * lengths have to carry the destination to the next one's, and the
+         * last one's to where the tail begins. A scan that dropped a sequence,
+         * doubled one, or ran in the wrong order fails here rather than
+         * writing over a neighbour's bytes. */
+        if (at > plan->block_size ||
+            literals_length + match_length > plan->block_size - at ||
+            at + literals_length + match_length != destinations[index + 1]) {
+            return ZstdExecRefuse(kZstdExecRejectPlanInconsistent,
+                                  CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        if (literals_length > literals_size - literal_at) {
+            return ZstdExecRefuse(kZstdExecRejectLiteralsExhausted,
+                                  CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+
+        uint64_t to = base + at;
+        for (uint64_t i = 0; i < literals_length; i++) {
+            dst[to + i] = literals[literal_at + i];
+        }
+        literal_at += literals_length;
+        to += literals_length;
+
+        const uint64_t offset = offsets[index];
+        if (offset == 0) {
+            return ZstdExecRefuse(kZstdExecRejectOffsetZero,
+                                  CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        if (offset > window_size) {
+            return ZstdExecRefuse(kZstdExecRejectOffsetPastWindow,
+                                  CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        /* `to` is where this match starts, so the bytes produced before it are
+         * everything the frame holds up to that point - the earlier blocks,
+         * this block's earlier sequences, and this sequence's own literals.
+         * Comparing against the block's own start instead would refuse the
+         * cross-block match the format allows. */
+        if (offset > to) {
+            return ZstdExecRefuse(kZstdExecRejectOffsetBeforeOutput,
+                                  CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        const uint64_t from = to - offset;
+        for (uint64_t i = 0; i < match_length; i++) {
+            dst[to + i] = dst[from + i];
+        }
+    }
+
+    /* Where the tail begins, and the last thing the plan is held to.
+     *
+     * The per-sequence check above compares each destination against the SUM
+     * of a sequence's two lengths, so it cannot tell a literal byte from a
+     * match byte, and with no sequences at all it does not run. Three things
+     * therefore reach here unchecked: the tail's start, the literals it is
+     * made of, and whether the block size the destination bound was taken from
+     * accounts for it. All three are one equation, and it is stated once here
+     * rather than trusted three times. Without it a block size of zero beside
+     * a literals section of any length writes past the bound this function
+     * already passed. */
+    const uint64_t tail_at = destinations[sequence_count];
+    if (literal_at != plan->literals_used || tail_at > plan->block_size ||
+        literals_size - literal_at != plan->block_size - tail_at) {
+        return ZstdExecRefuse(kZstdExecRejectPlanInconsistent,
+                              CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    /* The literals after the last sequence, copied verbatim. They are part of
+     * what the block regenerates rather than a remainder to discard, which is
+     * what makes a literals-only block - no sequences at all - decode to its
+     * literals. */
+    for (uint64_t i = 0; i + literal_at < literals_size; i++) {
+        dst[base + tail_at + i] = literals[literal_at + i];
+    }
+
+    *produced = base + plan->block_size;
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_ZSTD_EXEC_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -330,6 +330,19 @@ cudec_add_test(zstd_repcode_twin SOURCES zstd_repcode_twin.cpp zstd_corpus.cpp
 target_include_directories(zstd_repcode_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_compile_definitions(zstd_repcode_twin PRIVATE HUF_STATIC_LINKING_ONLY)
+# Zstd sequence execution: the prefix sum that names every sequence's
+# destination, the literal and match copies it addresses, and the two bounds on
+# a resolved offset (issue #198). Host-side and GPU-less, and the ONE Zstd twin
+# that links no oracle: the reference exposes no entry point that executes a
+# sequence stream, so what the reference has an opinion about is a whole frame
+# and that parity lives in zstd_entropy_twin below, which drives this unit for
+# every compressed block it decodes. What is here is the branch set a
+# compressor cannot emit - the offset one past a bound, the destination array
+# that disagrees with its own sequences, the block past its maximum - written
+# by hand, one per rung. It compiles no corpus for the same reason.
+cudec_add_test(zstd_exec_twin SOURCES zstd_exec_twin.cpp)
+target_include_directories(zstd_exec_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 # The whole M5 entropy stage over both corpora, two-directionally (issue
 # #223). It is the only Zstd test that decodes a FRAME: the sibling twins each
 # prove one unit against the reference entry point that matches it, and none of

--- a/tests/zstd_entropy_twin.cpp
+++ b/tests/zstd_entropy_twin.cpp
@@ -63,11 +63,11 @@ using cudec_twin::Run;
 /* ---- The count lock ----------------------------------------------------
  *
  * Every reject rung the Zstd surface can return, summed at compile time. The
- * six ladders are the bitstream reader, the FSE table description, the
- * Huffman tree description, the literals section, the sequences section and
- * the repeat-offset history - the whole surface rather than the entropy
- * subset, because a rung added to any of them is a refusal that arrives with
- * no negative behind it unless somebody wrote one.
+ * seven ladders are the bitstream reader, the FSE table description, the
+ * Huffman tree description, the literals section, the sequences section, the
+ * repeat-offset history and the sequence execution - the whole surface rather
+ * than the entropy subset, because a rung added to any of them is a refusal
+ * that arrives with no negative behind it unless somebody wrote one.
  *
  * Each ladder's `...RejectCount` counts kNone as well, so the sum below
  * subtracts one per ladder and the number is the count of real rungs.
@@ -82,9 +82,10 @@ constexpr int kZstdRejectRungs =
     (cudec_detail::kZstdHufRejectCount - 1) +
     (cudec_detail::kZstdLiteralsRejectCount - 1) +
     (cudec_detail::kZstdSeqRejectCount - 1) +
-    (cudec_detail::kZstdRepcodeRejectCount - 1);
+    (cudec_detail::kZstdRepcodeRejectCount - 1) +
+    (cudec_detail::kZstdExecRejectCount - 1);
 
-constexpr int kExpectedZstdRejectRungs = 59;
+constexpr int kExpectedZstdRejectRungs = 67;
 
 /* How many mutants land in the declared class below, measured on the pinned
  * zstd 1.5.7 and the pinned mutation corpus. Written down rather than derived

--- a/tests/zstd_exec_twin.cpp
+++ b/tests/zstd_exec_twin.cpp
@@ -185,7 +185,15 @@ int Accepts(const char* name, const std::vector<ZstdSequence>& sequences,
             const Bytes& prefix, uint64_t window_size, const char* want) {
     const Bytes expected = Ascii(want);
     Bytes dst(prefix.size() + expected.size() + 64, 0);
-    std::memcpy(dst.data(), prefix.data(), prefix.size());
+    /* Guarded on emptiness rather than called with a zero length: an empty
+     * vector's data() is a null pointer, and memcpy is declared never to take
+     * one however many bytes it is asked for. UBSan says so, and it said so
+     * here. */
+    if (!prefix.empty()) {
+        if (!prefix.empty()) {
+            std::memcpy(dst.data(), prefix.data(), prefix.size());
+        }
+    }
     const Outcome out =
         Execute(sequences, offsets, literals,
                 cudec_detail::kZstdBlockSizeCeiling, window_size, &dst,

--- a/tests/zstd_exec_twin.cpp
+++ b/tests/zstd_exec_twin.cpp
@@ -190,9 +190,7 @@ int Accepts(const char* name, const std::vector<ZstdSequence>& sequences,
      * one however many bytes it is asked for. UBSan says so, and it said so
      * here. */
     if (!prefix.empty()) {
-        if (!prefix.empty()) {
-            std::memcpy(dst.data(), prefix.data(), prefix.size());
-        }
+        std::memcpy(dst.data(), prefix.data(), prefix.size());
     }
     const Outcome out =
         Execute(sequences, offsets, literals,
@@ -640,7 +638,9 @@ int Sweep() {
                     "run %d: the model refused its own row", run);
 
         Bytes dst(expected.size() + 64, 0);
-        std::memcpy(dst.data(), prefix.data(), prefix.size());
+        if (!prefix.empty()) {
+            std::memcpy(dst.data(), prefix.data(), prefix.size());
+        }
         const Outcome out =
             Execute(sequences, offsets, literals,
                     cudec_detail::kZstdBlockSizeCeiling, kWideWindow, &dst,

--- a/tests/zstd_exec_twin.cpp
+++ b/tests/zstd_exec_twin.cpp
@@ -1,0 +1,702 @@
+/* Zstd sequence execution: the prefix sum over (Literal_Length +
+ * Match_Length), the literal and match copies it addresses, and the bound that
+ * refuses a match reaching outside what the frame has produced (issue #198).
+ * Host-side and GPU-less: every input this unit takes is an array a caller
+ * built, so nothing here needs a compressor and nothing here needs a device.
+ *
+ * WHY THIS TWIN LINKS NO ORACLE, WHICH IS DELIBERATE AND IS NOT A GAP. The
+ * reference exposes no entry point that executes a sequence stream: the
+ * quantities this unit consumes - the tuples, the decoded literals, the
+ * resolved distances - exist only inside its own decode loop. What the
+ * reference does have an opinion about is a whole frame, and that is where the
+ * parity lives: tests/zstd_twin_driver.h calls this unit for every compressed
+ * block it decodes, and tests/zstd_entropy_twin.cpp holds the result to
+ * libzstd over both corpora in both directions. A row here that passed while
+ * the unit was wrong would red there, and the two are meant to be read
+ * together.
+ *
+ * WHAT IS LEFT FOR THIS FILE IS WHAT A CORPUS CANNOT REACH. A compressor emits
+ * legal sequence streams, so it never produces the offset one past the bound,
+ * the destination array that disagrees with its own sequences, or the block
+ * that regenerates past its maximum - and those are the branches that decide
+ * whether the unit is fail-closed. They are written here by hand, one per
+ * rung, in the shape the sibling Zstd twins use.
+ *
+ * THE SWEEP COMPARES TWO IMPLEMENTATIONS AND THAT IS WORTH EXACTLY WHAT IT
+ * SOUNDS LIKE. The model below is the serial decoder anybody would write: a
+ * running cursor, copy the literals, copy the match. It shares no line with
+ * the unit, which addresses every copy through the prefix sum instead, so a
+ * scan that is off by one diverges from it on the first sequence. It does not
+ * share the unit's blind spots either, but it was written by the same hand
+ * against the same reading of the format, so it proves the two agree and not
+ * that either is right about RFC 8878. What proves that is the frame-level
+ * parity named above. */
+#include "require.h"
+#include "zstd_exec.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using cudec_detail::kZstdExecRejectBadRequest;
+using cudec_detail::kZstdExecRejectBlockTooLarge;
+using cudec_detail::kZstdExecRejectCount;
+using cudec_detail::kZstdExecRejectDestinationTooSmall;
+using cudec_detail::kZstdExecRejectLiteralsExhausted;
+using cudec_detail::kZstdExecRejectNone;
+using cudec_detail::kZstdExecRejectOffsetBeforeOutput;
+using cudec_detail::kZstdExecRejectOffsetPastWindow;
+using cudec_detail::kZstdExecRejectOffsetZero;
+using cudec_detail::kZstdExecRejectPlanInconsistent;
+using cudec_detail::ZstdExecPlan;
+using cudec_detail::ZstdExecPrefixSum;
+using cudec_detail::ZstdExecReject;
+using cudec_detail::ZstdExecuteBlock;
+using cudec_detail::ZstdSequence;
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+/* Which reject rungs a declared negative reached. Same discipline as the
+ * sibling twins: the enumeration lives once, in the header, and main()
+ * requires every rung to have been named by a negative written to reach it. */
+bool g_reject_covered[kZstdExecRejectCount] = {false};
+
+void CoverRung(ZstdExecReject rung) {
+    if (rung != kZstdExecRejectNone) {
+        g_reject_covered[rung] = true;
+    }
+}
+
+size_t g_rows = 0;
+size_t g_sequences = 0;
+size_t g_bytes = 0;
+
+/* One block put through both halves of the unit, with everything a row wants
+ * to assert on carried back. */
+struct Outcome {
+    cudec_status status = CUDEC_OK;
+    ZstdExecReject rung = kZstdExecRejectNone;
+    /* Where it stopped: false while the prefix sum was still running. */
+    bool executed = false;
+    uint64_t block_size = 0;
+    uint64_t literals_used = 0;
+    uint64_t produced = 0;
+    std::vector<uint64_t> destinations;
+};
+
+/* The window a row means when it does not care about the window bound. Larger
+ * than any offset written below, so a refusal is never accidentally the window
+ * rung. */
+constexpr uint64_t kWideWindow = 1ull << 20;
+
+Outcome Execute(const std::vector<ZstdSequence>& sequences,
+                const std::vector<uint64_t>& offsets, const Bytes& literals,
+                uint64_t block_maximum, uint64_t window_size, Bytes* dst,
+                uint64_t produced) {
+    Outcome out;
+    out.produced = produced;
+    out.destinations.assign(sequences.size() + 1, 0);
+    ZstdExecPlan plan;
+    plan.block_size = 0;
+    plan.literals_used = 0;
+    out.status = ZstdExecPrefixSum(
+        sequences.empty() ? 0 : sequences.data(),
+        static_cast<uint32_t>(sequences.size()), literals.size(),
+        block_maximum, out.destinations.data(),
+        static_cast<uint32_t>(out.destinations.size()), &plan, &out.rung);
+    out.block_size = plan.block_size;
+    out.literals_used = plan.literals_used;
+    if (out.status != CUDEC_OK) {
+        return out;
+    }
+    out.executed = true;
+    out.status = ZstdExecuteBlock(
+        sequences.empty() ? 0 : sequences.data(),
+        static_cast<uint32_t>(sequences.size()), out.destinations.data(),
+        offsets.empty() ? 0 : offsets.data(),
+        literals.empty() ? 0 : literals.data(), literals.size(), &plan,
+        window_size, dst->data(), dst->size(), &out.produced, &out.rung);
+    return out;
+}
+
+/* ------------------------------------------------------------- the model */
+
+/* The serial decoder the file header describes: a cursor, the literals, the
+ * match. It shares no addressing with the unit, and it is what the randomized
+ * sweep compares against. It assumes the row is legal - the bounds are the
+ * unit's claim, not this model's - so a caller only hands it rows it has
+ * already had accepted. */
+bool ModelExecute(const std::vector<ZstdSequence>& sequences,
+                  const std::vector<uint64_t>& offsets, const Bytes& literals,
+                  Bytes* frame) {
+    size_t literal_at = 0;
+    for (size_t index = 0; index < sequences.size(); index++) {
+        const uint32_t literals_length = sequences[index].literals_length;
+        if (literal_at + literals_length > literals.size()) {
+            return false;
+        }
+        for (uint32_t i = 0; i < literals_length; i++) {
+            frame->push_back(literals[literal_at + i]);
+        }
+        literal_at += literals_length;
+        const uint64_t offset = offsets[index];
+        if (offset == 0 || offset > frame->size()) {
+            return false;
+        }
+        const size_t from = frame->size() - static_cast<size_t>(offset);
+        for (uint32_t i = 0; i < sequences[index].match_length; i++) {
+            frame->push_back((*frame)[from + i]);
+        }
+    }
+    for (size_t i = literal_at; i < literals.size(); i++) {
+        frame->push_back(literals[i]);
+    }
+    return true;
+}
+
+/* ----------------------------------------------------------- the helpers */
+
+ZstdSequence Seq(uint32_t literals_length, uint32_t match_length) {
+    ZstdSequence sequence;
+    sequence.literals_length = literals_length;
+    sequence.match_length = match_length;
+    /* Not read by this unit: the Offset_Value is src/zstd_repcode.h's input
+     * and the resolved distance is what arrives here. Set to a value that is
+     * an explicit offset rather than a repeat, so a reader is not invited to
+     * believe the two are related. */
+    sequence.offset_value = 4;
+    return sequence;
+}
+
+Bytes Ascii(const char* text) {
+    return Bytes(reinterpret_cast<const unsigned char*>(text),
+                 reinterpret_cast<const unsigned char*>(text) +
+                     std::strlen(text));
+}
+
+/* A positive row: the block decodes, and it decodes to exactly these bytes on
+ * top of whatever the frame already held. */
+int Accepts(const char* name, const std::vector<ZstdSequence>& sequences,
+            const std::vector<uint64_t>& offsets, const Bytes& literals,
+            const Bytes& prefix, uint64_t window_size, const char* want) {
+    const Bytes expected = Ascii(want);
+    Bytes dst(prefix.size() + expected.size() + 64, 0);
+    std::memcpy(dst.data(), prefix.data(), prefix.size());
+    const Outcome out =
+        Execute(sequences, offsets, literals,
+                cudec_detail::kZstdBlockSizeCeiling, window_size, &dst,
+                prefix.size());
+    REQUIRE_CTX(out.status == CUDEC_OK, "%s: refused, rung %d", name,
+                static_cast<int>(out.rung));
+    REQUIRE_CTX(out.produced == prefix.size() + expected.size(),
+                "%s: produced %llu, want %llu", name,
+                static_cast<unsigned long long>(out.produced),
+                static_cast<unsigned long long>(prefix.size() +
+                                                expected.size()));
+    REQUIRE_CTX(out.block_size == expected.size(), "%s: block size %llu", name,
+                static_cast<unsigned long long>(out.block_size));
+    REQUIRE_CTX(equal_bytes(dst.data() + prefix.size(), expected.data(),
+                            expected.size()),
+                "%s: bytes", name);
+    /* The prefix is not touched by a block that writes after it. A unit that
+     * addressed from the block's start instead of the frame's would pass every
+     * byte assertion above on the first block of a frame and corrupt the one
+     * before it on every block after. */
+    REQUIRE_CTX(equal_bytes(dst.data(), prefix.data(), prefix.size()),
+                "%s: the earlier output moved", name);
+    g_rows++;
+    g_sequences += sequences.size();
+    g_bytes += expected.size();
+    return 0;
+}
+
+/* A negative row: the unit refuses, at this rung, with this status. */
+int Refuses(const char* name, const std::vector<ZstdSequence>& sequences,
+            const std::vector<uint64_t>& offsets, const Bytes& literals,
+            uint64_t block_maximum, uint64_t window_size, uint64_t capacity,
+            uint64_t produced, ZstdExecReject want_rung,
+            cudec_status want_status) {
+    Bytes dst(static_cast<size_t>(capacity), 0);
+    const Outcome out = Execute(sequences, offsets, literals, block_maximum,
+                                window_size, &dst, produced);
+    REQUIRE_CTX(out.status == want_status, "%s: status %d, want %d", name,
+                static_cast<int>(out.status), static_cast<int>(want_status));
+    REQUIRE_CTX(out.rung == want_rung, "%s: rung %d, want %d", name,
+                static_cast<int>(out.rung), static_cast<int>(want_rung));
+    /* A refusal leaves the caller's byte count where it was: a partial write
+     * is not a partial success, and a caller that advanced on one would
+     * present bytes it has no reason to believe. */
+    REQUIRE_CTX(out.produced == produced, "%s: produced moved to %llu", name,
+                static_cast<unsigned long long>(out.produced));
+    CoverRung(out.rung);
+    g_rows++;
+    return 0;
+}
+
+/* ------------------------------------------------------------- the rows */
+
+int Positives() {
+    /* A block with no sequences at all decodes to its literals. The tail is
+     * the whole block, and the prefix sum runs zero times, so this is the one
+     * row where every destination the copies use comes from the
+     * one-past-the-end entry alone. */
+    if (Accepts("literals-only", {}, {}, Ascii("abcdef"), Bytes(), kWideWindow,
+                "abcdef") != 0) {
+        return 1;
+    }
+
+    /* One sequence and a tail: three literals, a match four back over three
+     * bytes, then the literals nobody claimed. */
+    if (Accepts("one-sequence", {Seq(3, 3)}, {3}, Ascii("abcdef"), Bytes(),
+                kWideWindow, "abcabcdef") != 0) {
+        return 1;
+    }
+
+    /* Offset one over a long match: the run-fill. The source runs into the
+     * bytes the match is writing, so a copy that read the range once - a
+     * vector load, a memcpy - would produce different bytes rather than the
+     * same bytes faster. */
+    if (Accepts("run-fill-offset-one", {Seq(1, 9)}, {1}, Ascii("a"), Bytes(),
+                kWideWindow, "aaaaaaaaaa") != 0) {
+        return 1;
+    }
+
+    /* An overlap that is not a run: offset two over five bytes alternates. */
+    if (Accepts("overlap-offset-two", {Seq(2, 5)}, {2}, Ascii("ab"), Bytes(),
+                kWideWindow, "abababa") != 0) {
+        return 1;
+    }
+
+    /* A match reaching into what an earlier block produced. This is the case
+     * the format is built around - it is what makes the blocks of a frame
+     * sequential - and a decoder bounding an offset against the block instead
+     * of the frame refuses it. */
+    if (Accepts("cross-block-match", {Seq(1, 5)}, {12}, Ascii("!"),
+                Ascii("hello world"), kWideWindow, "!hello") != 0) {
+        return 1;
+    }
+
+    /* The offset exactly at the bound: the match starts at position four of
+     * the frame and reaches back four, to the first byte there is. One less
+     * and the read is outside the output. */
+    if (Accepts("offset-at-the-output-bound", {Seq(4, 4)}, {4}, Ascii("wxyz"),
+                Bytes(), kWideWindow, "wxyzwxyz") != 0) {
+        return 1;
+    }
+
+    /* The offset exactly at the window, which is a different bound and is
+     * checked separately. Eight bytes of earlier output, a window of eight, a
+     * match reaching all eight back. */
+    if (Accepts("offset-at-the-window-bound", {Seq(0, 3)}, {8}, Bytes(),
+                Ascii("01234567"), 8, "012") != 0) {
+        return 1;
+    }
+
+    /* Several sequences and a tail, so the prefix sum has more than one entry
+     * to get right. Destinations 0, 5 and 9; the tail at 12. */
+    if (Accepts("multi-sequence",
+                {Seq(2, 3), Seq(1, 3), Seq(1, 2)}, {2, 5, 1},
+                Ascii("abcdXY"), Bytes(), kWideWindow, "ababacbabdddXY") != 0) {
+        return 1;
+    }
+
+    /* A sequence with no literals at all: the match starts where the previous
+     * one ended. */
+    if (Accepts("zero-literal-sequence", {Seq(3, 2), Seq(0, 2)}, {3, 5},
+                Ascii("xyz"), Bytes(), kWideWindow, "xyzxyxy") != 0) {
+        return 1;
+    }
+
+    /* A block that regenerates exactly its maximum is legal; one byte more is
+     * the negative below. Written with the ceiling handed in explicitly rather
+     * than through Accepts(), because the row is about that number. */
+    {
+        const std::vector<ZstdSequence> sequences = {Seq(4, 4)};
+        const std::vector<uint64_t> offsets = {4};
+        Bytes dst(64, 0);
+        uint64_t produced = 0;
+        const Outcome out = Execute(sequences, offsets, Ascii("wxyz"), 8,
+                                    kWideWindow, &dst, produced);
+        REQUIRE(out.status == CUDEC_OK);
+        REQUIRE(out.block_size == 8);
+        REQUIRE(out.produced == 8);
+        g_rows++;
+    }
+    return 0;
+}
+
+int Negatives() {
+    const Bytes literals = Ascii("abcdef");
+
+    /* The destinations array with no room for the one-past-the-end entry. The
+     * entry is not a convenience: it is what the execution holds the last
+     * sequence's own arithmetic against, and what tells the tail where it
+     * starts. */
+    {
+        std::vector<ZstdSequence> sequences = {Seq(1, 1)};
+        uint64_t destinations[1] = {0};
+        ZstdExecPlan plan;
+        ZstdExecReject rung = kZstdExecRejectNone;
+        const cudec_status status = ZstdExecPrefixSum(
+            sequences.data(), 1, literals.size(),
+            cudec_detail::kZstdBlockSizeCeiling, destinations, 1, &plan,
+            &rung);
+        REQUIRE(status == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == kZstdExecRejectBadRequest);
+        CoverRung(rung);
+        g_rows++;
+    }
+
+    /* A ceiling past the format's own. Refused rather than used, because every
+     * sum in the unit is bounded by it and a ceiling nobody bounded is a bound
+     * that proves nothing. */
+    if (Refuses("ceiling-past-the-format", {Seq(1, 1)}, {1}, literals,
+                cudec_detail::kZstdBlockSizeCeiling + 1, kWideWindow, 256, 0,
+                kZstdExecRejectBadRequest, CUDEC_ERR_INVALID_ARGUMENT) != 0) {
+        return 1;
+    }
+
+    /* More literal bytes claimed than the literals section produced. */
+    if (Refuses("literals-exhausted", {Seq(7, 1)}, {1}, literals,
+                cudec_detail::kZstdBlockSizeCeiling, kWideWindow, 256, 0,
+                kZstdExecRejectLiteralsExhausted, CUDEC_ERR_CORRUPT_INPUT) !=
+        0) {
+        return 1;
+    }
+
+    /* The literals run out on the SECOND sequence, so the row also says the
+     * accounting is running rather than per sequence. */
+    if (Refuses("literals-exhausted-later", {Seq(4, 1), Seq(4, 1)}, {1, 1},
+                literals, cudec_detail::kZstdBlockSizeCeiling, kWideWindow,
+                256, 0, kZstdExecRejectLiteralsExhausted,
+                CUDEC_ERR_CORRUPT_INPUT) != 0) {
+        return 1;
+    }
+
+    /* A block one byte past its maximum. */
+    if (Refuses("block-past-its-maximum", {Seq(4, 5)}, {4}, Ascii("wxyz"), 8,
+                kWideWindow, 256, 0, kZstdExecRejectBlockTooLarge,
+                CUDEC_ERR_CORRUPT_INPUT) != 0) {
+        return 1;
+    }
+
+    /* The tail alone carries a block past its maximum, which the per-sequence
+     * bound above cannot see. */
+    if (Refuses("tail-past-the-maximum", {Seq(2, 2)}, {2}, literals, 5,
+                kWideWindow, 256, 0, kZstdExecRejectBlockTooLarge,
+                CUDEC_ERR_CORRUPT_INPUT) != 0) {
+        return 1;
+    }
+
+    /* A resolved offset of zero. src/zstd_repcode.h refuses one already; this
+     * is the offset array that did not come from it. */
+    if (Refuses("offset-zero", {Seq(2, 2)}, {0}, literals,
+                cudec_detail::kZstdBlockSizeCeiling, kWideWindow, 256, 0,
+                kZstdExecRejectOffsetZero, CUDEC_ERR_CORRUPT_INPUT) != 0) {
+        return 1;
+    }
+
+    /* One past the window, with enough output behind it that the other bound
+     * would have accepted it. The two rungs are only distinguishable on a row
+     * where exactly one of them bites. */
+    if (Refuses("offset-past-the-window", {Seq(0, 2)}, {9}, Bytes(),
+                cudec_detail::kZstdBlockSizeCeiling, 8, 256, 32,
+                kZstdExecRejectOffsetPastWindow, CUDEC_ERR_CORRUPT_INPUT) !=
+        0) {
+        return 1;
+    }
+
+    /* One past the output, with a window wide enough that the other bound
+     * would have accepted it: the case a decoder checking only the window
+     * reads outside its own buffer on, which is every frame near its start. */
+    if (Refuses("offset-before-the-output", {Seq(3, 2)}, {4}, literals,
+                cudec_detail::kZstdBlockSizeCeiling, kWideWindow, 256, 0,
+                kZstdExecRejectOffsetBeforeOutput, CUDEC_ERR_CORRUPT_INPUT) !=
+        0) {
+        return 1;
+    }
+
+    /* The destination does not hold the frame's output plus this block. Its
+     * status is OUTPUT_TOO_SMALL and not CORRUPT_INPUT: the bytes are good and
+     * the buffer is short, and a caller that cannot tell those apart cannot
+     * retry with a larger one. */
+    if (Refuses("destination-too-small", {Seq(3, 3)}, {3}, literals,
+                cudec_detail::kZstdBlockSizeCeiling, kWideWindow, 8, 0,
+                kZstdExecRejectDestinationTooSmall,
+                CUDEC_ERR_OUTPUT_TOO_SMALL) != 0) {
+        return 1;
+    }
+
+    /* The destinations array that disagrees with the sequences that write to
+     * it. Reached by a scan that is wrong rather than by a stream, which is
+     * why it is built here by hand: the prefix sum would never produce it, and
+     * the execution is what has to refuse rather than believe it. Three
+     * shapes, because they fail in three different places. */
+    {
+        const std::vector<ZstdSequence> sequences = {Seq(2, 2), Seq(1, 1)};
+        const std::vector<uint64_t> offsets = {2, 3};
+        ZstdExecPlan plan;
+        ZstdExecReject rung = kZstdExecRejectNone;
+        std::vector<uint64_t> good(3, 0);
+        REQUIRE(ZstdExecPrefixSum(sequences.data(), 2, literals.size(),
+                                  cudec_detail::kZstdBlockSizeCeiling,
+                                  good.data(), 3, &plan,
+                                  &rung) == CUDEC_OK);
+
+        struct Row {
+            const char* name;
+            unsigned entry;
+            uint64_t value;
+        };
+        const Row rows[] = {
+            /* A successor one short: the scan dropped a byte. */
+            {"plan-successor-short", 1, 3},
+            /* A successor one long: the scan double-counted. */
+            {"plan-successor-long", 1, 5},
+            /* The last sequence's successor IS the tail's start, so a tail
+             * that moved on a block with sequences is caught by the same
+             * comparison. The case only that equation sees is the block with
+             * none, and it is the row after this loop. */
+            {"plan-tail-moved", 2, 7},
+        };
+        for (const Row& row : rows) {
+            std::vector<uint64_t> broken = good;
+            broken[row.entry] = row.value;
+            Bytes dst(256, 0);
+            uint64_t produced = 0;
+            rung = kZstdExecRejectNone;
+            const cudec_status status = ZstdExecuteBlock(
+                sequences.data(), 2, broken.data(), offsets.data(),
+                literals.data(), literals.size(), &plan, kWideWindow,
+                dst.data(), dst.size(), &produced, &rung);
+            REQUIRE_CTX(status == CUDEC_ERR_CORRUPT_INPUT, "%s: status %d",
+                        row.name, static_cast<int>(status));
+            REQUIRE_CTX(rung == kZstdExecRejectPlanInconsistent,
+                        "%s: rung %d", row.name, static_cast<int>(rung));
+            REQUIRE_CTX(produced == 0, "%s: produced moved", row.name);
+            CoverRung(rung);
+            g_rows++;
+        }
+
+        /* The literals bound inside the execution, reached by calling it
+         * directly with a plan and a destinations array that agree with each
+         * other and not with the literals buffer. The prefix sum refuses this
+         * one sequence earlier, so nothing that goes through both halves ever
+         * arrives here - and this is the guard between a caller that computed
+         * its plan somewhere else and a read outside the literals it was
+         * handed. The refusal has to come BEFORE the copy, which is why the
+         * row exists rather than a comment saying the sum already checked. */
+        {
+            const std::vector<ZstdSequence> lying_sequences = {Seq(4, 1)};
+            const std::vector<uint64_t> lying_offsets = {1};
+            const Bytes short_literals = Ascii("ab");
+            const uint64_t lying_destinations[2] = {0, 5};
+            ZstdExecPlan lying_plan;
+            lying_plan.block_size = 5;
+            lying_plan.literals_used = 4;
+            Bytes short_dst(256, 0);
+            uint64_t short_produced = 0;
+            ZstdExecReject short_rung = kZstdExecRejectNone;
+            const cudec_status short_status = ZstdExecuteBlock(
+                lying_sequences.data(), 1, lying_destinations,
+                lying_offsets.data(), short_literals.data(),
+                short_literals.size(), &lying_plan, kWideWindow,
+                short_dst.data(), short_dst.size(), &short_produced,
+                &short_rung);
+            REQUIRE(short_status == CUDEC_ERR_CORRUPT_INPUT);
+            REQUIRE(short_rung == kZstdExecRejectLiteralsExhausted);
+            REQUIRE(short_produced == 0);
+            CoverRung(short_rung);
+            g_rows++;
+        }
+
+        /* A block with NO sequences, whose tail was moved. The per-sequence
+         * comparison does not run at all here, so the equation at the end is
+         * the only thing between a destination somebody else computed and a
+         * write outside the block it was bounded against. */
+        {
+            std::vector<uint64_t> tail_moved(1, 3);
+            ZstdExecPlan empty_plan;
+            ZstdExecReject empty_rung = kZstdExecRejectNone;
+            std::vector<uint64_t> empty_destinations(1, 0);
+            REQUIRE(ZstdExecPrefixSum(0, 0, literals.size(),
+                                      cudec_detail::kZstdBlockSizeCeiling,
+                                      empty_destinations.data(), 1,
+                                      &empty_plan, &empty_rung) == CUDEC_OK);
+            Bytes empty_dst(256, 0);
+            uint64_t empty_produced = 0;
+            const cudec_status empty_status = ZstdExecuteBlock(
+                0, 0, tail_moved.data(), 0, literals.data(), literals.size(),
+                &empty_plan, kWideWindow, empty_dst.data(), empty_dst.size(),
+                &empty_produced, &empty_rung);
+            REQUIRE(empty_status == CUDEC_ERR_CORRUPT_INPUT);
+            REQUIRE(empty_rung == kZstdExecRejectPlanInconsistent);
+            REQUIRE(empty_produced == 0);
+            CoverRung(empty_rung);
+            g_rows++;
+        }
+
+        /* A plan whose literals_used disagrees with what the sequences
+         * consume. The per-sequence comparison holds destinations against the
+         * SUM of two lengths and cannot tell a literal byte from a match one,
+         * so this survives it - and a tail sized from that number would run
+         * past the block. */
+        ZstdExecPlan lying = plan;
+        lying.literals_used = plan.literals_used + 1;
+        Bytes dst(256, 0);
+        uint64_t produced = 0;
+        rung = kZstdExecRejectNone;
+        const cudec_status status = ZstdExecuteBlock(
+            sequences.data(), 2, good.data(), offsets.data(), literals.data(),
+            literals.size(), &lying, kWideWindow, dst.data(), dst.size(),
+            &produced, &rung);
+        REQUIRE(status == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(rung == kZstdExecRejectPlanInconsistent);
+        CoverRung(rung);
+        g_rows++;
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------- the sweep */
+
+/* A deterministic generator, so a failure is reproducible from the seed
+ * printed with it. xorshift64 rather than the standard library's engines:
+ * this file states the sequence it draws instead of depending on an
+ * implementation's. */
+uint64_t Next(uint64_t* state) {
+    uint64_t x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    return x;
+}
+
+int Sweep() {
+    constexpr int kRuns = 512;
+    size_t total_sequences = 0;
+    for (int run = 0; run < kRuns; run++) {
+        uint64_t state = 0x9e3779b97f4a7c15ull + static_cast<uint64_t>(run);
+        /* A prefix that plays the part of earlier blocks, so a sweep row
+         * reaches the cross-block case rather than only the first block. */
+        Bytes frame;
+        const size_t prefix_size = static_cast<size_t>(Next(&state) % 40);
+        for (size_t i = 0; i < prefix_size; i++) {
+            frame.push_back(static_cast<unsigned char>(Next(&state)));
+        }
+        const Bytes prefix = frame;
+
+        Bytes literals;
+        const size_t literals_size =
+            static_cast<size_t>(Next(&state) % 48) + 1;
+        for (size_t i = 0; i < literals_size; i++) {
+            literals.push_back(
+                static_cast<unsigned char>('a' + (Next(&state) % 26)));
+        }
+
+        std::vector<ZstdSequence> sequences;
+        std::vector<uint64_t> offsets;
+        size_t literal_at = 0;
+        size_t produced = prefix.size();
+        const size_t count = static_cast<size_t>(Next(&state) % 6);
+        for (size_t s = 0; s < count; s++) {
+            const size_t left = literals.size() - literal_at;
+            if (left == 0) {
+                break;
+            }
+            const uint32_t literals_length =
+                static_cast<uint32_t>(Next(&state) % (left + 1));
+            produced += literals_length;
+            literal_at += literals_length;
+            if (produced == 0) {
+                /* Nothing to match against yet: an offset needs a byte behind
+                 * it, and this row would be the negative rather than the
+                 * sweep. */
+                continue;
+            }
+            const uint64_t offset = (Next(&state) % produced) + 1;
+            const uint32_t match_length =
+                static_cast<uint32_t>(Next(&state) % 40) + 1;
+            produced += match_length;
+            sequences.push_back(Seq(literals_length, match_length));
+            offsets.push_back(offset);
+        }
+
+        Bytes expected = prefix;
+        REQUIRE_CTX(ModelExecute(sequences, offsets, literals, &expected),
+                    "run %d: the model refused its own row", run);
+
+        Bytes dst(expected.size() + 64, 0);
+        std::memcpy(dst.data(), prefix.data(), prefix.size());
+        const Outcome out =
+            Execute(sequences, offsets, literals,
+                    cudec_detail::kZstdBlockSizeCeiling, kWideWindow, &dst,
+                    prefix.size());
+        REQUIRE_CTX(out.status == CUDEC_OK, "run %d: refused, rung %d", run,
+                    static_cast<int>(out.rung));
+        REQUIRE_CTX(out.produced == expected.size(),
+                    "run %d: produced %llu, model %zu", run,
+                    static_cast<unsigned long long>(out.produced),
+                    expected.size());
+        REQUIRE_CTX(equal_bytes(dst.data(), expected.data(), expected.size()),
+                    "run %d: bytes", run);
+
+        /* The destinations the unit produced, checked against the model's own
+         * cursor. A scan that is wrong in a way the bytes happen to survive -
+         * two sequences whose lengths swap - is caught here and nowhere
+         * else. */
+        size_t cursor = 0;
+        for (size_t s = 0; s < sequences.size(); s++) {
+            REQUIRE_CTX(out.destinations[s] == cursor,
+                        "run %d: destination %zu is %llu, want %zu", run, s,
+                        static_cast<unsigned long long>(out.destinations[s]),
+                        cursor);
+            cursor += sequences[s].literals_length + sequences[s].match_length;
+        }
+        REQUIRE_CTX(out.destinations[sequences.size()] == cursor,
+                    "run %d: the tail starts at %llu, want %zu", run,
+                    static_cast<unsigned long long>(
+                        out.destinations[sequences.size()]),
+                    cursor);
+        total_sequences += sequences.size();
+        g_rows++;
+        g_sequences += sequences.size();
+        g_bytes += out.block_size;
+    }
+    /* A sweep that generated nothing passes every assertion in it. */
+    REQUIRE(total_sequences > 0);
+    std::printf("      sweep: %d rows, %zu sequences\n", kRuns,
+                total_sequences);
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    if (Positives() != 0) {
+        return 1;
+    }
+    if (Negatives() != 0) {
+        return 1;
+    }
+    if (Sweep() != 0) {
+        return 1;
+    }
+
+    /* Every rung the unit can return has a negative written to reach it. */
+    for (int rung = kZstdExecRejectNone + 1; rung < kZstdExecRejectCount;
+         rung++) {
+        REQUIRE_CTX(g_reject_covered[rung], "reject rung %d has no negative",
+                    rung);
+    }
+
+    std::printf("PASS: %zu rows, %zu sequences executed, %zu bytes "
+                "regenerated, %d reject rungs covered\n",
+                g_rows, g_sequences, g_bytes, kZstdExecRejectCount - 1);
+    return 0;
+}

--- a/tests/zstd_twin_driver.h
+++ b/tests/zstd_twin_driver.h
@@ -4,14 +4,20 @@
  *
  * WHY THIS IS A TEST FILE AND NOT A UNIT. Every stage it calls is shipped -
  * the frame and block headers, the literals section, the FSE tables, the
- * sequences loop, the repeat-offset history, the content checksum - and the
- * two things it adds are not: the loop over a frame's blocks and the copy
- * that executes one sequence. Those are their own issues with their own
- * contracts, and a shipped decoder will make different choices about where
- * the state lives and how the copy is laid out on a device. What is here is
- * the least code that turns the stages into one byte string, so that
- * "the offset resolved to four" and "this literals section decodes" become
- * "the frame decodes to exactly what libzstd decodes it to".
+ * sequences loop, the repeat-offset history, the sequence execution, the
+ * content checksum - and the one thing it adds is not: the loop over a
+ * frame's blocks. That is its own issue with its own contract, and a shipped
+ * decoder will make different choices about where the per-frame state lives.
+ * What is here is the least code that turns the stages into one byte string,
+ * so that "the offset resolved to four" and "this literals section decodes"
+ * become "the frame decodes to exactly what libzstd decodes it to".
+ *
+ * THE COPY THAT EXECUTES A SEQUENCE USED TO BE HERE AND IS NOW SHIPPED. It
+ * moved to src/zstd_exec.h under issue #198, which is what makes the corpus
+ * runs below a statement about the decoder rather than about a copy loop that
+ * only tests ever compile. The driver still owns the block loop and the
+ * per-frame state it carries, because that is the sub-issue that has not
+ * landed.
  *
  * ALL OF THE STATE IS PER-FRAME AND NONE OF IT IS PER-BLOCK. The Huffman
  * table a Treeless literals section reuses, the three FSE tables a Repeat
@@ -27,6 +33,7 @@
 #ifndef CUDEC_TESTS_ZSTD_TWIN_DRIVER_H
 #define CUDEC_TESTS_ZSTD_TWIN_DRIVER_H
 
+#include "zstd_exec.h"
 #include "zstd_frame.h"
 #include "zstd_literals.h"
 #include "zstd_repcode.h"
@@ -194,8 +201,18 @@ inline Run DecodeFrame(const Bytes& frame, uint64_t dst_capacity) {
         return run;
     }
 
+    /* The frame's whole output, sized to what it declares, which the subset
+     * guarantees exists and the check above bounded. One byte of slack so the
+     * buffer has an address even for a frame declaring nothing; the capacity
+     * handed to the units is the declared size and never the slack. */
+    run.output.assign(static_cast<size_t>(header.frame_content_size) + 1, 0);
+    const uint64_t capacity = header.frame_content_size;
+    uint64_t produced = 0;
+
     uint64_t pos = header.header_size;
     Bytes literals;
+    std::vector<uint64_t> offsets;
+    std::vector<uint64_t> destinations;
     for (;;) {
         cudec_detail::ZstdBlockHeader block;
         const cudec_status block_status = cudec_detail::ZstdParseBlockHeader(
@@ -209,9 +226,25 @@ inline Run DecodeFrame(const Bytes& frame, uint64_t dst_capacity) {
         run.blocks++;
         const unsigned char* body = frame.data() + pos + 3;
         if (block.block_type == cudec_detail::kZstdBlockTypeRaw) {
-            run.output.insert(run.output.end(), body, body + block.body_size);
+            if (block.body_size > capacity - produced) {
+                Stop(&run, kStageContentSize, 0, CUDEC_ERR_OUTPUT_TOO_SMALL,
+                     "the frame regenerated more than the destination");
+                return run;
+            }
+            for (uint64_t i = 0; i < block.body_size; i++) {
+                run.output[static_cast<size_t>(produced + i)] = body[i];
+            }
+            produced += block.body_size;
         } else if (block.block_type == cudec_detail::kZstdBlockTypeRle) {
-            run.output.insert(run.output.end(), block.block_size, body[0]);
+            if (block.block_size > capacity - produced) {
+                Stop(&run, kStageContentSize, 0, CUDEC_ERR_OUTPUT_TOO_SMALL,
+                     "the frame regenerated more than the destination");
+                return run;
+            }
+            for (uint64_t i = 0; i < block.block_size; i++) {
+                run.output[static_cast<size_t>(produced + i)] = body[0];
+            }
+            produced += block.block_size;
         } else {
             /* A block may regenerate at most the block maximum, which is what
              * sizes the literals buffer: the section's own bound is checked
@@ -219,20 +252,20 @@ inline Run DecodeFrame(const Bytes& frame, uint64_t dst_capacity) {
             const uint64_t block_max =
                 cudec_detail::ZstdLiteralsBlockMaximum(header.window_size);
             literals.assign(static_cast<size_t>(block_max), 0);
-            uint64_t produced = 0;
+            uint64_t literals_produced = 0;
             uint64_t consumed = 0;
             cudec_detail::ZstdLiteralsReject literals_rung =
                 cudec_detail::kZstdLiteralsRejectNone;
             if (cudec_detail::ZstdDecodeLiterals(
                     body, block.body_size, header.window_size,
                     &driver.literals_table, &driver.literals_scratch,
-                    literals.data(), literals.size(), &produced, &consumed,
-                    &literals_rung) != CUDEC_OK) {
+                    literals.data(), literals.size(), &literals_produced,
+                    &consumed, &literals_rung) != CUDEC_OK) {
                 Stop(&run, kStageLiterals, static_cast<int>(literals_rung),
                      CUDEC_ERR_CORRUPT_INPUT, "literals section refused");
                 return run;
             }
-            literals.resize(static_cast<size_t>(produced));
+            literals.resize(static_cast<size_t>(literals_produced));
 
             const unsigned char* section = body + consumed;
             uint64_t remaining = block.body_size - consumed;
@@ -289,25 +322,20 @@ inline Run DecodeFrame(const Bytes& frame, uint64_t dst_capacity) {
                 }
             }
 
-            size_t literal_pos = 0;
+            /* The repeat-offset history is a serial chain over the frame and
+             * is resolved for every sequence before any byte moves, which is
+             * the shape the execution below asks for: with the distances in
+             * hand each copy is independent of every other. The rungs stay
+             * this stage's, so a twin can still say which of the two refused.
+             */
+            offsets.assign(sequences.size(), 0);
             for (size_t s = 0; s < sequences.size(); s++) {
                 const cudec_detail::ZstdSequence& sequence = sequences[s];
-                if (literal_pos + sequence.literals_length > literals.size()) {
-                    Stop(&run, kStageExecute, 0, CUDEC_ERR_CORRUPT_INPUT,
-                         "a sequence asked for literals that are not there");
-                    return run;
-                }
-                for (uint32_t i = 0; i < sequence.literals_length; i++) {
-                    run.output.push_back(literals[literal_pos + i]);
-                }
-                literal_pos += sequence.literals_length;
-
-                uint64_t resolved = 0;
                 cudec_detail::ZstdRepcodeReject repcode_rung =
                     cudec_detail::kZstdRepcodeRejectNone;
                 if (cudec_detail::ZstdRepcodeResolve(
                         &driver.repcodes, sequence.offset_value,
-                        sequence.literals_length, &resolved,
+                        sequence.literals_length, &offsets[s],
                         &repcode_rung) != CUDEC_OK) {
                     Stop(&run, kStageRepcode, static_cast<int>(repcode_rung),
                          CUDEC_ERR_CORRUPT_INPUT, "repeat offset refused");
@@ -320,37 +348,34 @@ inline Run DecodeFrame(const Bytes& frame, uint64_t dst_capacity) {
                     cudec_detail::kZstdRepcodeMaxSlotValue) {
                     run.repeats++;
                 }
-                /* Two bounds, and they are different statements. A match may
-                 * not reach before the output, which is what makes the index
-                 * below defined; and it may not reach further back than the
-                 * window, which is what the format promises a decoder it will
-                 * never have to hold. */
-                if (resolved > run.output.size() ||
-                    resolved > header.window_size) {
-                    Stop(&run, kStageExecute, 0, CUDEC_ERR_CORRUPT_INPUT,
-                         "a match reached past the window or before the "
-                         "output");
-                    return run;
-                }
-                const size_t from = run.output.size() - resolved;
-                for (uint32_t i = 0; i < sequence.match_length; i++) {
-                    run.output.push_back(run.output[from + i]);
-                }
-                if (run.output.size() > dst_capacity) {
-                    Stop(&run, kStageContentSize, 0,
-                         CUDEC_ERR_OUTPUT_TOO_SMALL,
-                         "the frame regenerated more than the destination");
-                    return run;
-                }
             }
-            for (size_t i = literal_pos; i < literals.size(); i++) {
-                run.output.push_back(literals[i]);
+
+            destinations.assign(sequences.size() + 1, 0);
+            cudec_detail::ZstdExecPlan plan;
+            cudec_detail::ZstdExecReject exec_rung =
+                cudec_detail::kZstdExecRejectNone;
+            cudec_status exec_status = cudec_detail::ZstdExecPrefixSum(
+                sequences.empty() ? 0 : sequences.data(),
+                static_cast<uint32_t>(sequences.size()), literals.size(),
+                block_max, destinations.data(),
+                static_cast<uint32_t>(destinations.size()), &plan, &exec_rung);
+            if (exec_status != CUDEC_OK) {
+                Stop(&run, kStageExecute, static_cast<int>(exec_rung),
+                     exec_status, "sequence destinations refused");
+                return run;
             }
-        }
-        if (run.output.size() > dst_capacity) {
-            Stop(&run, kStageContentSize, 0, CUDEC_ERR_OUTPUT_TOO_SMALL,
-                 "the frame regenerated more than the destination");
-            return run;
+            exec_status = cudec_detail::ZstdExecuteBlock(
+                sequences.empty() ? 0 : sequences.data(),
+                static_cast<uint32_t>(sequences.size()), destinations.data(),
+                offsets.empty() ? 0 : offsets.data(),
+                literals.empty() ? 0 : literals.data(), literals.size(), &plan,
+                header.window_size, run.output.data(), capacity, &produced,
+                &exec_rung);
+            if (exec_status != CUDEC_OK) {
+                Stop(&run, kStageExecute, static_cast<int>(exec_rung),
+                     exec_status, "sequence execution refused");
+                return run;
+            }
         }
         pos += 3 + block.body_size;
         if (block.last_block) {
@@ -359,12 +384,15 @@ inline Run DecodeFrame(const Bytes& frame, uint64_t dst_capacity) {
     }
 
     /* Section 3.1.1.1.1: where a content size is declared it is exact, and a
-     * frame in this subset always declares one. */
-    if (run.output.size() != header.frame_content_size) {
+     * frame in this subset always declares one. The buffer was sized to that
+     * number, so a frame producing MORE has already been refused for want of
+     * room; what is left for this check is the frame that produced less. */
+    if (produced != header.frame_content_size) {
         Stop(&run, kStageContentSize, 0, CUDEC_ERR_CORRUPT_INPUT,
              "the frame produced other than its declared content size");
         return run;
     }
+    run.output.resize(static_cast<size_t>(produced));
 
     if (header.content_checksum) {
         const uint64_t digest =


### PR DESCRIPTION
Closes #198.

`src/zstd_exec.h` is the sequence execution as a shipped unit: the prefix sum
over `(Literal_Length + Match_Length)` that names every sequence's destination,
the literal and match copies addressed by it, and the two bounds on a resolved
offset. The copy it replaces lived in `tests/zstd_twin_driver.h`, which said in
its own header that the copy and the block loop were the two things it added
that were not shipped. The block loop still is; the copy is not any more.

## Why the prefix sum is a function and not a cursor

A serial decoder carries a running output position and never needs one, which
is why a serial decoder proves nothing about the copies a warp makes. Every
destination is a pure function of the lengths before it, so the sum is computed
once and each copy is independent of every other - a scan on the device, this
loop on the host, the same array either way. An off-by-one in the scan cannot
then hide behind a cursor that happened to be right.

The execution does not trust the array it is handed. A caller that computes the
destinations elsewhere hands in something this unit had no part in producing,
and believing it would put every bound behind an unchecked number. Each
sequence re-derives its own successor from its lengths; the plan's literals
accounting and the tail are held to one equation before the tail is copied.

## The bounds

Two, and they are different statements, each with its own rung. A match may not
reach further back than the window, and it may not reach before the first byte
the frame has produced. A decoder checking only the window reads outside its own
output on every frame near its start. The bytes-produced-so-far are the
FRAME's, never the block's: a match legitimately reaches back across a block
boundary, and bounding against the block would refuse it.

An overlapping match replicates a pattern rather than copying a range - byte by
byte in increasing order, the same semantics `src/lz4_block.h` and
`src/snappy_block.h` carry, and the closed-form modular gather in
`src/lz4_decode.cuh` is the device spelling of it. An offset of one over a long
match is the extreme case and is a row below.

There is no overflow rung, deliberately. Both length fields are 32-bit, so an
overflow would need billions of sequences and no negative could ever red a guard
against it. Instead the ceiling the sums are compared against is itself refused
above Block_Maximum_Size, so the running sum never leaves a 128 KiB range and no
addition in the file can wrap.

## Evidence

Every number below came from this machine, which has no GPU, no nvcc and no
Docker. CI is the gate for the build and for `ctest`, and nothing here stands in
for it. What could be run here was run by compiling the twins directly against
libzstd built from the archive `cmake/CudecZstdOracle.cmake` pins, byte for
byte:

    sha256sum zstd-1.5.7.tar.gz
    eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3

The new twin, which links no oracle and needs none:

    g++ -std=c++17 -O2 -I include -I src -I tests -Wall -Wextra -Werror \
      tests/zstd_exec_twin.cpp -o exec_twin && ./exec_twin
          sweep: 512 rows, 1122 sequences
    PASS: 538 rows, 1133 sequences executed, 35436 bytes regenerated, 8 reject rungs covered

The corpus parity, through the rewired driver, over both corpora in both
directions:

    g++ -std=c++17 -O2 -I include -I src -I tests -I zstd-1.5.7/lib \
      -DHUF_STATIC_LINKING_ONLY tests/zstd_entropy_twin.cpp tests/zstd_corpus.cpp \
      libzstd.a -o entropy_twin && ./entropy_twin
    PASS: 17 fixtures decoded byte-identical to libzstd and to their own sources (1596416 bytes), 2 declined as outside the v1 subset; 784 mutants, 679 refused by libzstd with 0 fail-opens, 98 accepted by both with 0 byte divergences, 6 declined as outside the subset; 67 reject rungs locked
          driver refusals by stage: frame-header 209 block-header 144 literals 48 sequence-header 25 sequence-table 69 sequences 122 execute 6 content-size 35 checksum 27 trailing-bytes 1

The three sibling twins that share the driver, unmoved:

    ./zstd_repcode_twin
    PASS: 34 frames decoded byte-identical to the reference, 3120393 bytes, 173319 sequences of which 2590 resolved a repeat offset, 2 reject rungs covered; 2 corpus frames left undecoded as outside the v1 subset
    ./zstd_seq_twin
    PASS: 125067 sequences decoded across 332 corpus blocks, 332 section headers reproduced against the frame walker, 16 of 16 reject rungs covered by a declared negative
    ./zstd_literals_twin
    PASS: 333 literals sections decoded (22 raw, 1 rle, 13 compressed, 297 treeless), 42340 literal bytes diffed against HUF_decompress, 3 four-stream sections with a short last segment, 14 reject rungs covered; 2 corpus frames left unswept as outside the v1 subset

## The guards, proven by deleting them

Seventeen mutants, each one guard or one copy rule removed, the twin rebuilt and
run. All seventeen red:

    ceiling bound dropped                      RED
    destinations capacity check dropped        RED
    per-sequence block ceiling dropped         RED
    prefix-sum literals bound dropped          RED
    tail block ceiling dropped                 RED
    destination bound dropped                  RED
    per-sequence plan check dropped            RED
    execute literals bound dropped             RED
    offset-zero check dropped                  RED
    window bound dropped                       RED
    output bound dropped                       RED
    final plan equation dropped                RED
    overlap copied as a range                  RED
    prefix sum off by one                      RED
    produced not advanced                      RED
    tail copy dropped                          RED
    literal copy addressed from the block      RED

Three survived a first pass and each was a real answer rather than a weak test.
A `plan->literals_used > literals_size` check in the execution was redundant
against the equation at the end and is gone rather than reworded. The literals
bound inside the copy loop is NOT redundant: the prefix sum refuses that stream
earlier, so nothing going through both halves reaches it, and it is the guard
between a caller that computed its plan elsewhere and a read outside the
literals it was handed - it now has a row calling the execution directly. The
third was a contrived mutant that only bit on a zero-size block, replaced by one
that drops the advance outright.

## What is NOT covered here

- `ctest` was not run on this machine and neither was the build. The test net
  configures only under `CUDEC_ENABLE_CUDA=ON`, and there is no CUDA toolchain
  here. The registration in `tests/CMakeLists.txt` and the two `ci.yml` lines
  are gated by CI alone.
- Nothing ran under ASan or UBSan on this machine; there is no sanitizer in the
  toolchain here. CI ran them, and putting the twin into that selection paid for
  itself on the first run - UBSan refused the harness twice, both times for the
  same defect in the test rather than in the unit:

      tests/zstd_exec_twin.cpp:188:16: runtime error: null pointer passed as
      argument 2, which is declared to never be null

  An empty vector's `data()` is a null pointer and `memcpy` is declared never to
  take one, however many bytes it is asked for, and both rows that start from an
  empty frame prefix called it that way. The first repair guarded one site and
  replaced the wrong occurrence at the second, so the sanitizer named the
  remaining line on the next run and the second commit fixed it. Nothing about
  `src/zstd_exec.h` moved for either.
- The Done-when's named cases are rows in the twin; the byte-exact-over-the-
  forced-mode-corpora half is the entropy twin run above rather than a second
  corpus sweep in the new file.
- Block_Maximum_Size is now enforced on a block's regenerated size, which the
  driver did not check before. It is the format's own bound and the reference
  enforces it, so it refuses nothing libzstd accepts - the 784-mutant run above
  is where that was tested rather than assumed.
- This change had no second reader. The evidence above stands in place of one.

## Files outside the unit, and why each is touched

`tests/zstd_twin_driver.h` calls the unit instead of its own copy and keeps the
repeat-offset resolution at its own stage, so `zstd_repcode_twin`'s stage
assertions still hold. `tests/zstd_entropy_twin.cpp` carries the reject-rung
count lock, which now sums seven ladders rather than six and moves from 59 to
67 - the eight new rungs each have a negative in the new twin, which is what the
lock's own comment asks for before the number moves. `.github/workflows/ci.yml`
gains the twin in the sanitizer selection and its `test -x` assertion.
