### PR TITLE
Measure the GDeflate CPU denominator over the recorded level set [#224]

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -131,6 +131,56 @@ add_test(NAME bench_snappy_worst_selfcheck COMMAND bench_snappy --worst
 add_test(NAME bench_snappy_worstlit_selfcheck COMMAND bench_snappy --worstlit
                                                       --selfcheck)
 
+# The GDeflate CPU denominator (issue #224). No CUDA in it at all: there is
+# no GDeflate kernel yet, so the reference decodes on the host and the binary
+# needs neither a device nor a cudec entry point. When the kernel lands, the
+# device rows join this binary the way they joined bench_snappy.
+#
+# It links gdeflate_oracle alone - the same target tests/ pins - because the
+# GDeflate streams in this project have ONE provenance, and a bench that
+# reached for a second compressor would be a second one nobody reconciles.
+add_executable(bench_gdeflate bench_gdeflate.cpp)
+target_link_libraries(bench_gdeflate PRIVATE gdeflate_oracle)
+# ../src for the corpus digest, which reads src/xxhash64.h - the hash already
+# in the tree rather than a new dependency for a bench.
+target_include_directories(bench_gdeflate PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The report names the oracle pin, and it is passed in from the one place that
+# holds it (cmake/CudecGDeflateOracle.cmake) rather than typed into the source:
+# a commit written twice is a commit that can disagree with itself, and the
+# half a reader would trust is the printed one.
+if(NOT CUDEC_GDEFLATE_COMMIT)
+  message(
+    FATAL_ERROR
+      "the gdeflate oracle pin did not reach this directory - bench_gdeflate "
+      "prints it in its methodology block, and a report attesting an unnamed "
+      "commit is the one failure that block may not have")
+endif()
+target_compile_definitions(
+  bench_gdeflate PRIVATE CUDEC_GDEFLATE_COMMIT="${CUDEC_GDEFLATE_COMMIT}")
+set_target_properties(bench_gdeflate PROPERTIES CXX_STANDARD 17
+                                                CXX_STANDARD_REQUIRED ON)
+# -O2 unconditionally for the reason bench_lz4 gives above: the documented
+# container command sets no CMAKE_BUILD_TYPE, and an -O0 reference decoder
+# would be timed instead of the reference decoder.
+target_compile_options(bench_gdeflate PRIVATE -Wall -Wextra -Werror -O2)
+
+# Same rot protection as the entries above. The selfcheck builds the whole
+# level set from a fixed source and asserts the digest of each, so a moved
+# oracle pin, a changed page split or a generator that lost its noise source
+# reds CI - none of which would stop the pages round-tripping, which is why
+# the round trip alone is not the check. CPU-only, so it runs on the GPU-less
+# runner.
+add_test(NAME bench_gdeflate_selfcheck COMMAND bench_gdeflate --selfcheck)
+
+# The asset-like corpus through the same grid (issue #139's block, issue
+# #224's path). Separate entry because it locks different bytes: the source
+# block comes from bench/assetlike_source.h, which bench_lz4 reads too, so a
+# generator that lost a region moves a digest here as well as there.
+# CPU-only, like the entry above.
+add_test(NAME bench_gdeflate_assetlike_selfcheck COMMAND bench_gdeflate
+                                                  --assetlike --selfcheck)
+
 # The Zstd worst-case corpus (issue #229). No CUDA in it at all: the frames
 # are constructed on the host, emitted through the reference's own
 # sequence-compression entry point and decoded by the reference, so the
@@ -195,5 +245,6 @@ set_tests_properties(
   bench_assetlike_selfcheck bench_zstd_worst_selfcheck bench_zstd_selfcheck
   bench_zstd_coverage_selfcheck bench_frame_selfcheck bench_snappy_selfcheck
   bench_snappy_worst_selfcheck bench_snappy_worstlit_selfcheck
+  bench_gdeflate_selfcheck bench_gdeflate_assetlike_selfcheck
   PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 cudec_assert_test_timeouts()

--- a/bench/assetlike_source.h
+++ b/bench/assetlike_source.h
@@ -1,0 +1,232 @@
+/* The game-asset-like source block (issue #139), as one generator two
+ * benchmark harnesses read.
+ *
+ * It models the payload of a shipped asset package - block-compressed
+ * texture, interleaved geometry, streamed audio - and it is the one regime
+ * none of the fetched corpora reaches: most of the block is incompressible,
+ * so a decode over it is dominated by literal transfer rather than by
+ * sequence parsing or match copying.
+ *
+ * It is a MODEL of the workload, not the workload. A synthetic mixture is not
+ * a measurement on real game data, and no number taken here may be quoted as
+ * one; docs/BENCHMARK-METHODOLOGY.md carries the same sentence beside the
+ * corpus entry. The decision on issue #139 chose the generator over a
+ * hash-pinned asset pack deliberately: no network, no mirror that can rot, no
+ * licence review on a third-party package, and CI stays offline. A vetted
+ * pack may later join the set beside this generator; it does not replace it.
+ *
+ * WHY IT IS A HEADER RATHER THAN A COPY. The block's bytes are what a
+ * recorded number is attested against, so two harnesses generating "the
+ * asset-like block" from two sources would be two corpora under one name, and
+ * a drift between them would move a number with nothing to notice it. The
+ * shape LOCKS stay in the harnesses: what a block has to look like on the
+ * wire is a per-format question, and only the source bytes are shared.
+ *
+ * Bench-only. Nothing here is compiled into the library. */
+#ifndef CUDEC_BENCH_ASSETLIKE_SOURCE_H
+#define CUDEC_BENCH_ASSETLIKE_SOURCE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace cudec_bench {
+
+/* The block is one 64 KiB unit, which is the LZ4/Snappy chunk and the
+ * GDeflate page alike. Each consumer static_asserts its own unit against this
+ * one, so a harness whose granularity moved fails to compile rather than
+ * silently benchmarking a differently-tiled block. */
+constexpr size_t kAssetlikeBlockBytes = 65536;
+
+/* The three regions of the block, in bytes, tiling one chunk exactly. The
+ * proportions follow a shipped package: block-compressed texture dominates,
+ * geometry follows, streamed audio fills the rest. */
+constexpr size_t kAssetTextureBytes = 32768;
+constexpr size_t kAssetVertexBytes = 14336;
+constexpr size_t kAssetIndexBytes = 2048;
+constexpr size_t kAssetAudioBytes = 16384;
+static_assert(kAssetTextureBytes + kAssetVertexBytes + kAssetIndexBytes +
+                      kAssetAudioBytes ==
+                  kAssetlikeBlockBytes,
+              "the asset-like regions must tile the 64 KB chunk exactly: a "
+              "short block would change the chunk-size distribution the "
+              "report attests");
+
+/* BC1/DXT1 layout: two 16-bit endpoints plus 32 bits of 2-bit indices. */
+constexpr size_t kAssetTexBlockBytes = 8;
+/* A 64-block-wide image, in 8x8-block tiles. */
+constexpr size_t kAssetTexBlocksPerRow = 64;
+constexpr size_t kAssetTexTileBlocks = 8;
+/* Interleaved position/normal/uv/colour/tangent record. */
+constexpr size_t kAssetVertexStride = 32;
+/* The lattice the geometry sits on, and the row step the index buffer uses. */
+constexpr size_t kAssetLatticeWidth = 28;
+
+
+/* Deterministic byte source for the asset-like block. SplitMix64, chosen
+ * because it is four lines of integer arithmetic with no state beyond a
+ * uint64: the corpus must be byte-identical on the CI runner and on the GPU
+ * box, and a library generator's stream is not fixed across standard
+ * libraries. */
+uint64_t SplitMix64(uint64_t* state) {
+    uint64_t z = (*state += 0x9E3779B97F4A7C15ull);
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
+    return z ^ (z >> 31);
+}
+
+/* Parabolic sine approximation over a 1024-step period, in [-16384, 16384].
+ * Integer-only on purpose: a libm sine is free to differ in the last bits
+ * between platforms, which would make the corpus - and therefore every
+ * recorded number taken on it - not reproducible off this machine. */
+int32_t PseudoSine(uint32_t phase) {
+    const uint32_t p = phase & 1023u;
+    const uint32_t half = p & 511u;
+    const int32_t y = static_cast<int32_t>((half * (512u - half)) >> 2);
+    return p < 512u ? y : -y;
+}
+
+void PushLe16(std::vector<unsigned char>* out, uint16_t v) {
+    out->push_back(static_cast<unsigned char>(v & 0xFF));
+    out->push_back(static_cast<unsigned char>((v >> 8) & 0xFF));
+}
+
+/* A 32-bit float's byte pattern without touching a float: the high half
+ * carries sign, exponent and the top mantissa bits, which barely move across
+ * neighbouring vertices, while the low half is noise. That split is what
+ * makes vertex data compress the way it does - partial matches at the record
+ * stride - and building it from integers keeps the block reproducible and
+ * the harness free of the floating-point types the project bans in sources. */
+void PushPseudoFloat(std::vector<unsigned char>* out, uint16_t hi,
+                     uint16_t lo) {
+    PushLe16(out, lo);
+    PushLe16(out, hi);
+}
+
+/* Block-compressed texture: 8-byte BC1 blocks in raster order over a
+ * 64-block-wide image. A third of the 8x8-block tiles are flat - every block
+ * in them identical, which is what a BC1 flat region really is - and the
+ * rest carry smoothly varying endpoints with high-entropy index bits. The
+ * flat tiles are the only source of long matches in the whole corpus; the
+ * detailed ones are where its incompressible share comes from. */
+void BuildTextureRegion(std::vector<unsigned char>* out, uint64_t* rng) {
+    const size_t blocks = kAssetTextureBytes / kAssetTexBlockBytes;
+    for (size_t b = 0; b < blocks; b++) {
+        const size_t bx = b % kAssetTexBlocksPerRow;
+        const size_t by = b / kAssetTexBlocksPerRow;
+        const size_t tx = bx / kAssetTexTileBlocks;
+        const size_t ty = by / kAssetTexTileBlocks;
+        const bool flat = ((tx + ty) % 3u) == 0u;
+        /* Inside a flat tile the endpoints depend on the TILE, not on the
+         * block, so all 64 of its blocks are byte-identical. */
+        const uint16_t r =
+            static_cast<uint16_t>((flat ? (tx * 5u) : (bx >> 1)) & 0x1F);
+        const uint16_t g = static_cast<uint16_t>((flat ? (ty * 9u) : by) &
+                                                 0x3F);
+        const uint16_t bl = static_cast<uint16_t>(
+            (flat ? (tx + ty) : ((bx + by) >> 2)) & 0x1F);
+        const uint16_t c0 = static_cast<uint16_t>((r << 11) | (g << 5) | bl);
+        const uint16_t c1 = static_cast<uint16_t>(c0 - 0x0821u);
+        PushLe16(out, c0);
+        PushLe16(out, c1);
+        if (flat) {
+            for (size_t i = 0; i < 4; i++) {
+                out->push_back(0x00);
+            }
+        } else {
+            const uint64_t bits = SplitMix64(rng);
+            for (size_t i = 0; i < 4; i++) {
+                out->push_back(static_cast<unsigned char>(bits >> (i * 8)));
+            }
+        }
+    }
+}
+
+/* Interleaved vertex records at a fixed 32-byte stride: position, packed
+ * normal, uv, colour, packed tangent. Everything that varies smoothly across
+ * the lattice sits in the high halves; everything noisy sits in the low
+ * halves. */
+void BuildVertexRegion(std::vector<unsigned char>* out, uint64_t* rng) {
+    const size_t records = kAssetVertexBytes / kAssetVertexStride;
+    static const unsigned char kPacked[8][4] = {
+        {0x7F, 0x00, 0x00, 0x00}, {0x00, 0x7F, 0x00, 0x00},
+        {0x00, 0x00, 0x7F, 0x00}, {0x5A, 0x5A, 0x00, 0x00},
+        {0x5A, 0x00, 0x5A, 0x00}, {0x00, 0x5A, 0x5A, 0x00},
+        {0x49, 0x49, 0x49, 0x00}, {0x81, 0x00, 0x00, 0x00}};
+    for (size_t v = 0; v < records; v++) {
+        const uint16_t gx = static_cast<uint16_t>(v % kAssetLatticeWidth);
+        const uint16_t gy = static_cast<uint16_t>(v / kAssetLatticeWidth);
+        const uint64_t noise = SplitMix64(rng);
+        PushPseudoFloat(out, static_cast<uint16_t>(0x3F80u + gx),
+                        static_cast<uint16_t>(noise & 0xFFFFu));
+        PushPseudoFloat(out, static_cast<uint16_t>(0x3F80u + gy),
+                        static_cast<uint16_t>((noise >> 16) & 0xFFFFu));
+        PushPseudoFloat(out, static_cast<uint16_t>(0x3E00u + ((gx + gy) & 7u)),
+                        static_cast<uint16_t>((noise >> 32) & 0xFFFFu));
+        const unsigned char* n = kPacked[(gx + gy) & 7u];
+        for (size_t i = 0; i < 4; i++) {
+            out->push_back(n[i]);
+        }
+        PushPseudoFloat(out, static_cast<uint16_t>(0x3F00u + (gx & 3u)),
+                        static_cast<uint16_t>((noise >> 48) & 0xFFFFu));
+        PushPseudoFloat(out, static_cast<uint16_t>(0x3F00u + (gy & 3u)),
+                        static_cast<uint16_t>(SplitMix64(rng) & 0xFFFFu));
+        out->push_back(static_cast<unsigned char>(0xC0u + (gx & 0x1Fu)));
+        out->push_back(static_cast<unsigned char>(0xC0u + (gy & 0x1Fu)));
+        out->push_back(0xB4);
+        out->push_back(0xFF);
+        const unsigned char* t = kPacked[(gx * 3u + gy) & 7u];
+        for (size_t i = 0; i < 4; i++) {
+            out->push_back(t[i]);
+        }
+    }
+}
+
+/* A triangle-list index buffer over the same lattice: three 16-bit indices
+ * per triangle, the base walking forward one vertex at a time. Slowly
+ * increasing 16-bit values are the shape that defeats a 4-byte minimum
+ * match, which is why the region is carried rather than assumed away. */
+void BuildIndexRegion(std::vector<unsigned char>* out) {
+    const size_t indices = kAssetIndexBytes / 2;
+    const size_t records = kAssetVertexBytes / kAssetVertexStride;
+    /* Every emitted index stays inside the vertex region. */
+    const size_t bases = records - (kAssetLatticeWidth + 2);
+    static const size_t kCorner[3] = {0, 1, kAssetLatticeWidth};
+    for (size_t i = 0; i < indices; i++) {
+        const size_t base = (i / 3) % bases;
+        PushLe16(out, static_cast<uint16_t>(base + kCorner[i % 3]));
+    }
+}
+
+/* Streamed audio: 16-bit stereo PCM, three detuned oscillators plus a small
+ * dither. The high byte of each sample moves smoothly and the low byte does
+ * not, so the region is effectively incompressible - which is what audio in
+ * an asset package is, and a large part of why this corpus sits where it
+ * does on the ratio scale. */
+void BuildAudioRegion(std::vector<unsigned char>* out, uint64_t* rng) {
+    const size_t frames = kAssetAudioBytes / 4;
+    for (size_t f = 0; f < frames; f++) {
+        const uint64_t noise = SplitMix64(rng);
+        for (size_t ch = 0; ch < 2; ch++) {
+            const uint32_t phase = static_cast<uint32_t>(f * 7u + ch * 61u);
+            int32_t s = PseudoSine(phase) + (PseudoSine(phase * 3u) >> 1) +
+                        (PseudoSine(phase * 11u) >> 2);
+            s += static_cast<int32_t>((noise >> (ch * 8)) & 0x7F) - 64;
+            PushLe16(out, static_cast<uint16_t>(s & 0xFFFF));
+        }
+    }
+}
+
+void BuildAssetlikeSource(std::vector<unsigned char>* original) {
+    uint64_t rng = 0x5C0DEC0A55E7ull;
+    original->clear();
+    original->reserve(kAssetlikeBlockBytes);
+    BuildTextureRegion(original, &rng);
+    BuildVertexRegion(original, &rng);
+    BuildIndexRegion(original);
+    BuildAudioRegion(original, &rng);
+}
+
+}  // namespace cudec_bench
+
+#endif /* CUDEC_BENCH_ASSETLIKE_SOURCE_H */

--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -1,0 +1,618 @@
+/* The GDeflate benchmark harness: the CPU denominator for M4 (issue #224).
+ *
+ * There is no GDeflate kernel yet, so this measures the vendored reference
+ * alone and says so in its own report rather than leaving a reader to infer
+ * it from the absence of a GPU row (docs/MASTERPLAN.md section 5, honest
+ * numbers). When the kernel lands, the device rows are read against these.
+ *
+ * THE UNIT IS THE PAGE, and that is the format's decision rather than this
+ * harness's. GDeflate fixes a 64 KiB page, no match crosses one, and the
+ * batch surface cudec will expose takes raw pages with caller-supplied sizes
+ * (issue #216). So the source is cut into 64 KiB pieces, each piece is
+ * compressed on its own - which is what makes every page independently
+ * decodable - and the timed loop decodes them one at a time. A corpus built
+ * by handing the whole file to the compressor would produce the same bytes
+ * but would measure a decode this project's batch model never performs.
+ *
+ * THE LEVEL SET IS SECTION 11.8's, executed rather than re-taken: 0, 1, 6 and
+ * 12, and each is there to reach something. Level 0 emits uncompressed blocks
+ * by construction, which is the only block-type guarantee the reference's own
+ * header gives; 1 is the fast end of the search; 6 is the default and
+ * therefore the shape most data arrives in; 12 is the densest table
+ * description and the most aggressively chosen block boundaries.
+ *
+ * WHAT THIS PATH DOES NOT CLAIM. Section 11.8 says the level list is the plan
+ * for coverage and not the coverage argument: a compressor chooses block
+ * types for its own reasons. Asserting the block-type composition a family
+ * actually reached needs a walk over the emitted page, which needs the
+ * substream machine, and that lock is issue #225's rather than this one's.
+ * Nothing here claims a block type was reached.
+ *
+ * Ratio is printed beside throughput on every row. For a DEFLATE-class format
+ * the ratio is half the pitch, and a throughput-only table would misreport
+ * what the format is for.
+ *
+ * No CUDA in this binary at all: the reference decodes on the host, and there
+ * is no cudec GDeflate path to launch.
+ *
+ * Bench-only. Nothing here is compiled into the library. */
+#include "assetlike_source.h"
+#include "bench_stats.h"
+
+#include <libdeflate.h>
+
+#include "xxhash64.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using cudec_bench::GbpsFromMs;
+using cudec_bench::Percentile;
+
+/* 64 KiB, the GDeflate page, fixed by the format rather than by this harness
+ * (docs/MASTERPLAN.md section 11.2). */
+constexpr size_t kPageBytes = 65536;
+
+/* The levels section 11.8 names, and the order the report rows follow. */
+constexpr int kLevels[] = {0, 1, 6, 12};
+constexpr size_t kLevelCount = sizeof(kLevels) / sizeof(kLevels[0]);
+
+/* The asset-like corpus replicates one generated block to this many pages:
+ * the same ~210 MB scale as the recorded Silesia rows, so the two throughput
+ * numbers are directly comparable. */
+constexpr size_t kAssetlikePages = 3200;
+
+/* The CI rot checks run the identical construction over a handful of pages so
+ * they stay fast on the GPU-less runner. What is built is the same either
+ * way - only the page count moves. */
+constexpr size_t kSelfcheckPages = 4;
+
+/* The selfcheck source for the file path: several pages long, compressible
+ * enough that the pages are not all stored blocks, and from a fixed PRNG so a
+ * failure reproduces byte for byte. */
+constexpr size_t kSelfcheckBytes = kPageBytes * kSelfcheckPages;
+
+constexpr size_t kMaxRuns = 1000000;
+
+/* The generator's block and this harness's page are one granularity. A
+ * granularity that moved on either side must fail to compile rather than
+ * quietly benchmark a differently-tiled block. */
+static_assert(cudec_bench::kAssetlikeBlockBytes == kPageBytes,
+              "the asset-like generator's block is the GDeflate page");
+
+struct Corpus {
+    std::string name;
+    std::vector<std::vector<unsigned char>> originals;
+    std::vector<std::vector<unsigned char>> compressed;
+    size_t original_bytes = 0;
+    size_t compressed_bytes = 0;
+    /* Printed verbatim in the methodology block, so it must stay true for
+     * whichever corpus ran. */
+    std::string provenance;
+};
+
+/* One page compressed on its own. The page count is read back from the
+ * reference rather than assumed: the page split is the reference's to decide,
+ * and a pin whose geometry moved must fail here rather than pass quietly. */
+bool CompressPage(libdeflate_gdeflate_compressor* c,
+                  const std::vector<unsigned char>& in,
+                  std::vector<unsigned char>* out) {
+    size_t npages = 0;
+    const size_t bound =
+        libdeflate_gdeflate_compress_bound(c, in.size(), &npages);
+    if (bound == 0 || npages != 1) {
+        std::fprintf(stderr,
+                     "the reference splits %zu bytes into %zu pages; this "
+                     "harness compresses one page at a time\n",
+                     in.size(), npages);
+        return false;
+    }
+    std::vector<unsigned char> buffer(bound, 0);
+    libdeflate_gdeflate_out_page page{};
+    page.data = buffer.data();
+    page.nbytes = bound;
+    if (libdeflate_gdeflate_compress(c, in.data(), in.size(), &page, 1) == 0) {
+        std::fprintf(stderr,
+                     "the reference refused to compress a %zu-byte page\n",
+                     in.size());
+        return false;
+    }
+    /* What the compressor WROTE, not what it was offered: page.nbytes is an
+     * out-parameter here, and timing the offered bound would time bytes the
+     * page does not contain. */
+    buffer.resize(page.nbytes);
+    *out = std::move(buffer);
+    return true;
+}
+
+/* Decodes one page through the reference into `out`, which the caller has
+ * already sized to the page's decoded length.
+ *
+ * SUCCESS ALONE IS NOT THE CHECK, and this is the first thing
+ * tests/oracle_gdeflate.cpp pins about this reference: it hands back an
+ * actual output size and its own header says it may be used only where the
+ * uncompressed size is known, so a status read without the size has a hole
+ * exactly where a wrong stream lands. Every caller here compares the size,
+ * and the round-trip pass compares the bytes. */
+bool DecodePage(libdeflate_gdeflate_decompressor* d,
+                const std::vector<unsigned char>& page,
+                std::vector<unsigned char>* out) {
+    libdeflate_gdeflate_in_page in{};
+    in.data = page.data();
+    in.nbytes = page.size();
+    size_t got = 0;
+    const libdeflate_result r =
+        libdeflate_gdeflate_decompress(d, &in, 1, out->data(), out->size(),
+                                       &got);
+    return r == LIBDEFLATE_SUCCESS && got == out->size();
+}
+
+/* Cuts `source` into pages and compresses each one at `level`. */
+bool BuildCorpus(const std::vector<unsigned char>& source, int level,
+                 Corpus* corpus) {
+    libdeflate_gdeflate_compressor* c =
+        libdeflate_alloc_gdeflate_compressor(level);
+    if (c == nullptr) {
+        std::fprintf(stderr, "cannot allocate a level-%d compressor\n", level);
+        return false;
+    }
+    bool ok = true;
+    for (size_t at = 0; at < source.size() && ok; at += kPageBytes) {
+        const size_t n = std::min(kPageBytes, source.size() - at);
+        std::vector<unsigned char> original(
+            source.begin() + static_cast<std::ptrdiff_t>(at),
+            source.begin() + static_cast<std::ptrdiff_t>(at + n));
+        std::vector<unsigned char> page;
+        ok = CompressPage(c, original, &page);
+        if (ok) {
+            corpus->originals.push_back(std::move(original));
+            corpus->compressed.push_back(std::move(page));
+        }
+    }
+    libdeflate_free_gdeflate_compressor(c);
+    if (!ok) {
+        return false;
+    }
+    if (corpus->originals.empty()) {
+        std::fprintf(stderr, "the corpus is empty at level %d\n", level);
+        return false;
+    }
+    corpus->original_bytes = 0;
+    corpus->compressed_bytes = 0;
+    for (size_t i = 0; i < corpus->originals.size(); i++) {
+        corpus->original_bytes += corpus->originals[i].size();
+        corpus->compressed_bytes += corpus->compressed[i].size();
+    }
+    return true;
+}
+
+/* Every page round-trips through the reference before anything is timed, and
+ * the decoded pages are compared against the source they were cut from. A
+ * number taken on a page set that dropped, reordered or truncated part of the
+ * corpus is a number about a different corpus, and the ratio it reports would
+ * still look plausible. */
+bool CorpusRoundTrips(const std::vector<unsigned char>& source,
+                      const Corpus& corpus) {
+    if (corpus.original_bytes != source.size()) {
+        std::fprintf(stderr,
+                     "the pages hold %zu bytes but the source is %zu - the "
+                     "corpus is not the one the report would name\n",
+                     corpus.original_bytes, source.size());
+        return false;
+    }
+    libdeflate_gdeflate_decompressor* d =
+        libdeflate_alloc_gdeflate_decompressor();
+    if (d == nullptr) {
+        std::fprintf(stderr, "cannot allocate a decompressor\n");
+        return false;
+    }
+    bool ok = true;
+    size_t at = 0;
+    for (size_t i = 0; i < corpus.compressed.size() && ok; i++) {
+        std::vector<unsigned char> back(corpus.originals[i].size(), 0);
+        if (!DecodePage(d, corpus.compressed[i], &back)) {
+            std::fprintf(stderr, "the reference refuses page %zu of %s\n", i,
+                         corpus.name.c_str());
+            ok = false;
+            break;
+        }
+        if (std::memcmp(back.data(), source.data() + at, back.size()) != 0) {
+            std::fprintf(stderr, "page %zu does not round-trip\n", i);
+            ok = false;
+            break;
+        }
+        at += back.size();
+    }
+    libdeflate_free_gdeflate_decompressor(d);
+    return ok;
+}
+
+/* Destinations allocated outside the timed region, so the number is the
+ * decoder's and not the allocator's. */
+std::vector<std::vector<unsigned char>> MakeBuffers(const Corpus& corpus) {
+    std::vector<std::vector<unsigned char>> buffers;
+    buffers.reserve(corpus.originals.size());
+    for (const auto& original : corpus.originals) {
+        buffers.push_back(std::vector<unsigned char>(original.size()));
+    }
+    return buffers;
+}
+
+/* One timed pass over the whole page set. The timed region is the decompress
+ * call alone. Returns a negative duration if any page fails, so a broken
+ * decode can never be reported as a fast one. */
+double DecodeAllSeconds(libdeflate_gdeflate_decompressor* d,
+                        const Corpus& corpus,
+                        std::vector<std::vector<unsigned char>>* buffers) {
+    const auto start = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        if (!DecodePage(d, corpus.compressed[i], &(*buffers)[i])) {
+            return -1.0;
+        }
+    }
+    const auto end = std::chrono::steady_clock::now();
+    return std::chrono::duration<double>(end - start).count();
+}
+
+/* The corpus lock, on the model bench_snappy.cpp and bench_zstd.cpp record in
+ * full: a fold of each page's length and XXH64 in corpus order, hashed again.
+ * What it has to catch is drift - an oracle pin that moved, a page split that
+ * changed, an input file that is not the one the report names - and all three
+ * change the produced pages, so the digest runs over those. The fetched
+ * inputs are already pinned by the manifest bench/get-corpora.sh writes, and a
+ * second input lock here would be two authorities on one fact.
+ *
+ * XXH64 and not SHA-256, said plainly so nobody reads more into it: this is a
+ * drift detector over data the harness just built, not a defence against a
+ * chosen collision, and it is the hash already in the tree. */
+void AppendLe64(uint64_t value, std::vector<unsigned char>* out) {
+    for (unsigned i = 0; i < 8; i++) {
+        out->push_back(static_cast<unsigned char>(value >> (i * 8)));
+    }
+}
+
+uint64_t CorpusDigest(const Corpus& corpus) {
+    std::vector<unsigned char> fold;
+    fold.reserve(corpus.compressed.size() * 16);
+    for (const auto& page : corpus.compressed) {
+        AppendLe64(page.size(), &fold);
+        AppendLe64(cudec_detail::Xxh64(page.data(), page.size()), &fold);
+    }
+    return cudec_detail::Xxh64(fold.data(), fold.size());
+}
+
+/* Reads one corpus file onto the end of `source`. Fails closed on I/O trouble
+ * and on a file that contributed nothing, per FILE rather than over the
+ * accumulated source: the accumulated test goes vacuous from the second
+ * argument on, and a file that contributed no bytes must never end up
+ * attested in the methodology block. */
+bool AppendFile(const std::string& path, std::vector<unsigned char>* source) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        std::fprintf(stderr, "cannot open corpus file: %s\n", path.c_str());
+        return false;
+    }
+    const size_t before = source->size();
+    char buffer[1 << 16];
+    while (in.read(buffer, sizeof(buffer)) || in.gcount() > 0) {
+        source->insert(source->end(), buffer, buffer + in.gcount());
+    }
+    if (in.bad()) {
+        std::fprintf(stderr, "read error in corpus file: %s\n", path.c_str());
+        return false;
+    }
+    if (source->size() == before) {
+        std::fprintf(stderr, "corpus file contributed no data: %s\n",
+                     path.c_str());
+        return false;
+    }
+    return true;
+}
+
+/* The file path's selfcheck source. Runs of a repeating alphabet with
+ * occasional noise: matches for the decoder to execute, without collapsing
+ * into one long match. */
+std::vector<unsigned char> MakeSelfcheckSource(size_t bytes) {
+    std::vector<unsigned char> out(bytes);
+    uint64_t state = 0x9E3779B97F4A7C15ull;
+    for (size_t i = 0; i < bytes; i++) {
+        state = state * 6364136223846793005ull + 1442695040888963407ull;
+        out[i] = (i % 61 == 0)
+                     ? static_cast<unsigned char>(state >> 56)
+                     : static_cast<unsigned char>('a' + (i / 7) % 26);
+    }
+    return out;
+}
+
+/* The asset-like source, replicated to `pages` identical pages. The block is
+ * generated in bench/assetlike_source.h, which bench_lz4 reads too: the
+ * recorded numbers are attested against those bytes, and two harnesses
+ * generating them separately would be two corpora under one name. */
+std::vector<unsigned char> MakeAssetlikeSource(size_t pages) {
+    std::vector<unsigned char> block;
+    cudec_bench::BuildAssetlikeSource(&block);
+    std::vector<unsigned char> out;
+    out.reserve(block.size() * pages);
+    for (size_t i = 0; i < pages; i++) {
+        out.insert(out.end(), block.begin(), block.end());
+    }
+    return out;
+}
+
+void PrintReport(const Corpus& corpus, int level,
+                 const std::vector<double>& sorted, size_t warmup,
+                 size_t runs) {
+    std::vector<size_t> sizes;
+    sizes.reserve(corpus.originals.size());
+    for (const auto& original : corpus.originals) {
+        sizes.push_back(original.size());
+    }
+    std::sort(sizes.begin(), sizes.end());
+    const double gb = static_cast<double>(corpus.original_bytes) / 1e9;
+
+    std::printf("## bench_gdeflate report\n");
+    std::printf("- decoder: CPU oracle, libdeflate_gdeflate_decompress (the "
+                "pinned NVIDIA/libdeflate gdeflate fork, commit %s), single "
+                "thread. cudec has no GDeflate kernel yet, so this report is "
+                "the denominator and carries no cudec number\n",
+                CUDEC_GDEFLATE_COMMIT);
+    std::printf("- host CPU: %s\n", cudec_bench::HostCpuName().c_str());
+    std::printf("- corpus: %s, %zu pages, %.2f MB original, %.2f MB "
+                "compressed (ratio %.4f), %s\n",
+                corpus.name.c_str(), corpus.originals.size(),
+                static_cast<double>(corpus.original_bytes) / 1e6,
+                static_cast<double>(corpus.compressed_bytes) / 1e6,
+                static_cast<double>(corpus.compressed_bytes) /
+                    static_cast<double>(corpus.original_bytes),
+                corpus.provenance.c_str());
+    std::printf("- granularity: %zu KiB pages, compression level %d\n",
+                kPageBytes / 1024, level);
+    std::printf("- corpus digest: %016llx (XXH64 over per-page length and "
+                "XXH64, little-endian, in corpus order)\n",
+                static_cast<unsigned long long>(CorpusDigest(corpus)));
+    std::printf("- page sizes: min %zu / median %zu / max %zu bytes "
+                "uncompressed\n",
+                sizes.front(), sizes[sizes.size() / 2], sizes.back());
+    std::printf("- method: %zu warmup + %zu measured runs, wall clock per "
+                "whole-batch decode; the timed region is "
+                "libdeflate_gdeflate_decompress only (destinations allocated "
+                "outside it); every page round-trip-verified against the "
+                "source once before timing; percentiles are nearest-rank\n",
+                warmup, runs);
+    std::printf("- block-type composition: not asserted here; reading it "
+                "needs a walk over the emitted page and that lock is issue "
+                "#225's\n");
+    const double p50 = Percentile(sorted, 50);
+    const double p90 = Percentile(sorted, 90);
+    const double p99 = Percentile(sorted, 99);
+    std::printf("- wall per run: p50 %.3f ms / p90 %.3f ms / p99 %.3f ms\n",
+                p50 * 1e3, p90 * 1e3, p99 * 1e3);
+    std::printf("- decode throughput: p50 %.3f GB/s / p90 %.3f GB/s / p99 "
+                "%.3f GB/s\n",
+                GbpsFromMs(gb, p50 * 1e3), GbpsFromMs(gb, p90 * 1e3),
+                GbpsFromMs(gb, p99 * 1e3));
+}
+
+/* Reports the digest of the corpus it built through `digest_out` rather than
+ * judging it here, so the caller can walk every level and name all of the
+ * ones that moved. Stopping at the first would report one drifted level and
+ * leave the rest unexamined, which reads as "only that one moved". */
+bool RunLevel(const std::vector<unsigned char>& source, const std::string& name,
+              const std::string& provenance, int level, size_t warmup,
+              size_t runs, uint64_t* digest_out) {
+    Corpus corpus;
+    corpus.name = name;
+    corpus.provenance = provenance;
+    if (!BuildCorpus(source, level, &corpus)) {
+        return false;
+    }
+    if (!CorpusRoundTrips(source, corpus)) {
+        return false;
+    }
+    *digest_out = CorpusDigest(corpus);
+
+    libdeflate_gdeflate_decompressor* d =
+        libdeflate_alloc_gdeflate_decompressor();
+    if (d == nullptr) {
+        std::fprintf(stderr, "cannot allocate a decompressor\n");
+        return false;
+    }
+    std::vector<std::vector<unsigned char>> buffers = MakeBuffers(corpus);
+    bool ok = true;
+    for (size_t i = 0; i < warmup && ok; i++) {
+        if (DecodeAllSeconds(d, corpus, &buffers) < 0) {
+            std::fprintf(stderr, "a warmup decode failed\n");
+            ok = false;
+        }
+    }
+    std::vector<double> times;
+    for (size_t i = 0; i < runs && ok; i++) {
+        const double seconds = DecodeAllSeconds(d, corpus, &buffers);
+        if (seconds < 0) {
+            std::fprintf(stderr, "a measured decode failed\n");
+            ok = false;
+            break;
+        }
+        times.push_back(seconds);
+    }
+    libdeflate_free_gdeflate_decompressor(d);
+    if (!ok || times.empty()) {
+        return false;
+    }
+    std::sort(times.begin(), times.end());
+    PrintReport(corpus, level, times, warmup, runs);
+    return true;
+}
+
+/* The selfcheck corpora are generated from a fixed source and compressed by
+ * the pinned reference, so every page set is reproducible byte for byte and
+ * its digest is a constant. Asserting them is what makes this a rot check
+ * rather than a run: an oracle pin that moved, a page split that changed, or
+ * a generator that lost a region all move a digest, and none of them would
+ * stop the corpus round-tripping - which is why the round trip alone is not
+ * the check.
+ *
+ * One digest per level, in the order kLevels lists them. */
+constexpr uint64_t kSelfcheckDigests[kLevelCount] = {
+    0xd46934fd0e71f055ull, 0x9ce5496f4c7cfc2eull, 0x808fbdf79a44154cull,
+    0x0a8fa51b3c17129dull};
+constexpr uint64_t kAssetlikeSelfcheckDigests[kLevelCount] = {
+    0xc27a1a3637c14945ull, 0x3c7582779571120full, 0x22c785b441c4cb03ull,
+    0xc8dda2e72b80524cull};
+
+/* The level list and the two pin tables are indexed by one loop variable, so
+ * a level added to one and not the others would read off the end. Refused at
+ * compile time rather than left to the run, because the read would be in the
+ * selfcheck - the one place a wrong answer looks like a verdict. */
+static_assert(sizeof(kSelfcheckDigests) / sizeof(kSelfcheckDigests[0]) ==
+                  kLevelCount,
+              "one selfcheck digest per level");
+static_assert(sizeof(kAssetlikeSelfcheckDigests) /
+                      sizeof(kAssetlikeSelfcheckDigests[0]) ==
+                  kLevelCount,
+              "one asset-like selfcheck digest per level");
+
+bool CheckDigest(uint64_t actual, const std::string& name, int level,
+                 uint64_t expected) {
+    if (actual == expected) {
+        return true;
+    }
+    std::fprintf(stderr,
+                 "the selfcheck corpus digest moved on %s at level %d: "
+                 "expected %016llx, built %016llx - the corpus this harness "
+                 "constructs is not the one its numbers were recorded on\n",
+                 name.c_str(), level,
+                 static_cast<unsigned long long>(expected),
+                 static_cast<unsigned long long>(actual));
+    return false;
+}
+
+bool ParseCount(const char* text, size_t lo, size_t hi, size_t* out) {
+    char* end = nullptr;
+    const unsigned long long v = std::strtoull(text, &end, 10);
+    if (end == text || *end != '\0' || v < lo || v > hi) {
+        return false;
+    }
+    *out = static_cast<size_t>(v);
+    return true;
+}
+
+void Usage(const char* argv0) {
+    std::fprintf(stderr,
+                 "usage: %s [--warmup N] [--runs N] [--assetlike] "
+                 "[--selfcheck] [corpus files...]\n",
+                 argv0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    size_t warmup = 3;
+    size_t runs = 30;
+    bool selfcheck = false;
+    bool assetlike = false;
+    std::vector<std::string> files;
+
+    for (int i = 1; i < argc; i++) {
+        const std::string arg = argv[i];
+        if (arg == "--assetlike") {
+            assetlike = true;
+        } else if (arg == "--selfcheck") {
+            selfcheck = true;
+        } else if (arg == "--runs" && i + 1 < argc) {
+            if (!ParseCount(argv[++i], 1, kMaxRuns, &runs)) {
+                Usage(argv[0]);
+                return 2;
+            }
+        } else if (arg == "--warmup" && i + 1 < argc) {
+            if (!ParseCount(argv[++i], 0, kMaxRuns, &warmup)) {
+                Usage(argv[0]);
+                return 2;
+            }
+        } else if (!arg.empty() && arg[0] == '-') {
+            Usage(argv[0]);
+            return 2;
+        } else {
+            files.push_back(arg);
+        }
+    }
+
+    if (assetlike && !files.empty()) {
+        std::fprintf(stderr, "--assetlike builds its own corpus; do not pass "
+                             "corpus files with it\n");
+        return 2;
+    }
+
+    if (selfcheck) {
+        /* Short and fixed, so the rot check stays fast on the GPU-less runner
+         * and its verdict is a digest rather than a timing. */
+        warmup = 0;
+        runs = 1;
+    }
+
+    std::vector<unsigned char> source;
+    std::string name;
+    std::string provenance;
+    if (assetlike) {
+        source =
+            MakeAssetlikeSource(selfcheck ? kSelfcheckPages : kAssetlikePages);
+        name = "asset-like";
+        provenance =
+            "generated in-harness, a MODEL of a game asset package "
+            "(bench/assetlike_source.h, issue #139) and not a measurement on "
+            "real game data; cut into 64 KiB pages and each page compressed "
+            "on its own by the pinned gdeflate fork";
+    } else if (selfcheck) {
+        source = MakeSelfcheckSource(kSelfcheckBytes);
+        name = "selfcheck";
+        provenance = "generated in-harness from a fixed PRNG; cut into 64 KiB "
+                     "pages and each page compressed on its own by the pinned "
+                     "gdeflate fork";
+    } else {
+        if (files.empty()) {
+            Usage(argv[0]);
+            std::fprintf(stderr, "no corpus files given (the recorded run "
+                                 "uses bench/corpora/silesia/*)\n");
+            return 2;
+        }
+        for (size_t i = 0; i < files.size(); i++) {
+            if (!AppendFile(files[i], &source)) {
+                return 1;
+            }
+            const size_t slash = files[i].find_last_of("/\\");
+            const std::string base = slash == std::string::npos
+                                         ? files[i]
+                                         : files[i].substr(slash + 1);
+            name += (i == 0 ? "" : "+") + base;
+        }
+        provenance = "cut into 64 KiB pages and each page compressed on its "
+                     "own by the pinned gdeflate fork; every page decoded "
+                     "back by the reference and compared against the source "
+                     "before timing";
+    }
+
+    const uint64_t* expected =
+        assetlike ? kAssetlikeSelfcheckDigests : kSelfcheckDigests;
+    bool ok = true;
+    for (size_t i = 0; i < kLevelCount; i++) {
+        uint64_t digest = 0;
+        if (!RunLevel(source, name, provenance, kLevels[i], warmup, runs,
+                      &digest)) {
+            return 1;
+        }
+        if (selfcheck && !CheckDigest(digest, name, kLevels[i], expected[i])) {
+            ok = false;
+        }
+        std::printf("\n");
+    }
+    return ok ? 0 : 1;
+}

--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -3,6 +3,7 @@
  * plugs in as a second timed path in this same harness. A report cannot
  * be produced without its methodology block; that is the point
  * (docs/MASTERPLAN.md section 5, honest numbers). */
+#include "assetlike_source.h"
 #include "bench_stats.h"
 #include "cudec.h"
 #include "fixtures.h"
@@ -84,29 +85,18 @@ static_assert(kLongmatchOffset >= kLongmatchMatchLen,
 constexpr size_t kAssetlikeChunks = 3200;
 constexpr size_t kAssetlikeSelfcheckChunks = 4;
 
-/* The three regions of the block, in bytes, tiling one chunk exactly. The
- * proportions follow a shipped package: block-compressed texture dominates,
- * geometry follows, streamed audio fills the rest. */
-constexpr size_t kAssetTextureBytes = 32768;
-constexpr size_t kAssetVertexBytes = 14336;
-constexpr size_t kAssetIndexBytes = 2048;
-constexpr size_t kAssetAudioBytes = 16384;
-static_assert(kAssetTextureBytes + kAssetVertexBytes + kAssetIndexBytes +
-                      kAssetAudioBytes ==
-                  kChunkBytes,
-              "the asset-like regions must tile the 64 KB chunk exactly: a "
-              "short block would change the chunk-size distribution the "
-              "report attests");
-
-/* BC1/DXT1 layout: two 16-bit endpoints plus 32 bits of 2-bit indices. */
-constexpr size_t kAssetTexBlockBytes = 8;
-/* A 64-block-wide image, in 8x8-block tiles. */
-constexpr size_t kAssetTexBlocksPerRow = 64;
-constexpr size_t kAssetTexTileBlocks = 8;
-/* Interleaved position/normal/uv/colour/tangent record. */
-constexpr size_t kAssetVertexStride = 32;
-/* The lattice the geometry sits on, and the row step the index buffer uses. */
-constexpr size_t kAssetLatticeWidth = 28;
+/* The block itself is generated in bench/assetlike_source.h, which
+ * bench_gdeflate reads too (issue #224): the recorded numbers are attested
+ * against those bytes, so two harnesses generating them separately would be
+ * two corpora under one name. What stays here is the LZ4 shape lock below -
+ * what the block has to look like on the wire is a per-format question. The
+ * assert ties this harness's chunk to the generator's block, so a granularity
+ * that moved on either side fails to compile rather than benchmarking a
+ * differently-tiled block. */
+using cudec_bench::BuildAssetlikeSource;
+static_assert(cudec_bench::kAssetlikeBlockBytes == kChunkBytes,
+              "the asset-like generator's block and this harness's chunk are "
+              "one granularity");
 
 struct Corpus {
     std::string name;
@@ -429,170 +419,6 @@ bool BuildLongmatchCorpus(Corpus* corpus, size_t chunks) {
                          "(offset 512 >= match length 255; oracle-validated; "
                          "LZ4_compress_default never emits it)";
     return true;
-}
-
-/* Deterministic byte source for the asset-like block. SplitMix64, chosen
- * because it is four lines of integer arithmetic with no state beyond a
- * uint64: the corpus must be byte-identical on the CI runner and on the GPU
- * box, and a library generator's stream is not fixed across standard
- * libraries. */
-uint64_t SplitMix64(uint64_t* state) {
-    uint64_t z = (*state += 0x9E3779B97F4A7C15ull);
-    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
-    z = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
-    return z ^ (z >> 31);
-}
-
-/* Parabolic sine approximation over a 1024-step period, in [-16384, 16384].
- * Integer-only on purpose: a libm sine is free to differ in the last bits
- * between platforms, which would make the corpus - and therefore every
- * recorded number taken on it - not reproducible off this machine. */
-int32_t PseudoSine(uint32_t phase) {
-    const uint32_t p = phase & 1023u;
-    const uint32_t half = p & 511u;
-    const int32_t y = static_cast<int32_t>((half * (512u - half)) >> 2);
-    return p < 512u ? y : -y;
-}
-
-void PushLe16(std::vector<unsigned char>* out, uint16_t v) {
-    out->push_back(static_cast<unsigned char>(v & 0xFF));
-    out->push_back(static_cast<unsigned char>((v >> 8) & 0xFF));
-}
-
-/* A 32-bit float's byte pattern without touching a float: the high half
- * carries sign, exponent and the top mantissa bits, which barely move across
- * neighbouring vertices, while the low half is noise. That split is what
- * makes vertex data compress the way it does - partial matches at the record
- * stride - and building it from integers keeps the block reproducible and
- * the harness free of the floating-point types the project bans in sources. */
-void PushPseudoFloat(std::vector<unsigned char>* out, uint16_t hi,
-                     uint16_t lo) {
-    PushLe16(out, lo);
-    PushLe16(out, hi);
-}
-
-/* Block-compressed texture: 8-byte BC1 blocks in raster order over a
- * 64-block-wide image. A third of the 8x8-block tiles are flat - every block
- * in them identical, which is what a BC1 flat region really is - and the
- * rest carry smoothly varying endpoints with high-entropy index bits. The
- * flat tiles are the only source of long matches in the whole corpus; the
- * detailed ones are where its incompressible share comes from. */
-void BuildTextureRegion(std::vector<unsigned char>* out, uint64_t* rng) {
-    const size_t blocks = kAssetTextureBytes / kAssetTexBlockBytes;
-    for (size_t b = 0; b < blocks; b++) {
-        const size_t bx = b % kAssetTexBlocksPerRow;
-        const size_t by = b / kAssetTexBlocksPerRow;
-        const size_t tx = bx / kAssetTexTileBlocks;
-        const size_t ty = by / kAssetTexTileBlocks;
-        const bool flat = ((tx + ty) % 3u) == 0u;
-        /* Inside a flat tile the endpoints depend on the TILE, not on the
-         * block, so all 64 of its blocks are byte-identical. */
-        const uint16_t r =
-            static_cast<uint16_t>((flat ? (tx * 5u) : (bx >> 1)) & 0x1F);
-        const uint16_t g = static_cast<uint16_t>((flat ? (ty * 9u) : by) &
-                                                 0x3F);
-        const uint16_t bl = static_cast<uint16_t>(
-            (flat ? (tx + ty) : ((bx + by) >> 2)) & 0x1F);
-        const uint16_t c0 = static_cast<uint16_t>((r << 11) | (g << 5) | bl);
-        const uint16_t c1 = static_cast<uint16_t>(c0 - 0x0821u);
-        PushLe16(out, c0);
-        PushLe16(out, c1);
-        if (flat) {
-            for (size_t i = 0; i < 4; i++) {
-                out->push_back(0x00);
-            }
-        } else {
-            const uint64_t bits = SplitMix64(rng);
-            for (size_t i = 0; i < 4; i++) {
-                out->push_back(static_cast<unsigned char>(bits >> (i * 8)));
-            }
-        }
-    }
-}
-
-/* Interleaved vertex records at a fixed 32-byte stride: position, packed
- * normal, uv, colour, packed tangent. Everything that varies smoothly across
- * the lattice sits in the high halves; everything noisy sits in the low
- * halves. */
-void BuildVertexRegion(std::vector<unsigned char>* out, uint64_t* rng) {
-    const size_t records = kAssetVertexBytes / kAssetVertexStride;
-    static const unsigned char kPacked[8][4] = {
-        {0x7F, 0x00, 0x00, 0x00}, {0x00, 0x7F, 0x00, 0x00},
-        {0x00, 0x00, 0x7F, 0x00}, {0x5A, 0x5A, 0x00, 0x00},
-        {0x5A, 0x00, 0x5A, 0x00}, {0x00, 0x5A, 0x5A, 0x00},
-        {0x49, 0x49, 0x49, 0x00}, {0x81, 0x00, 0x00, 0x00}};
-    for (size_t v = 0; v < records; v++) {
-        const uint16_t gx = static_cast<uint16_t>(v % kAssetLatticeWidth);
-        const uint16_t gy = static_cast<uint16_t>(v / kAssetLatticeWidth);
-        const uint64_t noise = SplitMix64(rng);
-        PushPseudoFloat(out, static_cast<uint16_t>(0x3F80u + gx),
-                        static_cast<uint16_t>(noise & 0xFFFFu));
-        PushPseudoFloat(out, static_cast<uint16_t>(0x3F80u + gy),
-                        static_cast<uint16_t>((noise >> 16) & 0xFFFFu));
-        PushPseudoFloat(out, static_cast<uint16_t>(0x3E00u + ((gx + gy) & 7u)),
-                        static_cast<uint16_t>((noise >> 32) & 0xFFFFu));
-        const unsigned char* n = kPacked[(gx + gy) & 7u];
-        for (size_t i = 0; i < 4; i++) {
-            out->push_back(n[i]);
-        }
-        PushPseudoFloat(out, static_cast<uint16_t>(0x3F00u + (gx & 3u)),
-                        static_cast<uint16_t>((noise >> 48) & 0xFFFFu));
-        PushPseudoFloat(out, static_cast<uint16_t>(0x3F00u + (gy & 3u)),
-                        static_cast<uint16_t>(SplitMix64(rng) & 0xFFFFu));
-        out->push_back(static_cast<unsigned char>(0xC0u + (gx & 0x1Fu)));
-        out->push_back(static_cast<unsigned char>(0xC0u + (gy & 0x1Fu)));
-        out->push_back(0xB4);
-        out->push_back(0xFF);
-        const unsigned char* t = kPacked[(gx * 3u + gy) & 7u];
-        for (size_t i = 0; i < 4; i++) {
-            out->push_back(t[i]);
-        }
-    }
-}
-
-/* A triangle-list index buffer over the same lattice: three 16-bit indices
- * per triangle, the base walking forward one vertex at a time. Slowly
- * increasing 16-bit values are the shape that defeats a 4-byte minimum
- * match, which is why the region is carried rather than assumed away. */
-void BuildIndexRegion(std::vector<unsigned char>* out) {
-    const size_t indices = kAssetIndexBytes / 2;
-    const size_t records = kAssetVertexBytes / kAssetVertexStride;
-    /* Every emitted index stays inside the vertex region. */
-    const size_t bases = records - (kAssetLatticeWidth + 2);
-    static const size_t kCorner[3] = {0, 1, kAssetLatticeWidth};
-    for (size_t i = 0; i < indices; i++) {
-        const size_t base = (i / 3) % bases;
-        PushLe16(out, static_cast<uint16_t>(base + kCorner[i % 3]));
-    }
-}
-
-/* Streamed audio: 16-bit stereo PCM, three detuned oscillators plus a small
- * dither. The high byte of each sample moves smoothly and the low byte does
- * not, so the region is effectively incompressible - which is what audio in
- * an asset package is, and a large part of why this corpus sits where it
- * does on the ratio scale. */
-void BuildAudioRegion(std::vector<unsigned char>* out, uint64_t* rng) {
-    const size_t frames = kAssetAudioBytes / 4;
-    for (size_t f = 0; f < frames; f++) {
-        const uint64_t noise = SplitMix64(rng);
-        for (size_t ch = 0; ch < 2; ch++) {
-            const uint32_t phase = static_cast<uint32_t>(f * 7u + ch * 61u);
-            int32_t s = PseudoSine(phase) + (PseudoSine(phase * 3u) >> 1) +
-                        (PseudoSine(phase * 11u) >> 2);
-            s += static_cast<int32_t>((noise >> (ch * 8)) & 0x7F) - 64;
-            PushLe16(out, static_cast<uint16_t>(s & 0xFFFF));
-        }
-    }
-}
-
-void BuildAssetlikeSource(std::vector<unsigned char>* original) {
-    uint64_t rng = 0x5C0DEC0A55E7ull;
-    original->clear();
-    original->reserve(kChunkBytes);
-    BuildTextureRegion(original, &rng);
-    BuildVertexRegion(original, &rng);
-    BuildIndexRegion(original);
-    BuildAudioRegion(original, &rng);
 }
 
 /* What one pass over a valid LZ4 block says about its shape. */

--- a/cmake/CudecGDeflateOracle.cmake
+++ b/cmake/CudecGDeflateOracle.cmake
@@ -43,7 +43,14 @@ include(FetchContent)
 #
 # The pinned commit is the branch head as of that read, so the pin does not
 # lag the fork; the fork lags upstream.
-set(CUDEC_GDEFLATE_COMMIT 8ba9502fb30d2bf728592d121f0d402e40c8cb05)
+# CACHE INTERNAL rather than a plain set: this file is included from tests/,
+# and the benchmark harness in bench/ prints the pin in its own methodology
+# block. A directory-scoped variable would reach that harness as the empty
+# string and it would attest an unnamed commit, which is the one failure a
+# methodology block may not have. bench/CMakeLists.txt refuses an empty value.
+set(CUDEC_GDEFLATE_COMMIT
+    8ba9502fb30d2bf728592d121f0d402e40c8cb05
+    CACHE INTERNAL "the pinned NVIDIA/libdeflate gdeflate commit")
 FetchContent_Declare(
   gdeflate
   URL https://github.com/NVIDIA/libdeflate/archive/${CUDEC_GDEFLATE_COMMIT}.tar.gz

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1509,6 +1509,180 @@ standing instrument rather than a one-off: the next attempt on this stage, for
 any format on this seam, reads the trigger rate before writing a kernel
 instead of arguing about it.
 
+## M4: the GDeflate CPU denominator (issue #224)
+
+There is no GDeflate kernel yet. This entry is the denominator a later device
+number will be read against, and the harness says so in its own report rather
+than leaving a reader to infer it from the absence of a GPU row.
+
+Eight cells, two corpora crossed with the level set section 11.8 of the
+[MASTERPLAN](MASTERPLAN.md) records. Silesia is the general-purpose half;
+`asset-like` is the generated game-asset model (issue #139), which is the one
+regime Silesia does not reach - most of its block is incompressible, so the
+decode is dominated by literal transfer. Both harnesses read that block from
+one generator, `bench/assetlike_source.h`, so the bytes a number is attested
+against cannot drift between them.
+
+The levels are 0, 1, 6 and 12, and each is there to reach something: 0 emits
+uncompressed blocks by construction, which is the only block-type guarantee
+the reference's own header gives; 1 is the fast end of the search; 6 is the
+default; 12 is the densest table description. Section 11.8 also says plainly
+that a level list is the PLAN for coverage and not the coverage argument, and
+nothing here asserts which block types a family actually reached - that lock
+needs a walk over the emitted page and is issue #225's.
+
+The unit is the 64 KiB GDeflate page, and each page is compressed on its own,
+which is what makes it independently decodable and what the batch surface
+(#216) will take. The timed loop decodes one page per call. Before anything is
+timed every page is decoded back by the reference and compared against the
+source it was cut from, so a page set that dropped, reordered or truncated
+part of the corpus fails instead of reporting a plausible ratio over different
+bytes.
+
+Each report carries a digest of the corpus that was actually built, folded
+over the produced pages rather than over the inputs (the inputs are already
+pinned by the manifest `bench/get-corpora.sh` writes). It is order-sensitive,
+so the digests below belong to the file order listed in the corpus line.
+
+Recorded 2026-08-26 in the Ubuntu-24.04 WSL distribution on the host CPU named
+in the blocks, against the gdeflate fork pinned at
+`8ba9502fb30d2bf728592d121f0d402e40c8cb05`. Reproduce with
+`bench_gdeflate --warmup 3 --runs 30 bench/corpora/silesia/*` and
+`bench_gdeflate --warmup 3 --runs 30 --assetlike`.
+
+**Read the p50 and treat the tail with suspicion on this run.** The host was
+carrying other work while these were taken - the Silesia level-0 cell spreads
+from 0.692 GB/s at p50 to 0.227 GB/s at p99 - so the p90/p99 columns of the
+blocks below carry that contention rather than a property of the decoder. The
+p50 is the denominator this entry exists to record; the tail is reported
+because the block reports it, not because it is clean.
+
+| corpus     | level | compressed | ratio  | p50 decode | corpus digest      |
+| ---------- | ----- | ---------- | ------ | ---------- | ------------------ |
+| Silesia    | 0     | 212.38 MB  | 1.0021 | 0.692 GB/s | `88ed82d5ec9df3ad` |
+| Silesia    | 1     | 75.89 MB   | 0.3581 | 0.313 GB/s | `131124d155e6672b` |
+| Silesia    | 6     | 70.84 MB   | 0.3343 | 0.362 GB/s | `042b2473240db0b0` |
+| Silesia    | 12    | 67.77 MB   | 0.3198 | 0.373 GB/s | `4b88e13a215ed884` |
+| asset-like | 0     | 210.15 MB  | 1.0021 | 0.678 GB/s | `08ac6ec118b60189` |
+| asset-like | 1     | 149.00 MB  | 0.7105 | 0.292 GB/s | `45690d97a5d3b054` |
+| asset-like | 6     | 147.40 MB  | 0.7029 | 0.322 GB/s | `47dad3ea983dc577` |
+| asset-like | 12    | 146.70 MB  | 0.6995 | 0.335 GB/s | `cb272ab3765d8378` |
+
+The table is a reading aid. The eight blocks below are the record, and each one
+carries the methodology its own numbers were taken under.
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. cudec has no GDeflate kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, 212.38 MB compressed (ratio 1.0021), cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- granularity: 64 KiB pages, compression level 0
+- corpus digest: 88ed82d5ec9df3ad (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's
+- wall per run: p50 306.237 ms / p90 431.330 ms / p99 933.635 ms
+- decode throughput: p50 0.692 GB/s / p90 0.491 GB/s / p99 0.227 GB/s
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. cudec has no GDeflate kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, 75.89 MB compressed (ratio 0.3581), cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- granularity: 64 KiB pages, compression level 1
+- corpus digest: 131124d155e6672b (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's
+- wall per run: p50 676.159 ms / p90 1124.385 ms / p99 1393.539 ms
+- decode throughput: p50 0.313 GB/s / p90 0.188 GB/s / p99 0.152 GB/s
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. cudec has no GDeflate kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, 70.84 MB compressed (ratio 0.3343), cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- granularity: 64 KiB pages, compression level 6
+- corpus digest: 042b2473240db0b0 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's
+- wall per run: p50 585.838 ms / p90 629.493 ms / p99 713.022 ms
+- decode throughput: p50 0.362 GB/s / p90 0.337 GB/s / p99 0.297 GB/s
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. cudec has no GDeflate kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, 67.77 MB compressed (ratio 0.3198), cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- granularity: 64 KiB pages, compression level 12
+- corpus digest: 4b88e13a215ed884 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's
+- wall per run: p50 568.204 ms / p90 589.782 ms / p99 615.539 ms
+- decode throughput: p50 0.373 GB/s / p90 0.359 GB/s / p99 0.344 GB/s
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. cudec has no GDeflate kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: asset-like, 3200 pages, 209.72 MB original, 210.15 MB compressed (ratio 1.0021), generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- granularity: 64 KiB pages, compression level 0
+- corpus digest: 08ac6ec118b60189 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's
+- wall per run: p50 309.432 ms / p90 327.616 ms / p99 345.187 ms
+- decode throughput: p50 0.678 GB/s / p90 0.640 GB/s / p99 0.608 GB/s
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. cudec has no GDeflate kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: asset-like, 3200 pages, 209.72 MB original, 149.00 MB compressed (ratio 0.7105), generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- granularity: 64 KiB pages, compression level 1
+- corpus digest: 45690d97a5d3b054 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's
+- wall per run: p50 719.320 ms / p90 757.564 ms / p99 781.417 ms
+- decode throughput: p50 0.292 GB/s / p90 0.277 GB/s / p99 0.268 GB/s
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. cudec has no GDeflate kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: asset-like, 3200 pages, 209.72 MB original, 147.40 MB compressed (ratio 0.7029), generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- granularity: 64 KiB pages, compression level 6
+- corpus digest: 47dad3ea983dc577 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's
+- wall per run: p50 651.308 ms / p90 673.832 ms / p99 688.227 ms
+- decode throughput: p50 0.322 GB/s / p90 0.311 GB/s / p99 0.305 GB/s
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. cudec has no GDeflate kernel yet, so this report is the denominator and carries no cudec number
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: asset-like, 3200 pages, 209.72 MB original, 146.70 MB compressed (ratio 0.6995), generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- granularity: 64 KiB pages, compression level 12
+- corpus digest: cb272ab3765d8378 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's
+- wall per run: p50 626.935 ms / p90 666.084 ms / p99 682.146 ms
+- decode throughput: p50 0.335 GB/s / p90 0.315 GB/s / p99 0.307 GB/s
+```
+
 ## M5: the Zstd CPU denominator (issue #227)
 
 There is no Zstd kernel yet. This entry is the denominator a later device


### PR DESCRIPTION
# What & why

Closes #224.

M4 has no kernel yet, so there is no honest device number to publish and no
denominator to read a later one against. This lands the CPU half of the M4
bench path — which #224 says explicitly does not need the kernel — as
`bench/bench_gdeflate`, eight recorded cells in `docs/BENCHMARKS.md`, and two
rot checks that keep the corpus from drifting under the numbers.

**The unit is the 64 KiB page**, and that is the format's decision rather than
the harness's. The source is cut into 64 KiB pieces and each piece is
compressed on its own, which is what makes it independently decodable and what
the batch surface (#216) will take. A corpus built by handing a whole file to
the compressor produces the same bytes but measures a decode this project's
batch model never performs.

**The timed region is `libdeflate_gdeflate_decompress` alone**, destinations
allocated outside it, 3 warmup + 30 measured runs, percentiles nearest-rank —
the protocol `docs/BENCHMARK-METHODOLOGY.md` already fixes for the liblz4
baseline.

**Before anything is timed** every page is decoded back by the reference and
compared against the source it was cut from. A number taken on a page set that
dropped, reordered or truncated part of the corpus is a number about a
different corpus, and the ratio it reports would still look plausible.

**The level set is executed, not re-taken.** 0, 1, 6, 12, from MASTERPLAN
section 11.8, and the harness's own header says what each is there to reach.

## What this change deliberately does not claim

Section 11.8 also says a level list is the PLAN for coverage and not the
coverage argument: a compressor chooses block types for its own reasons, and
incompressible input forces stored blocks at any level. Nothing here asserts
which block types a family actually reached. Reading that needs a walk over the
emitted page, which needs the substream machine, and that lock is #225's. The
report prints the absence on its own line rather than leaving it to be
inferred:

    - block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's

## The asset-like generator moves rather than being copied

`#224` says the path is corpus-source agnostic and that the asset-like corpus
is whatever #139 landed. #139 landed it as a generator inside `bench_lz4.cpp`
rather than as a file under `bench/corpora/`, so consuming it means reaching
the generator. The block therefore moves to `bench/assetlike_source.h` and both
harnesses read it from there.

The failure that prevents: a recorded number is attested against those bytes,
so two harnesses generating "the asset-like block" separately would be two
corpora under one name, and a drift between them would move a number with
nothing to notice it. Only the SOURCE bytes are shared — the shape locks stay
per format, because what a block has to look like on the wire is a per-format
question, and `bench_lz4.cpp` keeps its four-quantity LZ4 lock unchanged.

**The move is proven to change no produced byte**, rather than argued. The
moved region at `origin/main` diffed against the header:

    git show origin/main:bench/bench_lz4.cpp | sed -n '87,110p;434,596p' > before.txt
    sed -n '40,63p;66,228p' bench/assetlike_source.h > after.txt
    diff -u before.txt after.txt

returns two substantive lines, both `kChunkBytes` becoming
`kAssetlikeBlockBytes` — the same value, 65536 — one inside a `static_assert`
and one inside a `reserve()` capacity hint. Neither can change a generated
byte. Each consumer `static_assert`s its own granularity against the
generator's, so a page or chunk size that moved on either side fails to compile
instead of quietly benchmarking a differently-tiled block.

`bench_assetlike_selfcheck` is the executed half of the same proof: it asserts
compression ratio, literal share, sequence count and mean match length over the
generated block, and it is green below.

## The oracle pin reached bench/ as the empty string

`cmake/CudecGDeflateOracle.cmake` is included from `tests/`, so
`CUDEC_GDEFLATE_COMMIT` was directory-scoped and a report in `bench/` printed
`commit ` with nothing after it. It is `CACHE INTERNAL` now, and
`bench/CMakeLists.txt` refuses an empty value at configure time: a methodology
block attesting an unnamed commit is the one failure that block may not have.
This was found by reading the first run's output, not by review.

## Type of change

- [x] Build / CI / supply chain
- [x] Docs
- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality

## Engineering checklist

- [x] Fail-closed preserved: no parse or decode path is added. Every failure
      the harness can meet — a corpus file that opens but contributes nothing,
      a page the reference refuses, a page that does not round-trip, a page set
      whose byte total is not the source's, a decode that fails mid-timing —
      returns non-zero and prints what it refused. A failed decode returns a
      negative duration so a broken decode can never be reported as a fast one.
- [x] Oracle coverage: the vendored NVIDIA/libdeflate fork is the sole
      authority here. Every page in every cell round-trips through it before
      any timing, and the decoded pages are compared against the source.
- [x] Determinism preserved: no library code is touched. The corpora are
      reproducible byte for byte and the two selfchecks assert eight pinned
      digests.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI —
      vacuous, this binary links no CUDA at all.
- [ ] An adversarial review (`/security-review`) was run. **It was not.** See
      "Notes" below; this box stays unticked rather than being reworded.
- [ ] Review record. **There is none**, for the same reason.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. `bench_gdeflate`
      links `gdeflate_oracle` and nothing else, declares no CUDA language and
      no `CUDA::cudart`, and both of its ctest entries are CPU-only.

```
```

The block is left empty rather than removed, as the template asks.

## Performance checklist

- [x] The claim is measured, not reasoned. Eight cells, each with its full
      methodology block, in the new `## M4: the GDeflate CPU denominator`
      section of `docs/BENCHMARKS.md`.
- [x] No regression against the recorded baseline: no existing number moves.
      The only edit to a measured path is the asset-like source generator's
      move, proven byte-neutral above, and no recorded LZ4, Snappy or Zstd
      number is touched.

**Read the p50 and treat the tail with suspicion on this run**, which the
recorded section says in its own words too. The host was carrying other work
while these were taken — the Silesia level-0 cell spreads from 0.692 GB/s at
p50 to 0.227 GB/s at p99 — so the p90/p99 columns carry that contention rather
than a property of the decoder. The p50 is what this entry exists to record.

| corpus     | level | compressed | ratio  | p50 decode | corpus digest      |
| ---------- | ----- | ---------- | ------ | ---------- | ------------------ |
| Silesia    | 0     | 212.38 MB  | 1.0021 | 0.692 GB/s | `88ed82d5ec9df3ad` |
| Silesia    | 1     | 75.89 MB   | 0.3581 | 0.313 GB/s | `131124d155e6672b` |
| Silesia    | 6     | 70.84 MB   | 0.3343 | 0.362 GB/s | `042b2473240db0b0` |
| Silesia    | 12    | 67.77 MB   | 0.3198 | 0.373 GB/s | `4b88e13a215ed884` |
| asset-like | 0     | 210.15 MB  | 1.0021 | 0.678 GB/s | `08ac6ec118b60189` |
| asset-like | 1     | 149.00 MB  | 0.7105 | 0.292 GB/s | `45690d97a5d3b054` |
| asset-like | 6     | 147.40 MB  | 0.7029 | 0.322 GB/s | `47dad3ea983dc577` |
| asset-like | 12    | 146.70 MB  | 0.6995 | 0.335 GB/s | `cb272ab3765d8378` |

One number is worth stating because it reads backwards: **level 0 is the
FASTEST cell on both corpora**, at roughly twice the compressed levels, even
though it is the only level that carries no matches at all. That is the
format's stored-block shape rather than a memcpy — no byte alignment, no NLEN,
decoded as fixed 8-bit codes at 32 bytes per round (MASTERPLAN 11.3) — so a
stored page still runs the round machine. It is recorded here and nothing is
concluded from it; the device side of that question is #206's.

## Quality checklist

- [x] Minimal: one new harness, one moved generator, no duplicated generator
      and no second fetch path. `bench/get-corpora.sh` is reused as #224 asks.
- [x] Self-documenting: the harness's header says what it measures, what the
      unit is and why, and what it refuses to claim.
- [x] Conformance tests pass. The new structural property this change
      establishes — that the asset-like generator's block and each consumer's
      granularity are one number — is locked as a `static_assert` in both
      consumers rather than left as prose.

## Verification

Run in the Ubuntu-24.04 WSL distribution, CUDA 13.3 (V13.3.73), driver 610.88,
RTX 3080, at `076cfb16ee28a4326a5cab5ff4b04e850c9649af`.

- [x] `cmake --build` — clean, both configurations. Host-only
      (`cmake -S . -B ~/bhost && cmake --build ~/bhost -j8`) and the CUDA
      engine (`-DCUDEC_ENABLE_CUDA=ON`) both build with no warning.
- [x] `ctest` — green, including the device tests CI defers:

```
100% tests passed, 0 tests failed out of 51

Label Time Summary:
gpu    =   9.16 sec*proc (8 tests)

Total Test time (real) =  22.47 sec
```

49 before this change and 51 after; the two added are
`bench_gdeflate_selfcheck` and `bench_gdeflate_assetlike_selfcheck`, both
CPU-only so they run on the GPU-less runner, both carrying the mandatory finite
`TIMEOUT` through `cudec_assert_test_timeouts()`.

- [x] Prettier (`**/*.{md,yml,yaml}`) — `All matched files use Prettier code
      style!`
- [x] Docs synced: `docs/BENCHMARKS.md` gains the M4 section. No behaviour, API
      or existing performance number changes, so nothing else is owed.

### The selfchecks are shown to bite

The digests were not pinned first and confirmed after. The harness was built
with placeholder constants, run, and the run named all four levels as moved:

```
the selfcheck corpus digest moved on selfcheck at level 0: expected 1111111111111111, built d46934fd0e71f055 - the corpus this harness constructs is not the one its numbers were recorded on
the selfcheck corpus digest moved on selfcheck at level 1: expected 2222222222222222, built 9ce5496f4c7cfc2e - the corpus this harness constructs is not the one its numbers were recorded on
the selfcheck corpus digest moved on selfcheck at level 6: expected 3333333333333333, built 808fbdf79a44154c - the corpus this harness constructs is not the one its numbers were recorded on
the selfcheck corpus digest moved on selfcheck at level 12: expected 4444444444444444, built 0a8fa51b3c17129d - the corpus this harness constructs is not the one its numbers were recorded on
```

Four names, not one: the check reports every level that moved rather than
stopping at the first, because stopping reads as "only that one moved". The
same run on `--assetlike` named its four. The digests in the source are those
eight values, and both entries exit 0 with them.

## Notes

**No second reader, and no adversarial review lens was run.** The template asks
for `/security-review` on a change touching build files, and this change edits
`bench/CMakeLists.txt` and `cmake/CudecGDeflateOracle.cmake`. It did not
happen. What stands in its place is stated rather than implied: the whole
change is bench-only and docs, nothing under `src/` or `include/` is touched,
the new binary links no CUDA and no cudec target, and the two configuration
edits are a new consumer-only executable plus a variable scope widened with a
configure-time refusal on the empty case. That is an argument, not a review,
and it does not become one by being written down.

**What is left of #224 after this**, so the next reader does not have to
rediscover it: nothing. Both `Done looks like` corpora are recorded, the
selfcheck is green on the GPU-less path, and `docs/BENCHMARKS.md` carries the
entry with its full methodology block. The two siblings this touches the edge
of stay open and are named where they matter: #225 owns the block-composition
lock, #226 owns the max-rounds adversarial corpus and will extend this same
harness.
