### PR TITLE
Ship the Zstd block loop and the state it carries across blocks [#201]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,6 +438,7 @@ jobs:
           test -x build-san/tests/tilestream_host_negative &&
           test -x build-san/tests/gdeflate_schedule_twin &&
           test -x build-san/tests/zstd_exec_twin &&
+          test -x build-san/tests/zstd_blocks_twin &&
           test -x build-san/tests/termination
 
       # Prove the sanitizer runtimes are actually linked: a dropped or renamed
@@ -459,7 +460,7 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|zstd_frame_twin|zstd_exec_twin|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|zstd_frame_twin|zstd_exec_twin|zstd_blocks_twin|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
@@ -473,6 +474,7 @@ jobs:
           grep -E ': gdeflate_schedule_twin$' san-selected.txt &&
           grep -E ': zstd_frame_twin$' san-selected.txt &&
           grep -E ': zstd_exec_twin$' san-selected.txt &&
+          grep -E ': zstd_blocks_twin$' san-selected.txt &&
           grep -E ': termination$' san-selected.txt
 
   format:

--- a/src/zstd_blocks.h
+++ b/src/zstd_blocks.h
@@ -438,7 +438,18 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeBlocks(
 
     uint64_t produced = 0;
     uint64_t pos = 0;
-    for (;;) {
+    /* THE TERMINATION FUEL (issue #72), the same shape the LZ4 frame walk in
+     * src/frame.cpp uses. Every block consumes at least its three header
+     * bytes, so a frame of `size` bytes admits at most size/3 + 1 steps, and
+     * the step after the last one a legal frame could take finds no three
+     * bytes to read - so the budget is out of reach of any input rather than
+     * a guess at one. What it buys is that a future bounds bug becomes a
+     * rejected frame instead of a loop that never leaves, which on a device
+     * is a warp that never retires: a hang rather than a failure, and the
+     * fail-closed contract does not admit either. */
+    uint64_t fuel = size / 3 + 1;
+    bool last_seen = false;
+    while (fuel-- != 0) {
         ZstdBlockHeader block;
         ZstdFrameReject frame_rung = kZstdFrameRejectNone;
         const cudec_status block_status = ZstdParseBlockHeader(
@@ -482,8 +493,19 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeBlocks(
 
         pos += static_cast<uint64_t>(3) + block.body_size;
         if (block.last_block) {
+            last_seen = true;
             break;
         }
+    }
+    if (!last_seen) {
+        /* The fuel ran out, which the bound above puts beyond every input:
+         * the block header refuses for want of its three bytes first, and
+         * that is the refusal reported here. It is not a rung of its own,
+         * because a rung no stream can reach is a refusal nobody could ever
+         * show firing. */
+        ZstdBlocksStop(report, kZstdBlocksStageBlockHeader,
+                       static_cast<int>(kZstdFrameRejectBlockHeaderTruncated));
+        return CUDEC_ERR_CORRUPT_INPUT;
     }
 
     /* Section 3.1.1.1.1 from the other side. Every path that would have

--- a/src/zstd_blocks.h
+++ b/src/zstd_blocks.h
@@ -1,0 +1,506 @@
+/* The loop over one Zstd frame's blocks, and the per-frame state it carries
+ * across their boundaries. Single-sourced for host and device, the sibling of
+ * src/zstd_frame.h, src/zstd_literals.h, src/zstd_seq.h, src/zstd_repcode.h
+ * and src/zstd_exec.h - it composes them and owns nothing they own. Internal
+ * header, not part of the ABI.
+ *
+ * WHAT IS PER-FRAME AND WHAT IS PER-BLOCK IS THE WHOLE CONTRACT. The Huffman
+ * table a Treeless literals section reuses, the three FSE tables a Repeat
+ * mode reuses, and the repeat-offset history are exactly what survives a
+ * block boundary; the literals buffer, the sequences and their destinations
+ * are exactly what does not. A loop that reset the first group at a block
+ * start would decode the first block of every frame correctly and then
+ * produce wrong bytes, silently and only on streams the encoder chose to
+ * compress that way. So the reset lives in one place, ZstdFrameStateInit, and
+ * this loop never calls it.
+ *
+ * THE STATE IS THE CALLER'S, ALL OF IT. Every buffer this loop writes is
+ * handed in with its capacity, for the reason each unit below gives: a kernel
+ * decides where a frame's working memory lives - registers, shared memory, a
+ * per-warp slab - and a header that allocated would decide that for it. A
+ * capacity too small for the frame in hand is refused before anything is
+ * written, never grown.
+ *
+ * THE DECLARED CONTENT SIZE IS ENFORCED EXACTLY AND IS NEVER USED TO SIZE
+ * ANYTHING. Section 3.1.1.1.1: where a content size is declared it is exact,
+ * and the v1 subset requires one (docs/MASTERPLAN.md section 12). It is
+ * attacker-controlled, so it is compared against the caller's capacity before
+ * the loop runs and against what the frame actually produced after it, and
+ * the caller's capacity remains the truth in between. A frame producing fewer
+ * bytes than it declared is corrupt, and so is one producing more - the
+ * second is caught as it happens, because a copy that would pass the
+ * declaration is refused rather than measured afterwards.
+ *
+ * WHERE A RUN STOPPED IS REPORTED, NOT JUST THAT IT DID. Every unit below has
+ * its own reject ladder and every rung is that unit's vocabulary, so a stop
+ * carries the STAGE alongside the rung: reject parity over a mutation corpus
+ * is only worth something if a refusal can be attributed, and a caller
+ * comparing two decoders needs to know they refused the same thing rather
+ * than merely that both refused. */
+#ifndef CUDEC_ZSTD_BLOCKS_H
+#define CUDEC_ZSTD_BLOCKS_H
+
+#include "cudec.h"
+#include "zstd_exec.h"
+#include "zstd_frame.h"
+#include "zstd_literals.h"
+#include "zstd_repcode.h"
+#include "zstd_seq.h"
+
+#include <stdint.h>
+
+/* Guarded: every single-sourced header in this tree defines the same macro
+ * for the same reason, and a device translation unit that decodes more than
+ * one format includes more than one of them. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+/* Which stage stopped, named per STAGE rather than per rung: each stage's
+ * rungs are the business of that unit's own twin, and what a caller needs
+ * from the loop is which stage refused. The content-size stage is this loop's
+ * own and has no unit behind it, so its rung is always zero. */
+enum ZstdBlocksStage {
+    kZstdBlocksStageNone = 0,
+    kZstdBlocksStageBlockHeader,
+    kZstdBlocksStageLiterals,
+    kZstdBlocksStageSequenceHeader,
+    kZstdBlocksStageSequenceTable,
+    kZstdBlocksStageSequences,
+    kZstdBlocksStageRepcode,
+    kZstdBlocksStageExecute,
+    kZstdBlocksStageContentSize,
+    kZstdBlocksStageCount
+};
+
+/* This loop's own reject ladder - the refusals no unit below makes, so a
+ * negative can name one instead of counting a status that repeats. Every
+ * refusal returns through ZstdBlocksRefuse, the way every sibling header
+ * routes its own. */
+enum ZstdBlocksReject {
+    kZstdBlocksRejectNone = 0,
+    /* Storage the caller did not supply, or capacities that disagree with
+     * each other. A caller bug, refused rather than worked around. */
+    kZstdBlocksRejectBadRequest,
+    /* The frame declares more content than the destination holds. Refused
+     * before a byte is written rather than discovered by a copy, because the
+     * declaration is attacker-controlled. */
+    kZstdBlocksRejectContentPastCapacity,
+    /* A Raw or RLE block would regenerate past what the declared content size
+     * leaves. The compressed path reaches the same wall inside
+     * ZstdExecuteBlock, which is why only those two are named here. */
+    kZstdBlocksRejectBlockPastCapacity,
+    /* The frame ended having produced other than its declared content size.
+     * Only the short direction reaches this: the long one is refused as it
+     * happens, by the rung above and by the execution's own. */
+    kZstdBlocksRejectContentSizeMismatch,
+    /* More sequences than the caller's sequence storage holds. Separate from
+     * BadRequest because it depends on the frame rather than on the call: the
+     * same storage is right for one stream and short for the next, and a
+     * caller sizing it wants to know which of the two it hit. */
+    kZstdBlocksRejectSequenceStorageTooSmall,
+    /* Literals storage below the block maximum this frame's window implies.
+     * Checked against the window rather than against any section, so the
+     * refusal cannot depend on bytes an attacker chose. */
+    kZstdBlocksRejectLiteralsStorageTooSmall,
+    kZstdBlocksRejectCount
+};
+
+CUDEC_HOST_DEVICE inline cudec_status ZstdBlocksRefuse(
+    ZstdBlocksReject rung, cudec_status status, ZstdBlocksReject* out) {
+    if (out != 0) {
+        *out = rung;
+    }
+    return status;
+}
+
+/* Everything one frame's decode carries, in the shape each unit asks for.
+ *
+ * The first group survives a block boundary and is reset once per frame by
+ * ZstdFrameStateInit. The second is per-block working memory: this loop
+ * overwrites it every block and reads nothing out of it that a previous block
+ * wrote, which is what makes its sizes a function of the block maximum rather
+ * than of the frame.
+ *
+ * `sequences_capacity` is the one a caller has to think about. A block may
+ * declare as many sequences as it has room to regenerate, so the size that
+ * never refuses a legal frame is the block maximum; a smaller array is legal
+ * and refuses a frame needing more, by its own rung, rather than truncating
+ * one. */
+struct ZstdFrameState {
+    /* Carried across blocks. */
+    ZstdLiteralsTable literals_table;
+    ZstdSeqTable litlen;
+    ZstdSeqTable offset;
+    ZstdSeqTable matchlen;
+    ZstdRepcodeHistory repcodes;
+
+    /* Per-block working memory, all of it the caller's. */
+    ZstdLiteralsScratch* literals_scratch;
+    ZstdSeqScratch* seq_scratch;
+    unsigned char* literals;
+    uint64_t literals_capacity;
+    ZstdSequence* sequences;
+    uint32_t sequences_capacity;
+    uint64_t* offsets;
+    uint32_t offsets_capacity;
+    /* One entry per sequence plus one: ZstdExecPrefixSum's one-past-the-end
+     * destination is what the tail of the literals is found through. */
+    uint64_t* destinations;
+    uint32_t destinations_capacity;
+};
+
+/* Frame start, and the only place any of the carried state is reset.
+ *
+ * The cell arrays and the working buffers are the caller's and are left
+ * exactly as handed in; what is reset is the four `present` flags and the
+ * repeat-offset history, which is the whole of what "reset at frame start"
+ * means. Marking a table absent rather than clearing its cells is deliberate:
+ * a Treeless section in a frame's first block must be refused over an array
+ * that is allocated and holds the PREVIOUS frame's table, and only the flag
+ * can tell those two apart. */
+CUDEC_HOST_DEVICE inline void ZstdFrameStateInit(ZstdFrameState* state) {
+    if (state == 0) {
+        return;
+    }
+    state->literals_table.table_log = 0;
+    state->literals_table.present = false;
+    state->litlen.table_size = 0;
+    state->litlen.accuracy_log = 0;
+    state->litlen.present = false;
+    state->offset.table_size = 0;
+    state->offset.accuracy_log = 0;
+    state->offset.present = false;
+    state->matchlen.table_size = 0;
+    state->matchlen.accuracy_log = 0;
+    state->matchlen.present = false;
+    ZstdRepcodeInit(&state->repcodes);
+}
+
+/* Where a run stopped, and what it counted on the way.
+ *
+ * The tallies are not decoration. A corpus that decodes byte-identically
+ * proves nothing about a rule it never reached, so a caller measuring
+ * coverage needs the loop to say which of the repeat-offset rules a stream
+ * actually exercised; nothing downstream can recover it, because the
+ * sequences are overwritten block by block. A caller that does not care
+ * passes no report and the loop writes nothing. */
+struct ZstdBlocksReport {
+    ZstdBlocksStage stage;
+    /* The stage's own rung, as an int because each stage enumerates its own
+     * and the caller that cares knows which. */
+    int rung;
+    uint64_t blocks;
+    uint64_t sequences;
+    uint64_t repeats;
+    uint64_t path[kZstdRepcodePathCount];
+};
+
+CUDEC_HOST_DEVICE inline void ZstdBlocksReportInit(ZstdBlocksReport* report) {
+    if (report == 0) {
+        return;
+    }
+    report->stage = kZstdBlocksStageNone;
+    report->rung = 0;
+    report->blocks = 0;
+    report->sequences = 0;
+    report->repeats = 0;
+    for (unsigned index = 0; index < kZstdRepcodePathCount; index++) {
+        report->path[index] = 0;
+    }
+}
+
+CUDEC_HOST_DEVICE inline void ZstdBlocksStop(ZstdBlocksReport* report,
+                                             ZstdBlocksStage stage, int rung) {
+    if (report == 0) {
+        return;
+    }
+    report->stage = stage;
+    report->rung = rung;
+}
+
+/* One Compressed block: its literals section, its sequences section, the
+ * repeat-offset resolution over them and the copies that execute them.
+ *
+ * Split out of the loop below only because the loop is a walk and this is a
+ * decode; the two have different reasons to be read. `produced` is in and
+ * out, the frame's running total, and it is advanced only by a copy that
+ * completed - ZstdExecuteBlock leaves it exactly where it was on any refusal,
+ * so a partially written block is never reported as a partial success.
+ *
+ * `capacity` is the frame's declared content size rather than the caller's
+ * buffer, which is larger or equal. Handing the smaller of the two down is
+ * what makes a block that regenerates past the declaration refuse here rather
+ * than at the end of the frame, and the difference matters: at the end, the
+ * bytes are already written. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeCompressedBlock(
+    const unsigned char* body, uint64_t body_size,
+    const ZstdFrameHeader* header, ZstdFrameState* state, uint64_t block_max,
+    unsigned char* dst, uint64_t capacity, uint64_t* produced,
+    ZstdBlocksReport* report, ZstdBlocksReject* reject) {
+    uint64_t literals_size = 0;
+    uint64_t consumed = 0;
+    ZstdLiteralsReject literals_rung = kZstdLiteralsRejectNone;
+    const cudec_status literals_status = ZstdDecodeLiterals(
+        body, body_size, header->window_size, &state->literals_table,
+        state->literals_scratch, state->literals, state->literals_capacity,
+        &literals_size, &consumed, &literals_rung);
+    if (literals_status != CUDEC_OK) {
+        ZstdBlocksStop(report, kZstdBlocksStageLiterals,
+                       static_cast<int>(literals_rung));
+        return literals_status;
+    }
+
+    const unsigned char* section = body + consumed;
+    uint64_t remaining = body_size - consumed;
+    ZstdSeqSectionHeader seq_header;
+    uint64_t seq_consumed = 0;
+    ZstdSeqReject seq_rung = kZstdSeqRejectNone;
+    cudec_status status = ZstdParseSeqSectionHeader(
+        section, remaining, block_max, &seq_header, &seq_consumed, &seq_rung);
+    if (status != CUDEC_OK) {
+        ZstdBlocksStop(report, kZstdBlocksStageSequenceHeader,
+                       static_cast<int>(seq_rung));
+        return status;
+    }
+    section += seq_consumed;
+    remaining -= seq_consumed;
+
+    /* Checked before the tables are read rather than before the loop that
+     * fills the array, because reading three table descriptions into a frame
+     * whose sequences will not fit is work spent on a refusal already
+     * decided. */
+    if (seq_header.sequence_count > state->sequences_capacity) {
+        ZstdBlocksStop(report, kZstdBlocksStageSequences, 0);
+        return ZstdBlocksRefuse(kZstdBlocksRejectSequenceStorageTooSmall,
+                                CUDEC_ERR_OUTPUT_TOO_SMALL, reject);
+    }
+
+    if (seq_header.sequence_count != 0) {
+        /* The three fields in the order the section writes their
+         * descriptions, section 3.1.1.3.2.1. Repeat_Mode reads the table this
+         * state carried from an earlier block and is refused where none was
+         * carried; that refusal is ZstdSeqLoadTable's, over the `present`
+         * flag ZstdFrameStateInit cleared at frame start. */
+        const unsigned fields[3] = {kZstdSeqFieldLitLen, kZstdSeqFieldOffset,
+                                    kZstdSeqFieldMatchLen};
+        const unsigned modes[3] = {seq_header.litlen_mode,
+                                   seq_header.offset_mode,
+                                   seq_header.matchlen_mode};
+        ZstdSeqTable* targets[3] = {&state->litlen, &state->offset,
+                                    &state->matchlen};
+        for (unsigned index = 0; index < 3; index++) {
+            uint64_t table_consumed = 0;
+            status = ZstdSeqLoadTable(fields[index], modes[index], section,
+                                      remaining, state->seq_scratch,
+                                      targets[index], &table_consumed,
+                                      &seq_rung);
+            if (status != CUDEC_OK) {
+                ZstdBlocksStop(report, kZstdBlocksStageSequenceTable,
+                               static_cast<int>(seq_rung));
+                return status;
+            }
+            section += table_consumed;
+            remaining -= table_consumed;
+        }
+        status = ZstdDecodeSequences(section, remaining,
+                                     seq_header.sequence_count, &state->litlen,
+                                     &state->offset, &state->matchlen,
+                                     state->sequences,
+                                     state->sequences_capacity, &seq_rung);
+        if (status != CUDEC_OK) {
+            ZstdBlocksStop(report, kZstdBlocksStageSequences,
+                           static_cast<int>(seq_rung));
+            return status;
+        }
+    }
+
+    /* The repeat-offset history is a serial chain over the whole frame and is
+     * resolved for every sequence before any byte moves, which is the shape
+     * the execution below asks for: with the distances in hand each copy is
+     * independent of every other. */
+    for (uint32_t index = 0; index < seq_header.sequence_count; index++) {
+        const ZstdSequence sequence = state->sequences[index];
+        ZstdRepcodeReject repcode_rung = kZstdRepcodeRejectNone;
+        status = ZstdRepcodeResolve(&state->repcodes, sequence.offset_value,
+                                    sequence.literals_length,
+                                    &state->offsets[index], &repcode_rung);
+        if (status != CUDEC_OK) {
+            ZstdBlocksStop(report, kZstdBlocksStageRepcode,
+                           static_cast<int>(repcode_rung));
+            return status;
+        }
+        if (report != 0) {
+            report->sequences++;
+            report->path[ZstdRepcodeClassify(sequence.offset_value,
+                                             sequence.literals_length)]++;
+            if (sequence.offset_value <= kZstdRepcodeMaxSlotValue) {
+                report->repeats++;
+            }
+        }
+    }
+
+    ZstdExecPlan plan;
+    ZstdExecReject exec_rung = kZstdExecRejectNone;
+    status = ZstdExecPrefixSum(state->sequences, seq_header.sequence_count,
+                               literals_size, block_max, state->destinations,
+                               seq_header.sequence_count + 1, &plan,
+                               &exec_rung);
+    if (status != CUDEC_OK) {
+        ZstdBlocksStop(report, kZstdBlocksStageExecute,
+                       static_cast<int>(exec_rung));
+        return status;
+    }
+    status = ZstdExecuteBlock(state->sequences, seq_header.sequence_count,
+                              state->destinations, state->offsets,
+                              state->literals, literals_size, &plan,
+                              header->window_size, dst, capacity, produced,
+                              &exec_rung);
+    if (status != CUDEC_OK) {
+        ZstdBlocksStop(report, kZstdBlocksStageExecute,
+                       static_cast<int>(exec_rung));
+        return status;
+    }
+    return CUDEC_OK;
+}
+
+/* Decodes one frame's blocks, first to last, into `dst`.
+ *
+ * `src` points at the first block header - the frame header is
+ * ZstdParseFrameHeader's and is already parsed into `header` - and `size` is
+ * the bytes left in the frame from there, any trailer included.
+ * `out_consumed` is what the blocks occupied, which is where a content
+ * checksum trailer begins; the trailer itself is
+ * ZstdVerifyContentChecksum's.
+ *
+ * `state` carries the entropy tables and the repeat-offset history across the
+ * blocks and must have been through ZstdFrameStateInit for THIS frame. The
+ * loop never resets it, which is the contract, and cannot check that it was
+ * reset: a caller handing over a previous frame's state gets that frame's
+ * tables, which is why the reset has exactly one home.
+ *
+ * `out_produced` is the bytes written, and on every success it equals the
+ * declared content size. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeBlocks(
+    const unsigned char* src, uint64_t size, const ZstdFrameHeader* header,
+    ZstdFrameState* state, unsigned char* dst, uint64_t dst_capacity,
+    uint64_t* out_produced, uint64_t* out_consumed, ZstdBlocksReport* report,
+    ZstdBlocksReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdBlocksRejectNone;
+    }
+    ZstdBlocksReportInit(report);
+    if (out_produced != 0) {
+        *out_produced = 0;
+    }
+    if (out_consumed != 0) {
+        *out_consumed = 0;
+    }
+    if (src == 0 || header == 0 || state == 0 || dst == 0 ||
+        out_produced == 0 || out_consumed == 0 ||
+        state->literals_scratch == 0 || state->seq_scratch == 0 ||
+        state->literals == 0 || state->destinations == 0 ||
+        state->destinations_capacity == 0 ||
+        state->offsets_capacity < state->sequences_capacity ||
+        state->destinations_capacity - 1u < state->sequences_capacity ||
+        (state->sequences == 0 && state->sequences_capacity != 0) ||
+        (state->offsets == 0 && state->offsets_capacity != 0)) {
+        return ZstdBlocksRefuse(kZstdBlocksRejectBadRequest,
+                                CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+
+    /* The block maximum this frame's window implies, section 3.1.1.2.4. It is
+     * the ceiling on everything below and is derived from the header rather
+     * than from any block's own declaration, so a hostile block cannot move
+     * it. */
+    const uint64_t block_max = ZstdLiteralsBlockMaximum(header->window_size);
+    if (state->literals_capacity < block_max) {
+        return ZstdBlocksRefuse(kZstdBlocksRejectLiteralsStorageTooSmall,
+                                CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+
+    /* THE DECLARED SIZE IS CHECKED AGAINST THE CAPACITY, NEVER USED AS ONE.
+     * The frame says how much it will regenerate and the caller says how much
+     * room there is; the smaller is not silently taken, because a frame
+     * declaring more than fits is refused rather than truncated. */
+    const uint64_t declared = header->frame_content_size;
+    if (declared > dst_capacity) {
+        ZstdBlocksStop(report, kZstdBlocksStageContentSize, 0);
+        return ZstdBlocksRefuse(kZstdBlocksRejectContentPastCapacity,
+                                CUDEC_ERR_OUTPUT_TOO_SMALL, reject);
+    }
+
+    uint64_t produced = 0;
+    uint64_t pos = 0;
+    for (;;) {
+        ZstdBlockHeader block;
+        ZstdFrameReject frame_rung = kZstdFrameRejectNone;
+        const cudec_status block_status = ZstdParseBlockHeader(
+            src + pos, size - pos, header->window_size, &block, &frame_rung);
+        if (block_status != CUDEC_OK) {
+            ZstdBlocksStop(report, kZstdBlocksStageBlockHeader,
+                           static_cast<int>(frame_rung));
+            return block_status;
+        }
+        if (report != 0) {
+            report->blocks++;
+        }
+        const unsigned char* body = src + pos + 3;
+
+        if (block.block_type == kZstdBlockTypeRaw ||
+            block.block_type == kZstdBlockTypeRle) {
+            /* Both regenerate their declared size and differ only in where
+             * the bytes come from; ZstdParseBlockHeader already separated
+             * that size from the one byte an RLE block occupies. Bounded in
+             * the subtraction direction against what the declaration leaves,
+             * so nothing can wrap. */
+            const uint64_t regenerated = block.block_size;
+            if (regenerated > declared - produced) {
+                ZstdBlocksStop(report, kZstdBlocksStageContentSize, 0);
+                return ZstdBlocksRefuse(kZstdBlocksRejectBlockPastCapacity,
+                                        CUDEC_ERR_OUTPUT_TOO_SMALL, reject);
+            }
+            const bool raw = block.block_type == kZstdBlockTypeRaw;
+            for (uint64_t index = 0; index < regenerated; index++) {
+                dst[produced + index] = raw ? body[index] : body[0];
+            }
+            produced += regenerated;
+        } else {
+            const cudec_status status = ZstdDecodeCompressedBlock(
+                body, block.body_size, header, state, block_max, dst, declared,
+                &produced, report, reject);
+            if (status != CUDEC_OK) {
+                return status;
+            }
+        }
+
+        pos += static_cast<uint64_t>(3) + block.body_size;
+        if (block.last_block) {
+            break;
+        }
+    }
+
+    /* Section 3.1.1.1.1 from the other side. Every path that would have
+     * produced MORE than the declaration was refused where it happened, so
+     * what is left for this check is the frame that produced less - the one
+     * that would otherwise return a short buffer as a success. */
+    if (produced != declared) {
+        ZstdBlocksStop(report, kZstdBlocksStageContentSize, 0);
+        return ZstdBlocksRefuse(kZstdBlocksRejectContentSizeMismatch,
+                                CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    *out_produced = produced;
+    *out_consumed = pos;
+    return CUDEC_OK;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_ZSTD_BLOCKS_H */

--- a/src/zstd_repcode.h
+++ b/src/zstd_repcode.h
@@ -84,6 +84,45 @@ enum ZstdRepcodeReject {
     kZstdRepcodeRejectCount
 };
 
+/* The seven ways an Offset_Value can resolve, which is the same case split
+ * ZstdRepcodeResolve makes below and is named here so a caller can ask which
+ * of them a stream reached. That question is not decoration: a corpus that
+ * decodes byte-identically proves nothing about a rule it never took, and the
+ * seventh rule - value 3 with no literals, the most recent offset minus one -
+ * is both the rarest and the one whose arithmetic can wrap.
+ *
+ * Derived from the value and the literals length alone, exactly as the
+ * resolution is, so the two cannot disagree about which rule ran. */
+enum ZstdRepcodePath {
+    /* Offset_Value above three: an explicit distance. */
+    kZstdRepcodePathExplicit = 0,
+    /* Literals present, value 1, 2, 3: the most recent offset, the second,
+     * the third. */
+    kZstdRepcodePathSlot0,
+    kZstdRepcodePathSlot1,
+    kZstdRepcodePathSlot2,
+    /* No literals, value 1 and 2: the second offset and the third. */
+    kZstdRepcodePathShiftedSlot1,
+    kZstdRepcodePathShiftedSlot2,
+    /* No literals, value 3: the most recent offset, minus one. */
+    kZstdRepcodePathMinusOne,
+    kZstdRepcodePathCount
+};
+
+CUDEC_HOST_DEVICE inline ZstdRepcodePath ZstdRepcodeClassify(
+    uint64_t offset_value, uint32_t literals_length) {
+    if (offset_value > kZstdRepcodeMaxSlotValue || offset_value == 0) {
+        return kZstdRepcodePathExplicit;
+    }
+    if (literals_length != 0) {
+        return static_cast<ZstdRepcodePath>(
+            kZstdRepcodePathSlot0 + static_cast<unsigned>(offset_value) - 1u);
+    }
+    return static_cast<ZstdRepcodePath>(kZstdRepcodePathShiftedSlot1 +
+                                        static_cast<unsigned>(offset_value) -
+                                        1u);
+}
+
 CUDEC_HOST_DEVICE inline cudec_status ZstdRepcodeRefuse(
     ZstdRepcodeReject rung, cudec_status status, ZstdRepcodeReject* out) {
     if (out != 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -343,6 +343,20 @@ target_compile_definitions(zstd_repcode_twin PRIVATE HUF_STATIC_LINKING_ONLY)
 cudec_add_test(zstd_exec_twin SOURCES zstd_exec_twin.cpp)
 target_include_directories(zstd_exec_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The block loop and the per-frame state it carries (issue #201). Host-side and
+# GPU-less. What it adds to zstd_entropy_twin, which also decodes frames, is
+# the two questions a corpus run cannot ask: whether the entropy state that
+# must survive a block boundary does, and whether the state that must not
+# survive a FRAME boundary dies. Both are proven by removing the thing under
+# test and watching the verdict move. It links zstd_full alone for the reason
+# zstd_oracle_smoke gives above - it drives the compressor through
+# zstd_corpus.cpp for the forced-mode families, and it needs the reference to
+# agree that its hand-built frames are frames before it trusts a mutation of
+# one.
+cudec_add_test(zstd_blocks_twin SOURCES zstd_blocks_twin.cpp zstd_corpus.cpp
+               LIBS zstd_full)
+target_include_directories(zstd_blocks_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 # The whole M5 entropy stage over both corpora, two-directionally (issue
 # #223). It is the only Zstd test that decodes a FRAME: the sibling twins each
 # prove one unit against the reference entry point that matches it, and none of

--- a/tests/zstd_blocks_twin.cpp
+++ b/tests/zstd_blocks_twin.cpp
@@ -1,0 +1,690 @@
+/* The twin over the block loop and the per-frame state it carries (issue
+ * #201): src/zstd_blocks.h against the pinned libzstd, on the GPU-less
+ * runner.
+ *
+ * WHAT THIS ASKS THAT THE SIBLING TWINS CANNOT. Each unit's twin proves one
+ * unit against the reference entry point that matches it, and
+ * tests/zstd_entropy_twin.cpp drives whole frames for the entropy stage. What
+ * neither can ask is whether the state that must survive a block boundary
+ * actually survives it, and whether the state that must NOT survive a frame
+ * boundary actually dies. Those two are the loop's whole contract and they
+ * fail in the same silent way: the first block of every frame decodes
+ * correctly and the bytes after it are wrong, on exactly the streams a
+ * compressor chose to encode with a carry.
+ *
+ * SO THE CARRY IS PROVEN BY BREAKING IT RATHER THAN BY DECODING WITH IT. A
+ * frame whose first block asks for a Huffman table it has not been given is
+ * refused at the literals rung that says so; the SAME bytes, handed to a
+ * state that was not re-initialised after an earlier frame, walk past that
+ * rung. The refusal disappearing is what says ZstdFrameStateInit is
+ * load-bearing, and a decode that merely succeeds would say nothing.
+ *
+ * THE CONTENT-SIZE NEGATIVES ARE HAND-BUILT, AND THE BUILDER IS PROVEN FIRST.
+ * A frame that regenerates other than it declared cannot be produced by the
+ * pinned compressor, so the bytes are written here - and a hand-built frame is
+ * worth nothing until the reference agrees it is a frame, so the same builder
+ * emits a legal frame first and libzstd decodes it before any mutation of it
+ * is trusted.
+ *
+ * EVERY RUNG OF THE LOOP'S OWN LADDER IS REACHED, and the run says so at the
+ * end. A rung with no negative behind it is a refusal nobody has seen fire. */
+#include "require.h"
+#include "zstd_blocks.h"
+#include "zstd_corpus.h"
+#include "zstd_twin_driver.h"
+
+#include <zstd.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using cudec_twin::Bytes;
+using cudec_twin::DecodeFrame;
+using cudec_twin::Run;
+using cudec_detail::ZstdBlocksReject;
+
+/* Above anything the corpus regenerates, so a refusal is never about room
+ * except where the test asked for one. */
+constexpr uint64_t kCapacity = 8ull * 1024ull * 1024ull;
+
+size_t g_rung_seen[cudec_detail::kZstdBlocksRejectCount] = {0};
+size_t g_carry_treeless = 0;
+size_t g_carry_repeat[3] = {0, 0, 0};
+size_t g_carry_raw_then_compressed = 0;
+size_t g_carry_single_rle = 0;
+size_t g_multi_block_frames = 0;
+size_t g_fixture_bytes = 0;
+
+void CoverRung(ZstdBlocksReject rung) {
+    if (rung > cudec_detail::kZstdBlocksRejectNone &&
+        rung < cudec_detail::kZstdBlocksRejectCount) {
+        g_rung_seen[rung]++;
+    }
+}
+
+/* ---- The harness --------------------------------------------------------
+ *
+ * The loop asks the caller to place every buffer it writes, which is what
+ * lets a test hand it storage that is deliberately too small. The driver in
+ * tests/zstd_twin_driver.h sizes everything to the block maximum and is the
+ * shape a real caller uses; this one is the same thing with the sizes turned
+ * into parameters. */
+struct Harness {
+    std::vector<cudec_detail::ZstdHufCell> huf_cells;
+    std::vector<cudec_detail::ZstdFseCell> litlen_cells;
+    std::vector<cudec_detail::ZstdFseCell> offset_cells;
+    std::vector<cudec_detail::ZstdFseCell> matchlen_cells;
+    cudec_detail::ZstdLiteralsScratch literals_scratch;
+    cudec_detail::ZstdSeqScratch seq_scratch;
+    std::vector<unsigned char> literals;
+    std::vector<cudec_detail::ZstdSequence> sequences;
+    std::vector<uint64_t> offsets;
+    std::vector<uint64_t> destinations;
+    cudec_detail::ZstdFrameState state;
+
+    Harness(uint64_t literals_capacity, uint32_t sequences_capacity)
+        : huf_cells(1u << cudec_detail::kZstdLiteralsMaxTableLog),
+          litlen_cells(1u << cudec_detail::kZstdLitLenAccuracyLogMax),
+          offset_cells(1u << cudec_detail::kZstdOffsetAccuracyLogMax),
+          matchlen_cells(1u << cudec_detail::kZstdMatchLenAccuracyLogMax),
+          literals_scratch(),
+          seq_scratch(),
+          literals(static_cast<size_t>(literals_capacity) + 1),
+          sequences(static_cast<size_t>(sequences_capacity) + 1),
+          offsets(static_cast<size_t>(sequences_capacity) + 1),
+          destinations(static_cast<size_t>(sequences_capacity) + 2),
+          state() {
+        state.literals_table.cells = huf_cells.data();
+        state.literals_table.capacity =
+            static_cast<uint32_t>(huf_cells.size());
+        state.litlen.cells = litlen_cells.data();
+        state.litlen.capacity = static_cast<uint32_t>(litlen_cells.size());
+        state.offset.cells = offset_cells.data();
+        state.offset.capacity = static_cast<uint32_t>(offset_cells.size());
+        state.matchlen.cells = matchlen_cells.data();
+        state.matchlen.capacity = static_cast<uint32_t>(matchlen_cells.size());
+        state.literals_scratch = &literals_scratch;
+        state.seq_scratch = &seq_scratch;
+        state.literals = literals.data();
+        state.literals_capacity = literals_capacity;
+        state.sequences = sequences.data();
+        state.sequences_capacity = sequences_capacity;
+        state.offsets = offsets.data();
+        state.offsets_capacity = sequences_capacity;
+        state.destinations = destinations.data();
+        state.destinations_capacity = sequences_capacity + 1;
+        cudec_detail::ZstdFrameStateInit(&state);
+    }
+};
+
+constexpr uint64_t kBlockMaximum = cudec_detail::kZstdBlockSizeCeiling;
+
+/* ---- Hand-built frames --------------------------------------------------
+ *
+ * Single_Segment, a four-byte content size and no checksum, so the header is
+ * nine bytes and the declared size is written where a test can choose it. The
+ * window is the content size for a single-segment frame (section 3.1.1.1.1.2),
+ * which is what keeps these frames inside the subset. */
+Bytes FrameHeader(uint32_t content_size) {
+    Bytes frame;
+    frame.push_back(0x28);
+    frame.push_back(0xB5);
+    frame.push_back(0x2F);
+    frame.push_back(0xFD);
+    /* Frame_Content_Size_flag 2 (a four-byte field), Single_Segment set. */
+    frame.push_back(0xA0);
+    for (unsigned shift = 0; shift < 32; shift += 8) {
+        frame.push_back(static_cast<unsigned char>(content_size >> shift));
+    }
+    return frame;
+}
+
+void AppendBlockHeader(Bytes* frame, uint32_t block_size, unsigned type,
+                       bool last) {
+    const uint32_t raw = (block_size << 3) | (type << 1) | (last ? 1u : 0u);
+    frame->push_back(static_cast<unsigned char>(raw));
+    frame->push_back(static_cast<unsigned char>(raw >> 8));
+    frame->push_back(static_cast<unsigned char>(raw >> 16));
+}
+
+Bytes RawFrame(uint32_t declared, const Bytes& content, bool last) {
+    Bytes frame = FrameHeader(declared);
+    AppendBlockHeader(&frame, static_cast<uint32_t>(content.size()), 0, last);
+    frame.insert(frame.end(), content.begin(), content.end());
+    return frame;
+}
+
+/* Two raw blocks rather than one, which is the only way to build a frame that
+ * regenerates past its own declaration. A single-segment frame's window IS
+ * its declared size (section 3.1.1.1.2), so one oversized block is refused by
+ * the block header for passing the block maximum and never reaches the
+ * loop's own bound - the two rungs would be indistinguishable. Split across
+ * two blocks, each one is inside the maximum and only their sum is not. */
+Bytes TwoRawFrame(uint32_t declared, const Bytes& first, const Bytes& second) {
+    Bytes frame = FrameHeader(declared);
+    AppendBlockHeader(&frame, static_cast<uint32_t>(first.size()), 0, false);
+    frame.insert(frame.end(), first.begin(), first.end());
+    AppendBlockHeader(&frame, static_cast<uint32_t>(second.size()), 0, true);
+    frame.insert(frame.end(), second.begin(), second.end());
+    return frame;
+}
+
+Bytes RleFrame(uint32_t declared, unsigned char value, uint32_t run) {
+    Bytes frame = FrameHeader(declared);
+    AppendBlockHeader(&frame, run, 1, true);
+    frame.push_back(value);
+    return frame;
+}
+
+/* Two RLE blocks, for the reason TwoRawFrame gives, and because an RLE
+ * block's declared size is a REGENERATED length while its body is one byte -
+ * the one place where stepping by the declaration would over-read. */
+Bytes TwoRleFrame(uint32_t declared, unsigned char value, uint32_t run) {
+    Bytes frame = FrameHeader(declared);
+    AppendBlockHeader(&frame, run, 1, false);
+    frame.push_back(value);
+    AppendBlockHeader(&frame, run, 1, true);
+    frame.push_back(value);
+    return frame;
+}
+
+bool ReferenceAccepts(const Bytes& frame, Bytes* out) {
+    Bytes buffer(kCapacity, 0);
+    const size_t result = ZSTD_decompress(buffer.data(), buffer.size(),
+                                          frame.data(), frame.size());
+    if (ZSTD_isError(result) != 0) {
+        return false;
+    }
+    out->assign(buffer.begin(), buffer.begin() + static_cast<long>(result));
+    return true;
+}
+
+/* ---- The negatives over the loop's own ladder --------------------------- */
+
+int NegativeFrame(const char* name, const Bytes& frame, uint64_t capacity,
+                  ZstdBlocksReject want_rung, cudec_status want_status) {
+    Harness harness(kBlockMaximum, static_cast<uint32_t>(kBlockMaximum));
+    cudec_detail::ZstdFrameHeader header;
+    cudec_detail::ZstdFrameReject frame_rung =
+        cudec_detail::kZstdFrameRejectNone;
+    REQUIRE_CTX(cudec_detail::ZstdParseFrameHeader(frame.data(), frame.size(),
+                                                   &header,
+                                                   &frame_rung) == CUDEC_OK,
+                "%s: the frame header itself was refused", name);
+
+    Bytes out(static_cast<size_t>(capacity) + 1, 0);
+    uint64_t produced = 0;
+    uint64_t consumed = 0;
+    cudec_detail::ZstdBlocksReport report;
+    ZstdBlocksReject rung = cudec_detail::kZstdBlocksRejectNone;
+    const cudec_status status = cudec_detail::ZstdDecodeBlocks(
+        frame.data() + header.header_size, frame.size() - header.header_size,
+        &header, &harness.state, out.data(), capacity, &produced, &consumed,
+        &report, &rung);
+    REQUIRE_CTX(status == want_status, "%s: status %d, want %d", name,
+                static_cast<int>(status), static_cast<int>(want_status));
+    REQUIRE_CTX(rung == want_rung, "%s: rung %d, want %d", name,
+                static_cast<int>(rung), static_cast<int>(want_rung));
+    REQUIRE_CTX(produced == 0, "%s: reported %llu bytes on a refusal", name,
+                static_cast<unsigned long long>(produced));
+    CoverRung(rung);
+    return 0;
+}
+
+int RunHandBuiltFrames() {
+    /* The builder proven before anything built with it is trusted. */
+    Bytes content;
+    for (unsigned index = 0; index < 64; index++) {
+        content.push_back(static_cast<unsigned char>(index * 7u + 1u));
+    }
+    const Bytes legal = RawFrame(64, content, true);
+    Bytes reference;
+    REQUIRE(ReferenceAccepts(legal, &reference));
+    REQUIRE(reference.size() == content.size());
+    REQUIRE(equal_bytes(reference.data(), content.data(), content.size()));
+
+    Run run = DecodeFrame(legal, kCapacity);
+    REQUIRE_CTX(run.ok, "the hand-built raw frame: %s", run.why.c_str());
+    REQUIRE(run.output.size() == content.size());
+    REQUIRE(equal_bytes(run.output.data(), content.data(), content.size()));
+    REQUIRE(run.blocks == 1);
+
+    /* A frame of a single RLE block, which is one of the carries this issue
+     * names and the one shape the corpus cannot be relied on to hold. */
+    const Bytes rle = RleFrame(300, 0x5A, 300);
+    REQUIRE(ReferenceAccepts(rle, &reference));
+    REQUIRE(reference.size() == 300);
+    run = DecodeFrame(rle, kCapacity);
+    REQUIRE_CTX(run.ok, "the hand-built RLE frame: %s", run.why.c_str());
+    REQUIRE(run.output.size() == 300);
+    REQUIRE(equal_bytes(run.output.data(), reference.data(), 300));
+    REQUIRE(run.blocks == 1);
+    g_carry_single_rle++;
+
+    /* Produced less than declared. The block is legal and the declaration is
+     * one byte above what it regenerates, which is the shape that would
+     * otherwise return a short buffer as a success. */
+    const Bytes short_frame = RawFrame(65, content, true);
+    REQUIRE(!ReferenceAccepts(short_frame, &reference));
+    int rc = NegativeFrame("declared one byte more than produced", short_frame,
+                           kCapacity,
+                           cudec_detail::kZstdBlocksRejectContentSizeMismatch,
+                           CUDEC_ERR_CORRUPT_INPUT);
+    if (rc != 0) {
+        return rc;
+    }
+
+    /* Produced more than declared, refused as it happens rather than
+     * afterwards: at "afterwards" the bytes are already written. */
+    const Bytes half(content.begin(), content.begin() + 32);
+    const Bytes long_frame = TwoRawFrame(40, half, half);
+    REQUIRE(!ReferenceAccepts(long_frame, &reference));
+    rc = NegativeFrame("a raw block past the declared size", long_frame,
+                       kCapacity,
+                       cudec_detail::kZstdBlocksRejectBlockPastCapacity,
+                       CUDEC_ERR_OUTPUT_TOO_SMALL);
+    if (rc != 0) {
+        return rc;
+    }
+
+    /* The same wall for an RLE block, whose declared size is a regenerated
+     * length rather than a body length - the one place those two differ. */
+    const Bytes long_rle = TwoRleFrame(400, 0x5A, 250);
+    REQUIRE(!ReferenceAccepts(long_rle, &reference));
+    rc = NegativeFrame("an RLE block past the declared size", long_rle,
+                       kCapacity,
+                       cudec_detail::kZstdBlocksRejectBlockPastCapacity,
+                       CUDEC_ERR_OUTPUT_TOO_SMALL);
+    if (rc != 0) {
+        return rc;
+    }
+
+    /* The frame declares more than the caller has room for. Refused before a
+     * byte is written, which is why the capacity handed in is below the
+     * declaration rather than below what the blocks turn out to produce. */
+    rc = NegativeFrame("declared past the destination", legal, 32,
+                       cudec_detail::kZstdBlocksRejectContentPastCapacity,
+                       CUDEC_ERR_OUTPUT_TOO_SMALL);
+    if (rc != 0) {
+        return rc;
+    }
+
+    /* The input runs out before any block sets the last-block flag. */
+    const Bytes unterminated = RawFrame(64, content, false);
+    REQUIRE(!ReferenceAccepts(unterminated, &reference));
+    Harness harness(kBlockMaximum, static_cast<uint32_t>(kBlockMaximum));
+    run = DecodeFrame(unterminated, kCapacity);
+    REQUIRE(!run.ok);
+    REQUIRE_CTX(run.stage == cudec_twin::kStageBlockHeader,
+                "no last block: stopped at %s", cudec_twin::kStageNames[run.stage]);
+    REQUIRE(run.rung ==
+            static_cast<int>(cudec_detail::kZstdFrameRejectBlockHeaderTruncated));
+
+    /* A block claiming a size past the end of the frame. The block's declared
+     * size is raised by one and nothing else moves, so the only thing wrong
+     * with the frame is that the body it names is not there. The frame's
+     * content size is set well above the block for this one: a single-segment
+     * frame's window is its declared content size, so over a declaration of
+     * 64 the raised block would pass the block maximum first and refuse for
+     * being too large instead of for being absent. */
+    Bytes overrun = RawFrame(128, content, true);
+    const uint32_t raw = static_cast<uint32_t>(overrun[9]) |
+                         (static_cast<uint32_t>(overrun[10]) << 8) |
+                         (static_cast<uint32_t>(overrun[11]) << 16);
+    const uint32_t bigger = ((raw >> 3) + 1u) << 3 | (raw & 0x07u);
+    overrun[9] = static_cast<unsigned char>(bigger);
+    overrun[10] = static_cast<unsigned char>(bigger >> 8);
+    overrun[11] = static_cast<unsigned char>(bigger >> 16);
+    REQUIRE(!ReferenceAccepts(overrun, &reference));
+    run = DecodeFrame(overrun, kCapacity);
+    REQUIRE(!run.ok);
+    REQUIRE_CTX(run.stage == cudec_twin::kStageBlockHeader,
+                "block past the frame: stopped at %s",
+                cudec_twin::kStageNames[run.stage]);
+    REQUIRE(run.rung ==
+            static_cast<int>(cudec_detail::kZstdFrameRejectBlockBodyTruncated));
+    return 0;
+}
+
+/* ---- The storage rungs --------------------------------------------------
+ *
+ * Reachable only from a caller that placed the buffers, which is every caller
+ * the loop has: the two below are what a kernel sizing a per-warp slab gets
+ * wrong, and they are separated from the bad-request rung because they depend
+ * on the frame rather than on the call. */
+int RunStorageRungs(const Bytes& frame_with_sequences) {
+    cudec_detail::ZstdFrameHeader header;
+    cudec_detail::ZstdFrameReject frame_rung =
+        cudec_detail::kZstdFrameRejectNone;
+    REQUIRE(cudec_detail::ZstdParseFrameHeader(frame_with_sequences.data(),
+                                               frame_with_sequences.size(),
+                                               &header,
+                                               &frame_rung) == CUDEC_OK);
+    const uint64_t block_max =
+        cudec_detail::ZstdLiteralsBlockMaximum(header.window_size);
+    Bytes out(static_cast<size_t>(kCapacity), 0);
+    uint64_t produced = 0;
+    uint64_t consumed = 0;
+    cudec_detail::ZstdBlocksReport report;
+
+    {
+        /* One byte of literals room below the block maximum this frame's
+         * window implies. Checked against the window rather than against any
+         * section, so the refusal cannot depend on bytes an attacker chose. */
+        Harness harness(block_max - 1, static_cast<uint32_t>(block_max));
+        ZstdBlocksReject rung = cudec_detail::kZstdBlocksRejectNone;
+        const cudec_status status = cudec_detail::ZstdDecodeBlocks(
+            frame_with_sequences.data() + header.header_size,
+            frame_with_sequences.size() - header.header_size, &header,
+            &harness.state, out.data(), kCapacity, &produced, &consumed,
+            &report, &rung);
+        REQUIRE(status == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == cudec_detail::kZstdBlocksRejectLiteralsStorageTooSmall);
+        CoverRung(rung);
+    }
+
+    {
+        /* Room for no sequences at all, against a frame that has some. */
+        Harness harness(block_max, 0);
+        ZstdBlocksReject rung = cudec_detail::kZstdBlocksRejectNone;
+        const cudec_status status = cudec_detail::ZstdDecodeBlocks(
+            frame_with_sequences.data() + header.header_size,
+            frame_with_sequences.size() - header.header_size, &header,
+            &harness.state, out.data(), kCapacity, &produced, &consumed,
+            &report, &rung);
+        REQUIRE(status == CUDEC_ERR_OUTPUT_TOO_SMALL);
+        REQUIRE(rung == cudec_detail::kZstdBlocksRejectSequenceStorageTooSmall);
+        REQUIRE(report.stage == cudec_detail::kZstdBlocksStageSequences);
+        CoverRung(rung);
+    }
+
+    {
+        /* The destination array one entry short of what the sequence array
+         * would need. A caller bug rather than a stream, so it is refused
+         * before the frame is looked at. */
+        Harness harness(block_max, static_cast<uint32_t>(block_max));
+        harness.state.destinations_capacity =
+            harness.state.sequences_capacity;
+        ZstdBlocksReject rung = cudec_detail::kZstdBlocksRejectNone;
+        const cudec_status status = cudec_detail::ZstdDecodeBlocks(
+            frame_with_sequences.data() + header.header_size,
+            frame_with_sequences.size() - header.header_size, &header,
+            &harness.state, out.data(), kCapacity, &produced, &consumed,
+            &report, &rung);
+        REQUIRE(status == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == cudec_detail::kZstdBlocksRejectBadRequest);
+        CoverRung(rung);
+    }
+    return 0;
+}
+
+/* ---- The reset, proven by removing it ----------------------------------- */
+
+int RunResetProof(const Bytes& compressed_literals_frame) {
+    /* The first compressed block's literals section begins three bytes after
+     * the frame header - the block header is those three bytes - and its type
+     * is the low two bits of the section's first byte. Turning Compressed
+     * into Treeless leaves a section that asks for a table nobody gave it. */
+    cudec_detail::ZstdFrameHeader header;
+    cudec_detail::ZstdFrameReject frame_rung =
+        cudec_detail::kZstdFrameRejectNone;
+    REQUIRE(cudec_detail::ZstdParseFrameHeader(
+                compressed_literals_frame.data(),
+                compressed_literals_frame.size(), &header,
+                &frame_rung) == CUDEC_OK);
+    const size_t section = header.header_size + 3;
+    REQUIRE(section < compressed_literals_frame.size());
+
+    Bytes treeless_first = compressed_literals_frame;
+    treeless_first[section] = static_cast<unsigned char>(
+        (treeless_first[section] & ~0x03u) |
+        cudec_detail::kZstdLiteralsTypeTreeless);
+
+    /* A fresh frame state is the first block of a frame, and this is what the
+     * reset buys: the table is absent and the section is refused for it. */
+    Run fresh = DecodeFrame(treeless_first, kCapacity);
+    REQUIRE(!fresh.ok);
+    REQUIRE_CTX(fresh.stage == cudec_twin::kStageLiterals,
+                "treeless first block: stopped at %s",
+                cudec_twin::kStageNames[fresh.stage]);
+    REQUIRE_CTX(fresh.rung == static_cast<int>(
+                                  cudec_detail::kZstdLiteralsRejectNoPreviousTable),
+                "treeless first block: rung %d", fresh.rung);
+
+    /* The same bytes over a state that decoded a frame and was NOT
+     * re-initialised. If the reset were not load-bearing this would refuse
+     * identically; it does not, because the previous frame's tree is still
+     * marked present, so the refusal above is the reset doing its work. */
+    Harness harness(kBlockMaximum, static_cast<uint32_t>(kBlockMaximum));
+    Bytes out(static_cast<size_t>(kCapacity), 0);
+    uint64_t produced = 0;
+    uint64_t consumed = 0;
+    cudec_detail::ZstdBlocksReport report;
+    ZstdBlocksReject rung = cudec_detail::kZstdBlocksRejectNone;
+    REQUIRE(cudec_detail::ZstdDecodeBlocks(
+                compressed_literals_frame.data() + header.header_size,
+                compressed_literals_frame.size() - header.header_size, &header,
+                &harness.state, out.data(), kCapacity, &produced, &consumed,
+                &report, &rung) == CUDEC_OK);
+
+    uint64_t second_produced = 0;
+    const cudec_status carried = cudec_detail::ZstdDecodeBlocks(
+        treeless_first.data() + header.header_size,
+        treeless_first.size() - header.header_size, &header, &harness.state,
+        out.data(), kCapacity, &second_produced, &consumed, &report, &rung);
+    const bool refused_for_the_missing_table =
+        carried != CUDEC_OK &&
+        report.stage == cudec_detail::kZstdBlocksStageLiterals &&
+        report.rung == static_cast<int>(
+                           cudec_detail::kZstdLiteralsRejectNoPreviousTable);
+    REQUIRE_CTX(!refused_for_the_missing_table,
+                "the state was not reset and the table was still reported "
+                "missing, so the reset above proved nothing");
+    return 0;
+}
+
+/* ---- A frame whose first block is Raw and whose second is Compressed -----
+ *
+ * The pinned compressor does not emit that mixture: it chooses Raw only where
+ * a block does not compress, and those blocks arrive together rather than in
+ * front of a compressed one. So the mixture is grafted - a raw block written
+ * here in front of a real compressed body, under a header this file writes -
+ * and libzstd decodes the result before the twin's answer is compared to it,
+ * which is what makes the graft a frame rather than a guess.
+ *
+ * The graft is sound because everything the second block can reach still
+ * exists. Its match offsets never point behind the start of the frame it came
+ * from, the window of the new single-segment frame is the whole declared size
+ * and so is at least as large as the old one's reach, and the repeat-offset
+ * history starts a frame the same way whatever the first block was. */
+size_t FrameHeaderSize(const Bytes& frame) {
+    cudec_detail::ZstdFrameHeader header;
+    cudec_detail::ZstdFrameReject rung = cudec_detail::kZstdFrameRejectNone;
+    if (cudec_detail::ZstdParseFrameHeader(frame.data(), frame.size(), &header,
+                                           &rung) != CUDEC_OK) {
+        return 0;
+    }
+    return header.header_size;
+}
+
+int RunRawThenCompressed(const Bytes& body, const Bytes& original) {
+    Bytes prefix;
+    for (unsigned index = 0; index < 40; index++) {
+        prefix.push_back(static_cast<unsigned char>(0xC0u + (index & 0x0Fu)));
+    }
+    Bytes frame = FrameHeader(
+        static_cast<uint32_t>(prefix.size() + original.size()));
+    AppendBlockHeader(&frame, static_cast<uint32_t>(prefix.size()), 0, false);
+    frame.insert(frame.end(), prefix.begin(), prefix.end());
+    frame.insert(frame.end(), body.begin(), body.end());
+
+    Bytes reference;
+    REQUIRE(ReferenceAccepts(frame, &reference));
+    REQUIRE(reference.size() == prefix.size() + original.size());
+    REQUIRE(equal_bytes(reference.data(), prefix.data(), prefix.size()));
+    REQUIRE(equal_bytes(reference.data() + prefix.size(), original.data(),
+                        original.size()));
+
+    const Run run = DecodeFrame(frame, kCapacity);
+    REQUIRE_CTX(run.ok, "raw then compressed: %s", run.why.c_str());
+    REQUIRE(run.output.size() == reference.size());
+    REQUIRE(equal_bytes(run.output.data(), reference.data(),
+                        reference.size()));
+    REQUIRE(run.blocks >= 2);
+    g_carry_raw_then_compressed++;
+    return 0;
+}
+
+/* ---- The corpus, and which carries it actually holds -------------------- */
+
+int RunCorpus() {
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    REQUIRE(!fixtures.empty());
+
+    Bytes compressed_literals_frame;
+    Bytes frame_with_sequences;
+    Bytes graft_body;
+    Bytes graft_original;
+
+    for (size_t index = 0; index < fixtures.size(); index++) {
+        const ZstdFixture& fixture = fixtures[index];
+        const Bytes frame(fixture.compressed.begin(),
+                          fixture.compressed.end());
+        const Run run = DecodeFrame(frame, kCapacity);
+        if (!run.ok) {
+            /* A fixture outside the v1 subset is declined rather than
+             * refused, and declining is not this file's subject. */
+            REQUIRE_CTX(run.status == CUDEC_ERR_UNSUPPORTED,
+                        "%s: %s at %s rung %d", fixture.name.c_str(),
+                        run.why.c_str(), cudec_twin::kStageNames[run.stage],
+                        run.rung);
+            continue;
+        }
+        REQUIRE_CTX(run.output.size() == fixture.original.size(),
+                    "%s: %zu bytes, want %zu", fixture.name.c_str(),
+                    run.output.size(), fixture.original.size());
+        REQUIRE_CTX(equal_bytes(run.output.data(), fixture.original.data(),
+                                fixture.original.size()),
+                    "%s", fixture.name.c_str());
+        g_fixture_bytes += fixture.original.size();
+
+        ZstdFrameShape shape;
+        std::string why;
+        REQUIRE_CTX(ParseZstdFrameShape(frame, &shape, &why), "%s: %s",
+                    fixture.name.c_str(), why.c_str());
+        if (shape.blocks.size() > 1) {
+            g_multi_block_frames++;
+        }
+        bool seen_compressed_literals = false;
+        bool seen_raw_block = false;
+        for (size_t b = 0; b < shape.blocks.size(); b++) {
+            const ZstdBlockShape& block = shape.blocks[b];
+            if (block.block_type == kZstdBlockRaw) {
+                seen_raw_block = true;
+            }
+            if (block.block_type != kZstdBlockCompressed) {
+                continue;
+            }
+            if (seen_raw_block) {
+                g_carry_raw_then_compressed++;
+                seen_raw_block = false;
+            }
+            if (block.literals_type == kZstdLiteralsTreeless) {
+                /* Only a carry can satisfy it: a Treeless section reuses the
+                 * tree an earlier block described. */
+                REQUIRE_CTX(seen_compressed_literals,
+                            "%s: a treeless block with no compressed literals "
+                            "block before it", fixture.name.c_str());
+                g_carry_treeless++;
+            }
+            if (block.literals_type == kZstdLiteralsCompressed) {
+                seen_compressed_literals = true;
+                if (compressed_literals_frame.empty() && b == 0) {
+                    compressed_literals_frame = frame;
+                    graft_body.assign(
+                        frame.begin() +
+                            static_cast<long>(FrameHeaderSize(frame)),
+                        frame.end() -
+                            (shape.checksum_present ? 4 : 0));
+                    graft_original.assign(fixture.original.begin(),
+                                          fixture.original.end());
+                }
+            }
+            if (block.sequence_count > 0) {
+                if (frame_with_sequences.empty()) {
+                    frame_with_sequences = frame;
+                }
+                if (block.ll_mode == kZstdTableRepeat) {
+                    g_carry_repeat[0]++;
+                }
+                if (block.of_mode == kZstdTableRepeat) {
+                    g_carry_repeat[1]++;
+                }
+                if (block.ml_mode == kZstdTableRepeat) {
+                    g_carry_repeat[2]++;
+                }
+            }
+        }
+    }
+
+    /* The carries this issue names, each present in the corpus that was just
+     * decoded byte-exactly. A corpus that stopped holding one of them would
+     * leave this file passing over a carry it no longer exercises, which is
+     * the failure the counts exist to refuse. */
+    REQUIRE(g_carry_treeless > 0);
+    REQUIRE(g_carry_repeat[0] > 0);
+    REQUIRE(g_carry_repeat[1] > 0);
+    REQUIRE(g_carry_repeat[2] > 0);
+    REQUIRE(g_multi_block_frames > 0);
+    REQUIRE(!compressed_literals_frame.empty());
+    REQUIRE(!frame_with_sequences.empty());
+    REQUIRE(!graft_body.empty());
+
+    const int mixed = RunRawThenCompressed(graft_body, graft_original);
+    if (mixed != 0) {
+        return mixed;
+    }
+
+    const int storage = RunStorageRungs(frame_with_sequences);
+    if (storage != 0) {
+        return storage;
+    }
+    return RunResetProof(compressed_literals_frame);
+}
+
+}  // namespace
+
+int main() {
+    const int hand_built = RunHandBuiltFrames();
+    if (hand_built != 0) {
+        return hand_built;
+    }
+    const int corpus = RunCorpus();
+    if (corpus != 0) {
+        return corpus;
+    }
+
+    /* Every rung of the loop's own ladder reached by a negative above. A rung
+     * with nothing behind it is a refusal nobody has seen fire, and the whole
+     * point of enumerating them is that each one can be aimed at. */
+    for (int rung = cudec_detail::kZstdBlocksRejectNone + 1;
+         rung < cudec_detail::kZstdBlocksRejectCount; rung++) {
+        REQUIRE_CTX(g_rung_seen[rung] > 0, "block-loop rung %d never fired",
+                    rung);
+    }
+
+    std::printf(
+        "PASS: block loop - %zu fixture bytes decoded byte-exact, %zu "
+        "multi-block frames, carries seen: treeless %zu, repeat LL/OF/ML "
+        "%zu/%zu/%zu, raw-then-compressed %zu, single RLE %zu; %d reject "
+        "rungs each reached\n",
+        g_fixture_bytes, g_multi_block_frames, g_carry_treeless,
+        g_carry_repeat[0], g_carry_repeat[1], g_carry_repeat[2],
+        g_carry_raw_then_compressed, g_carry_single_rle,
+        cudec_detail::kZstdBlocksRejectCount - 1);
+    return 0;
+}

--- a/tests/zstd_blocks_twin.cpp
+++ b/tests/zstd_blocks_twin.cpp
@@ -316,7 +316,6 @@ int RunHandBuiltFrames() {
     /* The input runs out before any block sets the last-block flag. */
     const Bytes unterminated = RawFrame(64, content, false);
     REQUIRE(!ReferenceAccepts(unterminated, &reference));
-    Harness harness(kBlockMaximum, static_cast<uint32_t>(kBlockMaximum));
     run = DecodeFrame(unterminated, kCapacity);
     REQUIRE(!run.ok);
     REQUIRE_CTX(run.stage == cudec_twin::kStageBlockHeader,

--- a/tests/zstd_entropy_twin.cpp
+++ b/tests/zstd_entropy_twin.cpp
@@ -63,11 +63,12 @@ using cudec_twin::Run;
 /* ---- The count lock ----------------------------------------------------
  *
  * Every reject rung the Zstd surface can return, summed at compile time. The
- * seven ladders are the bitstream reader, the FSE table description, the
+ * eight ladders are the bitstream reader, the FSE table description, the
  * Huffman tree description, the literals section, the sequences section, the
- * repeat-offset history and the sequence execution - the whole surface rather
- * than the entropy subset, because a rung added to any of them is a refusal
- * that arrives with no negative behind it unless somebody wrote one.
+ * repeat-offset history, the sequence execution and the block loop - the
+ * whole surface rather than the entropy subset, because a rung added to any
+ * of them is a refusal that arrives with no negative behind it unless
+ * somebody wrote one.
  *
  * Each ladder's `...RejectCount` counts kNone as well, so the sum below
  * subtracts one per ladder and the number is the count of real rungs.
@@ -83,9 +84,10 @@ constexpr int kZstdRejectRungs =
     (cudec_detail::kZstdLiteralsRejectCount - 1) +
     (cudec_detail::kZstdSeqRejectCount - 1) +
     (cudec_detail::kZstdRepcodeRejectCount - 1) +
-    (cudec_detail::kZstdExecRejectCount - 1);
+    (cudec_detail::kZstdExecRejectCount - 1) +
+    (cudec_detail::kZstdBlocksRejectCount - 1);
 
-constexpr int kExpectedZstdRejectRungs = 68;
+constexpr int kExpectedZstdRejectRungs = 74;
 
 /* How many mutants land in the declared class below, measured on the pinned
  * zstd 1.5.7 and the pinned mutation corpus. Written down rather than derived

--- a/tests/zstd_twin_driver.h
+++ b/tests/zstd_twin_driver.h
@@ -2,37 +2,35 @@
  * units in src/, so a claim about one of them becomes bytes the pinned
  * reference has an opinion about.
  *
- * WHY THIS IS A TEST FILE AND NOT A UNIT. Every stage it calls is shipped -
- * the frame and block headers, the literals section, the FSE tables, the
- * sequences loop, the repeat-offset history, the sequence execution, the
- * content checksum - and the one thing it adds is not: the loop over a
- * frame's blocks. That is its own issue with its own contract, and a shipped
- * decoder will make different choices about where the per-frame state lives.
- * What is here is the least code that turns the stages into one byte string,
- * so that "the offset resolved to four" and "this literals section decodes"
- * become "the frame decodes to exactly what libzstd decodes it to".
+ * WHY THIS IS A TEST FILE AND NOT A UNIT, AND WHAT IS LEFT OF THAT. Every
+ * stage it calls is shipped, and since issue #201 the loop over a frame's
+ * blocks is shipped too: it is `ZstdDecodeBlocks` in src/zstd_blocks.h, with
+ * the per-frame entropy state it carries. What is left here is the frame
+ * envelope around that loop - the header parse, the content checksum, the
+ * refusal of bytes after the frame - and the storage the loop asks the caller
+ * to place, which on the host is three std::vectors and on a device will be
+ * whatever the kernel decides. That is the least code that turns the units
+ * into one byte string, so that "the offset resolved to four" and "this
+ * literals section decodes" become "the frame decodes to exactly what libzstd
+ * decodes it to".
  *
- * THE COPY THAT EXECUTES A SEQUENCE USED TO BE HERE AND IS NOW SHIPPED. It
- * moved to src/zstd_exec.h under issue #198, which is what makes the corpus
- * runs below a statement about the decoder rather than about a copy loop that
- * only tests ever compile. The driver still owns the block loop and the
- * per-frame state it carries, because that is the sub-issue that has not
- * landed.
- *
- * ALL OF THE STATE IS PER-FRAME AND NONE OF IT IS PER-BLOCK. The Huffman
- * table a Treeless literals section reuses, the three FSE tables a Repeat
- * mode reuses, and the repeat-offset history are exactly what survives a
- * block boundary. A driver that reset any of them would decode the first
- * block of every frame correctly and then produce wrong bytes, which is a
- * failure mode the corpus rows exist to catch.
+ * THE STATE THAT SURVIVES A BLOCK BOUNDARY IS NOT THIS FILE'S ANY MORE. The
+ * Huffman table a Treeless literals section reuses, the three FSE tables a
+ * Repeat mode reuses, and the repeat-offset history are reset by
+ * ZstdFrameStateInit once per frame and carried by the shipped loop, which is
+ * where the argument for that lives. A driver that reset any of them per
+ * block would decode the first block of every frame correctly and then
+ * produce wrong bytes, and the corpus rows exist to catch exactly that.
  *
  * WHERE A RUN STOPPED IS REPORTED, NOT JUST THAT IT DID. Reject parity over a
  * mutation corpus is only worth something if a refusal can be attributed, so
- * the stage is carried out alongside the verdict and a caller that cares
- * asserts on it. */
+ * the stage is carried alongside the verdict and a caller that cares asserts
+ * on it. The stages the loop walks are the loop's own enumeration and are
+ * spelled here by name rather than by number, so the two cannot drift. */
 #ifndef CUDEC_TESTS_ZSTD_TWIN_DRIVER_H
 #define CUDEC_TESTS_ZSTD_TWIN_DRIVER_H
 
+#include "zstd_blocks.h"
 #include "zstd_exec.h"
 #include "zstd_frame.h"
 #include "zstd_literals.h"
@@ -57,91 +55,114 @@ constexpr unsigned kOffsetCells = 1u
 constexpr unsigned kMatchLenCells =
     1u << cudec_detail::kZstdMatchLenAccuracyLogMax;
 
-/* Everything one frame's decode needs, in the shape each unit asks for. */
-struct Driver {
+/* What the per-block working buffers are sized to. The block maximum is the
+ * smaller of the window and the 128 KB ceiling (section 3.1.1.2.4), and the
+ * largest window the subset admits is 8 MB, so the ceiling is the answer for
+ * every frame this driver can be handed. Sizing to the frame's own window
+ * instead would make the driver refuse a legal frame whenever the window
+ * grew, and the loop's storage rungs would then be firing on the harness
+ * rather than on the stream. */
+constexpr uint64_t kDriverBlockMaximum = cudec_detail::kZstdBlockSizeCeiling;
+static_assert(cudec_detail::kZstdMaxWindowSize >=
+                  cudec_detail::kZstdBlockSizeCeiling,
+              "the ceiling is only the block maximum while the largest "
+              "admitted window is at least as large as it");
+
+/* Everything the shipped loop asks the caller to place. Heap-backed here
+ * because a host test can afford it; the reason the loop does not allocate is
+ * that a kernel decides where this lives. */
+struct Storage {
     std::vector<cudec_detail::ZstdHufCell> huf_cells;
-    cudec_detail::ZstdLiteralsScratch literals_scratch;
-    cudec_detail::ZstdLiteralsTable literals_table;
     cudec_detail::ZstdFseCell litlen_cells[kLitLenCells];
     cudec_detail::ZstdFseCell offset_cells[kOffsetCells];
     cudec_detail::ZstdFseCell matchlen_cells[kMatchLenCells];
-    cudec_detail::ZstdSeqTable litlen;
-    cudec_detail::ZstdSeqTable offset;
-    cudec_detail::ZstdSeqTable matchlen;
+    cudec_detail::ZstdLiteralsScratch literals_scratch;
     cudec_detail::ZstdSeqScratch seq_scratch;
-    cudec_detail::ZstdRepcodeHistory repcodes;
+    std::vector<unsigned char> literals;
+    std::vector<cudec_detail::ZstdSequence> sequences;
+    std::vector<uint64_t> offsets;
+    std::vector<uint64_t> destinations;
+    cudec_detail::ZstdFrameState state;
 
-    Driver()
+    Storage()
         : huf_cells(1u << cudec_detail::kZstdLiteralsMaxTableLog),
-          literals_scratch(), literals_table(), litlen(), offset(), matchlen(),
-          seq_scratch(), repcodes() {
-        literals_table.cells = huf_cells.data();
-        literals_table.capacity = static_cast<uint32_t>(huf_cells.size());
-        literals_table.table_log = 0;
-        literals_table.present = false;
-        litlen.cells = litlen_cells;
-        litlen.capacity = kLitLenCells;
-        offset.cells = offset_cells;
-        offset.capacity = kOffsetCells;
-        matchlen.cells = matchlen_cells;
-        matchlen.capacity = kMatchLenCells;
-        cudec_detail::ZstdRepcodeInit(&repcodes);
+          literals_scratch(),
+          seq_scratch(),
+          literals(static_cast<size_t>(kDriverBlockMaximum)),
+          /* A block regenerating N bytes carries at most N sequences, which
+           * is the bound ZstdParseSeqSectionHeader refuses past, so this size
+           * never refuses a legal frame. */
+          sequences(static_cast<size_t>(kDriverBlockMaximum)),
+          offsets(static_cast<size_t>(kDriverBlockMaximum)),
+          destinations(static_cast<size_t>(kDriverBlockMaximum) + 1),
+          state() {
+        state.literals_table.cells = huf_cells.data();
+        state.literals_table.capacity =
+            static_cast<uint32_t>(huf_cells.size());
+        state.litlen.cells = litlen_cells;
+        state.litlen.capacity = kLitLenCells;
+        state.offset.cells = offset_cells;
+        state.offset.capacity = kOffsetCells;
+        state.matchlen.cells = matchlen_cells;
+        state.matchlen.capacity = kMatchLenCells;
+        state.literals_scratch = &literals_scratch;
+        state.seq_scratch = &seq_scratch;
+        state.literals = literals.data();
+        state.literals_capacity = literals.size();
+        state.sequences = sequences.data();
+        state.sequences_capacity = static_cast<uint32_t>(sequences.size());
+        state.offsets = offsets.data();
+        state.offsets_capacity = static_cast<uint32_t>(offsets.size());
+        state.destinations = destinations.data();
+        state.destinations_capacity =
+            static_cast<uint32_t>(destinations.size());
+        cudec_detail::ZstdFrameStateInit(&state);
     }
 };
 
-/* Where a run stopped. Named per STAGE rather than per rung: each stage's
- * rungs are the business of that unit's own twin, and what a corpus-level run
- * needs is which stage refused. */
+/* Where a run stopped. The stages the block loop walks keep the loop's own
+ * numbering, spelled by name so a stage added there cannot silently become a
+ * different one here; the three the envelope owns follow after them. */
 enum DriverStage {
-    kStageNone = 0,
-    kStageFrameHeader,
-    kStageBlockHeader,
-    kStageLiterals,
-    kStageSequenceHeader,
-    kStageSequenceTable,
-    kStageSequences,
-    kStageRepcode,
-    kStageExecute,
-    kStageContentSize,
+    kStageNone = cudec_detail::kZstdBlocksStageNone,
+    kStageBlockHeader = cudec_detail::kZstdBlocksStageBlockHeader,
+    kStageLiterals = cudec_detail::kZstdBlocksStageLiterals,
+    kStageSequenceHeader = cudec_detail::kZstdBlocksStageSequenceHeader,
+    kStageSequenceTable = cudec_detail::kZstdBlocksStageSequenceTable,
+    kStageSequences = cudec_detail::kZstdBlocksStageSequences,
+    kStageRepcode = cudec_detail::kZstdBlocksStageRepcode,
+    kStageExecute = cudec_detail::kZstdBlocksStageExecute,
+    kStageContentSize = cudec_detail::kZstdBlocksStageContentSize,
+    kStageFrameHeader = cudec_detail::kZstdBlocksStageCount,
     kStageChecksum,
     kStageTrailingBytes,
     kStageCount
 };
 
 const char* const kStageNames[kStageCount] = {
-    "none",           "frame-header",  "block-header",   "literals",
-    "sequence-header", "sequence-table", "sequences",     "repcode",
-    "execute",        "content-size",  "checksum",       "trailing-bytes"};
+    "none",     "block-header",    "literals",      "sequence-header",
+    "sequence-table", "sequences", "repcode",       "execute",
+    "content-size",   "frame-header", "checksum",   "trailing-bytes"};
 
-/* The seven ways an Offset_Value can resolve, counted as the driver goes. A
+/* The seven ways an Offset_Value can resolve, counted as the loop goes. A
  * corpus that decodes byte-identically proves nothing about a rule it never
- * reached, and this is what says which rules it reached. */
+ * reached, and this is what says which rules it reached. The split itself is
+ * ZstdRepcodeClassify's, in src/zstd_repcode.h, so the names below label the
+ * shipped enumeration rather than a second copy of it. */
 enum RulePath {
-    kPathExplicit = 0, /* Offset_Value above three: an explicit distance */
-    kPathSlot0,        /* literals, value 1: the most recent offset */
-    kPathSlot1,        /* literals, value 2: the second */
-    kPathSlot2,        /* literals, value 3: the third */
-    kPathShiftedSlot1, /* no literals, value 1: the second */
-    kPathShiftedSlot2, /* no literals, value 2: the third */
-    /* no literals, value 3: the most recent offset, minus one */
-    kPathMinusOne,
-    kPathCount
+    kPathExplicit = cudec_detail::kZstdRepcodePathExplicit,
+    kPathSlot0 = cudec_detail::kZstdRepcodePathSlot0,
+    kPathSlot1 = cudec_detail::kZstdRepcodePathSlot1,
+    kPathSlot2 = cudec_detail::kZstdRepcodePathSlot2,
+    kPathShiftedSlot1 = cudec_detail::kZstdRepcodePathShiftedSlot1,
+    kPathShiftedSlot2 = cudec_detail::kZstdRepcodePathShiftedSlot2,
+    kPathMinusOne = cudec_detail::kZstdRepcodePathMinusOne,
+    kPathCount = cudec_detail::kZstdRepcodePathCount
 };
 
 const char* const kPathNames[kPathCount] = {
     "explicit", "rep1", "rep2", "rep3", "rep1-shifted", "rep2-shifted",
     "rep1-minus-one"};
-
-inline RulePath ClassifyPath(uint64_t offset_value,
-                             uint32_t literals_length) {
-    if (offset_value > cudec_detail::kZstdRepcodeMaxSlotValue) {
-        return kPathExplicit;
-    }
-    if (literals_length != 0) {
-        return static_cast<RulePath>(kPathSlot0 + (offset_value - 1));
-    }
-    return static_cast<RulePath>(kPathShiftedSlot1 + (offset_value - 1));
-}
 
 /* What a driver run produced, or where and why it stopped. */
 struct Run {
@@ -174,17 +195,18 @@ inline void Stop(Run* run, DriverStage stage, int rung, cudec_status status,
 
 /* Decodes one whole frame inside the v1 subset (#102).
  *
- * The frame-level enforcement is here rather than left out, because a run
- * that skipped it would ACCEPT frames the reference refuses and a reject
- * parity claim over a mutation corpus would be measuring the gap instead of
- * the decoder: the declared content size, the content checksum when the
- * descriptor sets it, the window bound on a match, and bytes after the frame.
+ * The frame-level enforcement is here or in the loop rather than left out,
+ * because a run that skipped it would ACCEPT frames the reference refuses and
+ * a reject parity claim over a mutation corpus would be measuring the gap
+ * instead of the decoder: the declared content size, the content checksum
+ * when the descriptor sets it, the window bound on a match, and bytes after
+ * the frame.
  *
  * `dst_capacity` bounds what the run will produce; a frame declaring more is
  * refused rather than truncated. */
 inline Run DecodeFrame(const Bytes& frame, uint64_t dst_capacity) {
     Run run;
-    Driver driver;
+    Storage storage;
     cudec_detail::ZstdFrameHeader header;
     cudec_detail::ZstdFrameReject frame_rung =
         cudec_detail::kZstdFrameRejectNone;
@@ -195,205 +217,51 @@ inline Run DecodeFrame(const Bytes& frame, uint64_t dst_capacity) {
              header_status, "frame header refused");
         return run;
     }
-    if (header.frame_content_size > dst_capacity) {
-        Stop(&run, kStageContentSize, 0, CUDEC_ERR_OUTPUT_TOO_SMALL,
-             "the declared content size is past the destination");
-        return run;
-    }
 
     /* The frame's whole output, sized to what it declares, which the subset
-     * guarantees exists and the check above bounded. One byte of slack so the
-     * buffer has an address even for a frame declaring nothing; the capacity
-     * handed to the units is the declared size and never the slack. */
-    run.output.assign(static_cast<size_t>(header.frame_content_size) + 1, 0);
-    const uint64_t capacity = header.frame_content_size;
+     * guarantees exists and which the loop bounds against this capacity
+     * before it writes anything. One byte of slack so the buffer has an
+     * address even for a frame declaring nothing; the capacity handed to the
+     * loop is the caller's number and never the slack. */
+    const uint64_t capacity = header.frame_content_size < dst_capacity
+                                  ? header.frame_content_size
+                                  : dst_capacity;
+    run.output.assign(static_cast<size_t>(capacity) + 1, 0);
+    /* The loop is handed the buffer's own size and never the caller's larger
+     * number, so a frame declaring more than the caller allowed is refused by
+     * the loop's capacity rung rather than by a write nobody bounded. Where
+     * the declaration fits, the two numbers are the same. */
+
     uint64_t produced = 0;
-
-    uint64_t pos = header.header_size;
-    Bytes literals;
-    std::vector<uint64_t> offsets;
-    std::vector<uint64_t> destinations;
-    for (;;) {
-        cudec_detail::ZstdBlockHeader block;
-        const cudec_status block_status = cudec_detail::ZstdParseBlockHeader(
-            frame.data() + pos, frame.size() - pos, header.window_size, &block,
-            &frame_rung);
-        if (block_status != CUDEC_OK) {
-            Stop(&run, kStageBlockHeader, static_cast<int>(frame_rung),
-                 block_status, "block header refused");
-            return run;
-        }
-        run.blocks++;
-        const unsigned char* body = frame.data() + pos + 3;
-        if (block.block_type == cudec_detail::kZstdBlockTypeRaw) {
-            if (block.body_size > capacity - produced) {
-                Stop(&run, kStageContentSize, 0, CUDEC_ERR_OUTPUT_TOO_SMALL,
-                     "the frame regenerated more than the destination");
-                return run;
-            }
-            for (uint64_t i = 0; i < block.body_size; i++) {
-                run.output[static_cast<size_t>(produced + i)] = body[i];
-            }
-            produced += block.body_size;
-        } else if (block.block_type == cudec_detail::kZstdBlockTypeRle) {
-            if (block.block_size > capacity - produced) {
-                Stop(&run, kStageContentSize, 0, CUDEC_ERR_OUTPUT_TOO_SMALL,
-                     "the frame regenerated more than the destination");
-                return run;
-            }
-            for (uint64_t i = 0; i < block.block_size; i++) {
-                run.output[static_cast<size_t>(produced + i)] = body[0];
-            }
-            produced += block.block_size;
-        } else {
-            /* A block may regenerate at most the block maximum, which is what
-             * sizes the literals buffer: the section's own bound is checked
-             * inside the unit against the same window. */
-            const uint64_t block_max =
-                cudec_detail::ZstdLiteralsBlockMaximum(header.window_size);
-            literals.assign(static_cast<size_t>(block_max), 0);
-            uint64_t literals_produced = 0;
-            uint64_t consumed = 0;
-            cudec_detail::ZstdLiteralsReject literals_rung =
-                cudec_detail::kZstdLiteralsRejectNone;
-            if (cudec_detail::ZstdDecodeLiterals(
-                    body, block.body_size, header.window_size,
-                    &driver.literals_table, &driver.literals_scratch,
-                    literals.data(), literals.size(), &literals_produced,
-                    &consumed, &literals_rung) != CUDEC_OK) {
-                Stop(&run, kStageLiterals, static_cast<int>(literals_rung),
-                     CUDEC_ERR_CORRUPT_INPUT, "literals section refused");
-                return run;
-            }
-            literals.resize(static_cast<size_t>(literals_produced));
-
-            const unsigned char* section = body + consumed;
-            uint64_t remaining = block.body_size - consumed;
-            cudec_detail::ZstdSeqSectionHeader seq_header;
-            uint64_t seq_consumed = 0;
-            cudec_detail::ZstdSeqReject seq_rung =
-                cudec_detail::kZstdSeqRejectNone;
-            if (cudec_detail::ZstdParseSeqSectionHeader(
-                    section, remaining, block_max, &seq_header, &seq_consumed,
-                    &seq_rung) != CUDEC_OK) {
-                Stop(&run, kStageSequenceHeader, static_cast<int>(seq_rung),
-                     CUDEC_ERR_CORRUPT_INPUT, "sequences header refused");
-                return run;
-            }
-            section += seq_consumed;
-            remaining -= seq_consumed;
-
-            std::vector<cudec_detail::ZstdSequence> sequences(
-                seq_header.sequence_count);
-            if (seq_header.sequence_count != 0) {
-                const unsigned fields[] = {
-                    cudec_detail::kZstdSeqFieldLitLen,
-                    cudec_detail::kZstdSeqFieldOffset,
-                    cudec_detail::kZstdSeqFieldMatchLen};
-                const unsigned modes[] = {seq_header.litlen_mode,
-                                          seq_header.offset_mode,
-                                          seq_header.matchlen_mode};
-                cudec_detail::ZstdSeqTable* targets[] = {
-                    &driver.litlen, &driver.offset, &driver.matchlen};
-                for (unsigned index = 0; index < 3; index++) {
-                    uint64_t table_consumed = 0;
-                    if (cudec_detail::ZstdSeqLoadTable(
-                            fields[index], modes[index], section, remaining,
-                            &driver.seq_scratch, targets[index],
-                            &table_consumed, &seq_rung) != CUDEC_OK) {
-                        Stop(&run, kStageSequenceTable,
-                             static_cast<int>(seq_rung),
-                             CUDEC_ERR_CORRUPT_INPUT,
-                             "sequence table refused");
-                        return run;
-                    }
-                    section += table_consumed;
-                    remaining -= table_consumed;
-                }
-                if (cudec_detail::ZstdDecodeSequences(
-                        section, remaining, seq_header.sequence_count,
-                        &driver.litlen, &driver.offset, &driver.matchlen,
-                        sequences.data(),
-                        static_cast<uint32_t>(sequences.size()),
-                        &seq_rung) != CUDEC_OK) {
-                    Stop(&run, kStageSequences, static_cast<int>(seq_rung),
-                         CUDEC_ERR_CORRUPT_INPUT, "sequences refused");
-                    return run;
-                }
-            }
-
-            /* The repeat-offset history is a serial chain over the frame and
-             * is resolved for every sequence before any byte moves, which is
-             * the shape the execution below asks for: with the distances in
-             * hand each copy is independent of every other. The rungs stay
-             * this stage's, so a twin can still say which of the two refused.
-             */
-            offsets.assign(sequences.size(), 0);
-            for (size_t s = 0; s < sequences.size(); s++) {
-                const cudec_detail::ZstdSequence& sequence = sequences[s];
-                cudec_detail::ZstdRepcodeReject repcode_rung =
-                    cudec_detail::kZstdRepcodeRejectNone;
-                if (cudec_detail::ZstdRepcodeResolve(
-                        &driver.repcodes, sequence.offset_value,
-                        sequence.literals_length, &offsets[s],
-                        &repcode_rung) != CUDEC_OK) {
-                    Stop(&run, kStageRepcode, static_cast<int>(repcode_rung),
-                         CUDEC_ERR_CORRUPT_INPUT, "repeat offset refused");
-                    return run;
-                }
-                run.sequences++;
-                run.path[ClassifyPath(sequence.offset_value,
-                                      sequence.literals_length)]++;
-                if (sequence.offset_value <=
-                    cudec_detail::kZstdRepcodeMaxSlotValue) {
-                    run.repeats++;
-                }
-            }
-
-            destinations.assign(sequences.size() + 1, 0);
-            cudec_detail::ZstdExecPlan plan;
-            cudec_detail::ZstdExecReject exec_rung =
-                cudec_detail::kZstdExecRejectNone;
-            cudec_status exec_status = cudec_detail::ZstdExecPrefixSum(
-                sequences.empty() ? 0 : sequences.data(),
-                static_cast<uint32_t>(sequences.size()), literals.size(),
-                block_max, destinations.data(),
-                static_cast<uint32_t>(destinations.size()), &plan, &exec_rung);
-            if (exec_status != CUDEC_OK) {
-                Stop(&run, kStageExecute, static_cast<int>(exec_rung),
-                     exec_status, "sequence destinations refused");
-                return run;
-            }
-            exec_status = cudec_detail::ZstdExecuteBlock(
-                sequences.empty() ? 0 : sequences.data(),
-                static_cast<uint32_t>(sequences.size()), destinations.data(),
-                offsets.empty() ? 0 : offsets.data(),
-                literals.empty() ? 0 : literals.data(), literals.size(), &plan,
-                header.window_size, run.output.data(), capacity, &produced,
-                &exec_rung);
-            if (exec_status != CUDEC_OK) {
-                Stop(&run, kStageExecute, static_cast<int>(exec_rung),
-                     exec_status, "sequence execution refused");
-                return run;
-            }
-        }
-        pos += 3 + block.body_size;
-        if (block.last_block) {
-            break;
-        }
+    uint64_t consumed = 0;
+    cudec_detail::ZstdBlocksReport report;
+    cudec_detail::ZstdBlocksReject blocks_rung =
+        cudec_detail::kZstdBlocksRejectNone;
+    const cudec_status blocks_status = cudec_detail::ZstdDecodeBlocks(
+        frame.data() + header.header_size, frame.size() - header.header_size,
+        &header, &storage.state, run.output.data(), capacity, &produced,
+        &consumed, &report, &blocks_rung);
+    run.blocks = static_cast<size_t>(report.blocks);
+    run.sequences = static_cast<size_t>(report.sequences);
+    run.repeats = static_cast<size_t>(report.repeats);
+    for (unsigned index = 0; index < kPathCount; index++) {
+        run.path[index] = static_cast<size_t>(report.path[index]);
     }
-
-    /* Section 3.1.1.1.1: where a content size is declared it is exact, and a
-     * frame in this subset always declares one. The buffer was sized to that
-     * number, so a frame producing MORE has already been refused for want of
-     * room; what is left for this check is the frame that produced less. */
-    if (produced != header.frame_content_size) {
-        Stop(&run, kStageContentSize, 0, CUDEC_ERR_CORRUPT_INPUT,
-             "the frame produced other than its declared content size");
+    if (blocks_status != CUDEC_OK) {
+        /* The loop's stage numbering IS this enumeration's for the stages it
+         * walks, which the enum above states rather than converts. Where the
+         * refusal is the loop's own rather than a unit's, the loop's rung is
+         * what a caller can assert on, and the report's rung is zero. */
+        const DriverStage stage = static_cast<DriverStage>(report.stage);
+        const int rung = report.stage == cudec_detail::kZstdBlocksStageContentSize
+                             ? static_cast<int>(blocks_rung)
+                             : report.rung;
+        Stop(&run, stage, rung, blocks_status, kStageNames[stage]);
         return run;
     }
     run.output.resize(static_cast<size_t>(produced));
 
+    uint64_t pos = header.header_size + consumed;
     if (header.content_checksum) {
         const uint64_t digest =
             cudec_detail::Xxh64(run.output.data(), run.output.size());


### PR DESCRIPTION
Closes #201. Unblocks #199, whose remaining child this was.

## What moves

The loop over a frame's blocks lived in `tests/zstd_twin_driver.h`, whose own
header said so: every stage it called was shipped and the loop was not. That
left the one thing no unit owned being the one thing a frame decode cannot be
right without. The Huffman table a Treeless literals section reuses, the three
FSE tables a Repeat mode reuses, and the repeat-offset history all have to
survive a block boundary, and all three have to die at a frame boundary. A
decoder that gets either wrong decodes the first block of every frame
correctly and produces wrong bytes after it, on exactly the streams a
compressor chose to encode with a carry.

`src/zstd_blocks.h` is that loop, single-sourced for host and device like
every unit it composes:

- Every buffer it writes is the caller's, handed in with its capacity, for the
  reason each unit below it gives. A kernel decides where a frame's working
  memory lives, and a header that allocated would decide that for it. Two of
  the reject rungs exist for a capacity that is too small.
- The reset has exactly one home, `ZstdFrameStateInit`, and the loop never
  calls it. Marking a table absent rather than clearing its cells is what lets
  a Treeless section in a frame's first block be refused over an array that is
  allocated and still holds the previous frame's table.
- The declared content size is enforced exactly and never used to size
  anything. It is checked against the caller's capacity before a byte is
  written; a Raw or RLE block that would pass it is refused as it happens
  rather than measured afterwards, because afterwards the bytes are already
  written; and a frame producing less is refused at the end.

The driver keeps only the frame envelope around the loop, the header parse,
the checksum and the refusal of bytes after the frame, and there is no second
copy of the loop anywhere. The stage enumeration it reports is the loop's own,
spelled by name rather than by number, so a stage added there cannot silently
become a different one here.

`ZstdRepcodeClassify` moves into `src/zstd_repcode.h` beside the resolution it
mirrors. It was a private copy of that case split inside the test driver, and
two copies of one seven-way split is one too many.

## How the carries are proven

Not by decoding with them. A corpus that decodes byte-identically says nothing
about a rule it never reached, and both halves of this contract fail silently.

The reset is proven by removing it. A frame whose first block asks for a
Huffman table it was not given is refused at
`kZstdLiteralsRejectNoPreviousTable`; the same bytes handed to a state that
decoded an earlier frame and was **not** re-initialised walk past that rung.
The refusal disappearing is what says `ZstdFrameStateInit` is load-bearing.

The carries themselves are counted in the corpus that was just decoded
byte-exactly, and the run refuses to pass if the corpus stops holding one:
297 Treeless blocks, each asserted to sit behind a compressed-literals block;
50 Repeat-mode blocks for each of LL, OF and ML; 8 multi-block frames.

The two shapes the pinned compressor does not emit are built here. A frame of
a single RLE block, and a frame whose first block is Raw and whose second is
Compressed, the second grafted from a real compressed body under a header this
file writes. libzstd decodes each one before the twin's answer is compared
against it, so a hand-built frame is a frame rather than a guess.

## The negatives

One per rung of the loop's own ladder, and `main` refuses to pass with any of
the six unfired.

| rung | reached by |
| --- | --- |
| `ContentSizeMismatch` | a raw block of 64 bytes under a declaration of 65 |
| `BlockPastCapacity` | two raw blocks of 32 under a declaration of 40, and two RLE blocks of 250 under 400 |
| `ContentPastCapacity` | a legal frame decoded into 32 bytes of room |
| `LiteralsStorageTooSmall` | literals room one byte under the frame's block maximum |
| `SequenceStorageTooSmall` | no sequence room at all, against a frame that has sequences |
| `BadRequest` | a destination array one entry short of the sequence array |

Two of the negatives this issue names are refused a step earlier than the
loop, by the block header, and the test asserts them there: input exhausted
before any last-block flag is `kZstdFrameRejectBlockHeaderTruncated`, and a
block claiming a size past the end of the frame is
`kZstdFrameRejectBlockBodyTruncated`.

Both content-size negatives needed two blocks rather than one, which is worth
knowing before anyone rewrites them. A single-segment frame's window IS its
declared content size, so a single oversized block is refused for passing the
block maximum and never reaches the loop's own bound; split across two blocks,
each is inside the maximum and only their sum is not.

The rung lock in `zstd_entropy_twin` goes from seven ladders to eight, 68 to
74.

## Runs

Local, mingw g++ 15 against libzstd 1.5.7 built from the source
`tests/CMakeLists.txt` already pins. The Windows host has no CUDA toolchain, so
the tests were built directly rather than through ctest; the ctest
registration and the sanitized build are CI's.

```
$ ./zstd_blocks_twin
PASS: block loop - 1596416 fixture bytes decoded byte-exact, 8 multi-block
frames, carries seen: treeless 297, repeat LL/OF/ML 50/50/50,
raw-then-compressed 1, single RLE 1; 6 reject rungs each reached

$ ./zstd_entropy_twin
PASS: 17 fixtures decoded byte-identical to libzstd and to their own sources
(1596416 bytes), 2 declined as outside the v1 subset; 784 mutants, 679 refused
by libzstd with 0 fail-opens, 98 accepted by both with 0 byte divergences, 6
declined as outside the subset; 74 reject rungs locked
      driver refusals by stage: block-header 144 literals 48 sequence-header 25
      sequence-table 69 sequences 122 execute 6 content-size 35 frame-header 209
      checksum 27 trailing-bytes 1

$ ./zstd_repcode_twin
PASS: 34 frames decoded byte-identical to the reference, 3120393 bytes, 173319
sequences of which 2590 resolved a repeat offset, 2 reject rungs covered

$ ./zstd_exec_twin
PASS: 538 rows, 1133 sequences executed, 35436 bytes regenerated, 8 reject
rungs covered
```

`zstd_entropy_twin` is the one that matters most for a refactor: it drives the
same 784 mutants through the moved loop and still reports 0 fail-opens and 0
byte divergences, so the move changed no verdict.

## CI at the head of this branch

```
build      100% tests passed, 0 tests failed out of 41
           24/41 Test #25: zstd_blocks_twin ................. Passed 0.21 sec
sanitize   100% tests passed, 0 tests failed out of 13
            9/13 Test #24: zstd_blocks_twin ................. Passed 0.77 sec
```

The second line is the one worth reading: that run is the ASan+UBSan build of
the untrusted-input subset, so the whole block walk over the mutation corpus
and every hand-built negative went through it with the sanitizers on.

## The sanitize gate

`zstd_blocks_twin` joins the untrusted-input subset in `ci.yml`, in all three
places that job names a test: the `test -x` line, the `-R` regex and the
identity grep. It links `zstd_full`, which `zstd_frame_twin` in the same set
already does, so no new link shape enters that build.

## What is not covered

No GPU ran. `src/zstd_blocks.h` is compiled `__host__` only by everything in
this change; the `__device__` instantiation arrives with the kernel in #203,
and nothing here claims it compiles there.

No sanitizer ran locally. The Windows host has no Clang and no CUDA toolchain,
and the container engine that would supply them is not up, so the ASan/UBSan
result above is the CI job's and was read out of its log rather than produced
here.

This change had no second reader. The evidence above stands in place of one:
every number was produced by running the binary named beside it, and the two
contract halves are proven by removing the thing under test and watching the
verdict move rather than by a passing decode.
