### PR TITLE
Record the short-copy predicated pass as not separable from noise [#163]

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1311,6 +1311,95 @@ bytes the tag implies while still removing the dependency - the tag alone
 first, then a single width-selected load - was not built or measured, and is
 the shape a future attempt would have to take.
 
+### M3 perf lever (issue #163): the short-copy predicated pass is not separable from noise
+
+Snappy caps a copy element at 64 bytes, so at a 32-lane warp most elements are
+at most two strided iterations and usually one. The hypothesis was that the
+strided loop's setup and back edge, rather than the copy, are what the short
+regime pays, and that a single predicated pass would remove them.
+
+What was measured. In `chunk_decode_batch`, both copy stages gained a short
+arm: `if (len <= kWarpSize) { if (lane < len) <one store> } else { <the
+existing strided loop> }`, on the literal copy and on the 32-bit match gather.
+Every test is warp-uniform - all lanes parsed the same element - so no lane can
+leave early and strand the others at a `__syncwarp()`, and the closed-form
+modular gather is unchanged in both arms. All 49 ctest gates were green on the
+patched kernel first.
+
+**The parse-only ceiling is the drift control, and it is what makes this
+verdict readable.** ParseOnly elides both copy stages, so this lever cannot
+touch it by construction: any difference in that row between the two sides is
+session drift, measured in the same invocation as the number it is controlling
+for. That is not a device this project can reserve, and the control says how
+much of any delta is the machine.
+
+Measured 2026-08-25 in the digest-pinned
+`nvidia/cuda:12.6.2-devel-ubuntu24.04` container on the RTX 3080, baseline and
+patched binaries built from the same tree and A/B-interleaved in one session,
+3 warmup + 30 CUDA-event-timed runs per invocation. The worst cases ran FIRST,
+which is the trap this lever walks into. Two interleaved passes on the three
+64 KiB-chunked corpora, one on the whole-file shape. Every column is
+throughput speedup, `baseline_ms / short_arm_ms − 1`.
+
+| Corpus                  | Pass | Decode     | Ceiling (control) | Decode less control |
+| ----------------------- | ---- | ---------- | ----------------- | ------------------- |
+| `--worst` (copy chain)  | 1    | **+7.75%** | **+9.10%**        | **−1.35 pp**        |
+| `--worst` (copy chain)  | 2    | −0.10%     | −0.38%            | +0.28 pp            |
+| `--worstlit` (parse)    | 1    | +1.19%     | −0.21%            | +1.40 pp            |
+| `--worstlit` (parse)    | 2    | +0.77%     | +0.34%            | +0.43 pp            |
+| Silesia, 64 KiB-chunked | 1    | +0.96%     | +1.04%            | −0.08 pp            |
+| Silesia, 64 KiB-chunked | 2    | −1.48%     | −1.88%            | +0.40 pp            |
+| Silesia, whole-file     | 1    | +1.40%     | +1.04%            | +0.36 pp            |
+
+**The first row is the reason the control is in the table.** Read alone it is
+a 7.75% win on the adversarial copy corpus, which is exactly the result this
+lever was built to find, on exactly the corpus the accept rule turns on. The
+ceiling beside it moved 9.10% in the same direction, on a code path the lever
+does not contain, and the second pass of the same corpus has both columns at
+zero. That cell is the first invocation of the session on a cold clock, and
+without a control measured in the same run it would have been recorded as the
+lever's headline number.
+
+**Corrected, every cell straddles zero: −1.35 to +1.40 percentage points,
+against a control that itself swings ±1.9%.** There is no corpus on which an
+improvement can be recorded, so the pre-registered accept rule (issue #163:
+recorded improvement on at least one corpus with zero regression on the Snappy
+worst-case corpus) is not met on its first clause. Rejected. No kernel code
+shipped; `src/chunk_decode.cuh` is untouched.
+
+**What this retires is the hypothesis rather than the lever.** Snappy's copy
+stage is not loop-overhead-bound: removing the loop from the short regime
+entirely changes nothing measurable, on a corpus whose every element is a
+4-byte copy. The upside was bounded before the measurement anyway - the M3
+baselines above put the whole copy stage at 31-35% of the kernel's time - and
+this says the setup inside that share is not where it goes.
+
+**And the #36 trap did not transfer, which is worth recording in its own
+right.** Perf pass 1-3 rejected an LZ4 match-copy fast path because the added
+per-element predicate cost 5-9% at maximum sequence density. The same shape of
+predicate, added to the same kernel for Snappy, costs nothing measurable on
+either Snappy worst case. The difference is what the predicate buys: LZ4's
+arm was never taken on the offset-1 corpus, so it was pure cost, while
+Snappy's short arm is taken by every element there. A future lever in this
+stage does not inherit a debt from that pass.
+
+**The second candidate named in the issue was not built, and the reason is a
+settled design decision rather than effort.** Sub-warp fan-out - several
+elements copying concurrently instead of idling lanes on a short one -
+requires knowing the next element before the current copy retires, which means
+parsing ahead of the copy. This kernel's parse is redundant across all 32
+lanes in lockstep and single-pass, settled at the #85 panel and in the
+masterplan's decomposition question; running the parse ahead of the copies is
+the two-phase design that was measured and refused, not a fan-out variant. So
+that candidate is a re-opening of #15 and not a lever this pass could take.
+
+**One disclosure about the shape as built.** The short arm went into the
+shared `chunk_decode_batch`, so it would have changed the LZ4 instantiation
+too. Nothing ships, so no LZ4 corpora were re-measured and none of the M1 rows
+above are touched or restated by this pass. A future variant that did win
+would owe either those LZ4 numbers or a template gate that keeps the arm on
+the Snappy instantiation alone.
+
 ## M5: the Zstd CPU denominator (issue #227)
 
 There is no Zstd kernel yet. This entry is the denominator a later device

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -668,6 +668,15 @@ to the element rate. It gains only on the whole-file shape, where twelve
 warps leave the device idle enough for early loads to hide latency. No kernel
 code shipped; `docs/BENCHMARKS.md` carries the tables and the mechanism.
 
+**Measured outcome (issue #163, 2026-08-25): the copy stage is not
+loop-overhead-bound either.** Snappy caps a copy at 64 bytes, so most elements
+fit one warp pass, and a predicated single pass replacing the strided loop in
+the short regime changes nothing measurable - every corpus lands inside a
+drift control taken in the same runs. The LZ4 pass that refused a per-element
+predicate on cost (#36) does not transfer: the same predicate here is taken by
+every element on the adversarial corpus rather than by none, and costs
+nothing. No kernel code shipped.
+
 Success is reported only at exact source consumption AND exact production
 of the declared length, which is what the reference enforces on both ends.
 Under-production, over-production and trailing bytes all reject.


### PR DESCRIPTION
Closes #163.

A negative, recorded whichever way it went, and no kernel code ships. The diff
is `docs/BENCHMARKS.md` and `docs/MASTERPLAN.md`; `src/chunk_decode.cuh` is
untouched on this branch.

## What was measured

Both copy stages of `chunk_decode_batch` gained a short arm:
`if (len <= kWarpSize) { if (lane < len) <one store> } else { <the existing
strided loop> }`, on the literal copy and on the 32-bit match gather. Every
test is warp-uniform - all lanes parsed the same element - so no lane can
leave early and strand the others at a `__syncwarp()`, and the closed-form
modular gather is unchanged in both arms.

All 49 ctest gates were green on the patched kernel before anything was timed:

```
100% tests passed, 0 tests failed out of 49
Label Time Summary:
gpu    =   8.87 sec*proc (8 tests)
```

## The drift control, and why this run needed one

ParseOnly elides both copy stages, so this lever cannot touch that row by
construction. Any difference in it between the two sides is session drift,
measured in the same invocation as the number it controls for. A/B-interleaved
in one session, both binaries from the same tree, 3 warmup + 30
CUDA-event-timed runs per invocation, worst cases first. Columns are
throughput speedup, `baseline_ms / short_arm_ms − 1`.

| Corpus                  | Pass | Decode     | Ceiling (control) | Decode less control |
| ----------------------- | ---- | ---------- | ----------------- | ------------------- |
| `--worst` (copy chain)  | 1    | **+7.75%** | **+9.10%**        | **−1.35 pp**        |
| `--worst` (copy chain)  | 2    | −0.10%     | −0.38%            | +0.28 pp            |
| `--worstlit` (parse)    | 1    | +1.19%     | −0.21%            | +1.40 pp            |
| `--worstlit` (parse)    | 2    | +0.77%     | +0.34%            | +0.43 pp            |
| Silesia, 64 KiB-chunked | 1    | +0.96%     | +1.04%            | −0.08 pp            |
| Silesia, 64 KiB-chunked | 2    | −1.48%     | −1.88%            | +0.40 pp            |
| Silesia, whole-file     | 1    | +1.40%     | +1.04%            | +0.36 pp            |

**The first row is the reason the control is in the table.** Read alone it is
a 7.75% win on the adversarial copy corpus - the exact result this lever was
built to find, on the exact corpus the accept rule turns on. The ceiling
beside it moved 9.10% in the same direction on a code path the lever does not
contain, and the second pass of the same corpus has both columns at zero. It
is the session's first invocation on a cold clock. Without a control taken in
the same runs it would have been recorded as the headline.

## Verdict

Corrected, every cell straddles zero, −1.35 to +1.40 percentage points against
a control that itself swings ±1.9%. No corpus carries a recordable
improvement, so the pre-registered accept rule fails on its first clause.
Rejected.

Three things the pass establishes rather than merely failing to:

- **Snappy's copy stage is not loop-overhead-bound.** Removing the loop
  entirely from the short regime changes nothing measurable on a corpus whose
  every element is a 4-byte copy. The upside was bounded anyway: the M3
  baselines put the whole copy stage at 31-35% of the kernel's time.
- **The #36 trap does not transfer.** That pass refused an LZ4 fast path
  because the per-element predicate cost 5-9% at maximum density; the same
  shape of predicate here costs nothing measurable on either Snappy worst
  case, because Snappy's short arm is taken by every element on that corpus
  where LZ4's was taken by none. A future lever in this stage inherits no debt
  from it.
- **The issue's second candidate is a design change and not a lever.**
  Sub-warp fan-out needs the parse to run ahead of the copies, which is the
  two-phase shape #15 measured and refused. Not built, and the record says why
  rather than leaving it looking unattempted.

## Gates

```
npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

```
git diff --name-only origin/main...HEAD
docs/BENCHMARKS.md
docs/MASTERPLAN.md
```

## What is NOT covered

The short arm as built went into the shared `chunk_decode_batch`, so it would
have changed the LZ4 instantiation too. Nothing ships, so no LZ4 corpora were
re-measured and no M1 row is touched. A variant that did win would owe those
numbers or a template gate.

`compute-sanitizer` did not run over the patched binaries; it cannot attach to
a device on this machine at all, which is #258. Nothing ships from this
branch, and the patched kernel's correctness rests on the 49 ctest gates.

The third M3 lever, #165, is untouched by this pass and is not decided by it.

There is no second reader for this branch tonight. The evidence above stands
in place of one: every number carries the invocation that produced it, the
control was measured rather than assumed, and the verdict is the
pre-registered rule applied to the corrected columns.
