### PR TITLE
Stop crediting M4 with interop evidence that does not exist [#169]

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -26,9 +26,12 @@ each carry that MIT notice together with an `SPDX-License-Identifier:
 Apache-2.0` line and an NVIDIA copyright.
 
 **The GDeflate subtree of `microsoft/DirectStorage`**, which carries its own
-Apache-2.0 `LICENSE` with NVIDIA and Microsoft copyrights, and whose
-`GDeflateTest` vectors are the one piece of interop evidence in M4 that comes
-from a different implementation lineage than the fork above.
+Apache-2.0 `LICENSE` with NVIDIA and Microsoft copyrights. It is read as the
+de-facto reference implementation. It supplies no test vectors and no second
+lineage: `GDeflate/GDeflateTest` is two source files that build their inputs
+at run time, and the reference codec they exercise reaches the same NVIDIA
+libdeflate fork pinned above. `docs/MASTERPLAN.md` section 11.7 carries the
+readings and what their absence costs.
 
 **The IETF draft `draft-uralsky-gdeflate-00`**, "GDEFLATE bitstream format
 specification", used under the BCP 78 terms it is published with. It is one

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1067,11 +1067,44 @@ is the interesting one for coverage**: the header defines it as "create a
 valid stream, but only emit uncompressed blocks", so it reaches the stored
 block type by construction rather than by luck.
 
-**Interop evidence: the DirectStorage `GDeflateTest` vectors.** These are
-the bit-exactness check against the shipping runtime, and they are the one
-piece of evidence that comes from a different implementation lineage than
-the libdeflate fork. Their intake is its own issue; what this section fixes
-is that they are load-bearing rather than decorative.
+**Interop evidence: there is none, and this paragraph claimed there was.**
+It recorded the DirectStorage `GDeflateTest` vectors as the one piece of
+evidence coming from a different implementation lineage than the libdeflate
+fork, and as load-bearing rather than decorative. Both halves are wrong, and
+both were found by reading the upstream tree instead of its description.
+
+There are no vectors:
+
+    gh api 'repos/microsoft/DirectStorage/git/trees/main?recursive=1' \
+      --jq '[.tree[]|select(.path|startswith("GDeflate/GDeflateTest/"))|.path]'
+    ["GDeflate/GDeflateTest/CMakeLists.txt","GDeflate/GDeflateTest/GDeflateTest.cpp"]
+
+`GDeflateTest.cpp` opens no file. It builds its inputs at run time from
+`std::default_random_engine`, compresses them and validates the result, so
+nothing is written out that anyone could check in.
+
+And the lineage is not a second one. The `GDeflate/` library those two files
+call takes its codec from a submodule, at the commit this project already
+pins in `cmake/CudecGDeflateOracle.cmake`:
+
+    gh api repos/microsoft/DirectStorage/contents/GDeflate/3rdparty/libdeflate \
+      --jq '{submodule_git_url, sha}'
+    {"sha":"8ba9502fb30d2bf728592d121f0d402e40c8cb05","submodule_git_url":"https://github.com/NVIDIA/libdeflate"}
+
+`GDeflate::Decompress` allocates that fork's decompressor and calls
+`libdeflate_gdeflate_decompress`, the same entry `tests/oracle_gdeflate.cpp`
+already drives. Bytes taken from there and diffed here would be one copy of
+libdeflate agreeing with another, and they would read as cross-implementation
+evidence because of where the wrapper lives, which is worse than holding
+none.
+
+What section 11.1 says about `GDeflateTest` stays true and is a different
+statement: upstream does cross-check the shipping runtime against that
+reference codec, in both directions, so bit-exact interop is the contract
+tested **there**. The runtime is the one genuinely external decoder in the
+picture, it is reached through `dstorage.h` as a Windows binary component,
+and getting its bytes into this tree is a host question rather than a
+harness one. Issue #169 carries what is left of the intake.
 
 **Independent second decoder: rejected.** The candidate was `sk-zk/GisDeflate`
 (MIT, C#). The decision is no, and the reason is not the harness cost.
@@ -1086,14 +1119,15 @@ is a managed .NET component in a tree that carries no .NET anywhere, for
 CI and for local runs - but that cost is what would have been weighed if
 the coverage had been genuine. It is not.
 
-**What that loses, stated rather than waved away.** M4 has no
-independent-lineage oracle for the _reject_ direction on arbitrary bytes:
-where the libdeflate fork refuses a stream, no second implementation
-confirms it should. Three things compensate, and none of them is a full
-substitute:
+**What that loses, stated rather than waved away, and it is more than this
+passage admitted.** M4 has no independent-lineage oracle for the _reject_
+direction on arbitrary bytes: where the libdeflate fork refuses a stream, no
+second implementation confirms it should. It has none for the accept
+direction either. This list named three compensations and put the
+`GDeflateTest` vectors first, as "lineage-independent but cover the accept
+direction only, on a fixed set"; the paragraph above records why that is
+wrong in both of its terms. Two are left, and neither is a full substitute:
 
-- the `GDeflateTest` vectors, which are lineage-independent but cover the
-  accept direction only, on a fixed set;
 - cudec's own CPU twin, which is written from the draft rather than from
   the fork, so a fork-specific parsing bug does not propagate into it by
   construction - the twin is the second implementation, and this section


### PR DESCRIPTION
Two tracked documents said M4 holds a piece of interop evidence from an
implementation lineage other than the pinned libdeflate fork. It does not, and
the claim was wrong in both of its terms.

## What was wrong

`docs/MASTERPLAN.md` section 11.7 recorded the DirectStorage `GDeflateTest`
vectors as "the one piece of evidence that comes from a different
implementation lineage than the libdeflate fork" and as "load-bearing rather
than decorative". The same section's honest-loss paragraph then listed those
vectors first among three things compensating for M4 having no
independent-lineage oracle. `NOTICE.md` carried the claim a third time.

## How it was found

By reading the upstream tree instead of the description of it that both
documents carried.

There are no vectors:

    gh api 'repos/microsoft/DirectStorage/git/trees/main?recursive=1' \
      --jq '[.tree[]|select(.path|startswith("GDeflate/GDeflateTest/"))|.path]'
    ["GDeflate/GDeflateTest/CMakeLists.txt","GDeflate/GDeflateTest/GDeflateTest.cpp"]

Two files, neither of them data. `GDeflateTest.cpp` opens no file: it builds
its inputs at run time from `std::default_random_engine`, compresses them and
validates the result, so nothing is written out that could be checked in.

And the lineage is the same one. The `GDeflate/` library those files call
takes its codec from a submodule, at the commit this project already pins:

    gh api repos/microsoft/DirectStorage/contents/GDeflate/3rdparty/libdeflate \
      --jq '{submodule_git_url, sha}'
    {"sha":"8ba9502fb30d2bf728592d121f0d402e40c8cb05","submodule_git_url":"https://github.com/NVIDIA/libdeflate"}

    grep -n 'set(CUDEC_GDEFLATE_COMMIT' cmake/CudecGDeflateOracle.cmake
    46:set(CUDEC_GDEFLATE_COMMIT 8ba9502fb30d2bf728592d121f0d402e40c8cb05)

`GDeflate::Decompress` allocates that fork's decompressor and calls
`libdeflate_gdeflate_decompress`, which is the entry `tests/oracle_gdeflate.cpp`
already drives.

## What the change does

Section 11.7's interop paragraph now records the absence and both readings
that establish it. The honest-loss paragraph drops the first compensation and
says the loss covers the accept direction too, so it is a sharper admission
than the one it replaces, not a softer one. `NOTICE.md` keeps the DirectStorage
subtree entry for what it actually is, the de-facto reference implementation,
and states that it supplies no vectors and no second lineage.

Section 11.1's sentence about `GDeflateTest` is deliberately untouched. It says
upstream cross-checks the shipping runtime against that reference codec, which
is true, and it is a statement about what upstream tests rather than about
evidence held here. The upstream file does create both codecs and compare them
in both directions.

## What this does not do

It does not close #169. That issue's Done-when asks for vectors checked into
this tree and decoded by the oracle in a ctest target, and the reading above is
why that cannot be met as written. Which shape the fixture rung should take
instead is recorded on the issue and is not decided here.

Nothing was measured, and no code, test or fixture changed.

## Gate

Documentation only.

    npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
    Checking formatting...
    All matched files use Prettier code style!

The build and sanitize jobs run on this pull request and are unaffected by a
documentation change; I did not build locally, and this host carries no CUDA
toolchain to do so.

This pull request had no second reader, and the readings above stand in place
of one.

Closes nothing. Refs #169.
