### PR TITLE
Derive every lane stride in the decode kernel from a wave-width parameter [#241]

### DIFF
--- a/bench/gpu_bench.cu
+++ b/bench/gpu_bench.cu
@@ -40,7 +40,7 @@ cudec_status LaunchParseOnly(const void* const* s, const size_t* ss,
         return valid;
     }
     (void)cudaGetLastError();
-    cudec_detail::chunk_decode_batch<Parser, true>
+    cudec_detail::chunk_decode_batch<Parser, true, cudec_detail::kCudaWaveSize>
         <<<cudec_detail::decode_grid_blocks(n), cudec_detail::kBlockThreads, 0,
            stream>>>(s, ss, d, dc, n, r);
     return cudaGetLastError() == cudaSuccess ? CUDEC_OK : CUDEC_ERR_CUDA;

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -30,7 +30,7 @@ cudec_status submit_batch(const void* const* d_src_ptrs,
      * call consumes the pending error state. */
     (void)cudaGetLastError();
 
-    cudec_detail::chunk_decode_batch<Parser, false>
+    cudec_detail::chunk_decode_batch<Parser, false, cudec_detail::kCudaWaveSize>
         <<<cudec_detail::decode_grid_blocks(chunk_count),
            cudec_detail::kBlockThreads, 0, stream>>>(
             d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,

--- a/src/chunk_decode.cuh
+++ b/src/chunk_decode.cuh
@@ -1,5 +1,6 @@
 /* The warp-per-chunk chunk decoder: one kernel, templated on the format
- * parser and on the copy mode. The parser is a template parameter rather
+ * parser, on the copy mode and on the wave width. The parser is a parameter
+ * rather
  * than a hard-wired type because everything below it - the fuel cap, the
  * two copy loops, the __syncwarp() placement, the geometry guards, the
  * failure contract - is format-independent, and a second copy of it per
@@ -8,7 +9,15 @@
  * per format; the bench instantiates ParseOnly for its honest parse-only
  * ceiling (masterplan section 9). Each translation unit emits only the
  * instantiations it launches, so the shipped library carries no parse-only
- * kernel. Internal header, not part of the ABI.
+ * kernel and, for the same reason, no wave64 kernel: the CUDA launches all
+ * name kCudaWaveSize. Internal header, not part of the ABI.
+ *
+ * THE WIDTH IS A PARAMETER BECAUSE THE HARDWARE HERE CANNOT FALSIFY A WRONG
+ * ONE (issue #241). Every lane-stride and geometry constant below is derived
+ * from WaveSize, so a hardcoded lane count cannot survive in a place only a
+ * wave64 device would expose. The parse uses no shuffle and no ballot, so no
+ * 64-bit lane mask arises and the port is the strides and the geometry
+ * guards rather than a second decode.
  *
  * What a Parser owes, and what this kernel is entitled to assume. The
  * requirements are stated here because this is the code that breaks when
@@ -24,8 +33,8 @@
  *    source size, so a parser that can return without advancing breaks
  *    termination for the whole family, not only for its own format;
  *  - LANE-UNIFORMITY: the parser reads source bytes and its own state and
- *    nothing else. All 32 lanes run it redundantly in lockstep, and that is
- *    sound only while every lane computes the same answer;
+ *    nothing else. Every lane of the wave runs it redundantly in lockstep,
+ *    and that is sound only while every lane computes the same answer;
  *  - ALL input validation inside the parser. The copy loops below perform
  *    no input-derived bound check of their own, by design: a parser that
  *    hands back an element it has not fully bounded has already failed
@@ -52,7 +61,24 @@
 namespace cudec_detail {
 
 constexpr unsigned kBlockWarps = 4;
-constexpr unsigned kBlockThreads = kWarpSize * kBlockWarps;  /* 128 */
+
+/* The block shape is derived from the wave width rather than written down:
+ * four waves to a block, whatever a wave is on the device being built for
+ * (issue #241). At wave32 this is the 128 threads the shipped launches have
+ * always used; at wave64 it is 256, which is the same four waves and not a
+ * different block shape. */
+template <int WaveSize>
+inline constexpr unsigned kBlockThreadsFor =
+    static_cast<unsigned>(WaveSize) * kBlockWarps;
+
+/* The one width this CUDA build instantiates. It is named here rather than
+ * written as digits at each launch, for the reason issue #211 gives, and it
+ * is a compile-time constant on purpose: the runtime-width dispatch is a
+ * sibling issue, and until it lands the CUDA translation units emit exactly
+ * one kernel per format. */
+constexpr int kCudaWaveSize = static_cast<int>(kWarpSize);
+
+constexpr unsigned kBlockThreads = kBlockThreadsFor<kCudaWaveSize>;
 
 /* One warp per chunk over a grid-stride loop. All 32 lanes run the
  * validated parser redundantly in lockstep and fan out by lane for every
@@ -62,26 +88,35 @@ constexpr unsigned kBlockThreads = kWarpSize * kBlockWarps;  /* 128 */
  * ordering at the two copy boundaries. ParseOnly elides the copies and the
  * syncs to isolate the parse cost - it writes no output and is a bench
  * ceiling only, never shipped. */
-template <class Parser, bool ParseOnly>
-__global__ void __launch_bounds__(kBlockThreads)
+template <class Parser, bool ParseOnly, int WaveSize>
+__global__ void __launch_bounds__(kBlockThreadsFor<WaveSize>)
     chunk_decode_batch(const void* const* src_ptrs, const size_t* src_sizes,
                        void* const* dst_ptrs, const size_t* dst_caps,
                        size_t chunk_count, cudec_chunk_result* results) {
-    const unsigned lane = threadIdx.x % kWarpSize;
+    /* Every lane-stride and geometry constant below is this one value. The
+     * cast is here rather than at each use so the parameter's own type stays
+     * the `int` the width family is written in, and the arithmetic below
+     * stays unsigned. */
+    constexpr unsigned kWaveSize = static_cast<unsigned>(WaveSize);
+
+    const unsigned lane = threadIdx.x % kWaveSize;
     const size_t warp_in_grid =
-        (blockIdx.x * blockDim.x + threadIdx.x) / kWarpSize;
+        (blockIdx.x * blockDim.x + threadIdx.x) / kWaveSize;
     const size_t total_warps =
-        (static_cast<size_t>(gridDim.x) * blockDim.x) / kWarpSize;
+        (static_cast<size_t>(gridDim.x) * blockDim.x) / kWaveSize;
     /* The chunk-to-lane mapping is sound only when the grid holds at least
      * one whole warp and every block is a whole number of warps. Both
      * failures are geometry rather than input, and both are silent:
      *  - fewer than one whole warp in the grid makes the grid-stride below
      *    advance by zero and spin forever;
-     *  - a block that is not a warp multiple splits a chunk's warp across two
-     *    blocks (<<<2, 16>>> and <<<2, 48>>> both do), so `lane` only ever
-     *    takes the low half of its range while the copy loops stride by
-     *    kWarpSize - every output byte at i % 32 >= 16 is written by nobody,
-     *    and the full-mask __syncwarp() is executed by half a warp.
+     *  - a block that is not a wave multiple splits a chunk's wave across two
+     *    blocks (a block of half a wave, or of one and a half, both do), so
+     *    `lane` only ever takes the low part of its range while the copy
+     *    loops stride by kWaveSize - every output byte whose index modulo the
+     *    wave width lands in the missing part is written by nobody, and the
+     *    full-mask __syncwarp() is executed by a fraction of a wave. Both
+     *    halves of that argument scale with the width rather than with the
+     *    digits they used to be written in.
      * The shipped entry always launches kBlockThreads, but the kernel must
      * not depend on its caller for either property. Both tests are
      * grid-uniform (gridDim/blockDim only), so neither can strand lanes at a
@@ -91,9 +126,11 @@ __global__ void __launch_bounds__(kBlockThreads)
      * gridDim.x * blockDim.x <= 2^32. That bound is DOCUMENTED rather than
      * enforced, and the reason is the asymmetry in what breaking it costs:
      * past it the index wraps modulo 2^32, but the guard below has already
-     * forced blockDim.x to a multiple of kWarpSize, so the wrapped base stays
-     * warp-aligned and the aliased block recomputes the SAME warp_in_grid
-     * values with a full 0-31 lane range. Two blocks then decode one chunk
+     * forced blockDim.x to a multiple of kWaveSize, so the wrapped base stays
+     * wave-aligned and the aliased block recomputes the SAME warp_in_grid
+     * values with a full lane range. That argument rests on the wrap modulus
+     * being a multiple of the wave width, which holds for every power-of-two
+     * width and so survives the port unchanged. Two blocks then decode one chunk
      * redundantly and write byte-identical values to the same addresses -
      * duplicated work, not missing bytes and not a hang, and the output stays
      * bit-identical. Enforcing it costs an occupancy step: three spellings
@@ -104,7 +141,7 @@ __global__ void __launch_bounds__(kBlockThreads)
      * redundant-but-correct output on a geometry needing 33 million blocks -
      * against a decode_grid_blocks cap of 8192, and unreachable through the
      * public ABI - is not a trade worth making. */
-    if (total_warps == 0 || blockDim.x % kWarpSize != 0) {
+    if (total_warps == 0 || blockDim.x % kWaveSize != 0) {
         return;
     }
 
@@ -140,7 +177,8 @@ __global__ void __launch_bounds__(kBlockThreads)
                 break;
             }
             if constexpr (!ParseOnly) {
-                for (uint64_t i = lane; i < seq.literals_len; i += kWarpSize) {
+                for (uint64_t i = lane; i < seq.literals_len;
+                     i += kWaveSize) {
                     dst[seq.literals_dst + i] = src[seq.literals_src + i];
                 }
                 /* The match may read literal bytes just written above. */
@@ -169,14 +207,14 @@ __global__ void __launch_bounds__(kBlockThreads)
                     if (seq.match_len <= UINT32_MAX) {
                         const uint32_t off32 = static_cast<uint32_t>(offset);
                         for (uint64_t i = lane; i < seq.match_len;
-                             i += kWarpSize) {
+                             i += kWaveSize) {
                             dst[seq.match_dst + i] =
                                 dst[seq.match_src +
                                     (static_cast<uint32_t>(i) % off32)];
                         }
                     } else {
                         for (uint64_t i = lane; i < seq.match_len;
-                             i += kWarpSize) {
+                             i += kWaveSize) {
                             dst[seq.match_dst + i] =
                                 dst[seq.match_src + (i % offset)];
                         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -428,6 +428,18 @@ if(TARGET gpu_fixture)
     gpu_fixture
     PRIVATE CUDEC_SNAPPY_TESTDATA_DIR="${CUDEC_SNAPPY_SOURCE_DIR}/testdata")
 endif()
+# The wave-width parameter (issue #241). It is the one property in this tree
+# that the hardware here cannot falsify: every other GPU test runs at one
+# width, so a wave64 instantiation that stopped compiling, or a block shape
+# that stopped following the parameter, would leave the whole suite green.
+# This test makes the second instantiation a build product and runs the
+# shipped one, and it needs the internal kernel header from src/ to reach
+# either.
+cudec_add_test(wave_width_gpu SOURCES wave_width_gpu.cu GPU)
+if(TARGET wave_width_gpu)
+  target_include_directories(wave_width_gpu
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+endif()
 cudec_add_test(frame_twin SOURCES frame_twin.cu LIBS lz4_frame_oracle GPU)
 # frame_twin verifies the library's own xxhash32.h against liblz4's XXH32.
 # Guarded: the host-only sanitizer build (issue #42) skips the GPU targets, so

--- a/tests/determinism_gpu.cu
+++ b/tests/determinism_gpu.cu
@@ -195,7 +195,8 @@ using DirectLaunch = void (*)(const Batch&, const Geometry&, cudaStream_t);
 
 template <class Parser>
 void LaunchDirect(const Batch& b, const Geometry& g, cudaStream_t stream) {
-    cudec_detail::chunk_decode_batch<Parser, false>
+    cudec_detail::chunk_decode_batch<Parser, false,
+                                    cudec_detail::kCudaWaveSize>
         <<<g.blocks, g.threads, 0, stream>>>(b.d_srcs, b.d_sizes, b.d_dsts,
                                              b.d_caps, b.n, b.d_results);
 }

--- a/tests/termination_gpu.cu
+++ b/tests/termination_gpu.cu
@@ -205,7 +205,8 @@ int RequireGeometryRefused(const Batch& b, const UnsupportedGeometry& g) {
     cudaEvent_t finished;
     REQUIRE_CUDA(cudaStreamCreate(&stream));
     REQUIRE_CUDA(cudaEventCreateWithFlags(&finished, cudaEventDisableTiming));
-    cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, false>
+    cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, false,
+                                    cudec_detail::kCudaWaveSize>
         <<<g.blocks, g.threads, 0, stream>>>(b.d_srcs, b.d_sizes, b.d_dsts,
                                              b.d_caps, b.n, b.d_results);
     REQUIRE_CUDA(cudaGetLastError());

--- a/tests/wave_width_gpu.cu
+++ b/tests/wave_width_gpu.cu
@@ -1,0 +1,198 @@
+/* The wave-width parameter, proved where nothing else can prove it (issue
+ * #241).
+ *
+ * WHAT THIS TEST IS FOR, AND WHY IT IS NOT COVERED BY THE REST OF THE SUITE.
+ * The decode kernel family is now `template <..., int WaveSize>`, and every
+ * lane stride and geometry constant is derived from that parameter. The
+ * hardware here is NVIDIA, so every other test in this tree exercises exactly
+ * one width - a wave64 instantiation that fails to compile, or a constant
+ * that quietly stayed a wave32 one, is invisible to all of them. This test
+ * makes the second instantiation a build product, so the failure surfaces on
+ * the machine that cannot run it.
+ *
+ * THE WAVE64 KERNEL IS INSTANTIATED AND NEVER LAUNCHED, and that is the
+ * point rather than a limitation. Launching it on a wave32 device would be a
+ * geometry the kernel's own guard refuses (a block that is not a whole
+ * number of waves), so the run would prove nothing about wave64 and would
+ * report a guard firing as a pass. What is claimed here is exactly what an
+ * NVIDIA machine can claim: the width-parameterised source compiles at both
+ * widths and derives the block shape from the parameter. Whether a wave64
+ * device decodes correctly is #212 and the AMD validation ladder, and this
+ * file asserts nothing about it.
+ *
+ * THE SHIPPED WIDTH IS RUN, because a compile-only test would pass over a
+ * kernel whose strides had been ported wrong in a way that still compiles. A
+ * chunk large enough to need several strides through the copy loops is
+ * decoded through the direct launch, at the block shape derived from the
+ * parameter, and its bytes are compared. */
+#include "chunk_decode.cuh"
+#include "cudec.h"
+#include "lz4_block.h"
+#include "require.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+/* The two widths the family is written for. The second is not this machine's
+ * and is named here rather than at the instantiations below, so the digits
+ * appear once and bound to a name (issue #211). */
+constexpr int kWave32 = 32;
+constexpr int kWave64 = 64;
+
+/* The block shape follows the parameter rather than a constant. Asserted
+ * rather than commented: this is the arithmetic every launch's thread count
+ * comes out of, and a shape that stopped tracking the width would give a
+ * wave64 device a block of the wrong number of waves. */
+static_assert(cudec_detail::kBlockThreadsFor<kWave32> ==
+                  cudec_detail::kBlockWarps * kWave32,
+              "the block shape must be waves-per-block times the wave width");
+static_assert(cudec_detail::kBlockThreadsFor<kWave64> ==
+                  cudec_detail::kBlockWarps * kWave64,
+              "the block shape must be waves-per-block times the wave width");
+static_assert(cudec_detail::kBlockThreadsFor<kWave64> !=
+                  cudec_detail::kBlockThreadsFor<kWave32>,
+              "a block shape that does not move with the width is a constant "
+              "wearing the parameter's name");
+static_assert(cudec_detail::kCudaWaveSize == kWave32,
+              "the CUDA build instantiates one width, and it is this one");
+
+/* Both instantiations, asked about through the driver rather than merely
+ * named. A __global__ function nothing references produces no code, so a
+ * wave64 body that does not compile would go unnoticed; and asking the
+ * driver for each one's attributes proves the kernel is in the binary rather
+ * than proving that a symbol could be spelled.
+ *
+ * The attribute read is also the check itself. `maxThreadsPerBlock` is what
+ * __launch_bounds__ put on the kernel, and that bound is written in terms of
+ * the parameter, so a launch bound that stopped following the width shows up
+ * here as a number that did not move. That is the one thing about the wave64
+ * kernel an NVIDIA device can actually answer. */
+int BothInstantiationsAreInTheBinary() {
+    /* REQUIRE returns 1 on failure, so this reports rather than aborts and
+     * main turns a non-zero answer into the test's own failure. */
+    using cudec_detail::chunk_decode_batch;
+    using cudec_detail::Lz4Parser;
+    cudaFuncAttributes at_wave32;
+    cudaFuncAttributes at_wave64;
+    REQUIRE_CUDA(cudaFuncGetAttributes(
+        &at_wave32, chunk_decode_batch<Lz4Parser, false, kWave32>));
+    REQUIRE_CUDA(cudaFuncGetAttributes(
+        &at_wave64, chunk_decode_batch<Lz4Parser, false, kWave64>));
+    REQUIRE(at_wave32.maxThreadsPerBlock ==
+            static_cast<int>(cudec_detail::kBlockThreadsFor<kWave32>));
+    REQUIRE(at_wave64.maxThreadsPerBlock ==
+            static_cast<int>(cudec_detail::kBlockThreadsFor<kWave64>));
+    return 0;
+}
+
+/* The literal length a token's own 4-bit field can hold; anything longer is
+ * spelled with the extension bytes below. */
+constexpr size_t kLz4TokenLiteralMax = 15;
+
+/* A literals-only LZ4 block long enough that the copy loop takes several
+ * strides at either width: a wave64 stride on a wave32 launch would leave
+ * every byte between the two strides unwritten, and a wave32 stride is the
+ * shipped one. The payload below is well past the token's own field, so the
+ * length extension is exercised too rather than a token the parser could
+ * special-case away.
+ *
+ * The caller's payload is longer than kLz4TokenLiteralMax by construction,
+ * which is why this carries no check of its own: a fixture builder that
+ * cannot fail is better than one whose failure path nothing runs. */
+std::vector<unsigned char> LiteralsOnlyBlock(const std::vector<unsigned char>&
+                                                 payload) {
+    std::vector<unsigned char> block;
+    const size_t n = payload.size();
+    block.push_back(0xF0); /* the token's literal-length field, all ones */
+    size_t remaining = n - kLz4TokenLiteralMax;
+    while (remaining >= 255) {
+        block.push_back(0xFF);
+        remaining -= 255;
+    }
+    block.push_back(static_cast<unsigned char>(remaining));
+    block.insert(block.end(), payload.begin(), payload.end());
+    return block;
+}
+
+}  // namespace
+
+int main() {
+    REQUIRE(BothInstantiationsAreInTheBinary() == 0);
+
+    /* Comfortably past the token's own literal-length field and past a
+     * single stride of either width, so both the extension bytes and the
+     * strided copy are exercised. */
+    std::vector<unsigned char> payload(300);
+    static_assert(300 > kLz4TokenLiteralMax,
+                  "the block builder below spells the length extension "
+                  "unconditionally");
+    for (size_t i = 0; i < payload.size(); i++) {
+        payload[i] = static_cast<unsigned char>(i * 7 + 1);
+    }
+    const std::vector<unsigned char> block = LiteralsOnlyBlock(payload);
+
+    unsigned char* d_src = nullptr;
+    unsigned char* d_dst = nullptr;
+    const void** d_src_ptrs = nullptr;
+    void** d_dst_ptrs = nullptr;
+    size_t* d_sizes = nullptr;
+    size_t* d_caps = nullptr;
+    cudec_chunk_result* d_results = nullptr;
+    REQUIRE_CUDA(cudaMalloc(&d_src, block.size()));
+    REQUIRE_CUDA(cudaMalloc(&d_dst, payload.size()));
+    REQUIRE_CUDA(cudaMalloc(&d_src_ptrs, sizeof(void*)));
+    REQUIRE_CUDA(cudaMalloc(&d_dst_ptrs, sizeof(void*)));
+    REQUIRE_CUDA(cudaMalloc(&d_sizes, sizeof(size_t)));
+    REQUIRE_CUDA(cudaMalloc(&d_caps, sizeof(size_t)));
+    REQUIRE_CUDA(cudaMalloc(&d_results, sizeof(cudec_chunk_result)));
+    REQUIRE_CUDA(cudaMemcpy(d_src, block.data(), block.size(),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemset(d_dst, 0, payload.size()));
+
+    const void* h_src_ptr = d_src;
+    void* h_dst_ptr = d_dst;
+    const size_t h_size = block.size();
+    const size_t h_cap = payload.size();
+    REQUIRE_CUDA(cudaMemcpy(d_src_ptrs, &h_src_ptr, sizeof(void*),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(cudaMemcpy(d_dst_ptrs, &h_dst_ptr, sizeof(void*),
+                            cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(
+        cudaMemcpy(d_sizes, &h_size, sizeof(size_t), cudaMemcpyHostToDevice));
+    REQUIRE_CUDA(
+        cudaMemcpy(d_caps, &h_cap, sizeof(size_t), cudaMemcpyHostToDevice));
+
+    /* The launch geometry is derived from the parameter, exactly as the
+     * shipped entry derives it. Hoisted into a named constant because the
+     * template argument's closing angle bracket would otherwise sit against
+     * the launch syntax's own. */
+    constexpr unsigned kThreads =
+        cudec_detail::kBlockThreadsFor<cudec_detail::kCudaWaveSize>;
+    cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, false,
+                                     cudec_detail::kCudaWaveSize>
+        <<<1, kThreads>>>(d_src_ptrs, d_sizes, d_dst_ptrs, d_caps, 1,
+                          d_results);
+    REQUIRE_CUDA(cudaGetLastError());
+    REQUIRE_CUDA(cudaDeviceSynchronize());
+
+    cudec_chunk_result result;
+    REQUIRE_CUDA(cudaMemcpy(&result, d_results, sizeof(result),
+                            cudaMemcpyDeviceToHost));
+    REQUIRE(result.status == CUDEC_OK);
+    REQUIRE(result.bytes_written == payload.size());
+
+    std::vector<unsigned char> out(payload.size(), 0);
+    REQUIRE_CUDA(cudaMemcpy(out.data(), d_dst, out.size(),
+                            cudaMemcpyDeviceToHost));
+    REQUIRE(std::memcmp(out.data(), payload.data(), payload.size()) == 0);
+
+    std::printf("PASS: both wave widths instantiate; the shipped width "
+                "decodes %zu bytes at %u threads per block\n",
+                payload.size(), kThreads);
+    return 0;
+}


### PR DESCRIPTION
Closes #241.

## What changed

`chunk_decode_batch` is now `template <class Parser, bool ParseOnly, int
WaveSize>`. The lane index, the wave-in-grid and total-waves divisions, the
geometry guard, both copy strides, the block shape and `__launch_bounds__` all
come out of the parameter. The block comment's two arguments are re-derived in
terms of the width rather than left in the digits they were written in: the
split-wave failure ("every output byte whose index modulo the wave width lands
in the missing part is written by nobody") and the `gridDim.x * blockDim.x <=
2^32` bound, which survives the port because the wrap modulus is a multiple of
every power-of-two width.

The CUDA translation units name `kCudaWaveSize` at every launch, so the shipped
library carries one width per format. Read out of the built archive rather than
asserted:

    nm -C build-cuda/libcudec.a | grep -o 'chunk_decode_batch<[^>]*>[^(]*' | sort -u
    chunk_decode_batch<cudec_detail::Lz4Parser, false, 32>
    chunk_decode_batch<cudec_detail::SnappyParser, false, 32>

Host dispatch on a runtime width and the batch geometry derived from it are the
sibling issue and are untouched here; `kWarpSize` in `src/batch_limits.h` still
holds the host's batch bound.

## Why the width is a parameter, and why the test exists

The hardware here cannot falsify a wrong lane count. A hardcoded 32 is
invisible to every test that can run on an NVIDIA device and wrong on every
wave64 device, so the width has to be something the source carries rather than
something the device happens to agree with.

`tests/wave_width_gpu.cu` is what makes that checkable here. It asks the driver
for **both** instantiations' attributes, so a wave64 body that stopped
compiling reds the build rather than going unnoticed, and it compares each
one's `maxThreadsPerBlock` against the block shape the parameter derives - the
one thing about the wave64 kernel this hardware can actually answer. It then
decodes a strided literals run through the shipped width at the derived
geometry, because a compile-only test would pass over a stride ported wrong in
a way that still compiles.

**The wave64 kernel is instantiated and never launched**, and that is the point
rather than a limitation: launching it on a wave32 device would hit the
kernel's own "block is not a whole number of waves" guard, and the run would
report a guard firing as a pass. Whether a wave64 device decodes correctly is
#212 and the AMD validation ladder. Nothing here claims it.

## The guard was proven by breaking it

The block shape was made to ignore the parameter (`kBlockThreadsFor` derived
from a fixed width instead of `WaveSize`) and the build was re-run:

    /w/tests/wave_width_gpu.cu(54): error: static assertion failed with
      "the block shape must be waves-per-block times the wave width"
    /w/tests/wave_width_gpu.cu(57): error: static assertion failed with
      "a block shape that does not move with the width is a constant
       wearing the parameter's name"
    2 errors detected

It refuses at compile time rather than at run time, which is stronger than the
red test that was aimed for. The tree was restored and the test passes again.

## Gates

Pinned container `nvidia/cuda:12.6.2-devel-ubuntu24.04@sha256:738fba0f...`,
nvcc V12.6.77, `--gpus all`, NVIDIA GeForce RTX 3080, driver 610.88.

**Build and the whole suite on the device:**

    cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON && cmake --build build-cuda -j
    ctest --test-dir build-cuda --output-on-failure
    100% tests passed, 0 tests failed out of 50
    Label Time Summary: gpu = 9.14 sec*proc (9 tests)

Zero warnings in the build log. The negatives, the determinism gate and the
`#211` bare-width conformance lock are all inside that 50 and all unchanged.

**Registers and occupancy - the bullet that says a templating change costing
occupancy has failed.** Same command on `origin/main` and on this branch:

    nvcc -arch=sm_86 -Xptxas -v -c src/batch.cu -Iinclude -Isrc -o /tmp/x.o

    origin/main   Lz4Parser    48 registers, 0 barriers, 400 bytes cmem[0]
                  SnappyParser 56 registers, 0 barriers, 400 bytes cmem[0]
    this branch   Lz4Parser    48 registers, 0 barriers, 400 bytes cmem[0]
                  SnappyParser 56 registers, 0 barriers, 400 bytes cmem[0]

Unmoved on both kernels. 48 registers is the figure `docs/BENCHMARKS.md`
records for the sm_86 occupancy plan.

**Whole-Silesia decode, A/B interleaved in one container session, both binaries
built from their own tree.** The harness byte-verifies the output against the
oracle once before timing, so a byte-identical decode is a precondition of
every number below rather than a separate claim:

    bench_lz4 --gpu --runs 30 --warmup 3 <all twelve Silesia files>
    corpus: 3239 chunks, 211.94 MB original, 102.44 MB compressed (ratio 0.483)

    pass 1  baseline  GPU decode p50 12.349 ms, 17.2 GB/s | parse-only 7.084 ms
    pass 1  branch    GPU decode p50 12.196 ms, 17.4 GB/s | parse-only 7.128 ms
    pass 2  baseline  GPU decode p50 12.479 ms, 17.0 GB/s | parse-only 6.701 ms
    pass 2  branch    GPU decode p50 12.051 ms, 17.6 GB/s | parse-only 6.801 ms

Baseline-to-baseline spread is 0.13 ms and branch-to-branch is 0.15 ms, against
a between-arm difference of about 0.3 ms. The branch is nominally the faster
arm in both passes; **that is not claimed as a win** - it is inside the same
run-to-run spread the two baseline passes show, which is what "within noise"
means here. No number moved in the direction this bullet exists to catch.

**Format:**

    npx prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

## What was NOT done, stated as an absence

- **No second reader.** Nobody else has read this change.
- **No wave64 device was involved and none is claimed.** The wave64
  instantiation is proven to compile and to carry the launch bound the
  parameter derives. It has never executed. Every correctness statement above
  is about the wave32 path.
- **No shim, and none was needed here.** The issue names the vendor shim as a
  dependency for the device-intrinsic mapping. The parse uses no shuffle and no
  ballot, so no 64-bit lane mask arises, and nothing in this diff maps an
  intrinsic. The shim is still owed by the port as a whole and by the test
  sources that call the CUDA runtime directly; this change does not supply it
  and does not remove the need for it.
- **The four-tool device sanitizer gate did not run and is not claimed** (#258:
  Compute Sanitizer cannot attach to a device on this machine). Nothing above
  asserts anything under memcheck, racecheck, initcheck or synccheck.
- **`docs/BENCHMARKS.md` is not touched.** The numbers above are a
  no-regression control for a correctness change, not a recorded baseline, and
  the tree's rule is that numbers and kernel changes never move in the same
  pull request.
