### PR TITLE
Materialize the chunk-decoder seam and instantiate Snappy on it [#150]

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,7 +1,7 @@
 # The benchmark harness: honest numbers or none - every report emits its
 # methodology block (docs/MASTERPLAN.md section 5). The CPU-oracle path is
 # always timed; --gpu adds the device-resident GPU decode path (gpu_bench.cu,
-# which shares the shipped kernel via src/lz4_decode.cuh). Consumer-only by
+# which shares the shipped kernel via src/chunk_decode.cuh). Consumer-only by
 # rule: this directory links project targets and never modifies them (the
 # conformance snapshot in tests/ runs before it).
 find_package(CUDAToolkit REQUIRED)

--- a/bench/gpu_bench.cu
+++ b/bench/gpu_bench.cu
@@ -6,7 +6,8 @@
 
 #include "bench_stats.h"
 #include "cudec.h"
-#include "lz4_decode.cuh"
+#include "chunk_decode.cuh"
+#include "lz4_block.h"
 
 #include <cuda_runtime.h>
 
@@ -30,7 +31,7 @@ cudec_status LaunchParseOnly(const void* const* s, const size_t* ss,
         return valid;
     }
     (void)cudaGetLastError();
-    cudec_detail::lz4_decode_batch<true>
+    cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, true>
         <<<cudec_detail::decode_grid_blocks(n), cudec_detail::kBlockThreads, 0,
            stream>>>(s, ss, d, dc, n, r);
     return cudaGetLastError() == cudaSuccess ? CUDEC_OK : CUDEC_ERR_CUDA;

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -581,12 +581,22 @@ bytes as well as cudec's, so a reject branch is demonstrably in parity
 rather than merely present.
 
 **Where this section is a commitment and where it is a description.** The
-parser core has landed; the seam and the batch entry have not. Each
+parser core, the seam and the batch entry have all landed; what has not is
+the device gate set (#154), the bench rung and the measured pass. Each
 subsection below says which it is, so the document cannot be read as a
 report of shipped code. The tree is the authority for the second kind and
 the commands that read it are given inline.
 
 ### The seam: what a parser owes the chunk decoder
+
+**Landed** as `src/chunk_decode.cuh` and `src/decode_sequence.h`, and the
+paragraphs below are what was committed to rather than a report of the
+result. The requirement list is stated at the head of the kernel header,
+where the code that breaks when one of them is missed can be read beside it,
+and the header carries one requirement this section did not name: a reported
+match offset below 2^32, which is what makes the 32-bit gather arm's
+narrowing lossless. It holds structurally from the offset field's width in
+both formats rather than from a check on parsed input.
 
 **A commitment.** The chunk decoder becomes
 `template <class Parser, bool ParseOnly>` in `src/chunk_decode.cuh`: the
@@ -713,14 +723,22 @@ the three outcomes are unchanged - and it buys the batch entry the declared
 length without parsing the varint twice. The panel's objection to a _seam_
 method stands; this is a parser-local one.
 
-**Not yet executed:** the panel also called for promoting the LZ4 sequence
-type to one shared element vocabulary in `src/decode_sequence.h`. The
-parser core kept a format-local element type instead, so there are two
-today. Materializing the seam is where that is either executed or overturned
-with a stated reason; it cannot be left implicit, because one shared element
-vocabulary is what the "copy engine checks nothing" rule rests on.
+**Executed with the seam:** the panel also called for promoting the LZ4
+sequence type to one shared element vocabulary in `src/decode_sequence.h`,
+and the parser core had kept a format-local element type instead. There is
+one type now. `DecodeSequence` carries a literals half and a match half;
+LZ4 fills both, and Snappy fills exactly one and leaves the other empty,
+which is what let the `is_copy` flag go rather than be carried across the
+seam. The copy engine runs both halves unconditionally and has nothing to
+branch on, which is the "copy engine checks nothing" rule with one contract
+behind it instead of two. `tests/CMakeLists.txt` locks the single source the
+way it already locks `cuda_raii.h` and the batch limit.
 
 ### The batch entry
+
+**Landed** in `include/cudec.h` and `src/batch.cu`; the paragraphs below are
+the commitment it was built to. Its contract conformance - every documented
+synchronous reject, one call each, from C99 - is the sibling rung (#152).
 
 **A commitment.** `cudec_snappy_decompress_batch` carries the
 `cudec_lz4_decompress_batch` contract with no deltas: device-side argument
@@ -738,8 +756,10 @@ supported surface as raw Snappy streams; M3 ships the batch entry only, and
 generalizing the streaming path to Snappy was a separate scope decision, filed
 rather than smuggled in here and now settled below.
 
-Today `include/cudec.h` declares no Snappy entry (`grep -c snappy
-include/cudec.h` reports 0). The batch-entry rung carries it.
+The entry is declared, and the count that used to read zero is derived
+rather than restated here:
+
+    grep -c snappy include/cudec.h
 
 ### The framing format: out of scope, with the evidence
 

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -107,6 +107,36 @@ cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
                                         cudec_chunk_result* d_results,
                                         cudec_stream_t stream);
 
+/* Batch Snappy block decode. The contract above holds argument for
+ * argument: the same device-side arrays, the same per-chunk result
+ * semantics, the same synchronous validation rejects with the same
+ * CUDEC_ERR_INVALID_ARGUMENT and the same launch limit, the same
+ * asynchronous launch on `stream`, and the same pending-CUDA-error
+ * semantics. Nothing about the batch contract varies by format.
+ *
+ * The supported surface is the RAW Snappy stream - the varint-prefixed
+ * block google/snappy's Compress and Uncompress produce. The Snappy FRAMING
+ * format (stream identifier, framed chunks, masked CRC-32C) is not
+ * decoded here and no entry point decodes it, so a framed stream is a
+ * malformed raw one and is rejected as CUDEC_ERR_CORRUPT_INPUT rather than
+ * partially decoded.
+ *
+ * The declared uncompressed length that opens every raw stream is
+ * attacker-controlled and is never used to size anything: it is checked
+ * against that chunk's d_dst_capacities entry before an element is parsed,
+ * and a declaration above the capacity reports CUDEC_ERR_OUTPUT_TOO_SMALL.
+ * Every later overrun of the declared length reports
+ * CUDEC_ERR_CORRUPT_INPUT: once a stream has declared its own length, an
+ * element that runs past it is inconsistent rather than short of room, and
+ * a larger destination would not make it valid. */
+cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
+                                           const size_t* d_src_sizes,
+                                           void* const* d_dst_ptrs,
+                                           const size_t* d_dst_capacities,
+                                           size_t chunk_count,
+                                           cudec_chunk_result* d_results,
+                                           cudec_stream_t stream);
+
 /* Decode a single LZ4 frame (the .lz4 container: magic, frame descriptor,
  * data blocks, end mark, optional checksums) from host memory into host
  * memory, using the GPU batch decoder internally. Synchronous.

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -1,15 +1,23 @@
 #include "cudec.h"
-#include "lz4_decode.cuh"
+#include "chunk_decode.cuh"
+#include "lz4_block.h"
+#include "snappy_block.h"
 
 #include <cuda_runtime.h>
 
-cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
-                                        const size_t* d_src_sizes,
-                                        void* const* d_dst_ptrs,
-                                        const size_t* d_dst_capacities,
-                                        size_t chunk_count,
-                                        cudec_chunk_result* d_results,
-                                        cudec_stream_t stream) {
+namespace {
+
+/* The two entries differ in one template argument and in nothing else, so
+ * the body they share is written once. Templated rather than handed a
+ * function pointer: a launch through an indirect call would put the kernel
+ * address in device memory and cost the compiler the inlining the parser
+ * depends on. */
+template <class Parser>
+cudec_status submit_batch(const void* const* d_src_ptrs,
+                          const size_t* d_src_sizes, void* const* d_dst_ptrs,
+                          const size_t* d_dst_capacities, size_t chunk_count,
+                          cudec_chunk_result* d_results,
+                          cudec_stream_t stream) {
     const cudec_status valid = cudec_detail::validate_batch_args(
         d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
         d_results);
@@ -22,10 +30,36 @@ cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
      * call consumes the pending error state. */
     (void)cudaGetLastError();
 
-    cudec_detail::lz4_decode_batch<false>
+    cudec_detail::chunk_decode_batch<Parser, false>
         <<<cudec_detail::decode_grid_blocks(chunk_count),
            cudec_detail::kBlockThreads, 0, stream>>>(
             d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
             d_results);
     return cudaGetLastError() == cudaSuccess ? CUDEC_OK : CUDEC_ERR_CUDA;
+}
+
+}  // namespace
+
+cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
+                                        const size_t* d_src_sizes,
+                                        void* const* d_dst_ptrs,
+                                        const size_t* d_dst_capacities,
+                                        size_t chunk_count,
+                                        cudec_chunk_result* d_results,
+                                        cudec_stream_t stream) {
+    return submit_batch<cudec_detail::Lz4Parser>(
+        d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
+        d_results, stream);
+}
+
+cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
+                                           const size_t* d_src_sizes,
+                                           void* const* d_dst_ptrs,
+                                           const size_t* d_dst_capacities,
+                                           size_t chunk_count,
+                                           cudec_chunk_result* d_results,
+                                           cudec_stream_t stream) {
+    return submit_batch<cudec_detail::SnappyParser>(
+        d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
+        d_results, stream);
 }

--- a/src/chunk_decode.cuh
+++ b/src/chunk_decode.cuh
@@ -1,15 +1,51 @@
-/* The warp-per-chunk LZ4 decode kernel, templated on the copy mode so the
- * shipped decoder and the bench's parse-only ceiling share ONE parse (an
- * honest ceiling - masterplan section 9). The public entry (src/batch.cu)
- * instantiates Full; the bench instantiates ParseOnly. Each translation
- * unit emits only the instantiation it launches, so the shipped library
- * carries no parse-only kernel. Internal header, not part of the ABI. */
-#ifndef CUDEC_LZ4_DECODE_CUH
-#define CUDEC_LZ4_DECODE_CUH
+/* The warp-per-chunk chunk decoder: one kernel, templated on the format
+ * parser and on the copy mode. The parser is a template parameter rather
+ * than a hard-wired type because everything below it - the fuel cap, the
+ * two copy loops, the __syncwarp() placement, the geometry guards, the
+ * failure contract - is format-independent, and a second copy of it per
+ * format would be a second place for the fail-closed discipline to drift
+ * (masterplan section 10, "The seam"). src/batch.cu instantiates it once
+ * per format; the bench instantiates ParseOnly for its honest parse-only
+ * ceiling (masterplan section 9). Each translation unit emits only the
+ * instantiations it launches, so the shipped library carries no parse-only
+ * kernel. Internal header, not part of the ABI.
+ *
+ * What a Parser owes, and what this kernel is entitled to assume. The
+ * requirements are stated here because this is the code that breaks when
+ * one of them is not met:
+ *
+ *  - construction from the chunk's source pointer, source size and
+ *    destination capacity, and nothing else;
+ *  - one entry point, Next(DecodeSequence*, bool*), returning exactly three
+ *    outcomes: an element to execute and call again, the single success
+ *    exit with *done set, or a reject status;
+ *  - LIVENESS: every call that hands back a non-terminal element consumes
+ *    at least one source byte. The fuel bound below is derived from the
+ *    source size, so a parser that can return without advancing breaks
+ *    termination for the whole family, not only for its own format;
+ *  - LANE-UNIFORMITY: the parser reads source bytes and its own state and
+ *    nothing else. All 32 lanes run it redundantly in lockstep, and that is
+ *    sound only while every lane computes the same answer;
+ *  - ALL input validation inside the parser. The copy loops below perform
+ *    no input-derived bound check of their own, by design: a parser that
+ *    hands back an element it has not fully bounded has already failed
+ *    closed-ness and nothing here will catch it;
+ *  - a dst_pos member holding the bytes produced, read once on success;
+ *  - a reported match offset (match_dst - match_src) that is at least 1 and
+ *    below 2^32. The lower bound keeps the closed-form gather from a
+ *    modulo by zero; the upper one is what makes the 32-bit gather arm
+ *    lossless. Both hold structurally from the offset field's width in
+ *    every format on this seam, and neither is re-checked here.
+ *
+ * The parse is redundant across lanes rather than broadcast, and the
+ * element type is shared across formats rather than associated with each
+ * parser - both settled at the #85 design panel and not re-opened here. */
+#ifndef CUDEC_CHUNK_DECODE_CUH
+#define CUDEC_CHUNK_DECODE_CUH
 
 #include "batch_limits.h"
 #include "cudec.h"
-#include "lz4_block.h"
+#include "decode_sequence.h"
 
 #include <cuda_runtime.h>
 
@@ -26,11 +62,11 @@ constexpr unsigned kBlockThreads = kWarpSize * kBlockWarps;  /* 128 */
  * ordering at the two copy boundaries. ParseOnly elides the copies and the
  * syncs to isolate the parse cost - it writes no output and is a bench
  * ceiling only, never shipped. */
-template <bool ParseOnly>
+template <class Parser, bool ParseOnly>
 __global__ void __launch_bounds__(kBlockThreads)
-    lz4_decode_batch(const void* const* src_ptrs, const size_t* src_sizes,
-                     void* const* dst_ptrs, const size_t* dst_caps,
-                     size_t chunk_count, cudec_chunk_result* results) {
+    chunk_decode_batch(const void* const* src_ptrs, const size_t* src_sizes,
+                       void* const* dst_ptrs, const size_t* dst_caps,
+                       size_t chunk_count, cudec_chunk_result* results) {
     const unsigned lane = threadIdx.x % kWarpSize;
     const size_t warp_in_grid =
         (blockIdx.x * blockDim.x + threadIdx.x) / kWarpSize;
@@ -83,11 +119,12 @@ __global__ void __launch_bounds__(kBlockThreads)
         unsigned char* dst = static_cast<unsigned char*>(dst_ptrs[chunk]);
 
         const size_t src_size = src_sizes[chunk];
-        Lz4Parser parser{src, src_size, dst_caps[chunk]};
-        Lz4Sequence seq;
+        Parser parser{src, src_size, dst_caps[chunk]};
+        DecodeSequence seq;
         cudec_status status = CUDEC_OK;
         bool done = false;
-        /* Fuel: Next consumes at least the token byte, so a chunk of n
+        /* Fuel: the seam's liveness requirement says every non-terminal
+         * call consumes at least one source byte, so a chunk of n
          * source bytes admits at most n + 1 calls - a budget no input the
          * parser accepts or rejects can reach. The saturating form matters:
          * a plain n + 1 would wrap to 0 for a SIZE_MAX chunk size and cap a
@@ -114,8 +151,12 @@ __global__ void __launch_bounds__(kBlockThreads)
                      * sm_86 has no integer-divide hardware, so a modulo by
                      * a runtime divisor is a software sequence, and the
                      * 64-bit one costs roughly twice the 32-bit one - paid
-                     * once per match byte per lane. `offset` is the LZ4
-                     * 2-byte offset field and never exceeds 65535, but `i`
+                     * once per match byte per lane. `offset` comes out of a
+                     * format's offset FIELD, whose width bounds it below
+                     * 2^32 structurally rather than by a check on parsed
+                     * input - two bytes for LZ4, at most four for Snappy -
+                     * which is the seam requirement stated at the top of
+                     * this header, and it is why off32 loses nothing. `i`
                      * is bounded only by match_len, which the ABI's size_t
                      * capacities admit above 2^32, so the narrowing is
                      * sound only under the test. No field is narrowed and
@@ -202,4 +243,4 @@ inline cudec_status validate_batch_args(const void* const* d_src_ptrs,
 
 }  // namespace cudec_detail
 
-#endif /* CUDEC_LZ4_DECODE_CUH */
+#endif /* CUDEC_CHUNK_DECODE_CUH */

--- a/src/decode_sequence.h
+++ b/src/decode_sequence.h
@@ -1,0 +1,61 @@
+/* The one element vocabulary every byte-oriented format parser hands the
+ * chunk decoder (masterplan section 10, "The seam"). Internal header, not
+ * part of the ABI.
+ *
+ * There is exactly one of these on purpose. The copy engine in
+ * src/chunk_decode.cuh performs no input-derived bound check of its own -
+ * all validation lives in the parser - so what stands between a parser bug
+ * and an out-of-bounds write is that the engine has ONE contract a reviewer
+ * can hold in their head, not one per format. A per-parser element type
+ * was proposed at the #85 design panel and refused for that reason, and
+ * this header is that refusal executed rather than restated.
+ *
+ * Executing a sequence means: copy literals_len bytes
+ * src[literals_src..] -> dst[literals_dst..], then match_len bytes
+ * dst[match_src + (i mod offset)] -> dst[match_dst + i], where
+ * offset = match_dst - match_src and is at least 1 by every parser's
+ * offset-zero refusal. Either half may be empty, which is what lets one
+ * struct carry two formats' element shapes:
+ *
+ *   LZ4      a literal run followed by a match; both halves usually used,
+ *            match_len zero only on the literals-only tail.
+ *   Snappy   a literal OR a copy, never both: a literal fills the literals
+ *            half and leaves match_len zero, a copy fills the match half
+ *            and leaves literals_len zero.
+ *
+ * Absolute offsets, and 64-bit throughout. Snappy's declared length is a
+ * varint32 so its positions provably fit in 32 bits, but the caller's
+ * capacity is a size_t and mixing the two widths in a bound comparison is
+ * where an overflow would hide. Whether the DEVICE side should carry
+ * narrower copies is a measured kernel-shape question (issue #292), not a
+ * width to change here on a guess. */
+#ifndef CUDEC_DECODE_SEQUENCE_H
+#define CUDEC_DECODE_SEQUENCE_H
+
+#include <stdint.h>
+
+/* Defined here rather than in each format header, so a translation unit
+ * that decodes two formats cannot pick up two definitions that have quietly
+ * stopped being identical. */
+#ifndef CUDEC_HOST_DEVICE
+#if defined(__CUDACC__)
+#define CUDEC_HOST_DEVICE __host__ __device__
+#else
+#define CUDEC_HOST_DEVICE
+#endif
+#endif
+
+namespace cudec_detail {
+
+struct DecodeSequence {
+    uint64_t literals_src;
+    uint64_t literals_dst;
+    uint64_t literals_len;
+    uint64_t match_src;
+    uint64_t match_dst;
+    uint64_t match_len;
+};
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_DECODE_SEQUENCE_H */

--- a/src/lz4_block.h
+++ b/src/lz4_block.h
@@ -19,21 +19,9 @@
 #define CUDEC_LZ4_BLOCK_H
 
 #include "cudec.h"
+#include "decode_sequence.h"
 
 #include <stdint.h>
-
-/* Guarded: src/snappy_block.h defines the same macro for the same reason,
- * and a device translation unit that decodes both formats includes both
- * headers. The definitions are identical, so an unguarded second one is
- * legal rather than an error - which is exactly why it would go unnoticed
- * if they ever stopped being identical. */
-#ifndef CUDEC_HOST_DEVICE
-#if defined(__CUDACC__)
-#define CUDEC_HOST_DEVICE __host__ __device__
-#else
-#define CUDEC_HOST_DEVICE
-#endif
-#endif
 
 namespace cudec_detail {
 
@@ -58,21 +46,6 @@ constexpr unsigned kLz4TokenLiteralShift = 4;
  * up to iend instead would ACCEPT streams liblz4 rejects (fail-open). */
 constexpr uint64_t kLz4LiteralReadMargin = kLz4RunMask;         /* 15 */
 constexpr uint64_t kLz4MatchReadMargin = kLz4LastLiterals - 1;  /* 4 */
-
-/* One parsed sequence, in absolute offsets. The literals live in src;
- * the match gathers from the already-written region of dst (match_len is
- * zero only for the literals-only tail). Executing a sequence means:
- * copy literals_len bytes src[literals_src..] -> dst[literals_dst..],
- * then match_len bytes dst[match_src + (i mod offset)] -> dst[match_dst + i]
- * (equivalently a sequential chasing copy; offset = match_dst - match_src). */
-struct Lz4Sequence {
-    uint64_t literals_src;
-    uint64_t literals_dst;
-    uint64_t literals_len;
-    uint64_t match_src;
-    uint64_t match_dst;
-    uint64_t match_len;
-};
 
 struct Lz4Parser {
     const unsigned char* src;
@@ -136,7 +109,7 @@ struct Lz4Parser {
      * over truncated, mutated, and crafted streams in
      * tests/termination.cpp, and backed by a fuel cap in every driver
      * loop so a regression rejects rather than hangs. */
-    CUDEC_HOST_DEVICE cudec_status Next(Lz4Sequence* sequence, bool* done) {
+    CUDEC_HOST_DEVICE cudec_status Next(DecodeSequence* sequence, bool* done) {
         *done = false;
         if (src_pos >= src_size) {
             return CUDEC_ERR_CORRUPT_INPUT; /* a token must exist */

--- a/src/snappy_block.h
+++ b/src/snappy_block.h
@@ -15,19 +15,21 @@
  * `decompressor->eof() && writer->CheckLength()` enforces on both ends.
  *
  * Two differences from LZ4 shape the code. An element is a literal OR a
- * copy rather than a literal run followed by a match, so SnappyElement
- * carries one range and a kind. And a length never continues across an
+ * copy rather than a literal run followed by a match, so exactly one half
+ * of the shared DecodeSequence is filled and the other is left empty - the
+ * copy engine runs both halves either way and needs no kind flag to branch
+ * on (src/decode_sequence.h). And a length never continues across an
  * unbounded chain of extension bytes: an element's header is the tag plus
  * at most four trailing bytes, which is snappy's kMaximumTagLength, so the
  * per-element termination argument needs no fuel counter.
  *
- * Widths, for the kernel that will consume this: the declared length is a
+ * Widths, for the kernel that consumes this: the declared length is a
  * varint32, so every output position, every copy offset and every element
- * length provably fits in 32 bits. The fields below are 64-bit anyway,
- * because the caller's capacity is a size_t and mixing the two widths in
- * the bound comparisons is where an overflow would hide. Whether the
- * DEVICE side should carry 32-bit copies of them is a kernel-shape question
- * and is not settled here.
+ * length provably fits in 32 bits. The shared element's fields are 64-bit
+ * anyway, because the caller's capacity is a size_t and mixing the two
+ * widths in the bound comparisons is where an overflow would hide. Whether
+ * the DEVICE side should carry 32-bit copies of them is a measured
+ * kernel-shape question (issue #292) and is not settled here.
  *
  * Edge semantics are settled empirically by oracle parity - whenever
  * snappy rejects, this parser must reject (tests/snappy_parser_twin.cpp).
@@ -37,21 +39,9 @@
 #define CUDEC_SNAPPY_BLOCK_H
 
 #include "cudec.h"
+#include "decode_sequence.h"
 
 #include <stdint.h>
-
-/* Guarded: src/lz4_block.h defines the same macro for the same reason, and
- * a device translation unit that decodes both formats includes both
- * headers. The definitions are identical, so an unguarded second one is
- * legal rather than an error - which is exactly why it would go unnoticed
- * if they ever stopped being identical. */
-#ifndef CUDEC_HOST_DEVICE
-#if defined(__CUDACC__)
-#define CUDEC_HOST_DEVICE __host__ __device__
-#else
-#define CUDEC_HOST_DEVICE
-#endif
-#endif
 
 namespace cudec_detail {
 
@@ -145,36 +135,33 @@ CUDEC_HOST_DEVICE inline cudec_status SnappyRefuse(SnappyReject branch,
     return status;
 }
 
-/* One parsed element, in absolute offsets.
+/* An element is reported in the shared vocabulary of
+ * src/decode_sequence.h, which the chunk decoder's copy engine is the sole
+ * consumer of. Snappy's element is a literal OR a copy, never both, so
+ * exactly one of the two halves is non-empty and the other has length zero.
  *
- * A LITERAL (is_copy false) copies `length` bytes from src[from ..
- * from+length) to dst[to .. to+length). `from` indexes the source stream
- * and `to` the destination; they count in different buffers and no
- * inequality relates them.
+ * A LITERAL fills the literals half: literals_len bytes from
+ * src[literals_src ..) to dst[literals_dst ..). The two positions index
+ * different buffers and no inequality relates them. match_len is zero.
  *
- * A COPY (is_copy true) replicates `length` bytes inside dst, reading from
- * dst[from ..]. The read may run into bytes this element is itself writing,
- * which is the pattern-repeating semantics an overlapping Snappy copy has,
- * so a caller executing it sequentially must copy byte by byte in
- * increasing order (offset = to - from, and a warp gather reduces by that
- * offset). `from < to` always holds: an offset of zero is refused.
+ * A COPY fills the match half: match_len bytes replicated inside dst,
+ * reading from dst[match_src ..). The read may run into bytes this element
+ * is itself writing, which is the pattern-repeating semantics an
+ * overlapping Snappy copy has, so a sequential executor must copy byte by
+ * byte in increasing order and a warp gather reduces by
+ * offset = match_dst - match_src. match_src < match_dst always holds: an
+ * offset of zero is refused. literals_len is zero.
  *
- * The TERMINAL element, the one handed back with *done set, is a literal of
- * length 0 with `from` 0 and `to` equal to the declared length. Executing
- * it copies nothing. It is spelled out rather than left undefined because
- * a caller that executes unconditionally before testing *done reads all
- * four fields.
+ * The TERMINAL element, the one handed back with *done set, has both
+ * lengths zero and every position zero. Executing it copies nothing. It is
+ * spelled out rather than left undefined because a caller that executes
+ * unconditionally before testing *done reads every field.
  *
- * What the parser has already proved when it hands one back: for a literal,
- * from + length <= the source size; for a copy, from < to and
- * to + length <= the declared output length; and in both cases
- * to + length <= the declared length <= the caller's capacity. */
-struct SnappyElement {
-    uint64_t from;
-    uint64_t to;
-    uint64_t length;
-    bool is_copy;
-};
+ * What the parser has already proved when it hands one back: for a
+ * literal, literals_src + literals_len <= the source size; for a copy,
+ * match_src < match_dst and match_dst + match_len <= the declared output
+ * length; and in both cases the write end is at or below the declared
+ * length, which is itself at or below the caller's capacity. */
 
 /* The preamble alone, for a caller that must BOUND its destination before
  * any element exists - the batch entry point checks the declared length
@@ -285,7 +272,7 @@ struct SnappyParser {
      * offset bytes - and each is a counted for whose trip count is bounded
      * by a compile-time maximum of five, four and four; the tag selects a
      * value inside that bound and cannot raise it. */
-    CUDEC_HOST_DEVICE cudec_status Next(SnappyElement* element, bool* done) {
+    CUDEC_HOST_DEVICE cudec_status Next(DecodeSequence* element, bool* done) {
         *done = false;
         if (finished) {
             /* Called past the terminal element. */
@@ -308,10 +295,7 @@ struct SnappyParser {
                 return SnappyRefuse(kSnappyRejectUnderProduction,
                                     CUDEC_ERR_CORRUPT_INPUT, &reject);
             }
-            element->from = 0;
-            element->to = dst_pos;
-            element->length = 0;
-            element->is_copy = false;
+            *element = DecodeSequence{};
             finished = true;
             *done = true;
             return CUDEC_OK;
@@ -367,10 +351,10 @@ struct SnappyParser {
                 return SnappyRefuse(kSnappyRejectLiteralOverProduction,
                                     CUDEC_ERR_CORRUPT_INPUT, &reject);
             }
-            element->from = src_pos;
-            element->to = dst_pos;
-            element->length = length;
-            element->is_copy = false;
+            *element = DecodeSequence{};
+            element->literals_src = src_pos;
+            element->literals_dst = dst_pos;
+            element->literals_len = length;
             src_pos += length;
             dst_pos += length;
             return CUDEC_OK;
@@ -426,10 +410,10 @@ struct SnappyParser {
             return SnappyRefuse(kSnappyRejectCopyOverProduction,
                                 CUDEC_ERR_CORRUPT_INPUT, &reject);
         }
-        element->from = dst_pos - offset;
-        element->to = dst_pos;
-        element->length = length;
-        element->is_copy = true;
+        *element = DecodeSequence{};
+        element->match_src = dst_pos - offset;
+        element->match_dst = dst_pos;
+        element->match_len = length;
         dst_pos += length;
         return CUDEC_OK;
     }

--- a/src/zstd_exec.h
+++ b/src/zstd_exec.h
@@ -46,7 +46,7 @@
  * increasing order - the same semantics src/lz4_block.h and src/snappy_block.h
  * carry, and the run-fill an offset of one produces is the extreme case. The
  * device form of the same statement is the closed-form modular gather
- * src/lz4_decode.cuh already uses, dst[to + i] = dst[to - offset + (i mod
+ * src/chunk_decode.cuh already uses, dst[to + i] = dst[to - offset + (i mod
  * offset)], which is defined for every i because an offset of zero is refused
  * below. A vector copy of the range would produce different bytes, not a
  * faster version of the same ones.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -418,6 +418,16 @@ set_tests_properties(launch_fail PROPERTIES ENVIRONMENT
 cudec_add_test(smoke SOURCES smoke.cu GPU)
 cudec_add_test(gpu_fixture SOURCES gpu_fixture.cu LIBS cudec_test_fixtures
                GPU)
+# The vendored corpus the Snappy half of that test decodes, handed in as a
+# path for the same reason snappy_upstream_negatives gets one: the archive's
+# URL_HASH already proves those bytes, and copying them here would restate it
+# in eleven binary blobs. Guarded like the other GPU follow-ups, because the
+# host-only sanitizer build does not create the target.
+if(TARGET gpu_fixture)
+  target_compile_definitions(
+    gpu_fixture
+    PRIVATE CUDEC_SNAPPY_TESTDATA_DIR="${CUDEC_SNAPPY_SOURCE_DIR}/testdata")
+endif()
 cudec_add_test(frame_twin SOURCES frame_twin.cu LIBS lz4_frame_oracle GPU)
 # frame_twin verifies the library's own xxhash32.h against liblz4's XXH32.
 # Guarded: the host-only sanitizer build (issue #42) skips the GPU targets, so
@@ -584,6 +594,38 @@ foreach(_tu frame.cpp stream.cpp)
   endforeach()
 endforeach()
 
+# Single-source lock for the shared decode element (issue #150): the one
+# struct every format parser hands the chunk decoder lives once, in
+# src/decode_sequence.h, and the format headers and the kernel reach for it
+# there rather than restating it. The copy engine performs no input-derived
+# bound check of its own, so the element's contract is the whole of what
+# stands between a parser bug and an out-of-bounds write - and a second
+# definition under the same name is that one contract quietly forking into
+# two. Honest limit, as with the locks above: a re-copy under a fresh name is
+# out of reach of a text scan and is what review is for.
+set(_sequence_header ${CMAKE_CURRENT_SOURCE_DIR}/../src/decode_sequence.h)
+if(NOT EXISTS ${_sequence_header})
+  message(FATAL_ERROR "src/decode_sequence.h is missing: the shared decode "
+                      "element must be single-sourced there (issue #150)")
+endif()
+file(READ ${_sequence_header} _sequence_src)
+if(NOT _sequence_src MATCHES "struct DecodeSequence")
+  message(FATAL_ERROR "src/decode_sequence.h no longer defines 'struct "
+                      "DecodeSequence' (issue #150)")
+endif()
+foreach(_tu lz4_block.h snappy_block.h chunk_decode.cuh)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_tu} _tu_src)
+  if(NOT _tu_src MATCHES "#include \"decode_sequence.h\"")
+    message(FATAL_ERROR "src/${_tu} no longer includes decode_sequence.h: the "
+                        "decode element is single-sourced there (issue #150)")
+  endif()
+  if(_tu_src MATCHES "struct DecodeSequence[ \t]*[{:]")
+    message(FATAL_ERROR "src/${_tu} defines a local 'struct DecodeSequence': "
+                        "the decode element is single-sourced in "
+                        "decode_sequence.h (issue #150)")
+  endif()
+endforeach()
+
 # Single-source lock for the batch launch limit (issue #39): the bound both
 # decode entry points enforce lives once, in src/batch_limits.h, and the two
 # callers read it from there. It used to be written twice and held in agreement
@@ -606,7 +648,7 @@ if(NOT _limits_src MATCHES "kMaxBatchChunks")
   message(FATAL_ERROR "src/batch_limits.h no longer defines kMaxBatchChunks "
                       "(issue #39)")
 endif()
-foreach(_tu lz4_decode.cuh stream.cpp)
+foreach(_tu chunk_decode.cuh stream.cpp)
   file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_tu} _tu_src)
   if(NOT _tu_src MATCHES "#include \"batch_limits.h\"")
     message(FATAL_ERROR "src/${_tu} no longer includes batch_limits.h: the "
@@ -837,7 +879,7 @@ function(cudec_check_snappy_locks src_dir out_violations)
   # exact, because the stripping replaces comment text in place instead of
   # dropping lines.
   cudec_code_lines(${_header} _header_lines)
-  foreach(_type SnappyParser SnappyElement)
+  foreach(_type SnappyParser)
     set(_defines FALSE)
     foreach(_line IN LISTS _header_lines)
       if(_line MATCHES "struct ${_type}")
@@ -864,7 +906,7 @@ function(cudec_check_snappy_locks src_dir out_violations)
     set(_names_parser FALSE)
     set(_includes_header FALSE)
     foreach(_line IN LISTS _source_lines)
-      foreach(_type SnappyParser SnappyElement)
+      foreach(_type SnappyParser)
         if(_line MATCHES "struct ${_type}[ \t]*[{:]")
           string(APPEND _violations
                  "  ${_source} defines a local 'struct ${_type}': the Snappy "
@@ -872,7 +914,7 @@ function(cudec_check_snappy_locks src_dir out_violations)
                  "(issue #173)\n")
         endif()
       endforeach()
-      if(_line MATCHES "SnappyParser|SnappyElement|SnappyDeclaredLength")
+      if(_line MATCHES "SnappyParser|SnappyDeclaredLength")
         set(_names_parser TRUE)
       endif()
       if(_line MATCHES "#include[ \t]+\"snappy_block.h\"")
@@ -984,7 +1026,7 @@ file(REMOVE_RECURSE ${_snappy_probe_root})
 # from it with string(REPLACE) and a list would come back joined on
 # semicolons - which is a stray separator written into a C header.
 #
-# The head is 21 lines, so an injected rung starts at line 22, which is the
+# The head is 18 lines, so an injected rung starts at line 19, which is the
 # number the two line-scoped rules are asserted on below.
 set(_probe_header_head "#ifndef PROBE_SNAPPY_H
 #define PROBE_SNAPPY_H
@@ -1000,9 +1042,6 @@ inline cudec_status SnappyRefuse(SnappyReject branch,
                                  SnappyReject* out) {
     return status;
 }
-struct SnappyElement {
-    uint64_t from;
-};
 struct SnappyParser {
     SnappyReject reject;
     cudec_status Next(bool first) {
@@ -1108,13 +1147,13 @@ set(_snappy_lock_probes
     "no_parser|no longer defines 'struct SnappyParser'"
     "local_copy|kernel.cu defines a local 'struct SnappyParser'"
     "no_include|kernel.cu names the Snappy parser without including"
-    "bare_return|snappy_block.h:22: refuses without going through SnappyRefuse"
-    "wrapped_refuse|snappy_block.h:22: a SnappyRefuse call with no ladder branch"
+    "bare_return|snappy_block.h:19: refuses without going through SnappyRefuse"
+    "wrapped_refuse|snappy_block.h:19: a SnappyRefuse call with no ladder branch"
     "branch_unused|ladder branch 'kSnappyRejectGamma' is declared and no refusal"
     "site_undeclared|a refusal site names 'kSnappyRejectGamma', which"
     "branch_shared|ladder branch 'kSnappyRejectAlpha' is named by 2 refusal"
     "no_enum|declares no reject ladder"
-    "bracket_above|snappy_block.h:23: refuses without going through")
+    "bracket_above|snappy_block.h:20: refuses without going through")
 foreach(_entry IN LISTS _snappy_lock_probes)
   string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")
   string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\2" _expected "${_entry}")
@@ -1754,7 +1793,7 @@ file(WRITE ${_probe_dir}/scan_bitstream_field.cu
      "__device__ int probe(int v, unsigned offset) {\n"
      "    return __shfl_sync(0xFFFFFFFFu, v, offset);\n" "}\n")
 file(WRITE ${_probe_dir}/scan_sequence_field.cu
-     "__device__ int probe(int v, Lz4Sequence seq) {\n"
+     "__device__ int probe(int v, DecodeSequence seq) {\n"
      "    return __shfl_sync(0xFFFFFFFFu, v, seq.lane);\n" "}\n")
 file(WRITE ${_probe_dir}/scan_wrapped_collective.cu
      "__device__ int probe(int v, unsigned mask_from_token) {\n"
@@ -1832,7 +1871,7 @@ file(WRITE ${_probe_dir}/scan_for_unbalanced_eof.cu
 # The wrap AFTER the mask: the mask itself is valid, so only a balance-based
 # wrapped-collective rule catches this one.
 file(WRITE ${_probe_dir}/scan_wrapped_after_mask.cu
-     "__device__ int probe(int v, Lz4Sequence seq) {\n"
+     "__device__ int probe(int v, DecodeSequence seq) {\n"
      "    return __shfl_sync(0xFFFFFFFFu, v,\n"
      "                       seq.match_len % 32);\n" "}\n")
 # The two halves of the macro case, and they are one pair rather than two
@@ -1899,7 +1938,7 @@ file(WRITE ${_probe_dir}/scan_continuation_at_eof.cu
 # report's own text is what the probe asserts and the alternation cannot go
 # half-dead, plus the two silent shapes the rule exists to permit: the width
 # arriving as the template parameter, and the one line that binds the digits to
-# a name - which is the shape src/lz4_decode.cuh has carried since M1.
+# a name - which is the shape src/chunk_decode.cuh has carried since M1.
 file(WRITE ${_probe_dir}/scan_width_literal_32.cu
      "template <int WaveSize>
 "

--- a/tests/determinism_gpu.cu
+++ b/tests/determinism_gpu.cu
@@ -16,7 +16,8 @@
  * knobs. */
 #include "cudec.h"
 #include "fixtures.h"
-#include "lz4_decode.cuh"
+#include "chunk_decode.cuh"
+#include "lz4_block.h"
 #include "require.h"
 
 #include <cuda_runtime.h>
@@ -176,8 +177,9 @@ int RunDirect(const Batch& b, const Geometry& g) {
     REQUIRE(ResetDeviceState(b) == 0);
     cudaStream_t stream;
     REQUIRE_CUDA(cudaStreamCreate(&stream));
-    cudec_detail::lz4_decode_batch<false><<<g.blocks, g.threads, 0, stream>>>(
-        b.d_srcs, b.d_sizes, b.d_dsts, b.d_caps, b.n, b.d_results);
+    cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, false>
+        <<<g.blocks, g.threads, 0, stream>>>(b.d_srcs, b.d_sizes, b.d_dsts,
+                                             b.d_caps, b.n, b.d_results);
     REQUIRE_CUDA(cudaGetLastError());
     REQUIRE_CUDA(cudaStreamSynchronize(stream));
     REQUIRE_CUDA(cudaStreamDestroy(stream));

--- a/tests/gpu_fixture.cu
+++ b/tests/gpu_fixture.cu
@@ -5,7 +5,14 @@
  * contract as the CPU twin (where cudec accepts, liblz4 accepts and the
  * bytes match; where liblz4 rejects, cudec rejects), with the documented
  * offset==0 stricter case allowed. On success the decoder writes exactly
- * bytes_written, so the poison beyond it must survive. */
+ * bytes_written, so the poison beyond it must survive.
+ *
+ * Both formats run through here, and the same plumbing drives both on
+ * purpose (issue #150): the two entry points differ in one template
+ * argument to one chunk decoder, so a difference this test could see would
+ * be a difference in the parser and nowhere else. The Snappy half is the
+ * pristine direction only - the mutant reject parity and the determinism
+ * gate for that format are the device gate set (#154). */
 #include "cudec.h"
 #include "fixtures.h"
 #include "require.h"
@@ -13,8 +20,13 @@
 #include <cuda_runtime.h>
 
 #include <cstdio>
+#include <fstream>
 #include <string>
 #include <vector>
+
+#ifndef CUDEC_SNAPPY_TESTDATA_DIR
+#error "CUDEC_SNAPPY_TESTDATA_DIR must name the pinned archive's testdata/"
+#endif
 
 namespace {
 
@@ -55,10 +67,17 @@ int UploadBatchTables(size_t n, const std::vector<const void*>& h_srcs,
     return 0;
 }
 
+/* The shape both public batch entries have. Taken as a parameter rather
+ * than branched on, so the plumbing below cannot treat one format
+ * differently from the other by accident. */
+using BatchEntry = cudec_status (*)(const void* const*, const size_t*,
+                                    void* const*, const size_t*, size_t,
+                                    cudec_chunk_result*, cudec_stream_t);
+
 /* Uploads a batch, runs it through the entry point on a created stream,
  * and returns the per-chunk results plus the downloaded (poisoned)
  * destination buffers. Plain int-returning so REQUIRE can early-abort. */
-int RunBatch(const std::vector<Chunk>& chunks,
+int RunBatch(const std::vector<Chunk>& chunks, BatchEntry entry,
              std::vector<cudec_chunk_result>* results,
              std::vector<std::vector<unsigned char>>* dst_bytes) {
     const size_t n = chunks.size();
@@ -93,8 +112,8 @@ int RunBatch(const std::vector<Chunk>& chunks,
 
     cudaStream_t stream;
     REQUIRE_CUDA(cudaStreamCreate(&stream));
-    REQUIRE(cudec_lz4_decompress_batch(d_srcs, d_sizes, d_dsts, d_caps, n,
-                                       d_results, stream) == CUDEC_OK);
+    REQUIRE(entry(d_srcs, d_sizes, d_dsts, d_caps, n, d_results, stream) ==
+            CUDEC_OK);
     REQUIRE_CUDA(cudaStreamSynchronize(stream));
     REQUIRE_CUDA(cudaStreamDestroy(stream));
 
@@ -130,6 +149,17 @@ int CheckDecodedOk(const char* ctx, const cudec_chunk_result& result,
     return 0;
 }
 
+/* One file out of the pinned snappy archive's testdata/, read whole. The
+ * bytes are proved by the archive's URL_HASH, so nothing is copied into
+ * this tree; a missing or unreadable file is an infrastructure failure and
+ * the caller reds on the empty result rather than skipping the entry. */
+std::vector<unsigned char> ReadTestdata(const char* name) {
+    const std::string path = std::string(CUDEC_SNAPPY_TESTDATA_DIR) + "/" + name;
+    std::ifstream in(path.c_str(), std::ios::binary);
+    return std::vector<unsigned char>(std::istreambuf_iterator<char>(in),
+                                      std::istreambuf_iterator<char>());
+}
+
 }  // namespace
 
 int main() {
@@ -152,7 +182,8 @@ int main() {
     }
     std::vector<cudec_chunk_result> results;
     std::vector<std::vector<unsigned char>> dsts;
-    REQUIRE(RunBatch(pairs, &results, &dsts) == 0);
+    REQUIRE(RunBatch(pairs, cudec_lz4_decompress_batch, &results, &dsts) ==
+            0);
     for (size_t i = 0; i < fixtures.size(); i++) {
         REQUIRE(CheckDecodedOk(pairs[i].context.c_str(), results[i],
                                fixtures[i].original, dsts[i]) == 0);
@@ -185,7 +216,8 @@ int main() {
         mutant_chunks.push_back(Chunk{mutant_contexts[i], &mutant_streams[i],
                                       mutant_capacities[i]});
     }
-    REQUIRE(RunBatch(mutant_chunks, &results, &dsts) == 0);
+    REQUIRE(RunBatch(mutant_chunks, cudec_lz4_decompress_batch, &results,
+                     &dsts) == 0);
     size_t rejected_count = 0;
     size_t stricter_count = 0;
     std::string stricter_ctx;
@@ -259,11 +291,74 @@ int main() {
         }
     }
 
-    std::printf("PASS: %zu pairs decoded byte-exact + %zu mutants in oracle "
-                "parity (%zu oracle-rejected, %zu offset==0 stricter) + 40000 "
-                "grid-stride wraparound chunks on the GPU decoder; failure "
-                "contract and poison beyond bytes_written intact\n",
+    /* Batch 4: the generated Snappy corpus through the Snappy
+     * instantiation of the same chunk decoder, at the same slack capacity,
+     * so the exactly-bytes_written guarantee is exercised on this format's
+     * primary success path too. A wider capacity cannot make a valid raw
+     * stream decode differently: the declaration is compared against it and
+     * every later bound is taken from the declaration. */
+    const auto snappy = MakeSnappyFixtures();
+    REQUIRE(!snappy.empty());
+    std::vector<Chunk> snappy_pairs;
+    for (const auto& f : snappy) {
+        snappy_pairs.push_back(
+            Chunk{f.name, &f.compressed, f.original.size() + 8});
+    }
+    REQUIRE(RunBatch(snappy_pairs, cudec_snappy_decompress_batch, &results,
+                     &dsts) == 0);
+    for (size_t i = 0; i < snappy.size(); i++) {
+        REQUIRE(CheckDecodedOk(snappy_pairs[i].context.c_str(), results[i],
+                               snappy[i].original, dsts[i]) == 0);
+    }
+
+    /* Batch 5: the whole vendored corpus, compressed by the oracle and
+     * decoded on the device, at exact capacity. The generated fixtures
+     * above are built against the format's own boundaries and are small;
+     * these are real inputs of a size where a page of literals, the 64-byte
+     * copy cap and the compressor's 65536-byte block split all occur many
+     * times over, which is the only place a lane-fan-out defect that
+     * survives a short stream would show. Named one by one rather than
+     * globbed: a directory that quietly lost a file would otherwise shrink
+     * this batch and still pass. The three baddata*.snappy entries are not
+     * here - they are already decoded streams and are the negative corpus
+     * of tests/snappy_upstream_negatives.cpp. */
+    static const char* const kTestdata[] = {
+        "alice29.txt", "asyoulik.txt",   "fireworks.jpeg", "geo.protodata",
+        "html",        "html_x_4",       "kppkn.gtb",      "lcet10.txt",
+        "paper-100k.pdf", "plrabn12.txt", "urls.10K"};
+    constexpr size_t kTestdataCount = sizeof(kTestdata) / sizeof(*kTestdata);
+    std::vector<std::vector<unsigned char>> corpus_original(kTestdataCount);
+    std::vector<std::vector<unsigned char>> corpus_compressed(kTestdataCount);
+    std::vector<std::string> corpus_names(kTestdataCount);
+    size_t corpus_bytes = 0;
+    for (size_t i = 0; i < kTestdataCount; i++) {
+        corpus_original[i] = ReadTestdata(kTestdata[i]);
+        REQUIRE_CTX(!corpus_original[i].empty(), "testdata %s unreadable",
+                    kTestdata[i]);
+        corpus_compressed[i] = SnappyCompressBlock(corpus_original[i]);
+        corpus_names[i] = std::string("testdata/") + kTestdata[i];
+        corpus_bytes += corpus_original[i].size();
+    }
+    std::vector<Chunk> corpus_chunks;
+    for (size_t i = 0; i < kTestdataCount; i++) {
+        corpus_chunks.push_back(Chunk{corpus_names[i], &corpus_compressed[i],
+                                      corpus_original[i].size()});
+    }
+    REQUIRE(RunBatch(corpus_chunks, cudec_snappy_decompress_batch, &results,
+                     &dsts) == 0);
+    for (size_t i = 0; i < kTestdataCount; i++) {
+        REQUIRE(CheckDecodedOk(corpus_names[i].c_str(), results[i],
+                               corpus_original[i], dsts[i]) == 0);
+    }
+
+    std::printf("PASS: %zu LZ4 pairs decoded byte-exact + %zu mutants in "
+                "oracle parity (%zu oracle-rejected, %zu offset==0 stricter) + "
+                "40000 grid-stride wraparound chunks + %zu Snappy pairs + %zu "
+                "vendored testdata files (%zu bytes) decoded byte-exact on the "
+                "GPU decoder; failure contract and poison beyond "
+                "bytes_written intact\n",
                 pairs.size(), mutant_chunks.size(), rejected_count,
-                stricter_count);
+                stricter_count, snappy_pairs.size(), kTestdataCount,
+                corpus_bytes);
     return 0;
 }

--- a/tests/huge_match_gpu.cu
+++ b/tests/huge_match_gpu.cu
@@ -1,6 +1,6 @@
 /* The match longer than 2^32, decoded on the device (issue #331).
  *
- * src/lz4_decode.cuh runs the closed-form overlap gather at two arithmetic
+ * src/chunk_decode.cuh runs the closed-form overlap gather at two arithmetic
  * widths and picks the 32-bit one under `seq.match_len <= UINT32_MAX`. Every
  * other test in the tree stays far below that bound, so deleting the test and
  * leaving the narrow arm unconditional left the whole suite green - a guard

--- a/tests/lz4_twin.h
+++ b/tests/lz4_twin.h
@@ -52,7 +52,7 @@ inline Lz4TwinResult Lz4TwinDecode(const unsigned char* stream,
     }
 
     cudec_detail::Lz4Parser parser{tight.get(), stream_size, capacity};
-    cudec_detail::Lz4Sequence sequence;
+    cudec_detail::DecodeSequence sequence;
     bool done = false;
     while (true) {
         const cudec_status status = parser.Next(&sequence, &done);

--- a/tests/parser_twin.cpp
+++ b/tests/parser_twin.cpp
@@ -427,7 +427,7 @@ int main() {
         const auto& f = fixtures.back();
         cudec_detail::Lz4Parser parser{f.compressed.data(),
                                        f.compressed.size(), SIZE_MAX};
-        cudec_detail::Lz4Sequence seq;
+        cudec_detail::DecodeSequence seq;
         bool done = false;
         while (true) {
             const cudec_status status = parser.Next(&seq, &done);

--- a/tests/snappy_block_device.cu
+++ b/tests/snappy_block_device.cu
@@ -58,7 +58,7 @@ CUDEC_HOST_DEVICE inline void RunParser(const unsigned char* src,
                                         unsigned long long capacity,
                                         Trace* trace) {
     cudec_detail::SnappyParser parser{src, src_size, capacity};
-    cudec_detail::SnappyElement element;
+    cudec_detail::DecodeSequence element;
     bool done = false;
     unsigned long long digest = 14695981039346656037ull;
     unsigned long long elements = 0;
@@ -77,10 +77,12 @@ CUDEC_HOST_DEVICE inline void RunParser(const unsigned char* src,
         if (status != CUDEC_OK) {
             break;
         }
-        digest = Mix(digest, element.from);
-        digest = Mix(digest, element.to);
-        digest = Mix(digest, element.length);
-        digest = Mix(digest, element.is_copy ? 1u : 0u);
+        digest = Mix(digest, element.literals_src);
+        digest = Mix(digest, element.literals_dst);
+        digest = Mix(digest, element.literals_len);
+        digest = Mix(digest, element.match_src);
+        digest = Mix(digest, element.match_dst);
+        digest = Mix(digest, element.match_len);
         elements++;
         if (done) {
             break;

--- a/tests/snappy_edge_sweep.cpp
+++ b/tests/snappy_edge_sweep.cpp
@@ -135,7 +135,7 @@ cudec_status TwinDecode(const Bytes& stream, Bytes* out) {
         return header;
     }
     out->assign(static_cast<size_t>(parser.declared), 0);
-    cudec_detail::SnappyElement element;
+    cudec_detail::DecodeSequence element;
     bool done = false;
     uint64_t fuel = static_cast<uint64_t>(stream_size) + 2;
     while (true) {
@@ -155,10 +155,10 @@ cudec_status TwinDecode(const Bytes& stream, Bytes* out) {
         const bool bounded =
             parser.src_pos <= parser.src_size &&
             parser.dst_pos <= parser.declared &&
-            element.to + element.length <= parser.dst_pos &&
-            (element.is_copy
-                 ? element.from < element.to
-                 : element.from + element.length <= parser.src_pos);
+            element.literals_dst + element.literals_len <= parser.dst_pos &&
+            element.literals_src + element.literals_len <= parser.src_pos &&
+            element.match_dst + element.match_len <= parser.dst_pos &&
+            (element.match_len == 0 || element.match_src < element.match_dst);
         if (!bounded) {
             std::fprintf(stderr, "the parser left its bounds on a %zu-byte "
                                  "stream\n",
@@ -167,11 +167,13 @@ cudec_status TwinDecode(const Bytes& stream, Bytes* out) {
             out->clear();
             return CUDEC_ERR_CORRUPT_INPUT;
         }
-        for (uint64_t i = 0; i < element.length; i++) {
-            const size_t to = static_cast<size_t>(element.to + i);
-            (*out)[to] = element.is_copy
-                             ? (*out)[static_cast<size_t>(element.from + i)]
-                             : tight[static_cast<size_t>(element.from + i)];
+        for (uint64_t i = 0; i < element.literals_len; i++) {
+            (*out)[static_cast<size_t>(element.literals_dst + i)] =
+                tight[static_cast<size_t>(element.literals_src + i)];
+        }
+        for (uint64_t i = 0; i < element.match_len; i++) {
+            (*out)[static_cast<size_t>(element.match_dst + i)] =
+                (*out)[static_cast<size_t>(element.match_src + i)];
         }
         if (done) {
             break;

--- a/tests/snappy_parser_twin.cpp
+++ b/tests/snappy_parser_twin.cpp
@@ -101,7 +101,7 @@ bool LivenessHolds(const Bytes& stream, const char** why) {
     }
     cudec_detail::SnappyParser parser{tight.get(), stream_size,
                                       kSnappyOracleMaxOutput};
-    cudec_detail::SnappyElement element;
+    cudec_detail::DecodeSequence element;
     bool done = false;
     uint64_t fuel = static_cast<uint64_t>(stream_size) + 2;
     while (true) {
@@ -656,7 +656,7 @@ int main() {
         Bytes valid = Preamble(4);
         Append(&valid, Literal(Ascii("abcd")));
         cudec_detail::SnappyParser parser{valid.data(), valid.size(), 4};
-        cudec_detail::SnappyElement element;
+        cudec_detail::DecodeSequence element;
         bool done = false;
         uint64_t fuel = valid.size() + 2;
         while (!done) {

--- a/tests/snappy_twin.h
+++ b/tests/snappy_twin.h
@@ -62,7 +62,7 @@ inline cudec_status SnappyTwinDrive(const unsigned char* src,
                                     SnappyTwinObserver* observer) {
     out->assign(static_cast<size_t>(capacity), 0);
     cudec_detail::SnappyParser parser{src, src_size, capacity};
-    cudec_detail::SnappyElement element;
+    cudec_detail::DecodeSequence element;
     bool done = false;
     uint64_t fuel = src_size + 2;
     while (true) {
@@ -92,37 +92,39 @@ inline cudec_status SnappyTwinDrive(const unsigned char* src,
             parser.src_pos <= parser.src_size &&
             parser.dst_pos <= parser.declared &&
             parser.declared <= capacity &&
-            element.to + element.length <= parser.dst_pos &&
-            (element.is_copy ? element.from < element.to
-                             : element.from + element.length <=
-                                   parser.src_pos);
+            element.literals_dst + element.literals_len <= parser.dst_pos &&
+            element.literals_src + element.literals_len <= parser.src_pos &&
+            element.match_dst + element.match_len <= parser.dst_pos &&
+            (element.match_len == 0 || element.match_src < element.match_dst);
         if (!bounded) {
             std::fprintf(stderr,
                          "the parser left its bounds: src_pos=%llu/%llu "
-                         "dst_pos=%llu/%llu element from=%llu to=%llu len=%llu "
-                         "copy=%d\n",
+                         "dst_pos=%llu/%llu literals %llu->%llu len=%llu "
+                         "match %llu->%llu len=%llu\n",
                          static_cast<unsigned long long>(parser.src_pos),
                          static_cast<unsigned long long>(parser.src_size),
                          static_cast<unsigned long long>(parser.dst_pos),
                          static_cast<unsigned long long>(parser.declared),
-                         static_cast<unsigned long long>(element.from),
-                         static_cast<unsigned long long>(element.to),
-                         static_cast<unsigned long long>(element.length),
-                         element.is_copy ? 1 : 0);
+                         static_cast<unsigned long long>(element.literals_src),
+                         static_cast<unsigned long long>(element.literals_dst),
+                         static_cast<unsigned long long>(element.literals_len),
+                         static_cast<unsigned long long>(element.match_src),
+                         static_cast<unsigned long long>(element.match_dst),
+                         static_cast<unsigned long long>(element.match_len));
             observer->bounds_violations++;
             out->clear();
             return CUDEC_ERR_CORRUPT_INPUT;
         }
-        if (element.is_copy) {
-            for (uint64_t i = 0; i < element.length; i++) {
-                (*out)[static_cast<size_t>(element.to + i)] =
-                    (*out)[static_cast<size_t>(element.from + i)];
-            }
-        } else {
-            for (uint64_t i = 0; i < element.length; i++) {
-                (*out)[static_cast<size_t>(element.to + i)] =
-                    src[element.from + i];
-            }
+        /* Both halves are executed unconditionally, in the kernel's order,
+         * because that is the contract the copy engine works to; Snappy
+         * leaves one of the two empty on every element. */
+        for (uint64_t i = 0; i < element.literals_len; i++) {
+            (*out)[static_cast<size_t>(element.literals_dst + i)] =
+                src[element.literals_src + i];
+        }
+        for (uint64_t i = 0; i < element.match_len; i++) {
+            (*out)[static_cast<size_t>(element.match_dst + i)] =
+                (*out)[static_cast<size_t>(element.match_src + i)];
         }
         if (done) {
             break;

--- a/tests/snappy_upstream_negatives.cpp
+++ b/tests/snappy_upstream_negatives.cpp
@@ -92,7 +92,7 @@ cudec_status TwinVerdict(const Bytes& stream, uint64_t* produced,
         *rung = parser.reject;
         return status;
     }
-    cudec_detail::SnappyElement element;
+    cudec_detail::DecodeSequence element;
     bool done = false;
     uint64_t fuel = static_cast<uint64_t>(size) + 2;
     while (true) {

--- a/tests/termination.cpp
+++ b/tests/termination.cpp
@@ -58,7 +58,7 @@ int RequireTerminates(const std::string& context, const Bytes& stream,
         std::memcpy(tight.get(), stream.data(), stream_size);
     }
     cudec_detail::Lz4Parser parser{tight.get(), stream_size, dst_capacity};
-    cudec_detail::Lz4Sequence seq;
+    cudec_detail::DecodeSequence seq;
 
     const uint64_t budget = static_cast<uint64_t>(stream_size) + 1;
     uint64_t steps = 0;

--- a/tests/termination_gpu.cu
+++ b/tests/termination_gpu.cu
@@ -20,7 +20,8 @@
 #include "adversarial_blocks.h"
 #include "cudec.h"
 #include "fixtures.h"
-#include "lz4_decode.cuh"
+#include "chunk_decode.cuh"
+#include "lz4_block.h"
 #include "require.h"
 
 #include <cuda_runtime.h>
@@ -204,8 +205,9 @@ int RequireGeometryRefused(const Batch& b, const UnsupportedGeometry& g) {
     cudaEvent_t finished;
     REQUIRE_CUDA(cudaStreamCreate(&stream));
     REQUIRE_CUDA(cudaEventCreateWithFlags(&finished, cudaEventDisableTiming));
-    cudec_detail::lz4_decode_batch<false><<<g.blocks, g.threads, 0, stream>>>(
-        b.d_srcs, b.d_sizes, b.d_dsts, b.d_caps, b.n, b.d_results);
+    cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, false>
+        <<<g.blocks, g.threads, 0, stream>>>(b.d_srcs, b.d_sizes, b.d_dsts,
+                                             b.d_caps, b.n, b.d_results);
     REQUIRE_CUDA(cudaGetLastError());
     REQUIRE_CUDA(cudaEventRecord(finished, stream));
     const auto start = std::chrono::steady_clock::now();


### PR DESCRIPTION
# What & why

The M3 kernel, built the way masterplan section 10 settled it: one chunk
decoder templated on the format parser, with Snappy as its second
instantiation. Closes #150.

`src/lz4_decode.cuh` becomes `src/chunk_decode.cuh` and takes a `Parser`
template parameter. Everything under the parse was already
format-independent - the fuel cap, the two copy loops, the `__syncwarp()`
placement, the geometry guards, the failure contract - and a second copy of it
per format is a second place for the fail-closed discipline to drift, in the
one file where drift is an out-of-bounds write rather than a wrong answer. LZ4
pays a rename and nothing else, which the register readout below confirms
rather than asserts.

**The seam's requirement list gained one the design did not name.** The 32-bit
gather arm narrows the match offset, and what makes that lossless is the
offset FIELD's width in each format - two bytes for LZ4, at most four for
Snappy - rather than any check on parsed input. That was implicit and
load-bearing, so it is written into the parser contract at the head of the
kernel header, beside the code that breaks without it.

**The shared element vocabulary is executed rather than overturned.** The #85
panel called for one element type in `src/decode_sequence.h` and the parser
core had kept a format-local one. `DecodeSequence` now carries a literals half
and a match half; LZ4 fills both, Snappy fills exactly one and leaves the
other empty, and the `is_copy` flag is gone because a copy engine that runs
both halves unconditionally has nothing to branch on. Overturning was the
other legal outcome and is not the better one: a per-parser element type was
refused at the panel because it invites the divergence the engine's single
contract exists to prevent, and nothing found in the building weakens that.

**`cudec_snappy_decompress_batch`** carries the frozen batch contract argument
for argument through the shared validator. The header documents the supported
surface as raw Snappy streams, so a framed stream is a malformed raw one and
is rejected rather than half-decoded, and it documents why the declared length
maps to `OUTPUT_TOO_SMALL` in exactly one place and every later overrun to
`CORRUPT_INPUT`. Contract conformance from C99 is the sibling rung (#152) and
is not claimed here.

## Type of change

- [x] Decode kernel / device code
- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] API surface
- [x] Refactor / code quality

## Engineering checklist

- [x] Fail-closed preserved. No reject path moved and no bound changed: the
      Snappy ladder is the one already in the tree, reporting into different
      field names. The copy engine still performs no input-derived bound check
      of its own, and the requirement that makes that safe is now written
      where the engine is rather than only in the design record.
- [x] Oracle coverage. The whole vendored corpus decodes byte-exact on the
      device against what the oracle compressed - see Verification.
- [x] Determinism preserved. Same input, same bytes; nothing in the decode
      path became order-dependent, and the LZ4 output is unchanged (the
      existing `determinism_gpu` and the LZ4 corpus and mutant batches are
      green).
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [ ] An adversarial review was NOT run for this change. There is no second
      reader available tonight, and this is a negative disclosure rather than
      a box left blank: the evidence below stands in its place, and a lens
      pass over this diff is owed.
- [ ] Review record: none, for the same reason.

## GPU sanitizer gate

The sweep could not be produced. The gate is parked, and the command that
shows it, re-run for this change:

```
$ compute-sanitizer --tool memcheck --error-exitcode 1 ./clean   # no fault in it
========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator
========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation
========= ERROR SUMMARY: 2 errors        (exit=1, and the same for the other three tools)
```

driver 610.88, CUDA 13.3, compute-sanitizer 2026.2.1.0. CONTRIBUTING.md
carries the parking beside the invocation. The block is left here rather than
removed.

## Performance checklist

No performance claim is made and no number here is one. The measured pass is
#292 and the bench rung is #167; numbers and kernel never move in the same
change.

What IS recorded, because the issue asks for it, is the resource readout - a
property of the binary rather than a measurement of throughput. Read through
the CUDA occupancy API rather than computed from the register count:

```
$ /tmp/occ
device=NVIDIA GeForce RTX 3080 sm_86 maxWarpsPerSM=48
lz4      regs=48  blocks/SM=10  warps/SM=40
snappy   regs=56  blocks/SM=9  warps/SM=36
```

The LZ4 kernel is at 48 registers and 40 warps/SM, which is exactly what
docs/BENCHMARKS.md records for it before this change: templating the decoder
on its parser cost that kernel nothing. The Snappy instantiation sits at 56
registers and 36 warps/SM. Whether that is the right shape is #292's question,
and it is the reason that issue asks for a measurement rather than a guess.

## Quality checklist

- [x] Minimal: the kernel body is unchanged except for the two lines the
      template touches; the element type went from two structs to one; the
      `CUDEC_HOST_DEVICE` macro went from two guarded definitions with a
      comment explaining the duplication to one definition.
- [x] Self-documenting: the parser contract is stated where a violation
      breaks something, not in a separate document.
- [x] The new structural property is locked. `tests/CMakeLists.txt` gains a
      single-source lock on `DecodeSequence` in the shape the `cuda_raii.h`
      and batch-limit locks already use, and the Snappy lock drops the type it
      no longer owns.

**The locks are proven by breaking them, one at a time, each restored after:**

```
=== snappy_block.h drops the decode_sequence.h include ===
  configure exit=1
  CMake Error at tests/CMakeLists.txt:619 (message):
    src/snappy_block.h no longer includes decode_sequence.h: the decode element
    is single-sourced there (issue #150)

=== chunk_decode.cuh carries its own DecodeSequence ===
  configure exit=1
  CMake Error at tests/CMakeLists.txt:623 (message):
    src/chunk_decode.cuh defines a local 'struct DecodeSequence': the decode
    element is single-sourced in decode_sequence.h (issue #150)

=== decode_sequence.h stops defining the struct ===
  configure exit=1
  CMake Error at tests/CMakeLists.txt:613 (message):
    src/decode_sequence.h no longer defines 'struct DecodeSequence' (issue
    #150)
```

**And the new test arm is proven to bite.** With the Snappy entry instantiated
on the LZ4 parser - a change that builds, links and leaves every host-side
twin green:

```
=== the Snappy entry instantiates the LZ4 parser ===
  build exit=0
  gpu_fixture exit=1
  FAIL tests/gpu_fixture.cu:139: result.status == CUDEC_OK | zeros-65536 status=2
  FAIL tests/gpu_fixture.cu:310: CheckDecodedOk(snappy_pairs[i]...) == 0
```

## Verification

Built and run in the Ubuntu-24.04 WSL distribution against the local RTX 3080,
driver 610.88, nvcc 13.3.73, at this branch's tree:

```
$ cmake -S . -B ~/cudec-bc -DCUDEC_ENABLE_CUDA=ON     # configure exit=0
$ cmake --build ~/cudec-bc -j"$(nproc)"               # build exit=0
$ ctest --test-dir ~/cudec-bc --output-on-failure
100% tests passed, 0 tests failed out of 49
Label Time Summary:
gpu    =   5.74 sec*proc (8 tests)
Total Test time (real) =  17.24 sec

$ ~/cudec-bc/tests/gpu_fixture
PASS: 12 LZ4 pairs decoded byte-exact + 310 mutants in oracle parity (248
oracle-rejected, 1 offset==0 stricter) + 40000 grid-stride wraparound chunks +
21 Snappy pairs + 11 vendored testdata files (2928371 bytes) decoded
byte-exact on the GPU decoder; failure contract and poison beyond
bytes_written intact

$ npx prettier@3 --check "**/*.{md,yml,yaml}"
All matched files use Prettier code style!
```

- [x] `cmake --build` - builds clean.
- [x] `ctest` - green, GPU tests included.
- [x] Prettier - clean.
- [x] Docs synced: section 10 of the masterplan now says which of its
      subsections are reports and which are the commitments they were built
      to, and its pasted count of zero Snappy mentions in the public header is
      replaced by the command that derives it.

## Notes

**Where the Done-when is met and where it is not.** The issue asks for a
whole-corpus GPU-vs-oracle byte diff over "Silesia-snappy + the vendored
testdata". The vendored half is here and is the stronger half for this
purpose: eleven real files out of the pinned archive, 2 928 371 bytes, decoded
on the device and compared byte for byte, at a size where the 64-byte copy cap
and the compressor's 65536-byte block split occur many times over. Silesia is
NOT included, and the reason is structural rather than an omission: no test
target in this tree consumes the downloaded corpora at all -
`bench/get-corpora.sh` feeds the bench harness, and wiring a corpus download
into a ctest entry is the bench rung's shape to decide (#167), not a line to
add here.

The mutant reject parity and the determinism gate for this format are the
device gate set (#154) and are deliberately not in this change.

**No second reader.** There is none available for this change. The commands
above are the evidence in place of one, and the adversarial lens pass the
sensitive surface calls for is owed rather than done.
