### PR TITLE
Record the GDeflate provenance posture and park the sanitizer gate [#162] [#258]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,15 @@ Issue-driven, gate-driven:
   nvCOMP is proprietary: never copy its headers or source, and cudec claims no
   compatibility with it (nominative references and CPU-only benchmark
   comparisons are fine).
+  **GDeflate is the one deliberate exception**, and it is narrow. That format
+  has no single canonical specification, and the artifact that carries a
+  patent grant is the Apache-2.0 code rather than the draft: the M4 work may
+  read and derive from the DirectStorage `GDeflate/` reference and the NVIDIA
+  fork of libdeflate, and every reliance is recorded at the site and in the
+  pull request - which file, what was taken, why. Section 16 of
+  [MASTERPLAN.md](docs/MASTERPLAN.md) is where that posture and its reason
+  live; it widens to no other format and to no other decoder, and it is
+  reasoning discipline rather than a statement that anything is patent-safe.
 - **Termination**: every loop whose exit depends on a value read from the
   bitstream carries an explicit decrementing fuel cap, sized so no input the
   validation ladder admits can reach it. A decoder that hangs on hostile input
@@ -121,13 +130,37 @@ racecheck checks shared-memory hazards only. A clean run says nothing about
 global-memory races, and reading it as clearance for them is the mistake this
 sentence exists to stop.
 
-The gate is written down here in full, and issue #258 records that no route to
-a device it can attach to is available today: under WSL2 the device is in WDDM
-mode, the debugger interface the sanitizer needs is absent, and all four tools
-report the same two initialization errors on a program with no fault in it. So
-the sweep is owed and currently cannot be produced on that route. Say that in
-the pull request, with the command that shows it, rather than leaving the block
-looking answered.
+The gate is written down here in full, and it is **parked**. No route to a
+device the four tools can attach to exists on this project's route, and the
+one attempt that could have produced one was made and failed. Under WSL2 the
+device is in WDDM mode, the debugger interface the sanitizer needs is absent,
+and all four tools report the same two initialization errors against a program
+with nothing wrong in it. Re-measured on 2026-08-24 against the newest pairing
+this machine can hold (driver 610.88, CUDA 13.3, compute-sanitizer 2026.2.1.0),
+run in the WSL distribution directly rather than in the container above:
+
+```
+for t in memcheck racecheck initcheck synccheck; do
+  compute-sanitizer --tool "$t" --error-exitcode 1 ./clean; done
+every tool: exit=1
+========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator
+========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation
+```
+
+A seeded 4 MiB out-of-bounds write does exit nonzero under memcheck, and that
+nonzero says nothing: what surfaces is the runtime's own
+`cudaErrorIllegalAddress` on `cudaDeviceSynchronize` with a host backtrace, no
+`Invalid __global__ write` and no device backtrace. The same fault run without
+the sanitizer produces the same information.
+
+Parked means owed and unproducible, not waived and not moved. It was not moved
+to a paid GPU runner: that is a standing cost, and it comes back as its own
+issue if device-side coverage becomes load-bearing. What would unpark it is a
+machine whose device offers a debugger interface, and the untried route is the
+Windows-native CUDA toolchain, which ships the `EnableDebuggerInterface.bat`
+the first error names. Until then, say in the pull request that the sweep could
+not be produced, with the command that shows it, rather than leaving the block
+looking answered. Issue #258 holds the parking.
 
 ### The fuzz gate
 

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -217,11 +217,14 @@ is not an empty AMD field), and **hackability**.
   the CUDA version it was produced against. **racecheck detects
   shared-memory hazards only** - global-memory races are outside its scope,
   and a clean sweep is never read as clearance for them. Today the gate is
-  owed and unproducible on the maintainer route: under WSL2 the device is in
-  WDDM mode, the debugger interface the tools need is absent, and all four
-  report the same two initialization errors against a program with no fault in
-  it, which #258 records with its commands. That is a gap in the evidence, not
-  a dispensation from the gate.
+  **parked**: owed and unproducible on the maintainer route, under WSL2 the
+  device is in WDDM mode, the debugger interface the tools need is absent, and
+  all four report the same two initialization errors against a program with no
+  fault in it. Re-measured against the newest driver and toolkit pairing the
+  machine can hold and unchanged by it, which #258 records with its commands
+  and CONTRIBUTING.md carries beside the invocation. Parked is a gap in the
+  evidence and not a dispensation from the gate: it was not moved to a paid GPU
+  runner, and what would lift it is a device offering a debugger interface.
 - **Oracle pinning policy**: oracles are vendored via FetchContent from
   maintainer-uploaded release assets, pinned by a self-computed SHA-256
   cross-checked against a second packaging ecosystem; auto-generated
@@ -1201,8 +1204,8 @@ Recording where the verification apparatus came from is worth doing on its
 own terms, and it means the vendoring rung has nothing left to invent.
 
 **This subsection is about attribution only.** The patent position and the
-implementation-provenance posture are a separate, maintainer-gated
-decision, and nothing here pre-empts or softens it.
+implementation-provenance posture were a separate, maintainer-gated
+decision; it is taken, and section 16 carries it. Nothing here softens it.
 
 ## 12. M5 Zstd v1 decode subset (RFC 8878)
 
@@ -2395,3 +2398,85 @@ The platform facts in 15.2 and 15.3 were read from the vendor documentation
 for this section. No ROCm toolchain and no AMD device were available while
 it was written, so nothing here is a measurement, and the first numbers for
 this backend arrive with #243 and the community route.
+
+## 16. Legal guardrails
+
+The standing rules about where implementation knowledge may come from, in
+one place, plus the GDeflate posture that section 11 deferred to a decision.
+This is internal reasoning discipline about how the code is produced. It is
+not legal advice, and nothing here states or implies that cudec is patent-safe
+for anybody who uses it.
+
+### 16.1 The standing rules
+
+- **Public specifications only, everywhere except GDeflate.** LZ4 block and
+  frame, Snappy, DEFLATE (RFC 1951) and Zstd (RFC 8878) are implemented from
+  their published specifications. liblz4, zlib, snappy and libzstd are test
+  oracles: they settle correctness by differential test, and their code is
+  never a source to derive from. They ship under BSD and zlib terms, and
+  pasted lines would muddy the provenance of an Apache-2.0 tree for no gain
+  a differential test does not already give.
+- **nvCOMP is proprietary and stays untouched.** Never copy its headers or
+  its source, and claim no compatibility with it. Naming it and comparing
+  against it on the CPU side is fine; deriving from it is not.
+- **The EULA check happens before a head-to-head table is published, not
+  after.** Section 8.9 of the NVIDIA Software License Agreement is read
+  against any published cudec-vs-nvCOMP number first; the reasoning and the
+  current state of that check live in
+  [BENCHMARK-METHODOLOGY.md](BENCHMARK-METHODOLOGY.md).
+
+### 16.2 The GDeflate posture: spec plus recorded reliance
+
+GDeflate is the one format where the rule above is deliberately not the rule.
+The M4 work may read and derive from the Apache-2.0 reference artifacts: the
+`GDeflate/` subtree of `microsoft/DirectStorage` (the CPU codec and the HLSL
+GPU decoder, NVIDIA and Microsoft copyrights) and the NVIDIA fork of
+libdeflate. Section 11.7 pins both by hash for the oracle path; this
+subsection is about what an engineer writing the kernel may take from them.
+
+**Why the exception sits here and nowhere else.** The other four formats have
+a published specification and a permissively licensed reference, and the
+specification is enough. GDeflate has no single canonical specification at
+all - section 11.1 assembles it from an expired IETF draft, a reference
+implementation and a Vulkan extension - and the two hygienes pull in opposite
+directions on it:
+
+- A decoder written from `draft-uralsky-gdeflate-00` alone is copyright-clean
+  and **patent-bare**. BCP 78 grants copyright permission to implement a
+  draft. It grants no patent licence, and it never did.
+- Apache-2.0 section 3 carries an express patent grant from each contributor
+  for their contributions. Relying on the licensed artifacts is what attaches
+  that grant to the thing actually being built.
+
+So on this format the patent-bearing artifact is the licensed code, and
+refusing to read it would buy copyright hygiene this project can pay for
+another way while giving up the only patent grant on offer. The copyright
+side is handled by complying with Apache-2.0 rather than by avoidance:
+attribution, `LICENSE` and `NOTICE` where they are owed (11.9 reads what is
+actually owed here), and a recorded derivation for every reliance.
+
+**What an engineer on the M4 kernel may do.**
+
+- Read the DirectStorage `GDeflate/` reference and the libdeflate fork,
+  including for bit-level questions the dossier leaves open.
+- Derive structure, table layouts, constants and decode order from them.
+- Copy code from them where that is the honest description of what happened.
+
+**What that costs, every time, with no exception.**
+
+- **The reliance is recorded where the code lands**: which upstream file, what
+  was taken, and why. A comment at the site plus the pull request body is the
+  form; a derivation nobody wrote down is the one shape this posture does not
+  permit, because an unrecorded derivation gets the patent grant's benefit
+  while leaving the attribution obligation unpaid and unpayable later.
+- **The artifact is one of the two named above.** The posture is about
+  Apache-2.0 GDeflate references. It does not widen to any other decoder,
+  and it does not touch the nvCOMP rule in 16.1, which is unconditional.
+- **The oracle diff still decides correctness.** Reading the reference is a
+  source of implementation knowledge, never a substitute for byte parity
+  against it (11.7, and the ladder in 13.3).
+
+**What this does not say.** It does not say the M4 decoder is free of
+third-party patent claims, and it does not say that relying on Apache-2.0
+artifacts makes a user of cudec safe. It says which artifacts this project's
+own engineering may draw on, and what it writes down when it does.


### PR DESCRIPTION
# What & why

Two decisions were taken and recorded only on the tracker. This writes them
into the files a contributor reads. Closes #162. Closes #258.

**#162, the GDeflate implementation-provenance posture.** Masterplan section 16
is new and is the one identifiable place the standing legal guardrails live:
public specifications only everywhere except GDeflate, never copy nvCOMP, and
the EULA check before any published head-to-head table. It carries the decided
posture - spec plus recorded reliance on the Apache-2.0 artifacts - with the
reason: GDeflate has no single canonical specification, and the artifact that
bears a patent grant is the licensed code rather than the draft, because BCP 78
grants copyright permission to implement and no patent licence. The subsection
says concretely what an engineer on the M4 kernel may read, derive and copy from
the DirectStorage `GDeflate/` reference and the NVIDIA libdeflate fork, and what
it costs each time: the reliance is recorded at the site and in the pull request
- which file, what was taken, why. Section 11.9 no longer defers the posture to
a question nobody had answered; it points at 16. `CONTRIBUTING.md`'s format-provenance
bullet gains the exception, so the narrow reading is not something a reader has
to infer from the wide rule.

The Done-when's last clause is met by construction: neither file states or
implies that cudec is patent-safe for its users, and section 16 says so twice in
its own words.

**#258, the parked sanitizer gate.** The decided attempt - the newest driver and
toolkit pairing this machine can hold - ran and failed, and the negative result
now sits beside the invocation in `CONTRIBUTING.md` and in the masterplan's
testing section. Re-measured for this change rather than quoted from the issue:

```
$ nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
NVIDIA GeForce RTX 3080, 610.88
$ nvcc --version | tail -2
Cuda compilation tools, release 13.3, V13.3.73
$ compute-sanitizer --version | head -3
NVIDIA (R) Compute Sanitizer
Version 2026.2.1.0 (build 38334959) (public-release)

$ ./clean; echo "exit=$?"          # a CUDA program with nothing wrong in it
exit=0
$ for t in memcheck racecheck initcheck synccheck; do
    compute-sanitizer --tool "$t" --error-exitcode 1 ./clean; done
every tool: exit=1
========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator
========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation

$ compute-sanitizer --tool memcheck --error-exitcode 1 ./fault   # seeded 4 MiB OOB write
========= Program hit cudaErrorIllegalAddress (error 700) ... on CUDA API call to cudaDeviceSynchronize.
=========     Saved host backtrace up to driver entry point at error
========= ERROR SUMMARY: 3 errors        (exit=1)
```

The same two initialization errors as under 560.94 / 12.6, unchanged by the
newest pairing, and the seeded fault still produces no `Invalid __global__
write` and no device backtrace. The nonzero exit is written down as the trap it
is: a reader who sees one is entitled to think the tool bit, and it did not.
Parked means owed and unproducible, not waived and not moved to a paid runner;
the untried Windows-native route that would lift it is named where the parking
is written.

## Type of change

- [x] Docs

## Engineering checklist

Not applicable line by line: this change adds no code and touches no parse,
decode, ABI or launch path. `git diff --name-only origin/main...HEAD` returns
`CONTRIBUTING.md` and `docs/MASTERPLAN.md` and nothing else.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

The block is left empty deliberately, and this pull request is the change that
records why an empty block is the expected state on this machine.

## Performance checklist

Not applicable. No hot path is touched and no number moved.

## Quality checklist

- [x] Minimal: two decisions, two files, no third topic.
- [x] Self-documenting: the posture says what may be done and what it costs,
      rather than restating the licence texts.
- [x] No structural property is established, so no conformance test is owed.

## Verification

```
$ cmake -S . -B ~/cudec-bc -DCUDEC_ENABLE_CUDA=ON     # configure exit=0
$ cmake --build ~/cudec-bc -j"$(nproc)"               # build exit=0
$ ctest --test-dir ~/cudec-bc --output-on-failure
100% tests passed, 0 tests failed out of 49
Label Time Summary:
gpu    =   5.57 sec*proc (8 tests)
Total Test time (real) =  16.08 sec

$ npx prettier@3 --check "**/*.{md,yml,yaml}"
All matched files use Prettier code style!
```

Run at this branch's tree in the Ubuntu-24.04 WSL distribution against the
local RTX 3080, driver 610.88, nvcc 13.3.73. That is worth stating plainly
because it is new: the build-and-run route was unavailable when the passages
this change edits were last written, and the 49-test run above is the whole
suite, GPU tests included.

- [x] `cmake --build` - builds clean.
- [x] `ctest` - green.
- [x] Prettier - clean.
- [x] Docs synced: this change is the doc sync.

## Notes

Two issues in one pull request, deliberately. Both land only prose in the same
two files, and separate landings would move the mainline under each other for
no reviewer benefit.

**No second reader.** There is none available for this change, so the evidence
above stands in place of one: every claim it makes carries the command that
produced it, and the two edited passages are quoted from the decisions on #162
and #258 rather than composed here.

What is deliberately not touched: `CONTRIBUTING.md` still documents the pinned
container as the maintained CUDA path and still says CUDA 12.x. The route that
now works on this machine is a WSL distribution with CUDA 13.3 installed
directly, which is a build-route change rather than a sanitizer or provenance
one, and it belongs to its own issue.
