### PR TITLE
Hold the Snappy decode path to the standing device gate set [#154]

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -581,8 +581,8 @@ bytes as well as cudec's, so a reject branch is demonstrably in parity
 rather than merely present.
 
 **Where this section is a commitment and where it is a description.** The
-parser core, the seam and the batch entry have all landed; what has not is
-the device gate set (#154), the bench rung and the measured pass. Each
+parser core, the seam, the batch entry and the device gate set have all
+landed; what has not is the bench rung and the measured pass. Each
 subsection below says which it is, so the document cannot be read as a
 report of shipped code. The tree is the authority for the second kind and
 the commands that read it are given inline.

--- a/tests/adversarial_snappy_blocks.h
+++ b/tests/adversarial_snappy_blocks.h
@@ -1,0 +1,294 @@
+/* The hand-crafted hostile Snappy corpus, single-sourced (issue #154) - the
+ * sibling of adversarial_blocks.h, which does the same job for LZ4.
+ *
+ * The seeded fixture/mutant corpus in fixtures.h covers "what the compressor
+ * produced, then damaged". This covers what a compressor never emits and an
+ * attacker writes by hand: the wide length and offset classes, the copy forms
+ * a compressor has no reason to choose, offsets reaching backwards past
+ * everything written, declared lengths at the varint's 2^32 ceiling, and the
+ * one arithmetic shape where cudec is deliberately stricter than the
+ * reference.
+ *
+ * Header-only and driven by both sides so a stream that behaves on the host
+ * and misbehaves in the kernel cannot hide: tests/snappy_block_device.cu
+ * parses every one of them with the host compiler and with nvcc and compares
+ * the element traces, and tests/gpu_fixture.cu drives the identical bytes
+ * through the public batch entry against the oracle's verdict.
+ *
+ * Nothing here goes through a compressor, on purpose: every byte is chosen,
+ * so a stream that stops exercising what its name says would have to be
+ * edited rather than drift. The verdicts are the oracle's wherever a caller
+ * asks for one; this header states no expected status of its own. */
+#ifndef CUDEC_TESTS_ADVERSARIAL_SNAPPY_BLOCKS_H
+#define CUDEC_TESTS_ADVERSARIAL_SNAPPY_BLOCKS_H
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+struct AdversarialSnappyBlock {
+    std::string name;
+    std::vector<unsigned char> stream;
+    /* The destination capacity a caller would plausibly pass. It matters
+     * here in a way it does not for LZ4: the declared length is compared
+     * against exactly this value, and that comparison is the only place a
+     * Snappy stream's own claim about its size is ever bounded. */
+    size_t dst_capacity;
+};
+
+/* The little-endian base-128 preamble, written without a minimality rule so
+ * the callers below can spell one length several ways. */
+inline std::vector<unsigned char> SnappyPreamble(unsigned long long length) {
+    std::vector<unsigned char> out;
+    unsigned long long v = length;
+    while (v >= 0x80) {
+        out.push_back(static_cast<unsigned char>((v & 0x7f) | 0x80));
+        v >>= 7;
+    }
+    out.push_back(static_cast<unsigned char>(v));
+    return out;
+}
+
+inline void SnappyAppend(std::vector<unsigned char>* out,
+                         const std::vector<unsigned char>& more) {
+    out->insert(out->end(), more.begin(), more.end());
+}
+
+/* A literal in the inline-length class: the six tag bits hold length-1. */
+inline std::vector<unsigned char> SnappyLiteral(const char* text,
+                                                size_t size) {
+    std::vector<unsigned char> out;
+    out.push_back(static_cast<unsigned char>((size - 1) << 2));
+    for (size_t i = 0; i < size; i++) {
+        out.push_back(static_cast<unsigned char>(text[i]));
+    }
+    return out;
+}
+
+/* The one-byte-offset copy form. It carries the offset's high three bits in
+ * the tag and cannot express a length below four. */
+inline std::vector<unsigned char> SnappyCopy1(unsigned length,
+                                              unsigned offset) {
+    std::vector<unsigned char> out;
+    out.push_back(static_cast<unsigned char>(((offset >> 8) << 5) |
+                                             ((length - 4) << 2) | 1));
+    out.push_back(static_cast<unsigned char>(offset & 0xff));
+    return out;
+}
+
+inline std::vector<unsigned char> SnappyCopy2(unsigned length,
+                                              unsigned offset) {
+    std::vector<unsigned char> out;
+    out.push_back(static_cast<unsigned char>(((length - 1) << 2) | 2));
+    out.push_back(static_cast<unsigned char>(offset & 0xff));
+    out.push_back(static_cast<unsigned char>((offset >> 8) & 0xff));
+    return out;
+}
+
+/* The four-byte-offset form. No compressor emits it - snappy's own writer
+ * never selects tag 3 - and the reference decoder takes it, so refusing it
+ * would be over-strictness the oracle diff would catch. */
+inline std::vector<unsigned char> SnappyCopy4(unsigned length,
+                                              unsigned long long offset) {
+    std::vector<unsigned char> out;
+    out.push_back(static_cast<unsigned char>(((length - 1) << 2) | 3));
+    for (int i = 0; i < 4; i++) {
+        out.push_back(static_cast<unsigned char>((offset >> (8 * i)) & 0xff));
+    }
+    return out;
+}
+
+inline std::vector<AdversarialSnappyBlock> MakeAdversarialSnappyBlocks() {
+    using Bytes = std::vector<unsigned char>;
+    std::vector<AdversarialSnappyBlock> out;
+    const auto add = [&out](std::string name, Bytes stream, size_t capacity) {
+        out.push_back({std::move(name), std::move(stream), capacity});
+    };
+    const size_t kCap = 1u << 20;
+
+    add("empty", {}, kCap);
+    add("preamble-only-zero", SnappyPreamble(0), kCap);
+
+    {
+        Bytes s = SnappyPreamble(4);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        add("one-literal", s, kCap);
+    }
+    {
+        Bytes s = SnappyPreamble(8);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        SnappyAppend(&s, SnappyCopy2(4, 4));
+        add("literal-then-copy", s, kCap);
+    }
+    {
+        /* Offset 1 is the pattern-repeating extreme: every byte of the copy
+         * reads the byte the copy itself wrote one position earlier, which
+         * is where a warp gather that is not a closed-form modulo diverges
+         * from a sequential executor. */
+        Bytes s = SnappyPreamble(64);
+        SnappyAppend(&s, SnappyLiteral("a", 1));
+        SnappyAppend(&s, SnappyCopy2(63, 1));
+        add("rle-offset-one-63", s, kCap);
+    }
+    {
+        /* The 64-byte cap of the two-byte form, at offset 2: an overlap that
+         * is neither a pure RLE nor disjoint. */
+        Bytes s = SnappyPreamble(66);
+        SnappyAppend(&s, SnappyLiteral("ab", 2));
+        SnappyAppend(&s, SnappyCopy2(64, 2));
+        add("copy2-max-length-overlap", s, kCap);
+    }
+    {
+        Bytes s = SnappyPreamble(8);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        SnappyAppend(&s, SnappyCopy2(4, 0));
+        add("copy2-offset-zero", s, kCap);
+    }
+    {
+        Bytes s = SnappyPreamble(8);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        SnappyAppend(&s, SnappyCopy1(4, 0));
+        add("copy1-offset-zero", s, kCap);
+    }
+    {
+        Bytes s = SnappyPreamble(8);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        SnappyAppend(&s, SnappyCopy4(4, 0));
+        add("copy4-offset-zero", s, kCap);
+    }
+    {
+        Bytes s = SnappyPreamble(8);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        SnappyAppend(&s, SnappyCopy2(4, 9));
+        add("copy-offset-past-output-start", s, kCap);
+    }
+    {
+        /* An offset far past anything written, in the only form wide enough
+         * to express it. The bound is the bytes produced, never the window
+         * convention. */
+        Bytes s = SnappyPreamble(8);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        SnappyAppend(&s, SnappyCopy4(4, 0xFFFFFFFFull));
+        add("copy4-offset-4g", s, kCap);
+    }
+    {
+        /* Copy lengths 1 to 3 cannot be spelled in the narrow form and are
+         * legal in the wide ones. A decoder that imposed a length floor
+         * would be stricter than the reference here. */
+        Bytes s = SnappyPreamble(5);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        SnappyAppend(&s, SnappyCopy2(1, 4));
+        add("copy2-length-one", s, kCap);
+    }
+    {
+        Bytes s = SnappyPreamble(8);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        SnappyAppend(&s, SnappyCopy4(4, 4));
+        add("copy4-ordinary", s, kCap);
+    }
+    {
+        /* An offset above 65536, which needs the four-byte form and a
+         * destination that has produced that much. Built as one literal run
+         * long enough to reach back into. */
+        Bytes s = SnappyPreamble(70000);
+        s.push_back(0xF4); /* long-form literal, two length bytes follow */
+        s.push_back(static_cast<unsigned char>((69995 - 1) & 0xff));
+        s.push_back(static_cast<unsigned char>(((69995 - 1) >> 8) & 0xff));
+        for (size_t i = 0; i < 69995; i++) {
+            s.push_back(static_cast<unsigned char>('a' + i % 26));
+        }
+        SnappyAppend(&s, SnappyCopy4(5, 69000));
+        add("copy4-offset-above-64k", s, kCap);
+    }
+    {
+        /* A non-minimal preamble: five groups spelling a small number. The
+         * reference accepts it, so cudec must too. */
+        Bytes s = {0x84, 0x80, 0x80, 0x80, 0x00};
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        add("preamble-non-minimal-five-groups", s, kCap);
+    }
+    add("preamble-final-group-sixteen",
+        std::vector<unsigned char>{0x80, 0x80, 0x80, 0x80, 0x10}, kCap);
+    {
+        /* The documented divergence: the four-byte literal length class
+         * spelling 0xFFFFFFFF. The reference adds one in 32 bits, wraps to a
+         * zero-length literal and accepts the stream; cudec refuses it,
+         * because a length that exists only because an accumulator wrapped
+         * is not a length. This is the ONE stream where the two verdicts
+         * differ by design. */
+        add("literal-length-wraps-to-zero",
+            std::vector<unsigned char>{0x00, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF},
+            kCap);
+    }
+    {
+        /* Header past the end: the long-form literal's length bytes are
+         * missing entirely. */
+        Bytes s = SnappyPreamble(300);
+        s.push_back(0xF0);
+        add("literal-header-truncated", s, kCap);
+    }
+    {
+        /* The payload is short of what the header declares. */
+        Bytes s = SnappyPreamble(64);
+        s.push_back(0xFC); /* 60 -> one length byte follows */
+        s.push_back(63);
+        for (int i = 0; i < 10; i++) {
+            s.push_back('a');
+        }
+        add("literal-payload-truncated", s, kCap);
+    }
+    {
+        /* Produces less than it declared: the source runs out first. */
+        Bytes s = SnappyPreamble(16);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        add("under-production", s, kCap);
+    }
+    {
+        /* Bytes after the declared length has been produced exactly. */
+        Bytes s = SnappyPreamble(4);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        SnappyAppend(&s, SnappyLiteral("e", 1));
+        add("trailing-element", s, kCap);
+    }
+
+    /* The capacity adversarials. The declared length is attacker-controlled
+     * and reaches 2^32 - 1; the caller's capacity is the only truth it is
+     * ever measured against, and nothing anywhere is sized from it. These
+     * carry SMALL capacities on purpose: the point is that a 4 GiB claim is
+     * refused at the preamble, before an element is parsed and before a byte
+     * is written, rather than that a 4 GiB buffer happens to exist. */
+    {
+        Bytes s = SnappyPreamble(0xFFFFFFFFull);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        add("declared-4g-minus-one-capacity-4k", s, 4096);
+    }
+    {
+        Bytes s = SnappyPreamble(0xFFFFFFFEull);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        add("declared-4g-minus-two-capacity-4k", s, 4096);
+    }
+    {
+        Bytes s = SnappyPreamble(0x80000000ull);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        add("declared-2g-capacity-4k", s, 4096);
+    }
+    {
+        /* The boundary from the other side: a declaration one byte above the
+         * capacity, where refusing and accepting are one comparison apart. */
+        Bytes s = SnappyPreamble(4097);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        add("declared-one-over-capacity", s, 4096);
+    }
+    {
+        /* And exactly at it, which must NOT be refused for capacity: this
+         * stream rejects for under-production instead, and a decoder with an
+         * off-by-one at the capacity comparison reports the wrong one. */
+        Bytes s = SnappyPreamble(4096);
+        SnappyAppend(&s, SnappyLiteral("abcd", 4));
+        add("declared-exactly-capacity", s, 4096);
+    }
+
+    return out;
+}
+
+#endif /* CUDEC_TESTS_ADVERSARIAL_SNAPPY_BLOCKS_H */

--- a/tests/determinism_gpu.cu
+++ b/tests/determinism_gpu.cu
@@ -7,17 +7,23 @@
  * streams. All of that changes which warp decodes which chunk and in what
  * order - and none of it may change a single output byte.
  *
- * One corpus, one reference decode through the shipped entry point, then five
- * runs each across five grid/block geometries plus a three-stream split, with
- * the whole destination arena re-poisoned before every run and compared in
- * full - decoded bytes AND the untouched poison beyond bytes_written - along
- * with every per-chunk result record. The geometries are launched directly on
- * the shipped kernel because the public ABI deliberately exposes no launch
- * knobs. */
+ * Per format: one corpus, one reference decode through the shipped entry
+ * point, then five runs each across five grid/block geometries plus a
+ * three-stream split, with the whole destination arena re-poisoned before
+ * every run and compared in full - decoded bytes AND the untouched poison
+ * beyond bytes_written - along with every per-chunk result record. The
+ * geometries are launched directly on the shipped kernel because the public
+ * ABI deliberately exposes no launch knobs.
+ *
+ * Both formats run it (issue #154). The geometry axis belongs to the chunk
+ * decoder rather than to a parser, and the two share one, so a format left
+ * out here would leave the shared mapping unproven for exactly the
+ * instantiation nobody looked at. */
 #include "cudec.h"
 #include "fixtures.h"
 #include "chunk_decode.cuh"
 #include "lz4_block.h"
+#include "snappy_block.h"
 #include "require.h"
 
 #include <cuda_runtime.h>
@@ -54,14 +60,18 @@ struct Chunk {
     size_t dst_capacity;
 };
 
+using Mutator = std::vector<Mutant> (*)(const std::vector<unsigned char>&,
+                                        uint64_t);
+
 /* Pristine fixtures and their whole mutant corpora: accepted and rejected
  * chunks side by side, so the compare covers the reject path's result records
  * and untouched destinations too, not just successful output. */
-std::vector<Chunk> MakeChunks(const std::vector<Fixture>& fixtures) {
+std::vector<Chunk> MakeChunks(const std::vector<Fixture>& fixtures,
+                              Mutator mutate) {
     std::vector<Chunk> chunks;
     for (const Fixture& f : fixtures) {
         chunks.push_back({f.name, f.compressed, f.original.size()});
-        for (const Mutant& m : MutateStream(f.compressed, f.seed)) {
+        for (const Mutant& m : mutate(f.compressed, f.seed)) {
             chunks.push_back(
                 {f.name + "/" + m.description, m.stream, f.original.size()});
         }
@@ -173,13 +183,34 @@ std::vector<Geometry> Geometries(size_t chunk_count) {
     };
 }
 
-int RunDirect(const Batch& b, const Geometry& g) {
+/* One format's two ways in: its public entry, and a direct launch of its
+ * instantiation of the one chunk decoder, which is how a geometry the public
+ * ABI exposes no knob for is reached. Both are function pointers so the whole
+ * sequence below runs unchanged per format - a second copy of it would be a
+ * second place for one format's axis to quietly stop being covered. */
+using BatchEntry = cudec_status (*)(const void* const*, const size_t*,
+                                    void* const*, const size_t*, size_t,
+                                    cudec_chunk_result*, cudec_stream_t);
+using DirectLaunch = void (*)(const Batch&, const Geometry&, cudaStream_t);
+
+template <class Parser>
+void LaunchDirect(const Batch& b, const Geometry& g, cudaStream_t stream) {
+    cudec_detail::chunk_decode_batch<Parser, false>
+        <<<g.blocks, g.threads, 0, stream>>>(b.d_srcs, b.d_sizes, b.d_dsts,
+                                             b.d_caps, b.n, b.d_results);
+}
+
+struct Format {
+    const char* name;
+    BatchEntry entry;
+    DirectLaunch launch;
+};
+
+int RunDirect(const Format& f, const Batch& b, const Geometry& g) {
     REQUIRE(ResetDeviceState(b) == 0);
     cudaStream_t stream;
     REQUIRE_CUDA(cudaStreamCreate(&stream));
-    cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, false>
-        <<<g.blocks, g.threads, 0, stream>>>(b.d_srcs, b.d_sizes, b.d_dsts,
-                                             b.d_caps, b.n, b.d_results);
+    f.launch(b, g, stream);
     REQUIRE_CUDA(cudaGetLastError());
     REQUIRE_CUDA(cudaStreamSynchronize(stream));
     REQUIRE_CUDA(cudaStreamDestroy(stream));
@@ -187,13 +218,12 @@ int RunDirect(const Batch& b, const Geometry& g) {
 }
 
 /* The shipped entry point, once over the whole batch. */
-int RunShippedEntry(const Batch& b) {
+int RunShippedEntry(const Format& f, const Batch& b) {
     REQUIRE(ResetDeviceState(b) == 0);
     cudaStream_t stream;
     REQUIRE_CUDA(cudaStreamCreate(&stream));
-    REQUIRE(cudec_lz4_decompress_batch(b.d_srcs, b.d_sizes, b.d_dsts,
-                                       b.d_caps, b.n, b.d_results,
-                                       stream) == CUDEC_OK);
+    REQUIRE(f.entry(b.d_srcs, b.d_sizes, b.d_dsts, b.d_caps, b.n, b.d_results,
+                    stream) == CUDEC_OK);
     REQUIRE_CUDA(cudaStreamSynchronize(stream));
     REQUIRE_CUDA(cudaStreamDestroy(stream));
     return 0;
@@ -203,7 +233,7 @@ int RunShippedEntry(const Batch& b) {
  * chunk k is decoded by a different warp of a different launch than in any
  * other geometry, and the sub-batches complete in an order the test does not
  * control. Per-chunk independence means the output must not notice. */
-int RunSplitStreams(const Batch& b, unsigned stream_count) {
+int RunSplitStreams(const Format& f, const Batch& b, unsigned stream_count) {
     REQUIRE(ResetDeviceState(b) == 0);
     std::vector<cudaStream_t> streams(stream_count);
     for (unsigned s = 0; s < stream_count; s++) {
@@ -218,10 +248,9 @@ int RunSplitStreams(const Batch& b, unsigned stream_count) {
         const size_t count = (begin + per <= b.n) ? per : b.n - begin;
         /* cudec_chunk_result is 16 bytes, so an element offset keeps the
          * 16-byte alignment the ABI requires of d_results. */
-        REQUIRE(cudec_lz4_decompress_batch(
-                    b.d_srcs + begin, b.d_sizes + begin, b.d_dsts + begin,
-                    b.d_caps + begin, count, b.d_results + begin,
-                    streams[s]) == CUDEC_OK);
+        REQUIRE(f.entry(b.d_srcs + begin, b.d_sizes + begin,
+                        b.d_dsts + begin, b.d_caps + begin, count,
+                        b.d_results + begin, streams[s]) == CUDEC_OK);
     }
     for (unsigned s = 0; s < stream_count; s++) {
         REQUIRE_CUDA(cudaStreamSynchronize(streams[s]));
@@ -266,12 +295,14 @@ int CompareAgainstReference(
     return 0;
 }
 
-}  // namespace
-
-int main() {
-    const std::vector<Fixture> fixtures = MakeLz4BlockFixtures();
+/* The whole sequence for one format: build the batch, take a reference decode
+ * through the shipped entry, then re-run it across every geometry and the
+ * stream split and require the byte image and every result record to be
+ * identical. */
+int RunFormat(const Format& f, const std::vector<Fixture>& fixtures,
+              Mutator mutate, size_t* chunks_out, size_t* decoded_out) {
     REQUIRE(!fixtures.empty());
-    const std::vector<Chunk> chunks = MakeChunks(fixtures);
+    const std::vector<Chunk> chunks = MakeChunks(fixtures, mutate);
     REQUIRE(!chunks.empty());
 
     Batch batch;
@@ -280,7 +311,7 @@ int main() {
     /* The reference: the shipped entry point on the shipped geometry. */
     std::vector<unsigned char> ref_dst;
     std::vector<cudec_chunk_result> ref_results;
-    REQUIRE(RunShippedEntry(batch) == 0);
+    REQUIRE(RunShippedEntry(f, batch) == 0);
     REQUIRE(Download(batch, &ref_dst, &ref_results) == 0);
     size_t decoded_chunks = 0;
     for (const cudec_chunk_result& r : ref_results) {
@@ -296,24 +327,57 @@ int main() {
     std::vector<cudec_chunk_result> results;
     for (const Geometry& g : Geometries(batch.n)) {
         for (int run = 0; run < kRunsPerGeometry; run++) {
-            REQUIRE(RunDirect(batch, g) == 0);
+            REQUIRE(RunDirect(f, batch, g) == 0);
             REQUIRE(Download(batch, &dst, &results) == 0);
-            REQUIRE(CompareAgainstReference(
-                        batch,
-                        std::string(g.name) + "/run-" + std::to_string(run),
-                        ref_dst, ref_results, dst, results) == 0);
+            REQUIRE(CompareAgainstReference(batch,
+                                            std::string(f.name) + "/" +
+                                                g.name + "/run-" +
+                                                std::to_string(run),
+                                            ref_dst, ref_results, dst,
+                                            results) == 0);
         }
     }
     for (int run = 0; run < kRunsPerGeometry; run++) {
-        REQUIRE(RunSplitStreams(batch, 3) == 0);
+        REQUIRE(RunSplitStreams(f, batch, 3) == 0);
         REQUIRE(Download(batch, &dst, &results) == 0);
-        REQUIRE(CompareAgainstReference(
-                    batch, "3-streams/run-" + std::to_string(run), ref_dst,
-                    ref_results, dst, results) == 0);
+        REQUIRE(CompareAgainstReference(batch,
+                                        std::string(f.name) +
+                                            "/3-streams/run-" +
+                                            std::to_string(run),
+                                        ref_dst, ref_results, dst,
+                                        results) == 0);
     }
+    *chunks_out = batch.n;
+    *decoded_out = decoded_chunks;
+    return 0;
+}
 
-    std::printf("determinism_gpu: %zu chunks (%zu decoded) bit-identical "
-                "across 6 launch configurations x %d runs\n",
-                batch.n, decoded_chunks, kRunsPerGeometry);
+}  // namespace
+
+int main() {
+    /* Both formats, one sequence. The geometry axis is a property of the
+     * chunk decoder rather than of a parser, so a format that skipped it
+     * would leave the shared kernel's mapping unproven for exactly the
+     * instantiation nobody looked at. */
+    const Format formats[] = {
+        {"lz4", cudec_lz4_decompress_batch,
+         LaunchDirect<cudec_detail::Lz4Parser>},
+        {"snappy", cudec_snappy_decompress_batch,
+         LaunchDirect<cudec_detail::SnappyParser>},
+    };
+    const std::vector<Fixture> corpora[] = {MakeLz4BlockFixtures(),
+                                            MakeSnappyFixtures()};
+    const Mutator mutators[] = {MutateStream, MutateSnappyStream};
+
+    for (size_t i = 0; i < 2; i++) {
+        size_t chunk_count = 0;
+        size_t decoded_chunks = 0;
+        REQUIRE(RunFormat(formats[i], corpora[i], mutators[i], &chunk_count,
+                          &decoded_chunks) == 0);
+        std::printf("determinism_gpu: %s %zu chunks (%zu decoded) "
+                    "bit-identical across 6 launch configurations x %d runs\n",
+                    formats[i].name, chunk_count, decoded_chunks,
+                    kRunsPerGeometry);
+    }
     return 0;
 }

--- a/tests/gpu_fixture.cu
+++ b/tests/gpu_fixture.cu
@@ -13,6 +13,7 @@
  * be a difference in the parser and nowhere else. The Snappy half is the
  * pristine direction only - the mutant reject parity and the determinism
  * gate for that format are the device gate set (#154). */
+#include "adversarial_snappy_blocks.h"
 #include "cudec.h"
 #include "fixtures.h"
 #include "require.h"
@@ -311,7 +312,69 @@ int main() {
                                snappy[i].original, dsts[i]) == 0);
     }
 
-    /* Batch 5: the whole vendored corpus, compressed by the oracle and
+    /* Batch 5: the Snappy mutant corpus, held to the same two-direction
+     * oracle-parity contract as the LZ4 one (issue #154). The capacity is the
+     * pristine original's size: a mutant that declares more is refused at the
+     * preamble, which is the one place a declared length is compared against
+     * a capacity at all.
+     *
+     * The stricter set is pinned at zero rather than at an identity, and that
+     * is a statement rather than a missing case. Snappy's decoder has one
+     * documented point where cudec is stricter - the four-byte literal length
+     * spelling 0xFFFFFFFF, which wraps to zero in the reference's 32-bit
+     * addition - and no mutation of a compressor-produced stream constructs
+     * it. The host twin pins that divergence on hand-built bytes; here the
+     * aggregate is what makes the named exception readable as the whole of
+     * it. */
+    std::vector<std::vector<unsigned char>> snappy_mutants;
+    std::vector<std::string> snappy_mutant_contexts;
+    std::vector<size_t> snappy_mutant_capacities;
+    std::vector<bool> snappy_oracle_accepts;
+    std::vector<std::vector<unsigned char>> snappy_oracle_outputs;
+    for (const auto& f : snappy) {
+        for (auto& m : MutateSnappyStream(f.compressed, f.seed)) {
+            std::vector<unsigned char> decoded;
+            const bool ok = SnappyOracleDecodes(m.stream, &decoded);
+            snappy_oracle_accepts.push_back(ok);
+            snappy_oracle_outputs.push_back(
+                ok ? decoded : std::vector<unsigned char>{});
+            snappy_mutants.push_back(std::move(m.stream));
+            snappy_mutant_contexts.push_back(f.name + "/" + m.description);
+            snappy_mutant_capacities.push_back(f.original.size());
+        }
+    }
+    std::vector<Chunk> snappy_mutant_chunks;
+    for (size_t i = 0; i < snappy_mutants.size(); i++) {
+        snappy_mutant_chunks.push_back(Chunk{snappy_mutant_contexts[i],
+                                             &snappy_mutants[i],
+                                             snappy_mutant_capacities[i]});
+    }
+    REQUIRE(RunBatch(snappy_mutant_chunks, cudec_snappy_decompress_batch,
+                     &results, &dsts) == 0);
+    size_t snappy_rejected = 0;
+    size_t snappy_stricter = 0;
+    for (size_t i = 0; i < snappy_mutant_chunks.size(); i++) {
+        const char* ctx = snappy_mutant_chunks[i].context.c_str();
+        if (results[i].status == CUDEC_OK) {
+            REQUIRE_CTX(snappy_oracle_accepts[i],
+                        "cudec accepts, snappy rejects: %s", ctx);
+            REQUIRE(CheckDecodedOk(ctx, results[i], snappy_oracle_outputs[i],
+                                   dsts[i]) == 0);
+        } else {
+            REQUIRE_CTX(results[i].bytes_written == 0, "reject bw: %s", ctx);
+            REQUIRE_CTX(results[i].reserved == 0, "reject reserved: %s", ctx);
+            if (snappy_oracle_accepts[i]) {
+                snappy_stricter++;
+                std::fprintf(stderr, "stricter than snappy: %s\n", ctx);
+            } else {
+                snappy_rejected++;
+            }
+        }
+    }
+    REQUIRE(snappy_rejected > 0);
+    REQUIRE(snappy_stricter == 0);
+
+    /* Batch 6: the whole vendored corpus, compressed by the oracle and
      * decoded on the device, at exact capacity. The generated fixtures
      * above are built against the format's own boundaries and are small;
      * these are real inputs of a size where a page of literals, the 64-byte
@@ -351,14 +414,110 @@ int main() {
                                corpus_original[i], dsts[i]) == 0);
     }
 
+    /* Batch 7: the hand-built hostile corpus, through the public entry and
+     * a real warp (issue #154). tests/snappy_block_device.cu parses the same
+     * bytes with one thread on both compilers; this is the arm that runs
+     * them under the copy engine, where 32 lanes fan out over an overlapping
+     * gather and a stream that behaves serially can still misbehave.
+     *
+     * The oracle decides every verdict, in both directions, with the one
+     * documented exception counted rather than exempted: cudec refuses the
+     * four-byte literal length that wraps to zero in the reference's 32-bit
+     * addition, and that stream is the whole of the stricter set. Pinning it
+     * by name rather than by count is what keeps the exception from growing
+     * quietly. */
+    const auto hostile = MakeAdversarialSnappyBlocks();
+    REQUIRE(!hostile.empty());
+    std::vector<bool> hostile_accepts;
+    std::vector<std::vector<unsigned char>> hostile_outputs;
+    std::vector<Chunk> hostile_chunks;
+    for (const auto& b : hostile) {
+        std::vector<unsigned char> decoded;
+        const bool ok = SnappyOracleDecodes(b.stream, &decoded);
+        hostile_accepts.push_back(ok);
+        hostile_outputs.push_back(ok ? decoded
+                                     : std::vector<unsigned char>{});
+    }
+    for (const auto& b : hostile) {
+        hostile_chunks.push_back(Chunk{b.name, &b.stream, b.dst_capacity});
+    }
+    REQUIRE(RunBatch(hostile_chunks, cudec_snappy_decompress_batch, &results,
+                     &dsts) == 0);
+    size_t hostile_accepted = 0;
+    size_t hostile_rejected = 0;
+    std::vector<std::string> hostile_stricter;
+    for (size_t i = 0; i < hostile_chunks.size(); i++) {
+        const char* ctx = hostile_chunks[i].context.c_str();
+        if (results[i].status == CUDEC_OK) {
+            REQUIRE_CTX(hostile_accepts[i],
+                        "cudec accepts, snappy rejects: %s", ctx);
+            REQUIRE(CheckDecodedOk(ctx, results[i], hostile_outputs[i],
+                                   dsts[i]) == 0);
+            hostile_accepted++;
+        } else {
+            /* A capacity refusal and a stream refusal are different
+             * statuses, and both are documented: only the declared length
+             * against the caller's capacity reports OUTPUT_TOO_SMALL. */
+            REQUIRE_CTX(results[i].status == CUDEC_ERR_CORRUPT_INPUT ||
+                            results[i].status == CUDEC_ERR_OUTPUT_TOO_SMALL,
+                        "%s: undefined reject status %d", ctx,
+                        static_cast<int>(results[i].status));
+            REQUIRE_CTX(results[i].bytes_written == 0, "reject bw: %s", ctx);
+            REQUIRE_CTX(results[i].reserved == 0, "reject reserved: %s", ctx);
+            if (hostile_accepts[i]) {
+                hostile_stricter.push_back(hostile[i].name);
+            } else {
+                hostile_rejected++;
+            }
+        }
+    }
+    REQUIRE(hostile_accepted > 0);
+    REQUIRE(hostile_rejected > 0);
+    REQUIRE(hostile_stricter.size() == 1);
+    REQUIRE(hostile_stricter[0] == "literal-length-wraps-to-zero");
+    /* The capacity adversarials are the reason this corpus carries its own
+     * capacities, so their outcome is pinned rather than merely counted among
+     * the rejects. Two things are asserted and they are different: the status
+     * is the capacity refusal, which is the ONE place a declared length maps
+     * to OUTPUT_TOO_SMALL, and the destination is still whole - a 4 GiB claim
+     * is refused at the preamble, before an element is parsed and before a
+     * byte is written.
+     *
+     * That second half is not the general reject contract and is not claimed
+     * as one. A stream refused mid-decode has already executed the elements
+     * before the refusal, and the header says the destination is then
+     * unspecified; what it never is, on either path, is presented as a valid
+     * decode, which bytes_written == 0 above is. */
+    size_t capacity_refusals = 0;
+    for (size_t i = 0; i < hostile_chunks.size(); i++) {
+        if (hostile[i].name.rfind("declared-", 0) != 0 ||
+            hostile[i].name == "declared-exactly-capacity") {
+            continue;
+        }
+        const char* name = hostile[i].name.c_str();
+        REQUIRE_CTX(results[i].status == CUDEC_ERR_OUTPUT_TOO_SMALL,
+                    "%s: expected the capacity refusal, got %d", name,
+                    static_cast<int>(results[i].status));
+        for (size_t j = 0; j < dsts[i].size(); j++) {
+            REQUIRE_CTX(dsts[i][j] == kDstPoison, "%s: wrote at %zu", name, j);
+        }
+        capacity_refusals++;
+    }
+    REQUIRE(capacity_refusals > 0);
+
     std::printf("PASS: %zu LZ4 pairs decoded byte-exact + %zu mutants in "
                 "oracle parity (%zu oracle-rejected, %zu offset==0 stricter) + "
                 "40000 grid-stride wraparound chunks + %zu Snappy pairs + %zu "
-                "vendored testdata files (%zu bytes) decoded byte-exact on the "
-                "GPU decoder; failure contract and poison beyond "
-                "bytes_written intact\n",
+                "Snappy mutants in oracle parity (%zu oracle-rejected, %zu "
+                "stricter) + %zu vendored testdata files (%zu bytes) decoded "
+                "byte-exact on the GPU decoder; failure contract and poison "
+                "beyond bytes_written intact; %zu hand-built hostile Snappy "
+                "streams in oracle parity (%zu accepted, %zu rejected, one "
+                "documented stricter)\n",
                 pairs.size(), mutant_chunks.size(), rejected_count,
-                stricter_count, snappy_pairs.size(), kTestdataCount,
-                corpus_bytes);
+                stricter_count, snappy_pairs.size(),
+                snappy_mutant_chunks.size(), snappy_rejected, snappy_stricter,
+                kTestdataCount, corpus_bytes, hostile_chunks.size(),
+                hostile_accepted, hostile_rejected);
     return 0;
 }

--- a/tests/snappy_block_device.cu
+++ b/tests/snappy_block_device.cu
@@ -11,9 +11,16 @@
  * determinism claim at the granularity this header owns: the same input
  * produces the same element sequence on both.
  *
- * Not the device gate set (#154), which is a kernel's business. There is no
- * kernel yet; this is the header on a device, one thread, no warp
- * cooperation. */
+ * The bytes are the single-sourced hostile corpus of
+ * tests/adversarial_snappy_blocks.h (issue #154), which the whole-batch
+ * device gate drives through the public entry as well - so a stream that
+ * behaves under one thread and misbehaves under a warp has two places to be
+ * caught rather than one.
+ *
+ * This is not itself the device gate set: one thread, no warp cooperation,
+ * no kernel. What it owns is the claim that one header compiled twice
+ * decides identically. */
+#include "adversarial_snappy_blocks.h"
 #include "cudec.h"
 #include "require.h"
 #include "snappy_block.h"
@@ -98,119 +105,33 @@ CUDEC_HOST_DEVICE inline void RunParser(const unsigned char* src,
 __global__ void ParseOnDevice(const unsigned char* streams,
                               const unsigned long long* offsets,
                               const unsigned long long* sizes,
-                              unsigned long long capacity, unsigned count,
-                              Trace* traces) {
+                              const unsigned long long* capacities,
+                              unsigned count, Trace* traces) {
     const unsigned index = blockIdx.x * blockDim.x + threadIdx.x;
     if (index >= count) {
         return;
     }
-    RunParser(streams + offsets[index], sizes[index], capacity,
+    RunParser(streams + offsets[index], sizes[index], capacities[index],
               &traces[index]);
-}
-
-Bytes Preamble(unsigned length) {
-    Bytes out;
-    unsigned v = length;
-    while (v >= 0x80) {
-        out.push_back(static_cast<unsigned char>((v & 0x7f) | 0x80));
-        v >>= 7;
-    }
-    out.push_back(static_cast<unsigned char>(v));
-    return out;
-}
-
-void Append(Bytes* out, const Bytes& more) {
-    out->insert(out->end(), more.begin(), more.end());
-}
-
-Bytes Literal(const char* text, size_t size) {
-    Bytes out;
-    out.push_back(static_cast<unsigned char>((size - 1) << 2));
-    for (size_t i = 0; i < size; i++) {
-        out.push_back(static_cast<unsigned char>(text[i]));
-    }
-    return out;
-}
-
-Bytes Copy2(unsigned length, unsigned offset) {
-    Bytes out;
-    out.push_back(static_cast<unsigned char>(((length - 1) << 2) | 2));
-    out.push_back(static_cast<unsigned char>(offset & 0xff));
-    out.push_back(static_cast<unsigned char>((offset >> 8) & 0xff));
-    return out;
-}
-
-/* Valid streams, rejects from several rungs of the ladder, and the shapes
- * whose arithmetic differs between the two compilers if anything does: the
- * wide length classes and the wide offset form. */
-std::vector<Bytes> MakeStreams() {
-    std::vector<Bytes> out;
-    out.push_back(Bytes{});                     /* no preamble */
-    out.push_back(Preamble(0));                 /* a valid empty stream */
-    {
-        Bytes s = Preamble(4);
-        Append(&s, Literal("abcd", 4));
-        out.push_back(s);                       /* one literal */
-    }
-    {
-        Bytes s = Preamble(8);
-        Append(&s, Literal("abcd", 4));
-        Append(&s, Copy2(4, 4));
-        out.push_back(s);                       /* literal then copy */
-    }
-    {
-        Bytes s = Preamble(8);
-        Append(&s, Literal("ab", 2));
-        Append(&s, Copy2(6, 1));
-        out.push_back(s);                       /* an overlapping copy */
-    }
-    {
-        Bytes s = Preamble(8);
-        Append(&s, Literal("abcd", 4));
-        Append(&s, Copy2(4, 0));
-        out.push_back(s);                       /* offset zero, refused */
-    }
-    {
-        Bytes s = Preamble(8);
-        Append(&s, Literal("abcd", 4));
-        Append(&s, Copy2(4, 9));
-        out.push_back(s);                       /* offset past the output */
-    }
-    out.push_back(Bytes{0x80, 0x80, 0x80, 0x80, 0x10}); /* varint overflow */
-    out.push_back(Bytes{0x00, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF}); /* the wrap */
-    {
-        Bytes s = Preamble(300);
-        s.push_back(0xF0); /* long-form literal, its length byte missing */
-        out.push_back(s);
-    }
-    {
-        Bytes s = Preamble(64);
-        s.push_back(0xF4); /* two length bytes for a 64-byte literal */
-        s.push_back(63);
-        s.push_back(0);
-        for (int i = 0; i < 64; i++) {
-            s.push_back(static_cast<unsigned char>('a' + i % 26));
-        }
-        out.push_back(s);
-    }
-    return out;
 }
 
 }  // namespace
 
 int main() {
-    const std::vector<Bytes> streams = MakeStreams();
-    const unsigned count = static_cast<unsigned>(streams.size());
+    const std::vector<AdversarialSnappyBlock> blocks =
+        MakeAdversarialSnappyBlocks();
+    const unsigned count = static_cast<unsigned>(blocks.size());
     REQUIRE(count > 0);
-    const unsigned long long capacity = 1u << 20;
 
     Bytes flat;
     std::vector<unsigned long long> offsets;
     std::vector<unsigned long long> sizes;
-    for (const auto& s : streams) {
+    std::vector<unsigned long long> caps;
+    for (const auto& b : blocks) {
         offsets.push_back(flat.size());
-        sizes.push_back(s.size());
-        flat.insert(flat.end(), s.begin(), s.end());
+        sizes.push_back(b.stream.size());
+        caps.push_back(b.dst_capacity);
+        flat.insert(flat.end(), b.stream.begin(), b.stream.end());
     }
     /* One byte of slack, so a zero-length stream still has a valid base
      * pointer to hand the parser and the allocation is never zero-sized. */
@@ -219,10 +140,12 @@ int main() {
     unsigned char* d_streams = nullptr;
     unsigned long long* d_offsets = nullptr;
     unsigned long long* d_sizes = nullptr;
+    unsigned long long* d_caps = nullptr;
     Trace* d_traces = nullptr;
     REQUIRE_CUDA(cudaMalloc(&d_streams, flat.size()));
     REQUIRE_CUDA(cudaMalloc(&d_offsets, offsets.size() * sizeof(*d_offsets)));
     REQUIRE_CUDA(cudaMalloc(&d_sizes, sizes.size() * sizeof(*d_sizes)));
+    REQUIRE_CUDA(cudaMalloc(&d_caps, caps.size() * sizeof(*d_caps)));
     REQUIRE_CUDA(cudaMalloc(&d_traces, count * sizeof(*d_traces)));
     REQUIRE_CUDA(cudaMemcpy(d_streams, flat.data(), flat.size(),
                             cudaMemcpyHostToDevice));
@@ -232,12 +155,15 @@ int main() {
     REQUIRE_CUDA(cudaMemcpy(d_sizes, sizes.data(),
                             sizes.size() * sizeof(*d_sizes),
                             cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_caps, caps.data(),
+                            caps.size() * sizeof(*d_caps),
+                            cudaMemcpyHostToDevice));
     /* Poisoned, so a trace the kernel never wrote cannot pass as a match. */
     REQUIRE_CUDA(cudaMemset(d_traces, 0xFF, count * sizeof(*d_traces)));
 
     ParseOnDevice<<<(count + kThreadsPerBlock - 1) / kThreadsPerBlock,
                     kThreadsPerBlock>>>(d_streams, d_offsets, d_sizes,
-                                        capacity, count, d_traces);
+                                        d_caps, count, d_traces);
     REQUIRE_CUDA(cudaGetLastError());
     REQUIRE_CUDA(cudaDeviceSynchronize());
 
@@ -248,25 +174,26 @@ int main() {
     size_t accepted = 0;
     for (unsigned i = 0; i < count; i++) {
         Trace host_trace;
-        RunParser(flat.data() + offsets[i], sizes[i], capacity, &host_trace);
+        RunParser(flat.data() + offsets[i], sizes[i], caps[i], &host_trace);
         const Trace& device_trace = device_traces[i];
+        const char* name = blocks[i].name.c_str();
         REQUIRE_CTX(host_trace.status == device_trace.status,
-                    "stream %u: host status %d, device status %d", i,
+                    "%s: host status %d, device status %d", name,
                     host_trace.status, device_trace.status);
         REQUIRE_CTX(host_trace.produced == device_trace.produced,
-                    "stream %u: produced %llu vs %llu", i, host_trace.produced,
+                    "%s: produced %llu vs %llu", name, host_trace.produced,
                     device_trace.produced);
         REQUIRE_CTX(host_trace.elements == device_trace.elements,
-                    "stream %u: %llu elements vs %llu", i, host_trace.elements,
+                    "%s: %llu elements vs %llu", name, host_trace.elements,
                     device_trace.elements);
         REQUIRE_CTX(host_trace.digest == device_trace.digest,
-                    "stream %u: element digest %llx vs %llx", i,
+                    "%s: element digest %llx vs %llx", name,
                     host_trace.digest, device_trace.digest);
         /* The fuel budget must never be what ended a parse, on either side. */
         REQUIRE_CTX(host_trace.out_of_fuel == 0,
-                    "stream %u did not terminate on the host", i);
+                    "%s did not terminate on the host", name);
         REQUIRE_CTX(device_trace.out_of_fuel == 0,
-                    "stream %u did not terminate on the device", i);
+                    "%s did not terminate on the device", name);
         if (host_trace.status == CUDEC_OK) {
             accepted++;
         }
@@ -279,6 +206,7 @@ int main() {
     REQUIRE_CUDA(cudaFree(d_streams));
     REQUIRE_CUDA(cudaFree(d_offsets));
     REQUIRE_CUDA(cudaFree(d_sizes));
+    REQUIRE_CUDA(cudaFree(d_caps));
     REQUIRE_CUDA(cudaFree(d_traces));
 
     std::printf("PASS: %u streams parsed identically by the host compiler and "


### PR DESCRIPTION
# What & why

The three standing gates for the Snappy decode path, on-device, every verdict
the oracle's. Closes #154.

**Determinism.** `tests/determinism_gpu.cu` ran one format; it runs both now,
through one sequence taken as function pointers rather than copied into a
second half. The geometry axis belongs to the chunk decoder and not to a
parser, and the two formats share one, so a format left out of it leaves the
shared chunk-to-warp mapping unproven for exactly the instantiation nobody
looked at.

**Two-directional mutant reject parity.** The Snappy mutation corpus goes
through the public entry into the fixture's plumbing: where cudec accepts,
snappy accepts and the bytes match its own output; where snappy rejects, cudec
rejects. The stricter set is pinned at zero, and that zero is a statement
rather than a missing case - the one point where cudec is deliberately
stricter is a four-byte literal length that wraps in the reference's 32-bit
addition, and no mutation of a compressor-produced stream constructs it. The
hand-built corpus below does construct it, and there it is pinned by name.

**The hostile corpus and the capacity adversarials.**
`tests/adversarial_snappy_blocks.h` is the sibling of `adversarial_blocks.h`
and holds what a compressor never emits: the four-byte offset form, copy
lengths below four, an offset at 4 GiB, offset-one pattern repetition at the
64-byte cap, an offset above 64 KiB, non-minimal preambles, and declared
lengths at the varint's ceiling against small capacities. Header-only and
driven from both sides, so a stream that behaves under one thread and
misbehaves under a warp has two places to be caught rather than one:
`tests/snappy_block_device.cu` parses each one with the host compiler and with
nvcc and compares element traces, and `tests/gpu_fixture.cu` drives the same
bytes through the batch entry against the oracle's verdict.

The capacity cases are pinned by status rather than counted among the rejects.
A 4 GiB claim is refused with `CUDEC_ERR_OUTPUT_TOO_SMALL` at the preamble,
before an element is parsed, with the destination still whole - which is the
anti-pattern rule this issue names, stated as an assertion: the
attacker-controlled varint is measured against the caller's capacity and
nothing anywhere is sized from it.

## Type of change

- [x] API surface (no change; the gates are tests)
- [x] Refactor / code quality
- [x] Bug fix (none found - see below)

## Engineering checklist

- [x] Fail-closed preserved: no `src/` file changes in this diff.
      `git diff --name-only origin/main...HEAD` returns `docs/MASTERPLAN.md`
      and four files under `tests/`.
- [x] Oracle coverage: every verdict in both new arms is the oracle's, in both
      directions.
- [x] Determinism preserved, and now asserted for this format across six
      launch configurations.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
- [ ] An adversarial review was NOT run. No second reader is available
      tonight; the evidence below stands in its place.
- [ ] Review record: none, for the same reason.

## GPU sanitizer gate

The sweep could not be produced; the gate is parked and CONTRIBUTING.md
carries why beside the invocation. This issue's own Done-when anticipates
that: "compute-sanitizer memcheck/racecheck per #73 once that gate exists;
until then the recorded substitute gate (whole-corpus diff + determinism) per
the standing machine constraint, stated explicitly on the PR." The substitute
gate is what the Verification block below reports.

**One consequence of the parking is measured here rather than assumed, and it
is the most important line in this pull request.** Removing the
`__syncwarp()` between the literal half and the match half of the copy engine
leaves every gate in this change GREEN:

```
=== the copy engine drops the sync between the two halves ===
  build exit=0
  gpu_fixture exit=0
  determinism_gpu exit=0
```

That is a real hole and it is not closed by anything here. The tool for it is
racecheck, which cannot attach on this machine (#258). The substitute gate
covers output correctness and reject parity; it does not cover intra-warp
memory ordering, and reading a green run as if it did is the mistake this
paragraph exists to stop.

## Performance checklist

Not applicable. No number in this change is a performance claim; the measured
pass is #292 and the bench rung is #167.

## Quality checklist

- [x] Minimal: the determinism test gained a format rather than a second copy
      of itself, and the hostile streams that `snappy_block_device.cu` already
      built by hand moved into the shared header instead of being written
      twice.
- [x] Self-documenting: each stream in the header says what it is for; the
      capacity block says why those cases carry their own capacities.
- [x] The properties are locked as tests, which is what this issue is.

**Each arm proven by breaking something, one at a time, restored after:**

```
=== the declared length is compared the wrong way round ===
  build exit=0
  gpu_fixture exit=1
  FAIL tests/gpu_fixture.cu:498: results[i].status == CUDEC_ERR_OUTPUT_TOO_SMALL
       | declared-one-over-capacity: expected the capacity refusal, got 2

=== an offset-zero copy reaches the copy engine ===
  build exit=0
  snappy_block_device exit=0
  PASS: 26 streams parsed identically by the host compiler and nvcc from one header (11 accepted, 15 rejected)
  gpu_fixture exit=1
  FAIL tests/gpu_fixture.cu:359: snappy_oracle_accepts[i]
       | cudec accepts, snappy rejects: zeros-65536/element-1-copy-offset-0
```

The second one is worth reading twice. The host-versus-device trace compare
stays GREEN under it and reports three more accepted streams, because it asks
whether two compilers agree and not whether the answer is right. The
oracle-parity arm is what catches it, and that is exactly the division of
labour the two arms exist for.

## Verification

Built and run in the Ubuntu-24.04 WSL distribution against the local RTX 3080,
driver 610.88, nvcc 13.3.73, at this branch's tree:

```
$ cmake -S . -B ~/cudec-bc -DCUDEC_ENABLE_CUDA=ON     # configure exit=0
$ cmake --build ~/cudec-bc -j"$(nproc)"               # build exit=0
$ ctest --test-dir ~/cudec-bc --output-on-failure
100% tests passed, 0 tests failed out of 49
Label Time Summary:
gpu    =   8.77 sec*proc (8 tests)
Total Test time (real) =  19.29 sec

$ ~/cudec-bc/tests/determinism_gpu
determinism_gpu: lz4 322 chunks (73 decoded) bit-identical across 6 launch configurations x 5 runs
determinism_gpu: snappy 1090 chunks (149 decoded) bit-identical across 6 launch configurations x 5 runs

$ ~/cudec-bc/tests/snappy_block_device
PASS: 26 streams parsed identically by the host compiler and nvcc from one header (8 accepted, 18 rejected)

$ ~/cudec-bc/tests/gpu_fixture
PASS: 12 LZ4 pairs decoded byte-exact + 310 mutants in oracle parity (248
oracle-rejected, 1 offset==0 stricter) + 40000 grid-stride wraparound chunks +
21 Snappy pairs + 1069 Snappy mutants in oracle parity (941 oracle-rejected, 0
stricter) + 11 vendored testdata files (2928371 bytes) decoded byte-exact on
the GPU decoder; failure contract and poison beyond bytes_written intact; 26
hand-built hostile Snappy streams in oracle parity (8 accepted, 17 rejected,
one documented stricter)

$ npx prettier@3 --check "**/*.{md,yml,yaml}"
All matched files use Prettier code style!
```

- [x] `cmake --build` - builds clean.
- [x] `ctest` - green, GPU tests included.
- [x] Prettier - clean.
- [x] Docs synced: the masterplan's M3 section records the device gate set as
      landed.

## Notes

**No defect was found by any of this.** Every arm was green the first time it
ran, which is worth saying plainly rather than leaving to be inferred from the
absence of a fix: the gates are new coverage over a decode path that already
behaved, and their value is what they will catch later.

**No second reader.** There is none available for this change, and the
commands above are the evidence in place of one.
