### PR TITLE
Hold the Snappy batch entry to the frozen contract, call for call [#152]

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -737,8 +737,12 @@ way it already locks `cuda_raii.h` and the batch limit.
 ### The batch entry
 
 **Landed** in `include/cudec.h` and `src/batch.cu`; the paragraphs below are
-the commitment it was built to. Its contract conformance - every documented
-synchronous reject, one call each, from C99 - is the sibling rung (#152).
+the commitment it was built to. Its contract conformance landed with it
+(#152): every documented synchronous reject, one call each, resolved from
+C99 in `tests/conformance_c.c`, and the launch-submission failure in
+`tests/launch_fail.cpp`. Both are written out call for call rather than
+inferred from the shared validator, because validation passing is the point
+where the two entries stop being the same code.
 
 **A commitment.** `cudec_snappy_decompress_batch` carries the
 `cudec_lz4_decompress_batch` contract with no deltas: device-side argument

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -76,6 +76,32 @@ int main(void) {
                                        aligned, 0) ==
             CUDEC_ERR_INVALID_ARGUMENT);
 
+    /* The same eight classes on the Snappy entry (issue #152). The contract
+     * is frozen and format-independent, and the two entries share one
+     * validator - which is exactly why this is written out call for call
+     * rather than trusted: a future entry that grew its own validation, or
+     * one wired to a different one, would pass a test that only counted on
+     * the sharing. Resolving the symbol from C99 at all is half of what
+     * this file is for. */
+    REQUIRE(cudec_snappy_decompress_batch(0, sizes, dsts, caps, 1, aligned,
+                                          0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_snappy_decompress_batch(srcs, 0, dsts, caps, 1, aligned,
+                                          0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, 0, caps, 1, aligned,
+                                          0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, 0, 1, aligned,
+                                          0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, 1, 0, 0) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, 1,
+                                          misaligned,
+                                          0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, 0, aligned,
+                                          0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, SIZE_MAX,
+                                          aligned,
+                                          0) == CUDEC_ERR_INVALID_ARGUMENT);
+
     /* The frame entry point resolves its own C linkage here. Every call
      * below is a documented argument reject that returns before any CUDA
      * call, so it runs on the GPU-less runner and never dereferences the

--- a/tests/launch_fail.cpp
+++ b/tests/launch_fail.cpp
@@ -1,4 +1,4 @@
-/* The launch-failure branch of cudec_lz4_decompress_batch, exercised with
+/* The launch-failure branch of both batch entry points, exercised with
  * defined behavior (deferred gap 1 from the #2 review): a process with
  * zero visible CUDA devices makes every launch submission fail
  * deterministically, so CI's GPU-lessness becomes the test condition and
@@ -36,7 +36,21 @@ int main() {
     REQUIRE(cudec_lz4_decompress_batch(srcs, sizes, dsts, caps, 1, results,
                                        nullptr) == CUDEC_ERR_CUDA);
 
+    /* The Snappy entry's two halves, in the same order and for the same
+     * reason (issue #152). The second one is what a shared validator cannot
+     * prove on its own: validation passing is the point where the two
+     * entries stop being the same code, and an entry that dropped the
+     * post-launch error check would return CUDEC_OK here while submitting
+     * nothing. */
+    REQUIRE(cudec_snappy_decompress_batch(nullptr, sizes, dsts, caps, 1,
+                                          results, nullptr) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, 1, results,
+                                          nullptr) == CUDEC_ERR_CUDA);
+    REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, 1, results,
+                                          nullptr) == CUDEC_ERR_CUDA);
+
     std::printf("PASS: launch-failure branch reports CUDEC_ERR_CUDA with "
-                "zero visible devices\n");
+                "zero visible devices, on both batch entries\n");
     return 0;
 }


### PR DESCRIPTION
# What & why

`cudec_snappy_decompress_batch` landed with the kernel; what it returns for
every documented reject was asserted by nothing. This is that half. Closes
#152.

Both entries go through one validator, and that is the reason to write the
calls out rather than to skip them: a future entry that grew its own
validation, or one wired to a different validator, would pass a test that only
counted on the sharing.

`tests/conformance_c.c` resolves the symbol from C99 and asserts all eight
documented synchronous reject classes - each of the four null arrays, a null
and a misaligned result buffer, an empty batch, and a batch past the launch
limit - one call each. Every one refuses before any CUDA call, so it runs on
the GPU-less runner exactly as the LZ4 half does.

`tests/launch_fail.cpp` covers the other side of validation, which is where
the two entries stop being the same code: with no visible device the
submission fails and the entry has to report `CUDEC_ERR_CUDA` rather than the
`CUDEC_OK` a dropped post-launch check would return. Twice, for the same
reason the LZ4 pair is run twice.

**The header half of this issue's surface was already in the tree** and is not
re-done here. `include/cudec.h` carries the entry's contract block, the
documented raw-Snappy surface with the framing format named as decoded by
nothing, and the status mapping for the declared length. It landed with #150
because a declaration without its contract is not a declaration anybody can
call; saying so here rather than restating the block a second time, which
would be two texts to keep in agreement.

## Type of change

- [x] API surface
- [x] Refactor / code quality (tests only, beyond the doc line)

## Engineering checklist

- [x] Fail-closed preserved: no code path changed. This change is two test
      files and one sentence of the design record.
- [x] Oracle coverage: not applicable, no decode path is touched.
- [x] Determinism preserved: unchanged, nothing in the decode path moved.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI -
      and the second test arm is precisely the assertion that this holds for
      the new entry.
- [ ] An adversarial review was NOT run. No second reader is available
      tonight; the evidence below stands in its place.
- [ ] Review record: none, for the same reason.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. `git diff --name-only origin/main...HEAD`
      returns `docs/MASTERPLAN.md`, `tests/conformance_c.c` and
      `tests/launch_fail.cpp`.

The gate is parked in any case; CONTRIBUTING.md carries why, beside the
invocation.

## Performance checklist

Not applicable. No hot path, no number.

## Quality checklist

- [x] Minimal: the assertions sit in the two files that already hold their
      LZ4 counterparts rather than in a new target, because a separate binary
      for the same eight refusals would be a second place to keep in step.
- [x] Self-documenting: each block says why it is written out rather than
      inferred from the shared validator.
- [x] The structural property is locked, and both arms are proven by breaking
      them one at a time.

```
=== the Snappy entry answers before validating ===
  build exit=0
  conformance_c exit=1
  FAIL tests/conformance_c.c:86: cudec_snappy_decompress_batch(0, sizes, dsts, caps, 1, aligned, 0) == CUDEC_ERR_INVALID_ARGUMENT

=== the Snappy entry drops the post-launch error check ===
  build exit=0
  conformance_c exit=0        (validation is untouched, so this arm stays green)
  launch_fail exit=1
  FAIL tests/launch_fail.cpp:48: cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, 1, results, nullptr) == CUDEC_ERR_CUDA
```

The second mutant is the one worth reading: it leaves the first arm green and
reds only the second, which is the isolation that arm exists for.

## Verification

Built and run in the Ubuntu-24.04 WSL distribution against the local RTX 3080,
driver 610.88, nvcc 13.3.73, at this branch's tree:

```
$ cmake -S . -B ~/cudec-bc -DCUDEC_ENABLE_CUDA=ON     # configure exit=0
$ cmake --build ~/cudec-bc -j"$(nproc)"               # build exit=0
$ ctest --test-dir ~/cudec-bc --output-on-failure
100% tests passed, 0 tests failed out of 49
Label Time Summary:
gpu    =   5.45 sec*proc (8 tests)
Total Test time (real) =  15.84 sec

$ npx prettier@3 --check "**/*.{md,yml,yaml}"
All matched files use Prettier code style!
```

- [x] `cmake --build` - builds clean.
- [x] `ctest` - green.
- [x] Prettier - clean.
- [x] Docs synced: the masterplan's batch-entry subsection records the
      conformance as landed rather than as a sibling rung.

## Notes

**No second reader.** There is none available for this change, and the
commands above are the evidence in place of one.
