### PR TITLE
Record the first Snappy GPU baselines and their parse-only ceiling [#167]

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -70,24 +70,39 @@ add_test(NAME bench_frame_selfcheck COMMAND bench_lz4 --frame --selfcheck)
 set_tests_properties(bench_frame_selfcheck PROPERTIES LABELS gpu RUN_SERIAL
                                                       TRUE)
 
-# The Snappy CPU denominator (issue #164). No CUDA in it at all: there is no
-# Snappy kernel yet, so the only decoder this times is the reference, and the
-# binary needs neither a device nor a kernel header. It links the same
-# oracle target tests/ pins and the same fixture library, because the Snappy
-# streams in this project have ONE provenance (tests/fixtures.h) and a bench
-# that compressed its own would be a second one nobody reconciles.
-add_executable(bench_snappy bench_snappy.cpp)
+# The Snappy CPU denominator (issue #164) and, since issue #167, the device
+# rows read against it. It links the same oracle target tests/ pins and the
+# same fixture library, because the Snappy streams in this project have ONE
+# provenance (tests/fixtures.h) and a bench that compressed its own would be a
+# second one nobody reconciles.
+#
+# gpu_bench.cu is compiled into this target as well as into bench_lz4, rather
+# than made a library the two share: it is one small translation unit, and a
+# library would have to be built with the CUDA properties both binaries
+# already declare for themselves. What that costs is stated rather than
+# discovered - this binary carries the LZ4 parse-only instantiation it never
+# launches, which is bench tooling and not the shipped library, where the
+# guarantee that no parse-only kernel ships is src/chunk_decode.cuh's and is
+# untouched by this.
+add_executable(bench_snappy bench_snappy.cpp gpu_bench.cu)
 target_link_libraries(bench_snappy PRIVATE cudec cudec_test_fixtures
-                                           snappy_oracle)
-# The corpus digest reads src/xxhash64.h, the hash already in the tree.
+                                           snappy_oracle CUDA::cudart)
+# The corpus digest reads src/xxhash64.h, the hash already in the tree;
+# gpu_bench.cu includes the internal kernel header from the same directory.
 target_include_directories(bench_snappy PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-set_target_properties(bench_snappy PROPERTIES CXX_STANDARD 17
-                                              CXX_STANDARD_REQUIRED ON)
+set_target_properties(
+  bench_snappy PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON
+                          CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON
+                          CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
 # -O2 unconditionally for the reason bench_lz4 gives above: the documented
 # container command sets no CMAKE_BUILD_TYPE, and an -O0 reference decoder
-# would be timed instead of the reference decoder.
-target_compile_options(bench_snappy PRIVATE -Wall -Wextra -Werror -O2)
+# would be timed instead of the reference decoder. The CUDA path carries the
+# project's strict device flags, as it does for bench_lz4.
+target_compile_options(
+  bench_snappy
+  PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror;-O2>
+          ${CUDEC_CUDA_STRICT_FLAGS})
 
 # Same rot protection as the entries above, and one more thing besides. The
 # selfcheck builds both corpus shapes from a fixed PRNG and asserts the

--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -8,7 +8,6 @@
 #include "fixtures.h"
 #include "gpu_bench.h"
 
-#include <cuda_runtime.h>
 #include <lz4.h>
 #include <lz4frame.h>
 
@@ -774,26 +773,13 @@ double DecodeAllSeconds(const Corpus& corpus, unsigned char* scratch) {
     return std::chrono::duration<double>(end - start).count();
 }
 
+/* The device line moved to gpu_bench (issue #167): the Snappy harness needs
+ * the identical string, and a methodology block is comparable across reports
+ * only while every report names the machine the same way. */
 std::string CudaDeviceLine() {
-    int count = 0;
-    if (cudaGetDeviceCount(&count) != cudaSuccess || count == 0) {
-        return "none visible to this process (the GPU decode path arrives "
-               "with M1)";
-    }
-    cudaDeviceProp prop{};
-    if (cudaGetDeviceProperties(&prop, 0) != cudaSuccess) {
-        return "device query failed";
-    }
-    int driver = 0;
-    int runtime = 0;
-    (void)cudaDriverGetVersion(&driver);
-    (void)cudaRuntimeGetVersion(&runtime);
-    return std::string(prop.name) + " (sm_" + std::to_string(prop.major) +
-           std::to_string(prop.minor) + "), driver " +
-           std::to_string(driver / 1000) + "." +
-           std::to_string((driver % 100) / 10) + ", runtime " +
-           std::to_string(runtime / 1000) + "." +
-           std::to_string((runtime % 100) / 10);
+    char line[256];
+    (void)cudec_bench_gpu_device_line(line, sizeof(line));
+    return std::string(line);
 }
 
 /* Strict count parsing: whole-string decimal in [min, max] - rejects

--- a/bench/bench_snappy.cpp
+++ b/bench/bench_snappy.cpp
@@ -1,8 +1,8 @@
-/* The Snappy benchmark harness: the CPU denominator every later GPU number
- * is read against. There is no Snappy kernel yet, so this measures the
- * reference decoder alone, and it says so in its own report rather than
- * leaving a reader to infer it (docs/MASTERPLAN.md section 5, honest
- * numbers).
+/* The Snappy benchmark harness: the CPU denominator every GPU number is read
+ * against, and - under --gpu (issue #167) - the device rows themselves. The
+ * default run measures the reference decoder alone and says so in its own
+ * report rather than leaving a reader to infer it (docs/MASTERPLAN.md
+ * section 5, honest numbers).
  *
  * Two corpus shapes, because the batch API and the format disagree about
  * what a unit is. Snappy's own framing is a whole stream per file; the
@@ -16,6 +16,7 @@
 #include "bench_stats.h"
 #include "cudec.h"
 #include "fixtures.h"
+#include "gpu_bench.h"
 #include "xxhash64.h"
 
 #include <snappy.h>
@@ -481,7 +482,7 @@ bool MakeBuffers(const Corpus& corpus,
 }
 
 void PrintReport(const Corpus& corpus, const std::vector<double>& sorted,
-                 size_t warmup, size_t runs) {
+                 size_t warmup, size_t runs, bool gpu) {
     std::vector<size_t> sizes;
     for (const auto& original : corpus.originals) {
         sizes.push_back(original.size());
@@ -489,13 +490,21 @@ void PrintReport(const Corpus& corpus, const std::vector<double>& sorted,
     std::sort(sizes.begin(), sizes.end());
     const double to_gbps = static_cast<double>(corpus.original_bytes) / 1e9;
 
+    char device[256];
+    (void)cudec_bench_gpu_device_line(device, sizeof(device));
+
     std::printf("## bench_snappy report\n");
     std::printf("- decoder: CPU oracle, snappy::RawUncompress (google/snappy "
-                "%d.%d.%d), single thread. cudec has no Snappy kernel yet, so "
-                "this report is the denominator and carries no cudec "
-                "number\n",
-                SNAPPY_MAJOR, SNAPPY_MINOR, SNAPPY_PATCHLEVEL);
+                "%d.%d.%d), single thread%s\n",
+                SNAPPY_MAJOR, SNAPPY_MINOR, SNAPPY_PATCHLEVEL,
+                gpu ? ". The GPU rows below time cudec's own decoder through "
+                      "cudec_snappy_decompress_batch, and the CPU rows are "
+                      "the denominator they are read against"
+                    : ". This run timed no cudec kernel - it is the "
+                      "denominator alone, and --gpu is what adds the device "
+                      "rows");
     std::printf("- host CPU: %s\n", cudec_bench::HostCpuName().c_str());
+    std::printf("- CUDA device: %s\n", device);
     std::printf("- cudec: %d\n", cudec_version());
     std::printf("- corpus: %s, %s, %zu streams, %.2f MB original, %.2f MB "
                 "compressed (ratio %.3f), %s\n",
@@ -529,7 +538,54 @@ void PrintReport(const Corpus& corpus, const std::vector<double>& sorted,
                 to_gbps / cudec_bench::Percentile(sorted, 99));
 }
 
-bool RunCorpus(Corpus* corpus, size_t warmup, size_t runs) {
+/* The device rows for one corpus, printed under the same methodology block
+ * as the CPU rows above them so the two cannot be quoted apart. The GPU
+ * decode is device-resident (H2D/D2H excluded) and CUDA-event timed, and
+ * cudec_bench_gpu_snappy refuses to time a batch whose chunks did not all
+ * decode to their original size, so a number here is never from an
+ * unverified decode.
+ *
+ * Three decimals on GB/s rather than the one bench_lz4 prints: the
+ * whole-file shape puts one warp on each of twelve streams, so its
+ * throughput lands two orders of magnitude below the chunked shape's and
+ * one decimal rounds the whole row to a single digit. */
+bool PrintGpuRows(const Corpus& corpus, double cpu_p50_seconds, size_t warmup,
+                  size_t runs) {
+    std::vector<const unsigned char*> comp_ptrs(corpus.compressed.size());
+    std::vector<size_t> comp_sizes(corpus.compressed.size());
+    std::vector<size_t> orig_sizes(corpus.originals.size());
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        comp_ptrs[i] = corpus.compressed[i].data();
+        comp_sizes[i] = corpus.compressed[i].size();
+        orig_sizes[i] = corpus.originals[i].size();
+    }
+    cudec_gpu_result g;
+    if (!cudec_bench_gpu_snappy(comp_ptrs.data(), comp_sizes.data(),
+                                orig_sizes.data(), corpus.originals.size(),
+                                static_cast<int>(warmup),
+                                static_cast<int>(runs), &g)) {
+        std::fprintf(stderr, "GPU bench failed\n");
+        return false;
+    }
+    std::printf("- GPU decode (device-resident, CUDA-event timed, %zu warmup "
+                "+ %zu runs, %zu chunks, every chunk verified to its original "
+                "size before timing): p50 %.3f ms, %.3f GB/s\n",
+                warmup, runs, g.chunks, g.full_ms_p50, g.full_gbps_p50);
+    std::printf("- GPU parse-only ceiling (copies elided, the identical "
+                "lockstep parse through the chunk-decoder template seam): p50 "
+                "%.3f ms, %.3f GB/s\n",
+                g.parse_only_ms_p50, g.parse_only_gbps_p50);
+    /* The ratio the milestone is read on: the device number against this
+     * report's own CPU denominator, computed from the two rows above rather
+     * than from a number quoted out of another run. */
+    std::printf("- GPU vs the CPU denominator in this report: %.2fx (CPU p50 "
+                "%.3f ms, GPU p50 %.3f ms)\n",
+                cpu_p50_seconds * 1e3 / g.full_ms_p50, cpu_p50_seconds * 1e3,
+                g.full_ms_p50);
+    return true;
+}
+
+bool RunCorpus(Corpus* corpus, size_t warmup, size_t runs, bool gpu) {
     Tally(corpus);
     if (corpus->original_bytes == 0) {
         std::fprintf(stderr, "corpus is empty - nothing to benchmark\n");
@@ -558,7 +614,11 @@ bool RunCorpus(Corpus* corpus, size_t warmup, size_t runs) {
         times.push_back(seconds);
     }
     std::sort(times.begin(), times.end());
-    PrintReport(*corpus, times, warmup, runs);
+    PrintReport(*corpus, times, warmup, runs, gpu);
+    if (gpu && !PrintGpuRows(*corpus, cudec_bench::Percentile(times, 50),
+                             warmup, runs)) {
+        return false;
+    }
     return true;
 }
 
@@ -619,6 +679,7 @@ int main(int argc, char** argv) {
     bool chunked = false;
     bool worst = false;
     bool worstlit = false;
+    bool gpu = false;
     std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
@@ -632,6 +693,8 @@ int main(int argc, char** argv) {
             worst = true;
         } else if (arg == "--worstlit") {
             worstlit = true;
+        } else if (arg == "--gpu") {
+            gpu = true;
         } else if (arg == "--runs" && i + 1 < argc) {
             if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
                 std::fprintf(stderr, "--runs must be in [1, %zu]\n", kMaxRuns);
@@ -649,7 +712,7 @@ int main(int argc, char** argv) {
         } else if (!arg.empty() && arg[0] == '-') {
             std::fprintf(stderr, "usage: bench_snappy [--runs N] [--warmup N] "
                                  "[--whole] [--chunked] [--worst] "
-                                 "[--worstlit] [--selfcheck] "
+                                 "[--worstlit] [--gpu] [--selfcheck] "
                                  "[corpus files...]\n");
             return 2;
         } else {
@@ -659,6 +722,16 @@ int main(int argc, char** argv) {
     if (selfcheck) {
         warmup = 1;
         runs = 3;
+    }
+
+    /* The selfcheck is the rot check the GPU-less CI runner runs, so it stays
+     * CPU-only by construction rather than by whoever invokes it remembering
+     * to. Refused rather than silently ignored: a run that was asked for
+     * device rows and printed none reads as a machine with no device. */
+    if (gpu && selfcheck) {
+        std::fprintf(stderr, "--gpu and --selfcheck are exclusive: the "
+                             "selfcheck runs on the GPU-less runner\n");
+        return 2;
     }
 
     /* The adversarial corpora are constructed rather than compressed, and
@@ -709,7 +782,7 @@ int main(int argc, char** argv) {
                     : CheckLiteralDensity(corpus, elements))) {
             return 1;
         }
-        if (!RunCorpus(&corpus, warmup, runs)) {
+        if (!RunCorpus(&corpus, warmup, runs, gpu)) {
             return 1;
         }
         std::printf("- element density: %zu elements, %.4f per compressed "
@@ -778,7 +851,7 @@ int main(int argc, char** argv) {
             }
         }
         CompressAll(&corpus);
-        if (!RunCorpus(&corpus, warmup, runs)) {
+        if (!RunCorpus(&corpus, warmup, runs, gpu)) {
             return 1;
         }
         if (selfcheck && !CheckDigest(corpus, shape == Shape::kWhole

--- a/bench/gpu_bench.cu
+++ b/bench/gpu_bench.cu
@@ -8,6 +8,7 @@
 #include "cudec.h"
 #include "chunk_decode.cuh"
 #include "lz4_block.h"
+#include "snappy_block.h"
 
 #include <cuda_runtime.h>
 
@@ -15,13 +16,21 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <string>
 #include <vector>
 
 namespace {
 
 /* Parse-only ceiling variant: the identical redundant lockstep parse with
  * the copies elided, launched exactly like the shipped decode. It ceilings
- * both single-pass and any two-phase phase-1 (which shares this parse). */
+ * both single-pass and any two-phase phase-1 (which shares this parse).
+ *
+ * Templated on the parser rather than written once per format, for the same
+ * reason src/chunk_decode.cuh is: the launch shape, the argument validation
+ * and the grid are format-independent, and a second copy of them here would
+ * be a second place for the bench and the shipped path to drift apart. Only
+ * the instantiations named below are emitted. */
+template <class Parser>
 cudec_status LaunchParseOnly(const void* const* s, const size_t* ss,
                              void* const* d, const size_t* dc, size_t n,
                              cudec_chunk_result* r, cudaStream_t stream) {
@@ -31,7 +40,7 @@ cudec_status LaunchParseOnly(const void* const* s, const size_t* ss,
         return valid;
     }
     (void)cudaGetLastError();
-    cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, true>
+    cudec_detail::chunk_decode_batch<Parser, true>
         <<<cudec_detail::decode_grid_blocks(n), cudec_detail::kBlockThreads, 0,
            stream>>>(s, ss, d, dc, n, r);
     return cudaGetLastError() == cudaSuccess ? CUDEC_OK : CUDEC_ERR_CUDA;
@@ -42,11 +51,16 @@ cudec_status LaunchParseOnly(const void* const* s, const size_t* ss,
         if ((call) != cudaSuccess) return false; \
     } while (0)
 
+/* The one launch shape every timed variant here has: the batch ABI's own
+ * argument list. Named once so the timing loop and the format entries below
+ * cannot disagree about it. */
+using LaunchFn = cudec_status (*)(const void* const*, const size_t*,
+                                  void* const*, const size_t*, size_t,
+                                  cudec_chunk_result*, cudaStream_t);
+
 /* Event-times `launch` over `runs` iterations after `warmup`, returning the
  * p50 milliseconds. */
-bool TimeKernel(cudec_status (*launch)(const void* const*, const size_t*,
-                                       void* const*, const size_t*, size_t,
-                                       cudec_chunk_result*, cudaStream_t),
+bool TimeKernel(LaunchFn launch,
                 const void** d_s, size_t* d_ss, void** d_d, size_t* d_dc,
                 size_t n, cudec_chunk_result* d_r, cudaStream_t stream,
                 int warmup, int runs, double* p50_ms) {
@@ -83,6 +97,12 @@ cudec_status LaunchFull(const void* const* s, const size_t* ss,
                         void* const* d, const size_t* dc, size_t n,
                         cudec_chunk_result* r, cudaStream_t stream) {
     return cudec_lz4_decompress_batch(s, ss, d, dc, n, r, stream);
+}
+
+cudec_status LaunchFullSnappy(const void* const* s, const size_t* ss,
+                              void* const* d, const size_t* dc, size_t n,
+                              cudec_chunk_result* r, cudaStream_t stream) {
+    return cudec_snappy_decompress_batch(s, ss, d, dc, n, r, stream);
 }
 
 double Median(std::vector<double>* t) {
@@ -160,11 +180,16 @@ bool TimeCtxCold(const void* const* h_src, const size_t* h_ssz,
     return true;
 }
 
-}  // namespace
-
-bool cudec_bench_gpu(const unsigned char* const* comp,
-                     const size_t* comp_sizes, const size_t* orig_sizes,
-                     size_t n, int warmup, int runs, cudec_gpu_result* out) {
+/* The device-resident measurement itself, format-agnostic: the two launchers
+ * are the only thing that differs between the formats on this seam, so the
+ * upload, the correctness precondition, the timing protocol and the
+ * throughput arithmetic are written once and both entries below share them.
+ * A second copy per format would be a second protocol, and two numbers
+ * produced by two protocols are not comparable. */
+bool BenchBatch(LaunchFn full, LaunchFn parse_only,
+                const unsigned char* const* comp, const size_t* comp_sizes,
+                const size_t* orig_sizes, size_t n, int warmup, int runs,
+                cudec_gpu_result* out) {
     std::vector<const void*> h_s(n);
     std::vector<void*> h_d(n);
     std::vector<size_t> h_ss(n), h_dc(n);
@@ -207,7 +232,7 @@ bool cudec_bench_gpu(const unsigned char* const* comp,
 
     /* Correctness precondition: every chunk must decode OK, or the numbers
      * are meaningless (honest-numbers discipline). */
-    if (LaunchFull(d_s, d_ss, d_d, d_dc, n, d_r, stream) != CUDEC_OK) {
+    if (full(d_s, d_ss, d_d, d_dc, n, d_r, stream) != CUDEC_OK) {
         return false;
     }
     BG_CUDA(cudaStreamSynchronize(stream));
@@ -224,12 +249,12 @@ bool cudec_bench_gpu(const unsigned char* const* comp,
 
     double full_ms = 0.0;
     double parse_ms = 0.0;
-    if (!TimeKernel(LaunchFull, d_s, d_ss, d_d, d_dc, n, d_r, stream, warmup,
-                    runs, &full_ms)) {
+    if (!TimeKernel(full, d_s, d_ss, d_d, d_dc, n, d_r, stream, warmup, runs,
+                    &full_ms)) {
         return false;
     }
-    if (!TimeKernel(LaunchParseOnly, d_s, d_ss, d_d, d_dc, n, d_r, stream,
-                    warmup, runs, &parse_ms)) {
+    if (!TimeKernel(parse_only, d_s, d_ss, d_d, d_dc, n, d_r, stream, warmup,
+                    runs, &parse_ms)) {
         return false;
     }
 
@@ -244,6 +269,48 @@ bool cudec_bench_gpu(const unsigned char* const* comp,
     /* Buffers are reclaimed at process exit; the bench is a short-lived
      * one-shot, like the test harness. */
     return true;
+}
+
+}  // namespace
+
+bool cudec_bench_gpu_device_line(char* out, size_t n) {
+    if (out == nullptr || n == 0) {
+        return false;
+    }
+    int count = 0;
+    if (cudaGetDeviceCount(&count) != cudaSuccess || count == 0) {
+        std::snprintf(out, n, "none visible to this process");
+        return false;
+    }
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, 0) != cudaSuccess) {
+        std::snprintf(out, n, "device query failed");
+        return false;
+    }
+    int driver = 0;
+    int runtime = 0;
+    (void)cudaDriverGetVersion(&driver);
+    (void)cudaRuntimeGetVersion(&runtime);
+    std::snprintf(out, n, "%s (sm_%d%d), driver %d.%d, runtime %d.%d",
+                  prop.name, prop.major, prop.minor, driver / 1000,
+                  (driver % 100) / 10, runtime / 1000, (runtime % 100) / 10);
+    return true;
+}
+
+bool cudec_bench_gpu(const unsigned char* const* comp,
+                     const size_t* comp_sizes, const size_t* orig_sizes,
+                     size_t n, int warmup, int runs, cudec_gpu_result* out) {
+    return BenchBatch(LaunchFull, LaunchParseOnly<cudec_detail::Lz4Parser>,
+                      comp, comp_sizes, orig_sizes, n, warmup, runs, out);
+}
+
+bool cudec_bench_gpu_snappy(const unsigned char* const* comp,
+                            const size_t* comp_sizes, const size_t* orig_sizes,
+                            size_t n, int warmup, int runs,
+                            cudec_gpu_result* out) {
+    return BenchBatch(LaunchFullSnappy,
+                      LaunchParseOnly<cudec_detail::SnappyParser>, comp,
+                      comp_sizes, orig_sizes, n, warmup, runs, out);
 }
 
 bool cudec_bench_gpu_stream_ctx(const unsigned char* const* comp,

--- a/bench/gpu_bench.h
+++ b/bench/gpu_bench.h
@@ -5,6 +5,14 @@
 
 #include <cstddef>
 
+/* The one description of the device a GPU row was produced on - name, sm_
+ * version, driver and runtime - written into `out` and truncated to `n`.
+ * It lives here rather than in each harness because a methodology block is
+ * only comparable across reports while every report names the machine the
+ * same way, and two copies of this string are two ways. Returns false, and
+ * writes the reason, when no device is visible to the process. */
+bool cudec_bench_gpu_device_line(char* out, size_t n);
+
 struct cudec_gpu_result {
     size_t chunks;
     size_t output_bytes;
@@ -21,6 +29,16 @@ struct cudec_gpu_result {
 bool cudec_bench_gpu(const unsigned char* const* comp,
                      const size_t* comp_sizes, const size_t* orig_sizes,
                      size_t n, int warmup, int runs, cudec_gpu_result* out);
+
+/* The same measurement over the Snappy batch entry (issue #167): the shipped
+ * cudec_snappy_decompress_batch, and the parse-only ceiling of the same
+ * parser through the chunk-decoder template seam. It reports through the
+ * struct above rather than one of its own, because the two formats are timed
+ * by the identical protocol and a second struct would let them drift apart. */
+bool cudec_bench_gpu_snappy(const unsigned char* const* comp,
+                            const size_t* comp_sizes, const size_t* orig_sizes,
+                            size_t n, int warmup, int runs,
+                            cudec_gpu_result* out);
 
 struct cudec_stream_ctx_result {
     size_t chunks;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -945,9 +945,10 @@ per call.
 
 ## M3: the Snappy CPU denominator (issue #164)
 
-There is no Snappy kernel yet. This entry is the denominator a later device
-number will be read against, and the harness says so in its own report rather
-than leaving a reader to infer it from the absence of a GPU row.
+There was no Snappy kernel when this ran. This entry is the denominator, and
+the harness says so in its own report rather than leaving a reader to infer it
+from the absence of a GPU row. The device numbers read against it were
+recorded later and are in the M3 GPU baselines section below.
 
 Two corpus shapes, because the format and the batch API disagree about what a
 unit is. Snappy's own framing is one stream per file; the shape this library
@@ -1025,8 +1026,9 @@ and its decoded bytes per element. A corpus that drifts off its shape reds
 `bench_snappy_worst_selfcheck` or `bench_snappy_worstlit_selfcheck` rather
 than quietly reporting a worst case it no longer measures.
 
-There is still no Snappy kernel, so these are denominators and carry no cudec
-number. Recorded 2026-08-10 inside the digest-pinned
+There was still no Snappy kernel when these ran, so they are denominators and
+carry no cudec number; the device rows read against them are in the M3 GPU
+baselines section below. Recorded 2026-08-10 inside the digest-pinned
 `nvidia/cuda:12.6.2-devel-ubuntu24.04` container. Reproduce with
 `bench_snappy --worstlit --warmup 3 --runs 30` and
 `bench_snappy --worst --warmup 3 --runs 30`.
@@ -1081,6 +1083,150 @@ than a serial copy, while the parse chain stays serial per chunk. Which corpus
 floors the GPU is a measurement nobody has taken, and neither this section nor
 the element counts settle it. It is recorded here so that whoever takes it has
 the CPU ordering in front of them rather than an assumption.
+
+## M3: first recorded Snappy GPU baselines and the ParseOnly ceiling (issue #167)
+
+The first device numbers for the Snappy path, read against the CPU
+denominators recorded in the two sections above. Every block below carries its
+own CPU rows, so the ratio in each one is against that run's own denominator
+rather than against a number quoted from another session.
+
+What is timed. `cudec_snappy_decompress_batch`, device-resident: the
+compressed batch is uploaded once and the timed region is the decode launch
+alone, CUDA-event timed, so H2D and D2H are excluded. Before any timing the
+batch is decoded once and every chunk is checked to return `CUDEC_OK` with
+exactly its original byte count; the harness refuses to report a number for a
+batch that did not.
+
+The ParseOnly ceiling is instantiable for Snappy and is reported. It is the
+same `chunk_decode_batch` with the copies elided, reached through the parser
+template seam rather than through a second kernel, so the parse it measures is
+the parse the shipped path runs and not a copy of it. That is what makes it a
+ceiling on this design and on the phase 1 of any two-phase design that would
+share the parse.
+
+Recorded 2026-08-25 inside the digest-pinned
+`nvidia/cuda:12.6.2-devel-ubuntu24.04` container
+(`sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`,
+nvcc 12.6) on the RTX 3080 named in each block, at 3 warmup + 30 measured
+runs. Reproduce with `bench_snappy --gpu bench/corpora/silesia/*`,
+`bench_snappy --worst --gpu` and `bench_snappy --worstlit --gpu`. The Silesia
+corpus digests are the ones the CPU denominator section above recorded, so the
+two sections were built from byte-identical corpora.
+
+```
+## bench_snappy report
+- decoder: CPU oracle, snappy::RawUncompress (google/snappy 1.2.2), single thread. The GPU rows below time cudec's own decoder through cudec_snappy_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 12.6
+- cudec: 100
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 64 KiB-chunked streams, 3239 streams, 211.94 MB original, 101.36 MB compressed (ratio 0.478), compressed in-harness by the pinned snappy oracle
+- corpus digest: be088850546d917c (XXH64 over per-stream length and XXH64, little-endian, in corpus order)
+- stream sizes: min 8066 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is snappy::RawUncompress only (no allocation, no length parse); every stream round-trip-verified against the original once before timing; percentiles are nearest-rank
+- wall per run: p50 191.581 ms / p90 202.740 ms / p99 206.972 ms
+- decode throughput: p50 1.106 GB/s / p90 1.045 GB/s / p99 1.024 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3239 chunks, every chunk verified to its original size before timing): p50 15.574 ms, 13.609 GB/s
+- GPU parse-only ceiling (copies elided, the identical lockstep parse through the chunk-decoder template seam): p50 10.746 ms, 19.723 GB/s
+- GPU vs the CPU denominator in this report: 12.30x (CPU p50 191.581 ms, GPU p50 15.574 ms)
+```
+
+```
+## bench_snappy report
+- decoder: CPU oracle, snappy::RawUncompress (google/snappy 1.2.2), single thread. The GPU rows below time cudec's own decoder through cudec_snappy_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 12.6
+- cudec: 100
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, whole-file streams, 12 streams, 211.94 MB original, 101.35 MB compressed (ratio 0.478), compressed in-harness by the pinned snappy oracle
+- corpus digest: 7bd83d9e3b24fd44 (XXH64 over per-stream length and XXH64, little-endian, in corpus order)
+- stream sizes: min 5345280 / median 10085684 / max 51220480 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is snappy::RawUncompress only (no allocation, no length parse); every stream round-trip-verified against the original once before timing; percentiles are nearest-rank
+- wall per run: p50 190.693 ms / p90 197.636 ms / p99 209.044 ms
+- decode throughput: p50 1.111 GB/s / p90 1.072 GB/s / p99 1.014 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 12 chunks, every chunk verified to its original size before timing): p50 3381.903 ms, 0.063 GB/s
+- GPU parse-only ceiling (copies elided, the identical lockstep parse through the chunk-decoder template seam): p50 1805.522 ms, 0.117 GB/s
+- GPU vs the CPU denominator in this report: 0.06x (CPU p50 190.693 ms, GPU p50 3381.903 ms)
+```
+
+```
+## bench_snappy report
+- decoder: CPU oracle, snappy::RawUncompress (google/snappy 1.2.2), single thread. The GPU rows below time cudec's own decoder through cudec_snappy_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 12.6
+- cudec: 100
+- corpus: max element density (constructed), 64 KiB-chunked streams, 3200 streams, 209.72 MB original, 104.88 MB compressed (ratio 0.500), hand-constructed in-harness as back-to-back minimum-cost copies at offset 1, which the reference compressor never emits; every stream validated by the pinned snappy oracle before timing
+- corpus digest: 1a7d7e76546da248 (XXH64 over per-stream length and XXH64, little-endian, in corpus order)
+- stream sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is snappy::RawUncompress only (no allocation, no length parse); every stream round-trip-verified against the original once before timing; percentiles are nearest-rank
+- wall per run: p50 1356.534 ms / p90 1420.085 ms / p99 1438.338 ms
+- decode throughput: p50 0.155 GB/s / p90 0.148 GB/s / p99 0.146 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3200 chunks, every chunk verified to its original size before timing): p50 26.082 ms, 8.041 GB/s
+- GPU parse-only ceiling (copies elided, the identical lockstep parse through the chunk-decoder template seam): p50 17.912 ms, 11.708 GB/s
+- GPU vs the CPU denominator in this report: 52.01x (CPU p50 1356.534 ms, GPU p50 26.082 ms)
+- element density: 52432000 elements, 0.4999 per compressed byte, 3.9998 decoded bytes each
+```
+
+```
+## bench_snappy report
+- decoder: CPU oracle, snappy::RawUncompress (google/snappy 1.2.2), single thread. The GPU rows below time cudec's own decoder through cudec_snappy_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 12.6
+- cudec: 100
+- corpus: max parse work per output byte (constructed), 64 KiB-chunked streams, 3200 streams, 209.72 MB original, 419.44 MB compressed (ratio 2.000), hand-constructed in-harness as one length-1 literal element per output byte, which the reference compressor never emits; every stream validated by the pinned snappy oracle before timing
+- corpus digest: a475ef89da01c0e4 (XXH64 over per-stream length and XXH64, little-endian, in corpus order)
+- stream sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-corpus decode; the timed region is snappy::RawUncompress only (no allocation, no length parse); every stream round-trip-verified against the original once before timing; percentiles are nearest-rank
+- wall per run: p50 1078.347 ms / p90 1100.253 ms / p99 1107.216 ms
+- decode throughput: p50 0.194 GB/s / p90 0.191 GB/s / p99 0.189 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3200 chunks, every chunk verified to its original size before timing): p50 58.537 ms, 3.583 GB/s
+- GPU parse-only ceiling (copies elided, the identical lockstep parse through the chunk-decoder template seam): p50 38.142 ms, 5.498 GB/s
+- GPU vs the CPU denominator in this report: 18.42x (CPU p50 1078.347 ms, GPU p50 58.537 ms)
+- element density: 209715200 elements, 0.5000 per compressed byte, 1.0000 decoded bytes each
+```
+
+**The parse is the bound on every corpus, and it is not close.** Eliding both
+copy loops removes 31% of the chunked-Silesia decode time (15.574 ms to 10.746
+ms), 31% on the copy chain (26.082 to 17.912) and 35% on the parse chain
+(58.537 to 38.142). Two thirds of the kernel's time is the redundant 32-lane
+lockstep parse in all three regimes. That is the same conclusion the LZ4 pass
+reached, and it is now measured for Snappy rather than transferred: the lever
+filed against these baselines that attacks the parse (#161) has a two-thirds
+share to move, and the ones that attack the copy stage (#163, #165) have a
+third.
+
+**The device is floored by the parse-bound corpus, not by the copy chain, and
+the CPU ordering is the opposite.** The adversarial-denominator section above
+records the reference decoder finishing the parse chain 20% SOONER than the
+copy chain, and says explicitly that which corpus floors the GPU is a
+measurement nobody has taken. Taken here: the copy chain runs at 8.041 GB/s
+and the parse chain at 3.583 GB/s, so the GPU is 2.2x apart in the direction
+the CPU is 1.25x apart the other way. The reason is the machinery each regime
+meets. The reference pays a serial byte-at-a-time overlapping copy for an
+offset-1 element, which the kernel answers with the closed-form modular
+gather; the parse stays serial per chunk on both. **So the DoS-resistance
+margin for M3, and the number the pre-registered accept rule of #161, #163 and
+#165 turns on, is the 3.583 GB/s parse-bound row rather than the copy chain.**
+
+**Against LZ4 on the same device, the same protocol and a comparable corpus,
+Snappy decodes slower and its ceiling is lower.** The M1 Silesia rows report
+18.1 GB/s decode with a 34.6 GB/s parse-only ceiling; the chunked Silesia rows
+here report 13.609 and 19.723. The two corpora are the same Silesia bytes at a
+near-identical ratio (0.483 against 0.478), so what is left is the format: a
+Snappy copy element carries at most 64 bytes where an LZ4 match is unbounded,
+so the same output costs more elements and the serial parse chain per chunk is
+longer. The adversarial rows land in the same place, LZ4's worst-4Bmatch at
+8.1 GB/s with a 15.3 GB/s ceiling against Snappy's copy chain at 8.041 and
+11.708.
+
+**The whole-file shape is a statement about the batch shape rather than about
+the decoder, and it is recorded here so that nobody quotes it as one.** Twelve
+streams is twelve warps on a device with 68 SMs, so that row measures one warp
+decoding up to 51 MB serially: 0.063 GB/s, 17x SLOWER than the
+single-threaded reference. The chunked shape over the identical bytes is 216x
+faster. That is the whole argument for the 64 KiB page unit the batch API is
+built around, and it is why the chunked row and not this one is the M3
+baseline. A caller holding whole-file Snappy streams has to cut them before
+this API can help, and the format's own framing does not do it for them.
 
 ## M5: the Zstd CPU denominator (issue #227)
 


### PR DESCRIPTION
Closes #167.

The Snappy bench carried a CPU denominator and nothing to read against it.
It has a `--gpu` path now, and four recorded measurements: Silesia in both
shapes, the maximum-element-density corpus and the parse-bound corpus. The
ParseOnly ceiling turned out to be instantiable for Snappy, so it is reported
rather than explained away.

## What I built

The device path shares the LZ4 one rather than copying it. What differed
between the two formats was two launchers, so the upload, the correctness
precondition, the timing protocol and the throughput arithmetic moved into one
`BenchBatch` that both entries call. Two numbers produced by two protocols
would not have been comparable, which is the whole reason the harness exists.

The parse-only launcher is templated on the parser for the same reason
`src/chunk_decode.cuh` is: the Snappy ceiling is then the shipped parse with
the copies elided, reached through the same seam, and not a second parse
written beside it. The device-description line moved into `gpu_bench` as well,
because a methodology block is comparable across reports only while every
report names the machine the same way; `bench_lz4` reads it from there now
instead of holding its own copy of it.

Two refusals rather than conveniences. The batch is decoded once and every
chunk checked to return `CUDEC_OK` with exactly its original byte count before
the first timed run, and the harness returns failure instead of a row if one
did not, so no number here is from an unverified decode. `--gpu` and
`--selfcheck` are refused together, so the rot check the GPU-less runner runs
stays CPU-only by construction rather than by whoever invokes it remembering.

`bench_snappy` now compiles `gpu_bench.cu` alongside `bench_lz4`. What that
costs is stated in the CMake comment rather than left to be discovered: this
binary carries the LZ4 parse-only instantiation it never launches. That is
bench tooling; the guarantee that no parse-only kernel reaches the shipped
library is `src/chunk_decode.cuh`'s and is untouched.

## The measurements

All four blocks, unedited and with their full methodology, are in
`docs/BENCHMARKS.md` under "M3: first recorded Snappy GPU baselines and the
ParseOnly ceiling (issue #167)". Recorded on an RTX 3080 (sm_86) inside the
digest-pinned `nvidia/cuda:12.6.2-devel-ubuntu24.04`
(`sha256:738fba0fbdb225b7a2931c58a5c8f03a84d3cd2f6a84975826a157339ef750b8`,
nvcc 12.6), 3 warmup + 30 measured runs, device-resident, CUDA-event timed.

| corpus                    | GPU decode p50 | GB/s   | parse-only ceiling | vs this run's CPU denominator |
| ------------------------- | -------------- | ------ | ------------------ | ----------------------------- |
| Silesia, 64 KiB-chunked   | 15.574 ms      | 13.609 | 19.723 GB/s        | 12.30x                        |
| Silesia, whole-file       | 3381.903 ms    | 0.063  | 0.117 GB/s         | 0.06x                         |
| max element density       | 26.082 ms      | 8.041  | 11.708 GB/s        | 52.01x                        |
| max parse work per byte   | 58.537 ms      | 3.583  | 5.498 GB/s         | 18.42x                        |

The Silesia corpus digests, `be088850546d917c` chunked and `7bd83d9e3b24fd44`
whole, are the ones the CPU denominator section already recorded, so the two
sections were built from byte-identical corpora and the ratios are not
flattered by a corpus that moved.

Three readings, all written up in the record:

**The parse is the bound, on every corpus.** Eliding both copy loops removes
31% of the chunked-Silesia time, 31% of the copy chain and 35% of the parse
chain. Two thirds of the kernel is the redundant 32-lane lockstep parse in
every regime, which is what #161 has to move and what #163 and #165 do not.

**The device is floored by the parse-bound corpus, not by the copy chain, and
the CPU ordering is the opposite.** 3.583 GB/s against 8.041, where the
reference decoder finishes the parse chain 20% sooner than the copy chain. The
adversarial-denominator section said which corpus floors the GPU was a
measurement nobody had taken; it is taken, and it decides which row the
pre-registered accept rule of #161, #163 and #165 turns on.

**The whole-file shape is a statement about the batch shape and not about the
decoder.** Twelve streams is twelve warps on 68 SMs, so that row is one warp
decoding up to 51 MB serially: 17x slower than one CPU thread, and 216x slower
than the same bytes cut into 64 KiB pages. Recorded rather than omitted,
because it is the argument for the page unit the batch API is built around.

## Gates

Run in the same pinned container on the RTX 3080.

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
ctest --test-dir build-cuda --output-on-failure
...
100% tests passed, 0 tests failed out of 49

Label Time Summary:
gpu    =   8.82 sec*proc (8 tests)
```

```
npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

The kernel is unchanged by this branch: the diff is `bench/` and
`docs/BENCHMARKS.md` only, so no number here is quoted against a decoder this
PR moved.

```
git diff --name-only origin/main...HEAD
bench/CMakeLists.txt
bench/bench_lz4.cpp
bench/bench_snappy.cpp
bench/gpu_bench.cu
bench/gpu_bench.h
docs/BENCHMARKS.md
```

## What is NOT covered

`compute-sanitizer` did not run over these binaries. It cannot attach to the
device on this machine at all, which is #258, so the four-tool net says
nothing about this branch either way.

The README status-table row does not flip here; it flips when M3 closes, as
the issue asks.

There is no second reader for this branch tonight. The evidence above stands
in place of one: the gates were run rather than asserted, and every number is
reproducible from the flags named beside it.
