### PR TITLE
Force and assert the GDeflate stored and static decode paths [#225]

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -181,6 +181,19 @@ add_test(NAME bench_gdeflate_selfcheck COMMAND bench_gdeflate --selfcheck)
 add_test(NAME bench_gdeflate_assetlike_selfcheck COMMAND bench_gdeflate
                                                   --assetlike --selfcheck)
 
+# The forced-block-type corpora (issue #225). Separate entry because it locks
+# a different property from the two above: those rot on corpus shape and are
+# proven by a digest, this one rots on BLOCK-TYPE COVERAGE and is proven by a
+# walk over each page's first block header. A corpus that quietly collapsed to
+# all-dynamic blocks would still round-trip and still carry a stable digest of
+# its own, so neither entry above would notice that the decode paths this
+# milestone claims to cover had stopped being reached.
+#
+# CPU-only, like the entries above: the walk uses the substream schedule in
+# src/gdeflate_schedule.h and the reference decoder, and touches no device.
+add_test(NAME bench_gdeflate_blocktypes_selfcheck COMMAND bench_gdeflate
+                                                  --blocktypes --selfcheck)
+
 # The Zstd worst-case corpus (issue #229). No CUDA in it at all: the frames
 # are constructed on the host, emitted through the reference's own
 # sequence-compression entry point and decoded by the reference, so the
@@ -246,5 +259,6 @@ set_tests_properties(
   bench_zstd_coverage_selfcheck bench_frame_selfcheck bench_snappy_selfcheck
   bench_snappy_worst_selfcheck bench_snappy_worstlit_selfcheck
   bench_gdeflate_selfcheck bench_gdeflate_assetlike_selfcheck
+  bench_gdeflate_blocktypes_selfcheck
   PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 cudec_assert_test_timeouts()

--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -21,12 +21,28 @@
  * therefore the shape most data arrives in; 12 is the densest table
  * description and the most aggressively chosen block boundaries.
  *
- * WHAT THIS PATH DOES NOT CLAIM. Section 11.8 says the level list is the plan
- * for coverage and not the coverage argument: a compressor chooses block
- * types for its own reasons. Asserting the block-type composition a family
- * actually reached needs a walk over the emitted page, which needs the
- * substream machine, and that lock is issue #225's rather than this one's.
- * Nothing here claims a block type was reached.
+ * WHAT THE LEVEL SWEEP DOES NOT CLAIM. Section 11.8 says the level list is
+ * the plan for coverage and not the coverage argument: a compressor chooses
+ * block types for its own reasons, and block type is not a pure function of
+ * level because incompressible input forces stored blocks at any level. So
+ * the four-level rows below claim no block type at all.
+ *
+ * WHAT --blocktypes ADDS (issue #225). A second corpus path whose families
+ * are level CROSSED WITH INPUT CHARACTER, each one asserting the block type
+ * it actually reached by walking the emitted page's first block header with
+ * the substream schedule in src/gdeflate_schedule.h. A family that did not
+ * reach its target type fails rather than quietly costing coverage, which is
+ * 11.8's rule executed rather than restated. Those rows are decode-path
+ * coverage and never headline numbers: they carry a ratio and they are not
+ * the milestone's throughput figures.
+ *
+ * WHAT THE COMPOSITION LOCK CANNOT SEE, said before anyone reads it as more.
+ * It reads the FIRST block of each page and stops. A GDeflate block boundary
+ * is not findable by scanning - dossier 11.3 D5, and the schedule header says
+ * the same - so reaching a page's second block means decoding to it, and
+ * there is no decoder in the tree yet (#176, #182). So a family asserting
+ * `static` proves every page OPENS with a static block, and says nothing
+ * about what follows in that page.
  *
  * Ratio is printed beside throughput on every row. For a DEFLATE-class format
  * the ratio is half the pitch, and a throughput-only table would misreport
@@ -41,6 +57,7 @@
 
 #include <libdeflate.h>
 
+#include "gdeflate_schedule.h"
 #include "xxhash64.h"
 
 #include <algorithm>
@@ -98,7 +115,97 @@ struct Corpus {
     /* Printed verbatim in the methodology block, so it must stay true for
      * whichever corpus ran. */
     std::string provenance;
+    /* What the block-type walk asserted about this corpus, or the sentence
+     * saying it asserted nothing. Printed rather than derived at the print
+     * site, so a corpus path that skips the walk cannot inherit a claim a
+     * different path earned. */
+    std::string composition;
 };
+
+/* The RFC 1951 block-type values the format keeps (dossier 11.3: D3 changes
+ * what a stored block CONTAINS, not the two bits that name it). Same three
+ * constants tests/gdeflate_probes.cpp reads; this binary links no test
+ * object, so they are stated rather than shared. */
+constexpr uint32_t kBlockStored = 0;
+constexpr uint32_t kBlockStatic = 1;
+constexpr uint32_t kBlockDynamic = 2;
+
+/* What a corpus path that did not walk the pages says about itself. A
+ * sentence rather than an empty string: an empty composition field printed
+ * as an empty line reads as a claim nobody made. */
+const char* const kCompositionNotAsserted =
+    "not asserted on this path; the four-level sweep claims no block type, "
+    "which is section 11.8's rule that a level list is a plan for coverage "
+    "and not the coverage argument";
+
+const char* BlockTypeName(uint32_t type) {
+    switch (type) {
+        case kBlockStored:
+            return "stored";
+        case kBlockStatic:
+            return "static";
+        case kBlockDynamic:
+            return "dynamic";
+        default:
+            return "reserved";
+    }
+}
+
+/* The first block header of a page: prime the 32 lanes, reset to lane 0
+ * (every block header rides lane 0, dossier 11.2), then BFINAL and BTYPE.
+ * This is the reading tests/gdeflate_probes.cpp pins, driven here over a
+ * corpus rather than over one crafted page.
+ *
+ * Returns false when the page is too short to prime or the schedule went
+ * sticky, which is a corpus this harness must not go on to time rather than
+ * a block type to report. */
+bool FirstBlockType(const std::vector<unsigned char>& page, uint32_t* out) {
+    cudec_detail::GDeflateSchedule s;
+    if (!cudec_detail::GDeflateInit(s, page.data(), page.size())) {
+        return false;
+    }
+    cudec_detail::GDeflateReset(s);
+    cudec_detail::GDeflatePop(s, 1); /* BFINAL, not read here */
+    const uint32_t type = cudec_detail::GDeflatePop(s, 2);
+    if (s.failed) {
+        return false;
+    }
+    *out = type;
+    return true;
+}
+
+/* 11.8's rule, executed: a family that did not reach its target block type
+ * fails rather than quietly costing coverage. Every page is walked and the
+ * first disagreement names the page and what was read there, because "some
+ * page in this corpus is wrong" is not a thing anyone can act on. */
+bool AssertComposition(Corpus* corpus, uint32_t want) {
+    for (size_t i = 0; i < corpus->compressed.size(); i++) {
+        uint32_t got = 0;
+        if (!FirstBlockType(corpus->compressed[i], &got)) {
+            std::fprintf(stderr,
+                         "page %zu of %s carries no readable block header - "
+                         "the schedule refused it before any type was read\n",
+                         i, corpus->name.c_str());
+            return false;
+        }
+        if (got != want) {
+            std::fprintf(stderr,
+                         "page %zu of %s opens with a %s block, not the %s "
+                         "block this family exists to reach - the corpus no "
+                         "longer covers the decode path it is named for\n",
+                         i, corpus->name.c_str(), BlockTypeName(got),
+                         BlockTypeName(want));
+            return false;
+        }
+    }
+    corpus->composition = std::string("every page opens with a ") +
+                          BlockTypeName(want) +
+                          " block, asserted by walking each page's first "
+                          "block header (the first block only - a later "
+                          "block in the same page is neither asserted nor "
+                          "denied, because reaching one means decoding to it)";
+    return true;
+}
 
 /* One page compressed on its own. The page count is read back from the
  * reference rather than assumed: the page split is the reference's to decide,
@@ -333,6 +440,40 @@ std::vector<unsigned char> MakeSelfcheckSource(size_t bytes) {
     return out;
 }
 
+/* THE TWO FORCED SOURCES, and why each one forces what it does.
+ *
+ * Neither is a plausible workload and neither is meant to be: these corpora
+ * exist to reach a decode path, and the report says so on their rows.
+ *
+ * Incompressible: a xorshift stream. LZ77 finds nothing and Huffman coding a
+ * uniform byte distribution costs more than it saves, so the reference emits
+ * a stored block at every level. This is the half of 11.8's sentence that
+ * says block type is not a pure function of level.
+ *
+ * Low-entropy: a short repeating alphabet with no noise at all. Everything
+ * after the first few bytes is one long match, the symbol set is tiny, and a
+ * dynamic table description costs more than the fixed one it would replace -
+ * so the reference takes the static block. */
+std::vector<unsigned char> MakeIncompressibleSource(size_t bytes) {
+    std::vector<unsigned char> out(bytes);
+    uint64_t x = 88172645463325252ull;
+    for (size_t i = 0; i < bytes; i++) {
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        out[i] = static_cast<unsigned char>(x);
+    }
+    return out;
+}
+
+std::vector<unsigned char> MakeLowEntropySource(size_t bytes) {
+    std::vector<unsigned char> out(bytes);
+    for (size_t i = 0; i < bytes; i++) {
+        out[i] = static_cast<unsigned char>('a' + (i % 7));
+    }
+    return out;
+}
+
 /* The asset-like source, replicated to `pages` identical pages. The block is
  * generated in bench/assetlike_source.h, which bench_lz4 reads too: the
  * recorded numbers are attested against those bytes, and two harnesses
@@ -388,9 +529,8 @@ void PrintReport(const Corpus& corpus, int level,
                 "outside it); every page round-trip-verified against the "
                 "source once before timing; percentiles are nearest-rank\n",
                 warmup, runs);
-    std::printf("- block-type composition: not asserted here; reading it "
-                "needs a walk over the emitted page and that lock is issue "
-                "#225's\n");
+    std::printf("- block-type composition: %s\n",
+                corpus.composition.c_str());
     const double p50 = Percentile(sorted, 50);
     const double p90 = Percentile(sorted, 90);
     const double p99 = Percentile(sorted, 99);
@@ -407,15 +547,24 @@ void PrintReport(const Corpus& corpus, int level,
  * ones that moved. Stopping at the first would report one drifted level and
  * leave the rest unexamined, which reads as "only that one moved". */
 bool RunLevel(const std::vector<unsigned char>& source, const std::string& name,
-              const std::string& provenance, int level, size_t warmup,
-              size_t runs, uint64_t* digest_out) {
+              const std::string& provenance, int level, int want_block_type,
+              size_t warmup, size_t runs, uint64_t* digest_out) {
     Corpus corpus;
     corpus.name = name;
     corpus.provenance = provenance;
+    corpus.composition = kCompositionNotAsserted;
     if (!BuildCorpus(source, level, &corpus)) {
         return false;
     }
     if (!CorpusRoundTrips(source, corpus)) {
+        return false;
+    }
+    /* Before the digest and before anything is timed: a family that missed
+     * its block type is not a corpus to record a number about, and a digest
+     * pinned over it would pin the miss. */
+    if (want_block_type >= 0 &&
+        !AssertComposition(&corpus,
+                           static_cast<uint32_t>(want_block_type))) {
         return false;
     }
     *digest_out = CorpusDigest(corpus);
@@ -481,6 +630,68 @@ static_assert(sizeof(kAssetlikeSelfcheckDigests) /
                   kLevelCount,
               "one asset-like selfcheck digest per level");
 
+/* THE FORCED-BLOCK-TYPE FAMILIES (issue #225), one row each.
+ *
+ * Section 11.8 says the sweep is level CROSSED WITH INPUT CHARACTER, so each
+ * family names both and the two stored rows differ in which of the two did
+ * the forcing. Dropping either would leave the corpus proving less than it
+ * looks like it proves: `stored-by-level` alone would let a reader conclude
+ * that only level 0 reaches a stored block, which is the sentence 11.8
+ * exists to refuse.
+ *
+ * MEASURED RATHER THAN ASSUMED, and the measurement is what decided that
+ * nothing here is hand-constructed. The issue's scope allows hand-building a
+ * stream where a block type cannot be forced out of the compressor; the
+ * probe over levels 0, 1, 6 and 12 crossed with incompressible, low-entropy
+ * and mixed input found both target types reachable, so no hand-built page
+ * is in this tree and none is owed. `dynamic` is not a family here: it is
+ * what the four-level sweep already produces on ordinary input, and a corpus
+ * forcing the common case would carry cost for no coverage. */
+struct ForcedFamily {
+    const char* name;
+    int level;
+    uint32_t want_type;
+    std::vector<unsigned char> (*source)(size_t);
+    const char* provenance;
+    /* The digest of the four-page selfcheck corpus this family builds. */
+    uint64_t selfcheck_digest;
+};
+
+/* Bigger than the selfcheck's four pages so the row's timing is not noise,
+ * and far smaller than the level sweep's corpora because these rows are
+ * decode-path coverage rather than a throughput figure anyone quotes. */
+constexpr size_t kBlocktypePages = 64;
+
+const ForcedFamily kForcedFamilies[] = {
+    {"stored-by-level", 0, kBlockStored, MakeSelfcheckSource,
+     "generated in-harness from a fixed PRNG and compressed at level 0, "
+     "which the reference's own header says emits uncompressed blocks by "
+     "construction; DECODE-PATH COVERAGE, not a throughput figure",
+     0xd46934fd0e71f055ull},
+    {"stored-by-input", 6, kBlockStored, MakeIncompressibleSource,
+     "generated in-harness from a xorshift PRNG, incompressible by "
+     "construction, compressed at the DEFAULT level 6 - the stored block "
+     "here is forced by the input and not by the level; DECODE-PATH "
+     "COVERAGE, not a throughput figure",
+     0x28488bd60cba9ce9ull},
+    {"static-low-entropy", 1, kBlockStatic, MakeLowEntropySource,
+     "generated in-harness as a seven-byte repeating alphabet with no noise, "
+     "compressed at level 1, where a dynamic table description costs more "
+     "than the fixed code it would replace; DECODE-PATH COVERAGE, not a "
+     "throughput figure",
+     0x8dfa68cd98743adeull},
+};
+constexpr size_t kForcedFamilyCount =
+    sizeof(kForcedFamilies) / sizeof(kForcedFamilies[0]);
+
+/* Both stored families and at least one static family must be present, or
+ * this path has stopped being the thing its issue asked for. Refused at
+ * compile time because a family deleted from the table above would otherwise
+ * leave a green selfcheck that covers one block type. */
+static_assert(kForcedFamilyCount >= 3,
+              "the forced set must keep both stored forcings and the static "
+              "one; a smaller table covers less than #225 asks for");
+
 bool CheckDigest(uint64_t actual, const std::string& name, int level,
                  uint64_t expected) {
     if (actual == expected) {
@@ -509,8 +720,32 @@ bool ParseCount(const char* text, size_t lo, size_t hi, size_t* out) {
 void Usage(const char* argv0) {
     std::fprintf(stderr,
                  "usage: %s [--warmup N] [--runs N] [--assetlike] "
-                 "[--selfcheck] [corpus files...]\n",
+                 "[--blocktypes] [--selfcheck] [corpus files...]\n",
                  argv0);
+}
+
+/* The forced-block-type path. Each family is its own corpus at its own
+ * level, so this walks the family table instead of the level list the
+ * other paths sweep. */
+int RunBlocktypes(size_t warmup, size_t runs, bool selfcheck) {
+    const size_t pages = selfcheck ? kSelfcheckPages : kBlocktypePages;
+    bool ok = true;
+    for (size_t i = 0; i < kForcedFamilyCount; i++) {
+        const ForcedFamily& f = kForcedFamilies[i];
+        const std::vector<unsigned char> source = f.source(pages * kPageBytes);
+        uint64_t digest = 0;
+        if (!RunLevel(source, f.name, f.provenance, f.level,
+                      static_cast<int>(f.want_type), warmup, runs,
+                      &digest)) {
+            return 1;
+        }
+        if (selfcheck &&
+            !CheckDigest(digest, f.name, f.level, f.selfcheck_digest)) {
+            ok = false;
+        }
+        std::printf("\n");
+    }
+    return ok ? 0 : 1;
 }
 
 }  // namespace
@@ -520,12 +755,15 @@ int main(int argc, char** argv) {
     size_t runs = 30;
     bool selfcheck = false;
     bool assetlike = false;
+    bool blocktypes = false;
     std::vector<std::string> files;
 
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
         if (arg == "--assetlike") {
             assetlike = true;
+        } else if (arg == "--blocktypes") {
+            blocktypes = true;
         } else if (arg == "--selfcheck") {
             selfcheck = true;
         } else if (arg == "--runs" && i + 1 < argc) {
@@ -552,11 +790,23 @@ int main(int argc, char** argv) {
         return 2;
     }
 
+    if (blocktypes && (assetlike || !files.empty())) {
+        std::fprintf(stderr,
+                     "--blocktypes builds its own corpora, one per forced "
+                     "block type; do not pass corpus files or --assetlike "
+                     "with it\n");
+        return 2;
+    }
+
     if (selfcheck) {
         /* Short and fixed, so the rot check stays fast on the GPU-less runner
          * and its verdict is a digest rather than a timing. */
         warmup = 0;
         runs = 1;
+    }
+
+    if (blocktypes) {
+        return RunBlocktypes(warmup, runs, selfcheck);
     }
 
     std::vector<unsigned char> source;
@@ -605,8 +855,8 @@ int main(int argc, char** argv) {
     bool ok = true;
     for (size_t i = 0; i < kLevelCount; i++) {
         uint64_t digest = 0;
-        if (!RunLevel(source, name, provenance, kLevels[i], warmup, runs,
-                      &digest)) {
+        if (!RunLevel(source, name, provenance, kLevels[i],
+                      /*want_block_type=*/-1, warmup, runs, &digest)) {
             return 1;
         }
         if (selfcheck && !CheckDigest(digest, name, kLevels[i], expected[i])) {


### PR DESCRIPTION
Closes #225.

## Why this exists

The four-level sweep #224 landed claims no block type, and section 11.8 says
why: a compressor chooses block types for its own reasons, and block type is
not a pure function of level, because incompressible input forces stored
blocks at any level. So the M4 corpus could quietly collapse to all-dynamic
blocks, round-trip cleanly, keep a stable digest of its own, and leave the
record claiming a stored and static coverage that no longer exists. Nothing
in the tree would have said so - `bench_gdeflate.cpp` said as much in its own
header, and named this issue.

## The measurement that decided the shape

The issue's scope allows hand-building a page where a block type cannot be
forced out of the vendored compressor. I probed first, over levels 0, 1, 6
and 12 crossed with three input characters, reading BFINAL/BTYPE off each
page with the tree's own schedule:

    all-zero 64K          L0=stored  L1=static  L6=static  L12=static
    xorshift random 64K   L0=stored  L1=stored  L6=stored  L12=stored
    constant 0x41 1024B   L0=stored  L1=static  L6=static  L12=static
    random 1024B          L0=stored  L1=stored  L6=stored  L12=stored
    repeating english 64K L0=stored  L1=static  L6=static  L12=static

Both target types come out of the pinned compressor, so **no page in this
diff is hand-built and none is owed**. The probe also shows the two forcings
are independent - level, and input character - which is why the stored side
gets two families rather than one.

## What landed

`--blocktypes` builds three corpora, each level CROSSED WITH INPUT CHARACTER,
and asserts what each actually reached:

| family               | level          | source                   | asserts |
| -------------------- | -------------- | ------------------------ | ------- |
| `stored-by-level`    | 0              | the existing mixed PRNG  | stored  |
| `stored-by-input`    | 6 (the DEFAULT)| xorshift, incompressible | stored  |
| `static-low-entropy` | 1              | 7-byte repeating alphabet| static  |

The two stored rows differ in which half did the forcing. Dropping either
would let a reader conclude that only level 0 reaches a stored block, which is
the sentence 11.8 exists to refuse.

The assertion walks EVERY page's first block header through
`src/gdeflate_schedule.h` - prime, reset to lane 0, BFINAL, BTYPE - which is
the reading `tests/gdeflate_probes.cpp` pins, driven over a corpus instead of
one crafted page. It runs BEFORE the digest is taken and before anything is
timed: a digest pinned over a family that missed its type pins the miss.

The rows carry a ratio and say on their own provenance line that they are
decode-path coverage and not a throughput figure. `PrintReport`'s composition
line is now read off the corpus rather than hardcoded, so the sweep path
prints the sentence saying it asserted nothing and cannot inherit a claim this
path earned.

**What the walk cannot see, stated where it is made.** It reads the first
block of each page and stops. A GDeflate block boundary is not findable by
scanning (dossier 11.3 D5), so reaching a page's second block means decoding
to it and there is no decoder in the tree yet (#176, #182). A family asserting
`static` proves every page OPENS with a static block and says nothing about
what follows in it.

## The guards were proven by breaking them

**Done-when 2, three times - once per forcing.** Each family reverted to
default settings, nothing else changed, rebuilt and re-run:

    A  stored-by-level at the default level 6 instead of 0
       page 0 of stored-by-level opens with a dynamic block, not the stored
       block this family exists to reach - the corpus no longer covers the
       decode path it is named for
       exit=1

    B  stored-by-input's source made ordinary (default input character)
       page 0 of stored-by-input opens with a dynamic block, not the stored
       block this family exists to reach ...
       exit=1

    C  static-low-entropy's source made ordinary (default input character)
       page 0 of static-low-entropy opens with a dynamic block, not the
       static block this family exists to reach ...
       exit=1

Each names its own family, so the guard bites for the reason it carries
rather than for its size. The tree was restored between each and after.

**Done-when 3.** One byte flipped in page 0 of every family, inside
`BuildCorpus`, and the run stops before timing:

    page 0 does not round-trip
    exit=1

**Read this one carefully rather than as a checkbox.** The rejection comes
from the BYTE COMPARISON and not from the decoder's status: GDeflate carries
no checksum of any kind (11.4), so the reference ACCEPTED the corrupted page
and returned wrong bytes of the right length. `CorpusRoundTrips` compares the
decoded bytes against the source, which is why it caught this and why a
status-only gate would not have. The same flip reds the pre-existing level
sweep identically, so this is the gate #224 built doing its job over a new
corpus rather than a gate added here.

## Gates

**The whole suite on the device, including the new entry.** Ubuntu-24.04 under
WSL2 on this machine, CUDA 13.3 (nvcc V13.3.73), `-DCMAKE_CUDA_ARCHITECTURES=86`,
NVIDIA GeForce RTX 3080, driver 610.88:

    cmake -B build-cuda -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86
    cmake --build build-cuda -j8            EXIT=0, zero warnings
    ctest --test-dir build-cuda --output-on-failure
    50/53 Test #50: bench_gdeflate_blocktypes_selfcheck ...   Passed  0.02 sec
    100% tests passed, 0 tests failed out of 53
    Label Time Summary:  gpu = 9.48 sec*proc (9 tests)

The same command on `origin/main` in the same environment gives 52 of 52, so
the entry this adds is the difference and nothing regressed beside it.

**How that run exists at all, since every recent note on this board says it
cannot.** The WSL distribution now carries a CUDA toolkit that was not there
when those notes were written - `/usr/local/cuda/bin/nvcc`, CUDA 13.3, with
cmake and working name resolution beside it. It is recorded on #203 rather
than five times here.

**The falsifiers and the host-compiler runs**, MinGW on the Windows side
against the pinned oracle, `-Wall -Wextra -Werror`, zero warnings:

    bench_gdeflate --blocktypes --selfcheck        exit=0   (3 families)
    bench_gdeflate --selfcheck                     exit=0   (unchanged)
    bench_gdeflate --assetlike --selfcheck         exit=0   (unchanged)
    bench_gdeflate --blocktypes --assetlike        exit=2   (refused)
    bench_gdeflate --blocktypes corpus.bin         exit=2   (refused)

The three new digests were read out of that construction and then reproduced
byte for byte by the WSL build under a different compiler and a different
optimisation level, which is what says they are a property of the pinned
compressor rather than of one toolchain. The two pre-existing selfchecks
reproduce their own pinned digests on both.

    npx prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

## What was NOT done, stated as an absence

- **No second reader.** Nobody else has read this change.
- **The run above is NOT the pinned container.** CLAUDE.md's documented gate
  is `nvidia/cuda:12.6.2-devel-ubuntu24.04` at a pinned digest, and the Docker
  engine on this machine is stopped; starting it raises a consent prompt,
  which is refused here rather than worked around:

      docker version --format "{{.Server.Version}}"
      failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine

  So what ran was CUDA 13.3 in WSL and not CUDA 12.6.2 in the pinned image.
  The two agreeing is likely and is not claimed. This pull request's `build`
  job remains the authoritative gate.
- **The four-tool device sanitizer gate did not run and is not claimed.** #258
  closed with the measurement that Compute Sanitizer cannot attach to a device
  on this machine at all, on the newest driver and toolkit pairing it can
  hold. Nothing above asserts anything under memcheck, racecheck, initcheck or
  synccheck.
- **No number here is a benchmark result.** The throughput figures the harness
  prints for these families are a host reference decoding a corpus built to
  reach a decode path, and `docs/BENCHMARKS.md` is untouched.
- **The composition of blocks after the first in a page is not asserted**, per
  the paragraph above. A family asserting `static` says every page opens with
  a static block and nothing more.
- **No GDeflate kernel was involved and none exists.** This binary contains no
  CUDA.
