### PR TITLE
Pin the GDeflate page layout against the reference [#170]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,10 +139,14 @@ cudec_add_test(oracle_gdeflate SOURCES oracle_gdeflate.cpp LIBS
 # The dossier's format facts executed against that oracle (issue #170), the
 # GDeflate counterpart of snappy_probes below. It links gdeflate_oracle alone
 # for the reason oracle_gdeflate gives above, and it is GPU-less because the
-# facts are measured through the reference's public API rather than on a
-# device.
+# facts are measured either through the reference's public API or through the
+# schedule header, neither of which needs a device. It reaches src/ for that
+# header: the probes that pin where bits sit inside a page walk the substreams
+# with src/gdeflate_schedule.h rather than reimplementing the cursor beside it.
 cudec_add_test(gdeflate_probes SOURCES gdeflate_probes.cpp LIBS
                gdeflate_oracle)
+target_include_directories(gdeflate_probes
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 # The GDeflate round/refill schedule (issue #178), the first rung of the M4
 # substream machine. GPU-less because the schedule is pure arithmetic over a
 # byte range and the CPU twin is the only place it is testable before a kernel

--- a/tests/gdeflate_probes.cpp
+++ b/tests/gdeflate_probes.cpp
@@ -607,9 +607,17 @@ int main() {
                         "lane-order assertion above pins nothing on this page",
                         c.seed, c.level);
         }
+        /* All six drew a dynamic block when this was written, and the floor
+         * is set below that on purpose: which block type the reference picks
+         * is its decision, and an oracle pin that shifts one case to static
+         * should not red a probe about the precode. Four is still enough that
+         * the run cannot pass having read none, which is the failure this
+         * guards - every assertion above is inside the loop, so a run that
+         * skipped every case would be green and empty. */
         REQUIRE_CTX(dynamic_seen >= 4,
-                    "only %d of %zu inputs drew a dynamic block; the precode "
-                    "layout is unpinned on a run that never reads one",
+                    "only %d of %zu inputs drew a dynamic block (six did when "
+                    "this was written); the precode layout is unpinned on a "
+                    "run that reads too few",
                     dynamic_seen, sizeof(cases) / sizeof(cases[0]));
     }
 

--- a/tests/gdeflate_probes.cpp
+++ b/tests/gdeflate_probes.cpp
@@ -644,6 +644,17 @@ int main() {
      *     follows takes no further word - both asserted, for the reasons
      *     given where they are asserted.
      *
+     * AND ONE OF THE FOUR ANSWERS A QUESTION THE DOSSIER RECORDS AS OPEN.
+     * Section 11.5 lists three things not to read into the source, and the
+     * third is that "the draft states no bit width for a non-compressed
+     * block's length field. It says what was removed, in D3, and no more."
+     * Sixteen bits is the reference's answer rather than the draft's, and the
+     * LEN assertion below is where that stops being an assumption: a stored
+     * block whose declared length equals the input at six different sizes is
+     * a width measured, not one carried over from RFC 1951 because it happens
+     * to be the same number. The dossier item stays true as written - the
+     * draft still says nothing - so there is nothing to report back to #145.
+     *
      * Why the ladder needs it: a stored block is the one place a decoder is
      * handed a length it must bound itself. RFC 1951 gives a decoder a free
      * consistency check on that number and GDeflate does not, so the M4

--- a/tests/gdeflate_probes.cpp
+++ b/tests/gdeflate_probes.cpp
@@ -10,19 +10,42 @@
  * Each probe below names the dossier item it pins and the draft section that
  * item cites. A probe with no citation would be an opinion.
  *
- * WHAT THIS FILE CAN AND CANNOT REACH, STATED SO THE GAP IS NOT MISTAKEN FOR
- * COVERAGE. Everything here is measured through the reference's public API -
- * compress, decompress, and the sizes they report. That reaches every fact
- * whose consequence is visible in what a compressor can and cannot encode. It
- * does not reach a fact about how the bits are laid out inside a page: the
- * block header rounds (D5, D6), the stored block's bit-packed body (D4) and
- * the lane-order refill schedule are all statements about the substream
- * machine, and reading them out of an emitted page means implementing that
- * machine, which is the CPU twin (#178, #176, #182). Those probes are owed
- * and are named on #170 rather than being approximated here.
+ * WHAT THIS FILE REACHES, IN TWO KINDS, AND WHERE THE SECOND KIND ARRIVED.
+ * Probes 1 to 4 are measured through the reference's public API - compress,
+ * decompress, and the sizes they report - which reaches every fact whose
+ * consequence is visible in what a compressor can and cannot encode. That is
+ * all this file could reach while it was written, and it said so: the block
+ * header rounds (D5, D6), the stored block's bit-packed body (D3, D4) and the
+ * lane-order refill schedule are statements about where bits sit INSIDE a
+ * page, and reading one out of an emitted page means walking the 32 substreams
+ * in the order the refill schedule produced them.
+ *
+ * That walk exists now. src/gdeflate_schedule.h owns the bit cursor and
+ * nothing else, so probes 5 to 7 open a real page with it and read the
+ * layout facts off the reference's own output. They decode no symbol and
+ * build no table: everything below is reachable with the cursor alone, which
+ * is why it does not wait for the code-length decode (#176) or the block loop
+ * (#182).
+ *
+ * EACH OF THE THREE CARRIES ITS OWN FALSIFIER, and that is the part to keep if
+ * these are ever rewritten. A layout probe that only reads the layout it
+ * believes in passes for a page whose layout is something else entirely, so
+ * every one of them also performs the WRONG reading - the one a decoder built
+ * on RFC 1951's shape or on a rotate-before-refill schedule would perform -
+ * and requires it to disagree. Without that half the probe pins nothing.
+ *
+ * WHAT IS STILL NOT REACHED, so the gap is not mistaken for coverage: the
+ * permutation the precode lengths are stored in (16, 17, 18, 0, 8, 7, ...) is
+ * NOT pinned here and cannot be by these means. A permutation reorders the
+ * same multiset of lengths, so every completeness test in probe 6 answers
+ * identically under the permuted and the unpermuted reading; separating them
+ * needs a decode that assigns those lengths to symbols, which is #176. The
+ * dynamic block's literal/length and distance lengths, the tables built from
+ * them, and every block type beyond the header round are the same case.
  *
  * No cudec code is under test. cudec has no GDeflate decoder yet; that is the
  * point of pinning these before one is written. */
+#include "gdeflate_schedule.h"
 #include "require.h"
 
 #include <libdeflate.h>
@@ -143,6 +166,90 @@ bool RoundTrips(int level, const std::vector<unsigned char>& in) {
     libdeflate_free_gdeflate_decompressor(d);
     return r == LIBDEFLATE_SUCCESS && got == in.size() &&
            std::memcmp(back.data(), in.data(), in.size()) == 0;
+}
+
+/* The single page the reference emitted for an input that fits in one. Probes
+ * 1 to 4 never needed the bytes, only the sizes; probes 5 to 7 read the bytes,
+ * so this returns them. An input above 64 KiB would be split and the caller
+ * would be reading a page it did not choose, so more than one page is a
+ * failure here rather than a silently-taken first element. */
+bool CompressOnePage(int level, const std::vector<unsigned char>& in,
+                     std::vector<unsigned char>& page) {
+    libdeflate_gdeflate_compressor* c =
+        libdeflate_alloc_gdeflate_compressor(level);
+    if (c == nullptr) {
+        return false;
+    }
+    size_t npages = 0;
+    const size_t bound =
+        libdeflate_gdeflate_compress_bound(c, in.size(), &npages);
+    if (bound == 0 || npages != 1) {
+        libdeflate_free_gdeflate_compressor(c);
+        return false;
+    }
+    std::vector<unsigned char> pool(bound, 0);
+    libdeflate_gdeflate_out_page out;
+    out.data = pool.data();
+    out.nbytes = bound;
+    const size_t total = libdeflate_gdeflate_compress(c, in.data(), in.size(),
+                                                     &out, 1);
+    libdeflate_free_gdeflate_compressor(c);
+    if (total == 0) {
+        return false;
+    }
+    const unsigned char* p = static_cast<const unsigned char*>(out.data);
+    page.assign(p, p + out.nbytes);
+    return true;
+}
+
+/* Input the reference answers with a DYNAMIC block. Incompressible() above is
+ * the wrong tool for that: the compressor answers pure noise with a stored
+ * block at every level, which is what probe 7 wants and the opposite of what
+ * probes 5 and 6 need. Mixing a skewed alphabet with noise gives a symbol
+ * distribution worth describing but not worth a static table. Which block type
+ * a given input actually draws is the reference's decision, so every probe
+ * below asserts the type it read rather than assuming the one it wanted. */
+std::vector<unsigned char> MixedEntropy(unsigned seed, size_t n) {
+    Lcg lcg(seed);
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; i++) {
+        const unsigned char r = lcg.Next();
+        v[i] = r < 200 ? static_cast<unsigned char>('a' + (r % 26)) : r;
+    }
+    return v;
+}
+
+/* GDeflate block types, the RFC 1951 values the format keeps (dossier 11.3:
+ * D3 changes what a stored block CONTAINS, not the two bits that name it). */
+constexpr uint32_t kBlockStored = 0;
+constexpr uint32_t kBlockStatic = 1;
+constexpr uint32_t kBlockDynamic = 2;
+
+/* The 19 code-length-code symbols and the order their 3-bit lengths are
+ * stored in. The permutation is the reference's own array
+ * (deflate_precode_lens_permutation in the pinned fork) and is NOT pinned by
+ * anything below - see the file header for why these means cannot pin it. */
+constexpr int kPrecodeSyms = 19;
+const int kPrecodePermutation[kPrecodeSyms] = {16, 17, 18, 0,  8,  7, 9,
+                                               6,  10, 5,  11, 4,  12, 3,
+                                               13, 2,  14, 1,  15};
+
+/* A precode length is 3 bits, so 7 is the longest codeword it can describe.
+ * Completeness is the Kraft equality sum(2^-len) == 1 over the non-zero
+ * lengths, scaled by 2^7 so it is integer arithmetic: a float sum of a dozen
+ * negative powers of two is exact today and is one refactor away from not
+ * being, and this is the assertion the whole probe rests on. */
+constexpr unsigned kPrecodeMaxLen = 7;
+constexpr unsigned kKraftUnity = 1u << kPrecodeMaxLen;
+
+unsigned KraftScaled(const unsigned char (&lens)[kPrecodeSyms]) {
+    unsigned sum = 0;
+    for (int i = 0; i < kPrecodeSyms; i++) {
+        if (lens[i] != 0) {
+            sum += 1u << (kPrecodeMaxLen - lens[i]);
+        }
+    }
+    return sum;
 }
 
 }  // namespace
@@ -308,8 +415,364 @@ int main() {
         REQUIRE(RoundTrips(12, twice));
     }
 
+    /* ---- Probe 5. D5 and D6: a block header rides substream 0 alone, and
+     * every field of it sits on that one lane with no round between them.
+     *
+     * Dossier 11.3 D5, citing draft sections 2.2 and 6: per D3 the bitstream
+     * is contiguous across blocks and the header still rides substream 0, so
+     * "the header is not findable by scanning; it is reached only by decoding
+     * to it". D6, citing sections 8.1, 8.2 and 9, is the consequence this
+     * probe reads: one table description per block, so HLIT, HDIST and HCLEN
+     * are read once, by lane 0, and every lane then decodes against what they
+     * describe.
+     *
+     * The reading: reset to lane 0, take BFINAL (1 bit) and BTYPE (2 bits),
+     * and for a dynamic block HLIT (5), HDIST (5) and HCLEN (4) - seventeen
+     * bits, one lane, no advance anywhere in them.
+     *
+     * The falsifier is the whole probe. Seventeen bits read off ANY lane
+     * produce three numbers, and all three have wide legal ranges, so a
+     * reading that lands in range proves little on its own. What proves it is
+     * that the OTHER reading - one round between each field, which is what a
+     * decoder that mistook the header for ordinary lane-serial data would do -
+     * does not survive: it is required below to disagree, either on the block
+     * type or on the completeness of the precode that follows.
+     *
+     * Why the ladder needs it: if the header did not ride one lane, a kernel
+     * would have to synchronise 32 lanes to read it. The whole warp-per-tile
+     * design (#94) rests on it being warp-uniform, read once, broadcast. */
+    {
+        const std::vector<unsigned char> in = MixedEntropy(11, 60000);
+        std::vector<unsigned char> page;
+        REQUIRE(CompressOnePage(6, in, page));
+        REQUIRE(RoundTrips(6, in));
+
+        cudec_detail::GDeflateSchedule s;
+        REQUIRE(cudec_detail::GDeflateInit(s, page.data(), page.size()));
+        cudec_detail::GDeflateReset(s);
+        const uint32_t is_final = cudec_detail::GDeflatePop(s, 1);
+        const uint32_t block_type = cudec_detail::GDeflatePop(s, 2);
+        cudec_detail::GDeflateEnsure(s, page.data());
+        REQUIRE(!s.failed);
+        REQUIRE_CTX(is_final <= 1, "BFINAL read as %u", is_final);
+        REQUIRE_CTX(block_type == kBlockDynamic,
+                    "expected a dynamic block from mixed-entropy input at "
+                    "level 6, read BTYPE %u",
+                    block_type);
+
+        const uint32_t hlit = cudec_detail::GDeflatePop(s, 5) + 257;
+        const uint32_t hdist = cudec_detail::GDeflatePop(s, 5) + 1;
+        const uint32_t hclen = cudec_detail::GDeflatePop(s, 4) + 4;
+        cudec_detail::GDeflateEnsure(s, page.data());
+        REQUIRE(!s.failed);
+        REQUIRE_CTX(hlit >= 257 && hlit <= 288, "HLIT+257 = %u", hlit);
+        REQUIRE_CTX(hdist >= 1 && hdist <= 32, "HDIST+1 = %u", hdist);
+        REQUIRE_CTX(hclen >= 4 && hclen <= 19, "HCLEN+4 = %u", hclen);
+
+        /* The wrong reading: one round between each header field. */
+        cudec_detail::GDeflateSchedule w;
+        REQUIRE(cudec_detail::GDeflateInit(w, page.data(), page.size()));
+        cudec_detail::GDeflateReset(w);
+        cudec_detail::GDeflatePop(w, 1);
+        cudec_detail::GDeflateAdvance(w, page.data());
+        const uint32_t wrong_type = cudec_detail::GDeflatePop(w, 2);
+        cudec_detail::GDeflateAdvance(w, page.data());
+        const uint32_t wrong_hlit = cudec_detail::GDeflatePop(w, 5) + 257;
+        cudec_detail::GDeflateAdvance(w, page.data());
+        const uint32_t wrong_hdist = cudec_detail::GDeflatePop(w, 5) + 1;
+        cudec_detail::GDeflateAdvance(w, page.data());
+        const uint32_t wrong_hclen = cudec_detail::GDeflatePop(w, 4) + 4;
+        cudec_detail::GDeflateAdvance(w, page.data());
+        unsigned char wrong_lens[kPrecodeSyms];
+        std::memset(wrong_lens, 0, sizeof(wrong_lens));
+        for (uint32_t i = 0; i < wrong_hclen && i < kPrecodeSyms; i++) {
+            wrong_lens[kPrecodePermutation[i]] =
+                static_cast<unsigned char>(cudec_detail::GDeflatePop(w, 3));
+            cudec_detail::GDeflateAdvance(w, page.data());
+        }
+        REQUIRE_CTX(w.failed || wrong_type != block_type ||
+                        wrong_hlit != hlit || wrong_hdist != hdist ||
+                        wrong_hclen != hclen ||
+                        KraftScaled(wrong_lens) != kKraftUnity,
+                    "a header read with a round between each field agreed with "
+                    "the lane-0 reading in every field (type %u, HLIT %u, "
+                    "HDIST %u, HCLEN %u) and produced a complete precode; this "
+                    "probe would pass on a page whose header is not lane-0",
+                    wrong_type, wrong_hlit, wrong_hdist, wrong_hclen);
+    }
+
+    /* ---- Probe 6. The precode round is one 3-bit length per lane, in lane
+     * order, with the refill happening before the rotation.
+     *
+     * Dossier 11.2, "the refill schedule IS the interleaving", citing draft
+     * section 5.3, and 11.3 D5 for why the round starts at lane 0. This is
+     * named on #170 as "the single most load-bearing assumption in the warp
+     * decode design ... and the one with no independent second source", so it
+     * is the one fact here that most needs an executed check rather than a
+     * cited one.
+     *
+     * The evidence is completeness, and it is what makes this probe possible
+     * without a decoder. A precode is a canonical Huffman code, so its
+     * non-zero lengths satisfy the Kraft equality exactly: sum(2^-len) == 1.
+     * Reading HCLEN+4 three-bit lengths off the wrong lanes yields a length
+     * vector that is arithmetically unrelated to any code, and the chance of
+     * such a vector landing exactly on the equality is small - which is
+     * exactly why the falsifier below is required to miss it on every page
+     * rather than argued to be unlikely.
+     *
+     * Why the ladder needs it: the refill order has no marker in the stream to
+     * check it against. Get it wrong by one lane and every symbol after it
+     * decodes from bits the encoder wrote for another lane, in silence, with
+     * no checksum anywhere in the format to catch it (dossier 11.4). */
+    {
+        struct Case {
+            unsigned seed;
+            int level;
+            size_t size;
+        };
+        const Case cases[] = {{11, 1, 60000},  {11, 6, 60000},
+                              {11, 12, 60000}, {23, 6, 40000},
+                              {41, 12, 50000}, {57, 1, 30000}};
+        int dynamic_seen = 0;
+        for (const Case& c : cases) {
+            const std::vector<unsigned char> in = MixedEntropy(c.seed, c.size);
+            std::vector<unsigned char> page;
+            REQUIRE(CompressOnePage(c.level, in, page));
+            REQUIRE(RoundTrips(c.level, in));
+
+            cudec_detail::GDeflateSchedule s;
+            REQUIRE(cudec_detail::GDeflateInit(s, page.data(), page.size()));
+            cudec_detail::GDeflateReset(s);
+            cudec_detail::GDeflatePop(s, 1);
+            const uint32_t block_type = cudec_detail::GDeflatePop(s, 2);
+            cudec_detail::GDeflateEnsure(s, page.data());
+            REQUIRE(!s.failed);
+            /* A stored or static block carries no precode. Skipped rather
+             * than failed: which type the reference picks is its decision,
+             * and the count below is what refuses a run that found none. */
+            if (block_type != kBlockDynamic) {
+                continue;
+            }
+            dynamic_seen++;
+
+            cudec_detail::GDeflatePop(s, 5);
+            cudec_detail::GDeflatePop(s, 5);
+            const uint32_t hclen = cudec_detail::GDeflatePop(s, 4) + 4;
+            cudec_detail::GDeflateEnsure(s, page.data());
+            REQUIRE(!s.failed);
+
+            unsigned char lens[kPrecodeSyms];
+            std::memset(lens, 0, sizeof(lens));
+            for (uint32_t i = 0; i < hclen; i++) {
+                lens[kPrecodePermutation[i]] =
+                    static_cast<unsigned char>(cudec_detail::GDeflatePop(s, 3));
+                cudec_detail::GDeflateAdvance(s, page.data());
+            }
+            REQUIRE_CTX(!s.failed,
+                        "seed %u level %d: the schedule refused inside the "
+                        "precode round",
+                        c.seed, c.level);
+            REQUIRE_CTX(KraftScaled(lens) == kKraftUnity,
+                        "seed %u level %d: precode lengths read one per lane "
+                        "in lane order are not a complete code (Kraft * %u = "
+                        "%u, want %u), so this reading is not the layout the "
+                        "reference emitted",
+                        c.seed, c.level, kKraftUnity, KraftScaled(lens),
+                        kKraftUnity);
+
+            /* The falsifier: the same HCLEN+4 lengths taken from lane 0 alone,
+             * which is what a decoder that read the precode as one serial bit
+             * stream would do. It must not produce a complete code - a refusal
+             * (lane 0 runs out of bits) counts, since both answers are "this
+             * is not a code". */
+            cudec_detail::GDeflateSchedule w;
+            REQUIRE(cudec_detail::GDeflateInit(w, page.data(), page.size()));
+            cudec_detail::GDeflateReset(w);
+            cudec_detail::GDeflatePop(w, 1);
+            cudec_detail::GDeflatePop(w, 2);
+            cudec_detail::GDeflateEnsure(w, page.data());
+            cudec_detail::GDeflatePop(w, 5);
+            cudec_detail::GDeflatePop(w, 5);
+            cudec_detail::GDeflatePop(w, 4);
+            cudec_detail::GDeflateEnsure(w, page.data());
+            unsigned char flat[kPrecodeSyms];
+            std::memset(flat, 0, sizeof(flat));
+            for (uint32_t i = 0; i < hclen; i++) {
+                flat[kPrecodePermutation[i]] =
+                    static_cast<unsigned char>(cudec_detail::GDeflatePop(w, 3));
+            }
+            REQUIRE_CTX(w.failed || KraftScaled(flat) != kKraftUnity,
+                        "seed %u level %d: reading the precode off lane 0 "
+                        "alone also produced a complete code, so the "
+                        "lane-order assertion above pins nothing on this page",
+                        c.seed, c.level);
+        }
+        REQUIRE_CTX(dynamic_seen >= 4,
+                    "only %d of %zu inputs drew a dynamic block; the precode "
+                    "layout is unpinned on a run that never reads one",
+                    dynamic_seen, sizeof(cases) / sizeof(cases[0]));
+    }
+
+    /* ---- Probe 7. D3 and D4: the stored block keeps neither the length
+     * complement nor the byte alignment, and its body is 8-bit atoms spread
+     * one per lane per round.
+     *
+     * Dossier 11.3 D3, citing draft section 2.2: "the one's complement of
+     * length is dropped from the header and the header is no longer required
+     * to be byte-aligned. As a result, data across all blocks, compressed or
+     * non-compressed, forms one contiguous bit stream". D4, citing section 7:
+     * the body's bytes are "fixed-size 8 bit atoms", one per lane per round,
+     * so the block takes floor(len / 32) full rounds and a final round with
+     * len % 32 lanes active.
+     *
+     * Four readings, three of them falsifiers:
+     *
+     *   - LEN is the 16 bits immediately after BFINAL and BTYPE, and it equals
+     *     the bytes the compressor was given. Unaligned by construction: those
+     *     three bits are not padded out to a byte.
+     *   - Aligning to the next byte boundary first yields a different number,
+     *     which is what a decoder carrying RFC 1951's alignment would read.
+     *   - The 16 bits following LEN are not its one's complement, so there is
+     *     no NLEN there to check LEN against. This is the half of D3 with a
+     *     security consequence and the dossier states it as such: with the
+     *     complement gone, "the declared length reaches the decoder unchecked
+     *     by the format".
+     *   - The body bytes come back identical to the input when read as one
+     *     8-bit pop per lane with a round between them, and the lane index
+     *     afterwards is len % 32, which is D4's round arithmetic. The page is
+     *     consumed exactly at that point, and the end-of-block round that
+     *     follows takes no further word - both asserted, for the reasons
+     *     given where they are asserted.
+     *
+     * Why the ladder needs it: a stored block is the one place a decoder is
+     * handed a length it must bound itself. RFC 1951 gives a decoder a free
+     * consistency check on that number and GDeflate does not, so the M4
+     * validation ladder has to bound the declared length against what the page
+     * can still supply - which is what the reference does, and the only thing
+     * standing between a declared length and a write past the end. */
+    {
+        /* Sizes chosen for their remainders mod 32 - 0, 1, 15 and a size that
+         * is a whole number of rounds - so the final partial round is
+         * exercised rather than assumed away. Noise at level 0: the reference
+         * answers it with a stored block, and the assertion below refuses the
+         * run if it ever stops doing so. */
+        const size_t sizes[] = {20000, 20001, 20015, 20032, 4096, 4097};
+        for (size_t n : sizes) {
+            const std::vector<unsigned char> in =
+                Incompressible(static_cast<unsigned>(n), n);
+            std::vector<unsigned char> page;
+            REQUIRE_CTX(CompressOnePage(0, in, page), "%zu bytes", n);
+            REQUIRE(RoundTrips(0, in));
+
+            cudec_detail::GDeflateSchedule s;
+            REQUIRE(cudec_detail::GDeflateInit(s, page.data(), page.size()));
+            cudec_detail::GDeflateReset(s);
+            cudec_detail::GDeflatePop(s, 1);
+            const uint32_t block_type = cudec_detail::GDeflatePop(s, 2);
+            cudec_detail::GDeflateEnsure(s, page.data());
+            REQUIRE(!s.failed);
+            REQUIRE_CTX(block_type == kBlockStored,
+                        "%zu bytes of noise at level 0 drew BTYPE %u, not a "
+                        "stored block",
+                        n, block_type);
+
+            const uint32_t len = cudec_detail::GDeflatePop(s, 16);
+            REQUIRE(!s.failed);
+            REQUIRE_CTX(len == n,
+                        "the 16 bits after the 3-bit header read %u for a "
+                        "%zu-byte block; LEN is not sitting there unaligned",
+                        len, n);
+
+            /* Falsifier 1: no NLEN. */
+            {
+                cudec_detail::GDeflateSchedule w = s;
+                const uint32_t next16 = cudec_detail::GDeflatePop(w, 16);
+                REQUIRE_CTX(next16 != ((~len) & 0xFFFFu),
+                            "the 16 bits after LEN are 0x%04x, the one's "
+                            "complement of LEN (%u); the header carries an "
+                            "NLEN after all",
+                            next16, len);
+            }
+
+            /* Falsifier 2: no byte alignment. Five more bits take lane 0 from
+             * bit 3 to bit 8, which is where a decoder holding RFC 1951's
+             * alignment rule would start reading LEN. */
+            {
+                cudec_detail::GDeflateSchedule w;
+                REQUIRE(
+                    cudec_detail::GDeflateInit(w, page.data(), page.size()));
+                cudec_detail::GDeflateReset(w);
+                cudec_detail::GDeflatePop(w, 1);
+                cudec_detail::GDeflatePop(w, 2);
+                cudec_detail::GDeflateEnsure(w, page.data());
+                cudec_detail::GDeflatePop(w, 5);
+                const uint32_t aligned = cudec_detail::GDeflatePop(w, 16);
+                REQUIRE_CTX(w.failed || aligned != len,
+                            "LEN read after padding to the next byte boundary "
+                            "is also %u, so this probe would pass on a "
+                            "byte-aligned stored block",
+                            aligned);
+            }
+
+            /* D4: one 8-bit atom per lane per round. */
+            for (uint32_t i = 0; i < len; i++) {
+                const uint32_t byte = cudec_detail::GDeflatePop(s, 8);
+                REQUIRE_CTX(!s.failed,
+                            "the schedule refused at body byte %u of %u", i,
+                            len);
+                REQUIRE_CTX(byte == in[i],
+                            "body byte %u of %u read %u, input holds %u", i,
+                            len, byte, static_cast<unsigned>(in[i]));
+                cudec_detail::GDeflateAdvance(s, page.data());
+                REQUIRE(!s.failed);
+            }
+            const uint32_t lanes = cudec_detail::kGDeflateNumStreams;
+            REQUIRE_CTX(s.idx == len % lanes,
+                        "after %u body bytes the current lane is %u, not %u: "
+                        "the body is not floor(len/%u) full rounds plus a "
+                        "final round of len%%%u lanes",
+                        len, s.idx, len % lanes, lanes, lanes);
+
+            /* The reference closes a block by walking all 32 lanes once -
+             * that is where its deferred copies run - and a stored block is
+             * no exception even though it defers none. On this block type
+             * that round takes NO word, and the assertion says so rather
+             * than passing over it: the body left every lane holding at
+             * least a full packet (measured floor of 32 bits over these six
+             * sizes), so no lane is under the watermark for the closing
+             * round to refill. A schedule that topped a lane up early would
+             * move the cursor here and be caught, which a bare "the round
+             * ran" would not be.
+             *
+             * DELETING THIS BLOCK LEAVES THE PAGE-EXHAUSTION CHECK BELOW
+             * GREEN, and that is stated rather than left for a reader to
+             * assume otherwise: the cursor is already at the last word when
+             * the body ends. So the exhaustion check is an end-to-end
+             * statement about the body walk - no word skipped, none taken
+             * twice - and not evidence about the closing round. */
+            const uint64_t cursor_at_body_end = s.cursor;
+            for (uint32_t k = 0; k < cudec_detail::kGDeflateNumStreams; k++) {
+                cudec_detail::GDeflateAdvance(s, page.data());
+                REQUIRE(!s.failed);
+            }
+            REQUIRE_CTX(s.cursor == cursor_at_body_end,
+                        "the end-of-block round consumed %llu word(s); a "
+                        "stored block leaves every lane above the watermark, "
+                        "so it should consume none",
+                        static_cast<unsigned long long>(s.cursor -
+                                                        cursor_at_body_end));
+            REQUIRE_CTX(s.cursor == s.word_count,
+                        "the walk ended at word %llu of %llu",
+                        static_cast<unsigned long long>(s.cursor),
+                        static_cast<unsigned long long>(s.word_count));
+        }
+    }
+
     std::printf("PASS: gdeflate probes - 128-byte minimum stream, length 285 "
-                "past 258 (D1), distance past 32768 (D2), pages "
-                "independent\n");
+                "past 258 (D1), distance past 32768 (D2), pages independent, "
+                "header on substream 0 (D5, D6), precode round one length per "
+                "lane, stored block unaligned and complement-free (D3) as "
+                "8-bit atoms (D4)\n");
     return 0;
 }
+


### PR DESCRIPTION
Part of #170, and deliberately not closing it. The keyword is absent because
one clause of that issue's own probe list is still unreachable, and this board
has already paid once for a `Closes` line that acted against a comment saying
the issue should stay open (#178, reopened by hand on 2026-08-21). What is left
is named at the bottom and written onto #170 itself.

## What this is

The second half of #170. The first half landed as four probes measured through
the reference's public API; the rest of the probe list — the block header
rounds, the stored block's shape and the lane-order refill — are statements
about where bits sit **inside** a page, and the file said so in its own header
rather than approximating them:

> It does not reach a fact about how the bits are laid out inside a page: the
> block header rounds (D5, D6), the stored block's bit-packed body (D4) and the
> lane-order refill schedule are all statements about the substream machine, and
> reading them out of an emitted page means implementing that machine, which is
> the CPU twin (#178, #176, #182).

That was written on 2026-08-09. The schedule landed on 2026-08-21:

```
$ git log --format='%h %ad %s' --date=short -2 -- src/gdeflate_schedule.h
501f4c0 2026-08-21 Name the lane bit-buffer width instead of spelling it [#178]
b312b63 2026-08-21 Add the GDeflate round/refill schedule and its CPU twin [#178]
```

`src/gdeflate_schedule.h` owns the bit cursor and nothing else, and all three
remaining probes are reachable with the cursor alone — none of them decodes a
symbol or builds a table, so none waits on #176 or #182. That is what this
change takes.

## The three probes

**Probe 5 — D5, D6: the block header rides substream 0 alone.** Reset to lane 0,
then BFINAL (1), BTYPE (2), HLIT (5), HDIST (5), HCLEN (4): seventeen bits, one
lane, no round between them. Values are required to land in the format's ranges.

**Probe 6 — the precode round is one 3-bit length per lane, in lane order.** The
evidence is completeness rather than a comparison, because the reference exposes
no code-length vector to compare against: a precode is a canonical Huffman code,
so `sum(2^-len) == 1` exactly over its non-zero lengths. Read one length per lane
in lane order, that equality holds on every dynamic page in the set. This is the
fact #170 calls "the single most load-bearing assumption in the warp decode
design ... the one with no independent second source".

**Probe 7 — D3, D4: the stored block.** The 16-bit LEN sits immediately after the
three header bits and equals the bytes the compressor was handed; the 16 bits
after LEN are never its one's complement; the body comes back byte-identical when
read as one 8-bit pop per lane with a round between them; the lane index
afterwards is `len % 32`; the page is consumed exactly.

**One of probe 7's four readings closes a question the dossier records as open.**
Section 11.5 lists the stored block's length width among the three things not to
read into the source: "the draft states no bit width for a non-compressed
block's length field. It says what was removed, in D3, and no more." Sixteen is
the reference's answer, and the LEN assertion is where it stops being a number
carried over from RFC 1951 because it happens to match. The dossier item is not
contradicted and stays as written, so nothing goes back to #145.

## Every probe carries its falsifier

A layout probe that only performs the reading it believes in passes on a page
laid out some other way, so each one also performs the **wrong** reading and
requires it to disagree: a header read with a round between its fields, a precode
read off lane 0 alone, and LEN read after padding to the next byte boundary.

## Proof that the guards bite

Each mutant applied to a copy of the tree, compiled and run; none of them was
committed. Re-run at the head being pushed rather than quoted from the first
draft, so the reported message is the one this tree produces.

| mutant                                                  | verdict                                                       |
| ------------------------------------------------------- | -------------------------------------------------------------- |
| `GDeflateAdvance` rotates before it refills              | RED — read BTYPE 1 where the page carries a dynamic block       |
| `GDeflateReset` returns to lane 1                        | RED — read BTYPE 0 where the page carries a dynamic block       |
| priming round loads 31 lanes instead of 32               | RED — schedule refused at body byte 31 of 20000                 |
| `GDeflateEnsure` refills without checking the watermark  | RED — body byte 129 of 20000 read 127, input holds 19           |
| probe 7 consumes a 16-bit NLEN after LEN                 | RED — body byte 0 of 20000 read 40, input holds 175             |
| probe 7 pads LEN to the next byte boundary               | RED — the 16 bits after the header read 31345 for 20000         |
| probe 6 drops the round between precode lengths          | RED — schedule refused inside the precode round                 |
| probe 7 drops the end-of-block round                     | SURVIVED — see below                                            |
| the precode permutation is dropped                       | SURVIVED — see below                                            |

**The two survivors are both disclosed in the file rather than repaired away.**

Dropping the end-of-block round leaves the page-exhaustion check green, because
the cursor is already at the last word when the body ends: a stored block leaves
every lane holding at least a full packet, so the closing round refills nothing.
Measured over the six sizes the probe uses, the minimum lane occupancy at the end
of the body is 32 bits and the cursor does not move across the round. The repair
is an assertion that says so — the round is now required to consume **no** word —
and a comment stating plainly that deleting the block leaves the exhaustion check
green, so the exhaustion check is read as an end-to-end statement about the body
walk and not as evidence about the closing round.

**One half of D6 is not reached and the probe does not claim it.** D6 is two
statements: one table description per block, and every lane decoding against it.
The first is what probe 5 reads - HLIT, HDIST and HCLEN taken once, off lane 0.
The second is only observable once symbols are being decoded, which is #182.

Dropping the permutation survives because a permutation reorders the same
multiset of lengths, so every completeness test here answers identically under
the permuted and the unpermuted reading. Separating them needs a decode that
assigns lengths to symbols, which is #176. The file header says the permutation
is not pinned and cannot be by these means; this mutant is what turns that from
an argument into a measurement.

## What was run, and on what

```
$ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

The probes themselves were compiled and run against the pinned oracle at
`8ba9502fb30d2bf728592d121f0d402e40c8cb05`:

```
$ g++ -std=c++17 -O1 -Wall -Wextra -Werror -o probes tests/gdeflate_probes.cpp \
    <the six oracle objects> -Isrc -Itests -I<oracle>
$ ./probes
PASS: gdeflate probes - 128-byte minimum stream, length 285 past 258 (D1),
distance past 32768 (D2), pages independent, header on substream 0 (D5, D6),
precode round one length per lane, stored block unaligned and complement-free
(D3) as 8-bit atoms (D4)
$ echo $?
0
```

**That run is NOT the documented gate and does not stand in for it.** It is a
MinGW host build on Windows, outside the pinned container, and it needed a
workaround the tree does not carry: the oracle's `compiler_gcc.h` defines
`_rotr64` as a macro and MinGW's `stdlib.h` declares it as a function, so the
oracle translation units were compiled with `-include stdlib.h`. Nothing in this
diff depends on that; it is a fact about the machine the probes were drafted on.
The authoritative run is `ctest -LE gpu` inside the pinned container, which is
what the `build` job on this pull request performs. It has run:

```
 5/43 Test  #5: gdeflate_probes ......................   Passed    0.06 sec
100% tests passed, 0 tests failed out of 43
```

and the `sanitize` job built and ran the same target under ASan+UBSan:

```
[ 58%] Built target gdeflate_probes
  Test  #5: gdeflate_probes
100% tests passed, 0 tests failed out of 13
```

## Means check

The means is C++17 in the existing GPU-less ctest target, `tests/require.h` as
the whole framework, against the vendored oracle. It is not chosen here so much
as continued: the probes read a header the tree already single-sources for host
and device, they are registered by the mechanism every other test uses, they run
under the same sanitizer leg, and each claim carries the command that produced
it. A second apparatus would fit the standpoint worse in every one of those.

## Negative disclosures

- **No GPU or container run.** The Docker daemon is not running on the machine
  that holds the device (`docker info` fails on the named pipe), so no
  `-DCUDEC_ENABLE_CUDA=ON` build and no on-device ctest was performed here.
  Nothing in this diff is device code and nothing in it is `gpu`-labelled, so the
  GPU-less subset the CI `build` job runs covers every line of it.
- **No second reader.** This change reaches the mainline having been read by its
  author alone; the mutant table above is what stands in place of one, and it is
  not the same thing.
- **`tests/CMakeLists.txt` is also touched by the open #381.** Two lines here, in
  the GDeflate block, well away from that branch's additions; flagging it because
  the file is shared, not because a conflict was observed.

## What #170 still owes after this

Its first probe bullet is "block-header rounds, headers ride substream 0; one
table set per block, **shared by all 32 lanes**". Probe 5 reads the first half:
the description is taken once, off lane 0. The second half is a statement about
what the lanes then do with it, which is only observable once symbols are being
decoded — #182. That is the whole residual, and it is why this pull request is
`Part of` rather than `Closes`.

## Size

481 lines added, of which the majority are the comments each probe's citation and
falsifier need. One property holds across every changed byte — a layout fact
executed against the reference, with the reading that would be wrong beside it —
which is what the reader checks instead of the diff.
