### PR TITLE
Settle the Snappy element carry width on a measurement [#292]

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1509,6 +1509,105 @@ standing instrument rather than a one-off: the next attempt on this stage, for
 any format on this seam, reads the trigger rate before writing a kernel
 instead of arguing about it.
 
+### M3 kernel shape (issue #292): the narrowed element buys occupancy and loses throughput
+
+The last width question the Snappy seam left open. The arithmetic width was
+settled with the gather (see the #58 pass above and the parser contract at the
+head of `src/chunk_decode.cuh`): the copy engine already picks a 32-bit modulo
+where the element admits one. What was not settled is the width the element is
+CARRIED in. `DecodeSequence` is six `uint64_t`, 48 bytes, and Snappy provably
+needs none of that range - its declared length is a varint32, so every position,
+offset and length fits in 32 bits. The struct's size is register pressure per
+lane, and the two instantiations of one kernel were already eight registers
+apart.
+
+Both arms were built and run rather than argued. The narrow arm is the same six
+fields declared `uint32_t`, which halves the element to 24 bytes. It is a
+measurement build and it is NOT in the tree: LZ4's `match_len` is bounded by the
+caller's `size_t` capacity rather than by any field width, and the tree carries
+a test that reaches past 2^32 through it, so a globally narrowed element is
+wrong for the other format on this seam. What the experiment answers is whether
+a SECOND, narrow element type for Snappy would be worth the panel decision it
+would cost - and it is not, so the question stops here rather than at that
+trade.
+
+Read out through `cudaFuncGetAttributes` and
+`cudaOccupancyMaxActiveBlocksPerMultiprocessor` on the shipped kernel:
+
+```
+device=NVIDIA GeForce RTX 3080 sm_86 maxWarpsPerSM=48 elementBytes=48
+lz4      regs=48   blocks/SM=10  warps/SM=40  (of 48)
+snappy   regs=56   blocks/SM=9   warps/SM=36  (of 48)
+
+device=NVIDIA GeForce RTX 3080 sm_86 maxWarpsPerSM=48 elementBytes=24
+lz4      regs=40   blocks/SM=12  warps/SM=48  (of 48)
+snappy   regs=48   blocks/SM=10  warps/SM=40  (of 48)
+```
+
+So the narrowing does exactly what it was expected to do to residency: eight
+registers back on both instantiations, one more resident block per SM for
+Snappy, and LZ4 reaching the architectural ceiling of 48 warps/SM. On the
+occupancy argument alone it wins.
+
+It loses on the clock, on every corpus:
+
+| corpus                 | 64-bit element | 32-bit element | delta     |
+| ---------------------- | -------------- | -------------- | --------- |
+| Silesia, 64 KiB chunks | 13.970 GB/s    | 12.899 GB/s    | **-7.7%** |
+| worst (copy chain)     | 8.064 GB/s     | 7.553 GB/s     | **-6.3%** |
+| worstlit (parse chain) | 3.612 GB/s     | 3.459 GB/s     | **-4.2%** |
+
+Repeated on Silesia because a single pair at that spread is a claim about one
+run. Three independent baseline samples against three narrow ones, alternating,
+same binaries, same corpus:
+
+```
+baseline  13.970 / 13.823 / 13.471 GB/s
+narrow    12.899 / 13.231 / 13.006 GB/s
+```
+
+Every baseline sample is above every narrow sample. GPU timing on this device
+jitters 1-2% run to run, which is the size of the spread WITHIN each arm and
+well under the gap between them.
+
+**The parse-only ceiling does not move, and that is what locates the cost.**
+Copies elided, the identical lockstep parse through the template seam:
+
+```
+baseline  19.911 / 19.693 / 18.734 GB/s
+narrow    19.648 / 19.683 / 20.044 GB/s
+```
+
+The two sets interleave completely. So the narrowing does not slow the parse -
+it slows the stage the parse feeds. The copy loops index global memory, where
+every field is an address operand and a 32-bit field is widened again at the
+point of use; the extra conversions are paid per lane per element, and they cost
+more than the resident block gains. On the adversarial corpora the direction is
+the same, which rules out an explanation that only holds for real data.
+
+**Rejected, and the accept rule that rejects it is the one already registered
+for this stage.** #161, #163 and #165 all turn on the parse-bound row as the
+DoS-resistance margin; this arm moves it 4.2% the wrong way and the general
+corpus 7.7% the wrong way. Occupancy is not the currency - the kernel was not
+short of resident warps, and buying more of them by making every element access
+more expensive is the trade this measurement refuses.
+
+So the element stays 64-bit on both sides of the seam, there is no narrowing to
+bounds-check, and the seam keeps ONE element contract - which is what the #85
+panel decided the copy engine's safety rests on, now costing nothing rather than
+costing an unmeasured amount. `src/decode_sequence.h` and `src/snappy_block.h`
+carry the answer where their next reader meets it.
+
+Recorded 2026-08-26 in the Ubuntu-24.04 WSL distribution, nvcc 13.3 (V13.3.73),
+driver 610.88, RTX 3080 (sm_86), 3 warmup + 30 measured runs, device-resident
+and CUDA-event timed, every chunk verified to its original size before timing.
+Both arms were built and run on this one toolchain in one sitting: the M3
+baselines above were taken under nvcc 12.6 in the pinned container, so the
+numbers here are compared against their own arm and never against those.
+Reproduce the baseline arm with `bench_snappy --gpu bench/corpora/silesia/*`,
+`bench_snappy --worst --gpu` and `bench_snappy --worstlit --gpu`; the narrow arm
+is those three over a build whose six `DecodeSequence` fields are `uint32_t`.
+
 ## M4: the GDeflate CPU denominator (issue #224)
 
 There is no GDeflate kernel yet. This entry is the denominator a later device

--- a/src/decode_sequence.h
+++ b/src/decode_sequence.h
@@ -26,9 +26,17 @@
  * Absolute offsets, and 64-bit throughout. Snappy's declared length is a
  * varint32 so its positions provably fit in 32 bits, but the caller's
  * capacity is a size_t and mixing the two widths in a bound comparison is
- * where an overflow would hide. Whether the DEVICE side should carry
- * narrower copies is a measured kernel-shape question (issue #292), not a
- * width to change here on a guess. */
+ * where an overflow would hide.
+ *
+ * THE DEVICE CARRIES THEM AT THIS WIDTH TOO, MEASURED RATHER THAN INHERITED.
+ * Issue #292 asked whether the kernel should hold a narrowed copy of this
+ * struct. Both arms were built and run: narrowing the six fields to 32 bits
+ * takes the Snappy instantiation from 56 registers to 48 and from 9 resident
+ * blocks per SM to 10 on sm_86, and it costs 4-8% of decode throughput on
+ * every recorded corpus while the parse-only ceiling does not move. The copy
+ * loops index global memory, so a narrow field is widened again at the point
+ * of use, and the occupancy the narrowing buys is occupancy this kernel was
+ * not short of. docs/BENCHMARKS.md carries both arms and the mechanism. */
 #ifndef CUDEC_DECODE_SEQUENCE_H
 #define CUDEC_DECODE_SEQUENCE_H
 

--- a/src/snappy_block.h
+++ b/src/snappy_block.h
@@ -27,9 +27,19 @@
  * varint32, so every output position, every copy offset and every element
  * length provably fits in 32 bits. The shared element's fields are 64-bit
  * anyway, because the caller's capacity is a size_t and mixing the two
- * widths in the bound comparisons is where an overflow would hide. Whether
- * the DEVICE side should carry 32-bit copies of them is a measured
- * kernel-shape question (issue #292) and is not settled here.
+ * widths in the bound comparisons is where an overflow would hide.
+ *
+ * WHETHER THE DEVICE SHOULD CARRY 32-BIT COPIES OF THEM IS SETTLED, AND THE
+ * ANSWER IS NO. Issue #292 asked it and it is decided on a measurement
+ * rather than on the fields' declaration: a narrowed element buys eight
+ * registers and one more resident block per SM on sm_86, and LOSES 4-8% of
+ * decode throughput on all three recorded corpora. The parse-only ceiling
+ * does not move, which is what says where the loss is - the copy loops
+ * index global memory, so every narrow field is widened again at the point
+ * of use. Occupancy this kernel does not spend is occupancy it does not
+ * need. The numbers, both arms and the mechanism are in docs/BENCHMARKS.md
+ * under the #292 lever; the arithmetic WIDTH question is a different one and
+ * is answered per element inside src/chunk_decode.cuh.
  *
  * Edge semantics are settled empirically by oracle parity - whenever
  * snappy rejects, this parser must reject (tests/snappy_parser_twin.cpp).


### PR DESCRIPTION
# What & why

Closes #292.

The issue asks for one thing and refuses substitutes for it: the element width
the M3 kernel carries, decided by a measurement on the recorded hardware rather
than inherited from the host header. It sat behind #167 for the harness, which
closed on 2026-08-25, so the number is producible now.

**Both arms were built and run.** The narrow arm is the same six
`DecodeSequence` fields declared `uint32_t`, halving the element from 48 bytes
to 24.

**Residency**, read out through `cudaFuncGetAttributes` and
`cudaOccupancyMaxActiveBlocksPerMultiprocessor` on the shipped kernel:

```
device=NVIDIA GeForce RTX 3080 sm_86 maxWarpsPerSM=48 elementBytes=48
lz4      regs=48   blocks/SM=10  warps/SM=40  (of 48)
snappy   regs=56   blocks/SM=9   warps/SM=36  (of 48)

device=NVIDIA GeForce RTX 3080 sm_86 maxWarpsPerSM=48 elementBytes=24
lz4      regs=40   blocks/SM=12  warps/SM=48  (of 48)
snappy   regs=48   blocks/SM=10  warps/SM=40  (of 48)
```

The 48-byte row reproduces the readout #292's own comment recorded, so the
probe agrees with the tree's earlier reading before it is used for anything.

**Throughput**, same protocol as the recorded M3 baselines — device-resident,
CUDA-event timed, 3 warmup + 30 measured runs, every chunk verified to its
original size before timing:

| corpus                 | 64-bit element | 32-bit element | delta      |
| ---------------------- | -------------- | -------------- | ---------- |
| Silesia, 64 KiB chunks | 13.970 GB/s    | 12.899 GB/s    | **-7.7%**  |
| worst (copy chain)     | 8.064 GB/s     | 7.553 GB/s     | **-6.3%**  |
| worstlit (parse chain) | 3.612 GB/s     | 3.459 GB/s     | **-4.2%**  |

**Repeated, because a single pair at that spread is a claim about one run.**
Three alternating baseline/narrow passes on Silesia, same binaries:

```
baseline  13.970 / 13.823 / 13.471 GB/s
narrow    12.899 / 13.231 / 13.006 GB/s
```

Every baseline sample is above every narrow sample. The spread within each arm
is the 1-2% this device jitters and is well under the gap between them.

**The parse-only ceiling does not move, and that is what locates the cost:**

```
baseline  19.911 / 19.693 / 18.734 GB/s
narrow    19.648 / 19.683 / 20.044 GB/s
```

The two sets interleave completely. So the narrowing does not slow the parse —
it slows the stage the parse feeds. The copy loops index global memory, where a
32-bit field is widened again at the point of use, and the conversions are paid
per lane per element. The direction is the same on both adversarial corpora,
which rules out an explanation that only holds for real data.

**Rejected**, on the accept rule already registered for this stage: #161, #163
and #165 all turn on the parse-bound row as the DoS-resistance margin, and this
arm moves it 4.2% the wrong way. Occupancy is not the currency here — the
kernel was not short of resident warps, and buying more of them by making every
element access more expensive is the trade the measurement refuses.

## What lands, and what does not

The narrow element is **not** in the tree, and it should not be: LZ4's
`match_len` is bounded by the caller's `size_t` capacity rather than by any
field width, and `tests/huge_match_gpu.cu` reaches past 2^32 through it. A
globally narrowed element is wrong for the other format on this seam, so the
experiment was a measurement build.

What the experiment answers is the arm #292's comment left open — whether a
SECOND, narrow element type for Snappy would be worth the #85 panel decision it
would cost. It would not, so the question stops before that trade rather than
at it.

So this change is a record and two comments:

- `docs/BENCHMARKS.md` gains the `### M3 kernel shape (issue #292)` section
  with both arms, the repeat pass, the ceiling that locates the cost, and the
  methodology.
- `src/decode_sequence.h` and `src/snappy_block.h` each replace their "not
  settled here / is a measured kernel-shape question" sentence with the answer.
  Both files pointed a reader at an open issue; neither does now.

The issue's second Done-when — that a narrowing be bounds-checked rather than
assumed — is discharged by there being no narrowing to check. The arithmetic
width narrowing that DOES exist is a different one, is inside
`src/chunk_decode.cuh`, and already carries its own contract at the head of
that file; nothing here touches it.

## Type of change

- [x] Performance
- [x] Docs
- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved: no executable line changes. `git diff` over `src/`
      is comment text only.
- [x] Oracle coverage: unchanged, and exercised — the full suite runs green
      below, including the Snappy oracle twins.
- [x] Determinism preserved: nothing that produces a byte was touched.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI —
      unchanged.
- [ ] An adversarial review (`/security-review`) was run. **It was not.** See
      "Notes"; the box stays unticked rather than being reworded.
- [ ] Review record. **There is none**, for the same reason.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. The two edited
      headers are edited in their comment blocks only.

```
```

Left empty rather than removed, as the template asks.

## Performance checklist

- [x] The claim is measured, not reasoned: both arms above, with GPU model,
      driver, CUDA version, corpora and protocol, and a repeat pass.
- [x] No regression against the recorded baseline: nothing that runs changes,
      so no recorded number moves. The baseline arm here is not comparable to
      the recorded M3 rows and is not compared to them — those were taken under
      nvcc 12.6 in the pinned container and this pass ran under nvcc 13.3 in
      WSL. Each arm is read against the other arm of its own sitting, which is
      the only comparison the experiment supports.

## Quality checklist

- [x] Minimal: no code added. The measurement build is not landed.
- [x] Self-documenting: the answer is written where the next reader of each
      header meets it, with the mechanism, not only the verdict.
- [x] Conformance tests pass. This change establishes no new structural
      property — it closes an open question, and the property it confirms (one
      element contract on the seam) is already the one the copy engine's safety
      rests on.

## Verification

Ubuntu-24.04 WSL, CUDA 13.3 (V13.3.73), driver 610.88, RTX 3080, at
`e0891013ac0fe8bf1857604b66f434fb64b4a215`.

- [x] `cmake --build` — clean, `-DCUDEC_ENABLE_CUDA=ON`, no warning.
- [x] `ctest` — green, including the eight device tests CI defers:

```
100% tests passed, 0 tests failed out of 51

Label Time Summary:
gpu    =   9.39 sec*proc (8 tests)

Total Test time (real) =  21.21 sec
```

- [x] Prettier (`**/*.{md,yml,yaml}`) — `All matched files use Prettier code
      style!`
- [x] Docs synced: `docs/BENCHMARKS.md` carries the record; the two headers
      carry the answer. No behaviour or API change, so nothing else is owed.

## Notes

**No second reader, and no adversarial review lens was run.** The change is a
benchmark record plus two comment blocks; `git diff -- src/` contains no
executable line, and the suite is green above. That is an argument for why the
risk is small, not a review, and it does not become one by being written down.

**What the narrow arm's LZ4 row is worth saying out loud**, because somebody
will read the occupancy table and want it: LZ4 reaches the architectural 48
warps/SM under a 24-byte element. That is not an available win either. The same
corpora were not run for LZ4 here, the element is shared, and the field width
LZ4 needs is set by a capacity the ABI admits above 2^32 rather than by a
format field. The row is recorded so it is not rediscovered as an opportunity;
nothing is concluded from it.
