### PR TITLE
Measure the Snappy literal distribution and reject the wide copy [#165]

### DIFF
--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -7,6 +7,8 @@
 #include "cudec.h"
 #include "fixtures.h"
 #include "gpu_bench.h"
+#include "literal_hist.h"
+#include "lz4_block.h"
 
 #include <lz4.h>
 #include <lz4frame.h>
@@ -1106,6 +1108,7 @@ int main(int argc, char** argv) {
     size_t warmup = 3;
     bool selfcheck = false;
     bool gpu = false;
+    bool literals = false;
     bool gpu_stream_ctx = false;
     bool worst4b = false;
     bool longmatch = false;
@@ -1116,6 +1119,8 @@ int main(int argc, char** argv) {
         const std::string arg = argv[i];
         if (arg == "--selfcheck") {
             selfcheck = true;
+        } else if (arg == "--literals") {
+            literals = true;
         } else if (arg == "--gpu") {
             gpu = true;
         } else if (arg == "--gpu-stream-ctx") {
@@ -1147,7 +1152,8 @@ int main(int argc, char** argv) {
             std::fprintf(stderr,
                          "usage: bench_lz4 [--runs N] [--warmup N] [--gpu] "
                          "[--gpu-stream-ctx] [--worst4b] [--longmatch] "
-                         "[--assetlike] [--frame] [--selfcheck] "
+                         "[--assetlike] [--frame] [--literals] "
+                         "[--selfcheck] "
                          "[corpus files...]\n");
             return 2;
         } else {
@@ -1326,6 +1332,30 @@ int main(int argc, char** argv) {
     std::sort(times.begin(), times.end());
 
     PrintReport(corpus, times, warmup, runs);
+
+    /* The literal-length distribution (issue #165), walked with the shipped
+     * parser. It is here rather than only in the Snappy harness because the
+     * question the Snappy pass asks is a COMPARISON against this format, and
+     * an LZ4 histogram quoted from a different bucketing would not answer
+     * it. A stream this harness just built and byte-verified must parse, so
+     * a refusal is a defect and is reported as one. */
+    if (literals) {
+        cudec_bench::LiteralHistogram hist;
+        for (size_t i = 0; i < corpus.compressed.size(); i++) {
+            if (!cudec_bench::AccumulateLiteralLengths<
+                    cudec_detail::Lz4Parser>(corpus.compressed[i].data(),
+                                             corpus.compressed[i].size(),
+                                             corpus.originals[i].size(),
+                                             &hist)) {
+                std::fprintf(stderr,
+                             "the parser refused chunk %zu of a corpus this "
+                             "harness built and verified\n",
+                             i);
+                return 1;
+            }
+        }
+        cudec_bench::PrintLiteralHistogram(hist);
+    }
 
     if (gpu) {
         std::vector<const unsigned char*> comp_ptrs(corpus.compressed.size());

--- a/bench/bench_snappy.cpp
+++ b/bench/bench_snappy.cpp
@@ -17,6 +17,8 @@
 #include "cudec.h"
 #include "fixtures.h"
 #include "gpu_bench.h"
+#include "literal_hist.h"
+#include "snappy_block.h"
 #include "xxhash64.h"
 
 #include <snappy.h>
@@ -585,7 +587,30 @@ bool PrintGpuRows(const Corpus& corpus, double cpu_p50_seconds, size_t warmup,
     return true;
 }
 
-bool RunCorpus(Corpus* corpus, size_t warmup, size_t runs, bool gpu) {
+/* The literal-length distribution of one corpus (issue #165), walked with
+ * the shipped parser so the elements counted are the elements the decoder
+ * executes. A stream this harness just built and round-trip-verified must
+ * parse, so a refusal is a defect and is reported as one rather than
+ * skipped. */
+bool PrintLiteralDistribution(const Corpus& corpus) {
+    cudec_bench::LiteralHistogram hist;
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        if (!cudec_bench::AccumulateLiteralLengths<cudec_detail::SnappyParser>(
+                corpus.compressed[i].data(), corpus.compressed[i].size(),
+                corpus.originals[i].size(), &hist)) {
+            std::fprintf(stderr,
+                         "the parser refused stream %zu of a corpus this "
+                         "harness built and verified\n",
+                         i);
+            return false;
+        }
+    }
+    cudec_bench::PrintLiteralHistogram(hist);
+    return true;
+}
+
+bool RunCorpus(Corpus* corpus, size_t warmup, size_t runs, bool gpu,
+               bool literals) {
     Tally(corpus);
     if (corpus->original_bytes == 0) {
         std::fprintf(stderr, "corpus is empty - nothing to benchmark\n");
@@ -615,6 +640,9 @@ bool RunCorpus(Corpus* corpus, size_t warmup, size_t runs, bool gpu) {
     }
     std::sort(times.begin(), times.end());
     PrintReport(*corpus, times, warmup, runs, gpu);
+    if (literals && !PrintLiteralDistribution(*corpus)) {
+        return false;
+    }
     if (gpu && !PrintGpuRows(*corpus, cudec_bench::Percentile(times, 50),
                              warmup, runs)) {
         return false;
@@ -680,6 +708,7 @@ int main(int argc, char** argv) {
     bool worst = false;
     bool worstlit = false;
     bool gpu = false;
+    bool literals = false;
     std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
@@ -695,6 +724,8 @@ int main(int argc, char** argv) {
             worstlit = true;
         } else if (arg == "--gpu") {
             gpu = true;
+        } else if (arg == "--literals") {
+            literals = true;
         } else if (arg == "--runs" && i + 1 < argc) {
             if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
                 std::fprintf(stderr, "--runs must be in [1, %zu]\n", kMaxRuns);
@@ -712,7 +743,8 @@ int main(int argc, char** argv) {
         } else if (!arg.empty() && arg[0] == '-') {
             std::fprintf(stderr, "usage: bench_snappy [--runs N] [--warmup N] "
                                  "[--whole] [--chunked] [--worst] "
-                                 "[--worstlit] [--gpu] [--selfcheck] "
+                                 "[--worstlit] [--gpu] [--literals] "
+                                 "[--selfcheck] "
                                  "[corpus files...]\n");
             return 2;
         } else {
@@ -782,7 +814,7 @@ int main(int argc, char** argv) {
                     : CheckLiteralDensity(corpus, elements))) {
             return 1;
         }
-        if (!RunCorpus(&corpus, warmup, runs, gpu)) {
+        if (!RunCorpus(&corpus, warmup, runs, gpu, literals)) {
             return 1;
         }
         std::printf("- element density: %zu elements, %.4f per compressed "
@@ -851,7 +883,7 @@ int main(int argc, char** argv) {
             }
         }
         CompressAll(&corpus);
-        if (!RunCorpus(&corpus, warmup, runs, gpu)) {
+        if (!RunCorpus(&corpus, warmup, runs, gpu, literals)) {
             return 1;
         }
         if (selfcheck && !CheckDigest(corpus, shape == Shape::kWhole

--- a/bench/literal_hist.h
+++ b/bench/literal_hist.h
@@ -1,0 +1,150 @@
+/* The literal-length distribution of a corpus, shared by both harnesses
+ * (issue #165).
+ *
+ * Why it is one header and not two functions. The question it answers is a
+ * COMPARISON - whether Snappy's literal runs are longer than LZ4's on the
+ * same bytes - and a comparison between two histograms is worth nothing
+ * unless both were bucketed the same way and printed the same way. Two
+ * copies of the bucket edges is how that stops being true, silently, the
+ * first time one of them is tuned.
+ *
+ * It walks the corpus with the shipped parser rather than with a reader of
+ * its own, so the elements it counts are the elements the decoder executes.
+ * Nothing here writes output: a parser hands back an element and the driver
+ * is what would copy it, so the walk costs the parse alone.
+ *
+ * The bucket edges are powers of two around the one that matters. A wide
+ * literal path copies 16 bytes at a time, so its trigger rate is the share
+ * of literal BYTES sitting in literals of at least 16 - the share of
+ * ELEMENTS is the wrong statistic and is reported beside it precisely so the
+ * two cannot be confused. */
+#ifndef CUDEC_BENCH_LITERAL_HIST_H
+#define CUDEC_BENCH_LITERAL_HIST_H
+
+#include "cudec.h"
+#include "decode_sequence.h"
+
+#include <cstdint>
+#include <cstdio>
+
+namespace cudec_bench {
+
+constexpr unsigned kLiteralBuckets = 8;
+
+/* Printed beside every row, so a reader never has to reconstruct the edges
+ * from the code. */
+inline const char* LiteralBucketName(unsigned bucket) {
+    static const char* const kNames[kLiteralBuckets] = {
+        "1", "2-3", "4-7", "8-15", "16-31", "32-63", "64-255", "256+"};
+    return kNames[bucket];
+}
+
+/* The wide path's threshold, in bucket terms: buckets at or above this index
+ * hold literals of at least 16 bytes. */
+constexpr unsigned kLiteralWideBucket = 4;
+
+struct LiteralHistogram {
+    uint64_t streams = 0;
+    uint64_t elements = 0;
+    uint64_t literal_elements = 0;
+    uint64_t literal_bytes = 0;
+    uint64_t count[kLiteralBuckets] = {0};
+    uint64_t bytes[kLiteralBuckets] = {0};
+};
+
+inline unsigned LiteralBucket(uint64_t length) {
+    if (length < 2) {
+        return 0;
+    }
+    if (length < 4) {
+        return 1;
+    }
+    if (length < 8) {
+        return 2;
+    }
+    if (length < 16) {
+        return 3;
+    }
+    if (length < 32) {
+        return 4;
+    }
+    if (length < 64) {
+        return 5;
+    }
+    if (length < 256) {
+        return 6;
+    }
+    return 7;
+}
+
+/* Walks one stream with the shipped parser and folds its literal lengths in.
+ * Returns false if the parser rejects the stream, which for a corpus this
+ * harness just built and verified is a defect rather than a datum, so every
+ * caller must treat it as one instead of skipping the stream. */
+template <class Parser>
+bool AccumulateLiteralLengths(const unsigned char* src, uint64_t src_size,
+                              uint64_t dst_capacity, LiteralHistogram* out) {
+    Parser parser{src, src_size, dst_capacity};
+    cudec_detail::DecodeSequence element;
+    bool done = false;
+    while (true) {
+        if (parser.Next(&element, &done) != CUDEC_OK) {
+            return false;
+        }
+        if (done) {
+            break;
+        }
+        out->elements++;
+        if (element.literals_len != 0) {
+            const unsigned bucket = LiteralBucket(element.literals_len);
+            out->literal_elements++;
+            out->literal_bytes += element.literals_len;
+            out->count[bucket]++;
+            out->bytes[bucket] += element.literals_len;
+        }
+    }
+    out->streams++;
+    return true;
+}
+
+inline double LiteralShare(uint64_t part, uint64_t whole) {
+    return whole == 0 ? 0.0
+                      : 100.0 * static_cast<double>(part) /
+                            static_cast<double>(whole);
+}
+
+inline void PrintLiteralHistogram(const LiteralHistogram& hist) {
+    uint64_t wide_bytes = 0;
+    uint64_t wide_count = 0;
+    for (unsigned b = kLiteralWideBucket; b < kLiteralBuckets; b++) {
+        wide_bytes += hist.bytes[b];
+        wide_count += hist.count[b];
+    }
+    std::printf("- literal distribution: %llu streams, %llu elements, %llu "
+                "of them literal (%.1f%%), %llu literal bytes\n",
+                static_cast<unsigned long long>(hist.streams),
+                static_cast<unsigned long long>(hist.elements),
+                static_cast<unsigned long long>(hist.literal_elements),
+                LiteralShare(hist.literal_elements, hist.elements),
+                static_cast<unsigned long long>(hist.literal_bytes));
+    for (unsigned b = 0; b < kLiteralBuckets; b++) {
+        std::printf("- literals %-7s: %12llu elements (%5.1f%%), %14llu "
+                    "bytes (%5.1f%%)\n",
+                    LiteralBucketName(b),
+                    static_cast<unsigned long long>(hist.count[b]),
+                    LiteralShare(hist.count[b], hist.literal_elements),
+                    static_cast<unsigned long long>(hist.bytes[b]),
+                    LiteralShare(hist.bytes[b], hist.literal_bytes));
+    }
+    /* The trigger rate a 16-byte wide copy would actually see, in both
+     * statistics, because the element share and the byte share answer
+     * different questions and only the second one is the work. */
+    std::printf("- wide-path trigger (literals >= 16 bytes): %.1f%% of "
+                "literal elements, %.1f%% of literal bytes\n",
+                LiteralShare(wide_count, hist.literal_elements),
+                LiteralShare(wide_bytes, hist.literal_bytes));
+}
+
+}  // namespace cudec_bench
+
+#endif /* CUDEC_BENCH_LITERAL_HIST_H */

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1400,6 +1400,115 @@ above are touched or restated by this pass. A future variant that did win
 would owe either those LZ4 numbers or a template gate that keeps the arm on
 the Snappy instantiation alone.
 
+### M3 perf lever (issue #165): the Snappy literal distribution, and the wide literal copy rejected a second time
+
+Perf pass 1 rejected a vectorized literal copy for LZ4 at −6% and gave a
+reason specific to a distribution: _"Silesia's literal runs are mostly < 16
+bytes, so the wide path rarely triggers and only adds setup/branch
+overhead."_ That is a statement about a trigger rate, so it does not transfer
+to a different format's literal shape by assertion. It transfers or it does
+not by measurement, and the distribution is what decides.
+
+**The distribution first, because it is the durable half of this pass.**
+Both harnesses gained a `--literals` mode (`bench/literal_hist.h`, shared so
+that one set of bucket edges and one print format serve both formats - two
+copies of the edges is how a comparison silently stops being one). It walks
+each stream with the SHIPPED parser, so the elements counted are the elements
+the decoder executes, and buckets the literal lengths. Reproduce with
+`bench_snappy --literals bench/corpora/silesia/*` and
+`bench_lz4 --literals bench/corpora/silesia/*`.
+
+Silesia, 64 KiB-chunked, the same source bytes through the two compressors:
+
+| Literal length | Snappy elements | Snappy bytes | LZ4 elements | LZ4 bytes |
+| -------------- | --------------- | ------------ | ------------ | --------- |
+| 1              | 38.5%           | 6.1%         | 36.0%        | 6.1%      |
+| 2-3            | 29.4%           | 10.9%        | 28.1%        | 11.1%     |
+| 4-7            | 17.3%           | 13.8%        | 18.9%        | 16.0%     |
+| 8-15           | 11.1%           | 19.6%        | 11.7%        | 21.8%     |
+| 16-31          | 2.9%            | 9.2%         | 3.8%         | 13.2%     |
+| 32-63          | 0.6%            | 4.0%         | 1.0%         | 6.8%      |
+| 64-255         | 0.2%            | 3.7%         | 0.4%         | 7.3%      |
+| 256+           | 0.0%            | 32.7%        | 0.1%         | 17.7%     |
+
+| Quantity                            | Snappy     | LZ4        |
+| ----------------------------------- | ---------- | ---------- |
+| Elements                            | 26,052,354 | 18,339,030 |
+| Literal elements                    | 7,274,444  | 7,560,402  |
+| Literal bytes                       | 45,773,418 | 44,916,934 |
+| Wide-path trigger, literal elements | 3.7%       | 5.3%       |
+| Wide-path trigger, literal bytes    | 49.6%      | 45.0%      |
+
+The two adversarial corpora are one line each: `--worst` is 6,400 literal
+elements in 52.4 M, all under four bytes, and `--worstlit` is 209,715,200
+literals of exactly one byte. The wide path's trigger on both is **0.0% of
+literal elements and 0.0% of literal bytes**, so those corpora can carry the
+added predicate and nothing else.
+
+**The premise this issue was written on is refuted.** It expected Snappy to
+emit more and longer literals than LZ4 on the same data. It emits slightly
+FEWER long ones by element share (3.7% against 5.3% at 16 bytes and up) and
+about the same by byte share, and its literal bytes and literal element counts
+are within 2% and 4% of LZ4's. The old rejection's premise therefore holds for
+this format too.
+
+**What Snappy's extra elements actually are, which the histogram settles as a
+by-product.** Snappy carries 42% more elements than LZ4 for identical output
+(26.05 M against 18.34 M) while its literal elements are 4% FEWER. Every extra
+element is a copy: 18.78 M against 10.78 M, 74% more. That is the 64-byte copy
+cap splitting what LZ4 spends one unbounded match on, and it is the mechanism
+behind the parse-chain gap the M3 baselines above record between the two
+formats. It was not the question this issue asked, and it is the answer to
+the one the baselines section raised.
+
+**The old sentence needs one correction, in the reader's favour.** "Rarely
+triggers" is true of ELEMENTS and false of BYTES: at 16 bytes and up the
+trigger is 3.7% of Snappy's literal elements but 49.6% of its literal bytes,
+and a wide copy's work scales with bytes. So the trigger rate alone did not
+settle it, and the A/B was owed rather than optional.
+
+**The A/B.** A 4-byte-per-lane literal copy for literals of 32 bytes and up,
+with a byte head and tail, guarded on the ABSOLUTE addresses rather than the
+offsets - the caller's `dst` carries no alignment guarantee and a misaligned
+32-bit access is undefined - so the wide arm runs where both sides share a
+4-byte phase and the head aligns them. All 49 ctest gates green on the patched
+kernel first. Same protocol as the two levers above: A/B-interleaved in one
+session, both binaries from the same tree, 3 warmup + 30 CUDA-event-timed runs,
+worst cases first, with the parse-only ceiling as the drift control - it elides
+the copies, so this lever cannot touch it and any movement there is the
+machine.
+
+| Corpus                  | Pass | Decode | Ceiling (control) | Decode less control |
+| ----------------------- | ---- | ------ | ----------------- | ------------------- |
+| `--worst` (copy chain)  | 1    | −4.12% | +0.20%            | −4.32 pp            |
+| `--worst` (copy chain)  | 2    | −3.93% | −0.05%            | −3.88 pp            |
+| `--worstlit` (parse)    | 1    | −9.43% | +1.09%            | −10.52 pp           |
+| `--worstlit` (parse)    | 2    | −9.50% | −0.04%            | −9.46 pp            |
+| Silesia, 64 KiB-chunked | 1    | −4.72% | −1.28%            | −3.44 pp            |
+| Silesia, 64 KiB-chunked | 2    | −7.33% | −1.28%            | −6.05 pp            |
+| Silesia, whole-file     | 1    | −5.01% | −0.01%            | −5.00 pp            |
+
+**Rejected under the pre-registered accept rule**, and this time with no cell
+even ambiguous: every corpus regresses, both worst cases regress, and the two
+that cannot trigger the wide arm at all regress the hardest. `--worstlit` at
+−9.5% is the added predicate alone, paid 209.7 M times against zero wide
+copies, which is the cleanest possible reading of what the arm costs. No
+kernel code shipped; `src/chunk_decode.cuh` is untouched.
+
+**The negative is stronger than perf pass 1's and it closes the question for
+this format.** That pass could be read as a statement about one distribution;
+this one has the distribution measured beside it, shows the byte-share trigger
+at half of all literal bytes, and STILL loses on the corpus where the arm
+triggers most. A wide literal path is not rejected here for failing to fire -
+it fires - but for costing more than it saves, at 21.6% of the output being
+literal bytes in the first place and the whole copy stage being 31-35% of the
+kernel's time.
+
+**What ships from this pass is the `--literals` mode.** The histogram is a
+standing instrument rather than a one-off: the next attempt on this stage, for
+any format on this seam, reads the trigger rate before writing a kernel
+instead of arguing about it.
+
 ## M5: the Zstd CPU denominator (issue #227)
 
 There is no Zstd kernel yet. This entry is the denominator a later device

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -677,6 +677,16 @@ predicate on cost (#36) does not transfer: the same predicate here is taken by
 every element on the adversarial corpus rather than by none, and costs
 nothing. No kernel code shipped.
 
+**Measured outcome (issue #165, 2026-08-25): Snappy's literal shape is LZ4's,
+and the wide literal copy loses a second time.** The premise that Snappy emits
+more and longer literals on the same data is refuted by a measured histogram:
+on Silesia its literal element count is 4% BELOW LZ4's and its literal bytes
+within 2%, and its 42% extra elements are all copies, which is the 64-byte cap
+splitting what LZ4 spends one unbounded match on. A 4-byte-per-lane literal
+copy regresses every corpus, hardest on the two where it cannot trigger at
+all. What ships is the `--literals` histogram mode, so the next attempt on
+this stage reads a trigger rate instead of arguing one.
+
 Success is reported only at exact source consumption AND exact production
 of the declared length, which is what the reference enforces on both ends.
 Under-production, over-production and trailing bytes all reject.


### PR DESCRIPTION
Closes #165.

The distribution first, as the issue asks, then the A/B on it. What ships is
the histogram instrument and the record; no kernel code ships, and
`src/chunk_decode.cuh` is untouched on this branch.

## The instrument

`bench/literal_hist.h`, consumed by both harnesses through a new `--literals`
mode. One shared header rather than a function in each, for a reason the issue
makes load-bearing: the question is a COMPARISON between two formats, and a
comparison between two histograms bucketed separately is not one. It walks
each stream with the shipped parser, so the elements it counts are the
elements the decoder executes, and a parser refusal on a stream this harness
just built and verified is reported as a defect rather than skipped.

## The distribution

Silesia, 64 KiB-chunked, the same source bytes through the two compressors.
`bench_snappy --literals bench/corpora/silesia/*` and `bench_lz4 --literals
bench/corpora/silesia/*`.

| Quantity                            | Snappy     | LZ4        |
| ----------------------------------- | ---------- | ---------- |
| Elements                            | 26,052,354 | 18,339,030 |
| Literal elements                    | 7,274,444  | 7,560,402  |
| Literal bytes                       | 45,773,418 | 44,916,934 |
| Wide-path trigger, literal elements | 3.7%       | 5.3%       |
| Wide-path trigger, literal bytes    | 49.6%      | 45.0%      |

The full eight-bucket tables for both formats are in the record. The two
adversarial corpora trigger the wide path on **0.0% of literal elements and
0.0% of literal bytes**: `--worst` has 6,400 literals in 52.4 M elements, all
under four bytes, and `--worstlit` is 209,715,200 literals of exactly one
byte.

**The premise this issue was written on is refuted.** It expected Snappy to
emit more and longer literals than LZ4 on the same data. It emits slightly
fewer long ones by element share and about the same by byte share.

**A by-product worth the line it takes.** Snappy carries 42% more elements
than LZ4 for identical output while its literal elements are 4% fewer, so
every extra element is a copy - 74% more of them. That is the 64-byte cap
splitting what LZ4 spends one unbounded match on, and it is the mechanism
behind the parse-chain gap the M3 baselines recorded between the two formats
without being able to name it.

**And one correction the record owed a reader.** Perf pass 1's "rarely
triggers" is true of ELEMENTS and false of BYTES: 3.7% of literal elements but
49.6% of literal bytes at 16 and up, and a wide copy's work scales with bytes.
The trigger rate alone did not settle it, so the A/B was owed rather than
optional.

## The A/B

A 4-byte-per-lane literal copy for literals of 32 bytes and up, with a byte
head and tail, guarded on the ABSOLUTE addresses rather than the offsets - the
caller's `dst` carries no alignment guarantee and a misaligned 32-bit access
is undefined. All 49 ctest gates green on the patched kernel first.
A/B-interleaved in one session, both binaries from the same tree, 3 warmup +
30 CUDA-event-timed runs, worst cases first, with the parse-only ceiling as
the drift control - it elides the copies, so the lever cannot touch it.

| Corpus                  | Pass | Decode | Ceiling (control) | Decode less control |
| ----------------------- | ---- | ------ | ----------------- | ------------------- |
| `--worst` (copy chain)  | 1    | −4.12% | +0.20%            | −4.32 pp            |
| `--worst` (copy chain)  | 2    | −3.93% | −0.05%            | −3.88 pp            |
| `--worstlit` (parse)    | 1    | −9.43% | +1.09%            | −10.52 pp           |
| `--worstlit` (parse)    | 2    | −9.50% | −0.04%            | −9.46 pp            |
| Silesia, 64 KiB-chunked | 1    | −4.72% | −1.28%            | −3.44 pp            |
| Silesia, 64 KiB-chunked | 2    | −7.33% | −1.28%            | −6.05 pp            |
| Silesia, whole-file     | 1    | −5.01% | −0.01%            | −5.00 pp            |

Rejected under the pre-registered accept rule, with no ambiguous cell. Every
corpus regresses, both worst cases regress, and the two that cannot trigger
the wide arm at all regress hardest - `--worstlit` at −9.5% is the added
predicate alone, paid 209.7 M times against zero wide copies, which is the
cleanest reading of what the arm costs.

This negative is stronger than perf pass 1's rather than a repeat of it: the
distribution is measured beside it, the byte-share trigger is half of all
literal bytes, and it still loses on the corpus where the arm fires most. The
wide path is not rejected for failing to fire. It fires, and costs more than
it saves.

## Gates

```
cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
ctest --test-dir build-cuda --output-on-failure
...
100% tests passed, 0 tests failed out of 49

Label Time Summary:
gpu    =   8.80 sec*proc (8 tests)
```

```
npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

```
git diff --name-only origin/main...HEAD
bench/bench_lz4.cpp
bench/bench_snappy.cpp
bench/literal_hist.h
docs/BENCHMARKS.md
docs/MASTERPLAN.md
```

## What is NOT covered

The `--literals` mode is a host walk with no ctest entry of its own. It is
exercised by nothing on the GPU-less runner; the corpora it reads are already
locked by the existing selfchecks, and the walk itself has no invariant to
lock beyond "the parser accepts what the harness built", which the selfchecks
already assert by round-tripping. A rot check for the histogram would be
asserting bucket counts against a corpus digest, and that is worth filing
separately rather than smuggling in here.

The measured lever is a 4-byte variant. A 16-byte one would trigger strictly
less often - it needs a wider phase match - and pays a strictly larger
predicate, so the record does not claim it was measured and does not need to.

`compute-sanitizer` did not run over the patched binaries; it cannot attach to
a device on this machine, which is #258. Nothing kernel-side ships here.

There is no second reader for this branch tonight. The evidence above stands
in place of one: the histogram is reproducible from a documented flag, the
control was measured rather than assumed, and the verdict is the
pre-registered rule applied to the corrected columns.
