### PR TITLE
Freeze the batch ABI's chunk-count ceiling against the wave width [#242]

### DIFF
--- a/include/cudec.h
+++ b/include/cudec.h
@@ -96,7 +96,11 @@ typedef char cudec_chunk_result_layout_check
  * CUDEC_ERR_INVALID_ARGUMENT and launches nothing: any NULL array
  * argument, a misaligned d_results, an empty batch (chunk_count == 0), and
  * a batch beyond the implementation's launch limit (rejected, never
- * truncated). A rejected call makes no CUDA call and leaves the thread's
+ * truncated). That limit is a fixed property of this ABI: it is the same
+ * number on every backend and every device, and in particular it does not
+ * widen on a GPU whose wave is 64 lanes rather than 32. A chunk_count this
+ * call accepts is accepted everywhere, and one it refuses is refused
+ * everywhere. A rejected call makes no CUDA call and leaves the thread's
  * pending CUDA error state untouched; a call that passes validation
  * consumes that pending state (cudaGetLastError semantics), so the
  * returned status reflects this submission alone. */

--- a/src/batch_limits.h
+++ b/src/batch_limits.h
@@ -18,14 +18,38 @@
 
 namespace cudec_detail {
 
-/* Lanes per warp, the kernel's chunk-to-lane divisor and the multiplier below.
- * The one place the width's digits are written (issue #211); the width port
- * turns this into the WaveSize parameter (#241). */
+/* Lanes per warp on this backend, and the kernel's chunk-to-lane divisor.
+ * The one place the width's digits are written (issue #211). The width port
+ * landed and did NOT turn this into the parameter: the launch's width is the
+ * WaveSize template argument in src/chunk_decode.cuh and kCudaWaveSize seeds
+ * it from here, so this stays the CUDA build's width rather than becoming the
+ * family's. */
 constexpr unsigned kWarpSize = 32;
 
+/* The wave width the ABI's chunk-count ceiling below is FROZEN at, on every
+ * backend. It is a second name for the same digits as kWarpSize on purpose,
+ * and the two must be free to differ: this one is an ABI constant and that one
+ * is a device property (masterplan section 15.5, issue #242). */
+constexpr unsigned kAbiChunkLimitWaveSize = 32;
+
 /* One chunk per warp and at most INT32_MAX warps in a grid, so this is the
- * largest chunk_count either entry point can map onto a launch. */
-constexpr size_t kMaxBatchChunks = static_cast<size_t>(INT32_MAX) * kWarpSize;
+ * largest chunk_count either entry point can map onto a launch.
+ *
+ * IT DOES NOT MOVE WITH THE WAVE WIDTH, and the tempting spelling is the one
+ * that does: INT32_MAX times the width the kernel is launched at. A wave64
+ * device would then admit twice as many chunks, so the same call succeeds on
+ * one GPU and returns CUDEC_ERR_INVALID_ARGUMENT on another - a contract that
+ * varies by hardware, in a library whose claim is that the same input produces
+ * the same result on every path. The narrower bound costs nothing anybody will
+ * meet: INT32_MAX * 32 chunks is far past any real batch.
+ *
+ * The launch-shape refusal is the other half of the same question and it goes
+ * the other way. A block that is not a whole number of waves leaves a slice of
+ * a destination written by nobody (docs/DETERMINISM.md), so THAT guard is
+ * derived from the wave width, in src/chunk_decode.cuh. There it is a
+ * statement about the launch; here it is a statement about the ABI. */
+constexpr size_t kMaxBatchChunks =
+    static_cast<size_t>(INT32_MAX) * kAbiChunkLimitWaveSize;
 
 /* The over-limit contract test hands SIZE_MAX to both entry points and expects
  * a reject; that is only a test of the bound while the bound is below

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -796,9 +796,14 @@ function(cudec_check_abi_ceiling_derivation header_path out_violations)
     return()
   endif()
   file(READ ${header_path} _header_src)
-  # The initialiser, not the whole file: the ceiling's own definition is the
-  # subject, and the prose above it names both constants on purpose.
-  if(NOT _header_src MATCHES "kMaxBatchChunks[ \t\r\n]*=[^;]*;")
+  # The DECLARATION, not any mention of the name. The rules further down
+  # this file blank comments before they read a source; this one runs
+  # before that helper is defined, so it earns the same property from the
+  # pattern instead: the match has to start at a `constexpr` with no
+  # statement terminator between it and the identifier, and prose sitting
+  # under the previous definition is therefore out of reach. The probe
+  # named commented_mention.h is where that is watched rather than argued.
+  if(NOT _header_src MATCHES "constexpr[^;]*kMaxBatchChunks[ \t\r\n]*=[^;]*;")
     string(APPEND _violations
            "  no definition of kMaxBatchChunks was found to read - the rule "
            "is dead rather than satisfied (issue #242)\n")
@@ -822,10 +827,11 @@ function(cudec_check_abi_ceiling_derivation header_path out_violations)
   set(${out_violations} "${_violations}" PARENT_SCOPE)
 endfunction()
 
-# Three probes, planted first, for the reason the sweep above plants two: a
+# Four probes, planted first, for the reason the sweep above plants two: a
 # rule nobody has watched refuse anything is a rule nobody can show still
-# bites. The third is the dead-rule direction - a header the pattern stops
-# matching must report that it read nothing, never come back silent.
+# bites. The last two are the dead-rule direction - a header the pattern stops
+# matching, and one where the only occurrence of the name is in prose, must
+# both report that nothing was read rather than coming back silent.
 set(_abi_ceiling_probe_root ${CMAKE_CURRENT_BINARY_DIR}/abi-ceiling-probes)
 file(REMOVE_RECURSE ${_abi_ceiling_probe_root})
 file(WRITE ${_abi_ceiling_probe_root}/frozen.h
@@ -836,10 +842,14 @@ file(WRITE ${_abi_ceiling_probe_root}/width_derived.h
      "    static_cast<size_t>(INT32_MAX) * kWarpSize;\n")
 file(WRITE ${_abi_ceiling_probe_root}/no_definition.h
      "constexpr unsigned kWarpSize = 32;\n")
+file(WRITE ${_abi_ceiling_probe_root}/commented_mention.h
+     "constexpr unsigned kWarpSize = 32;\n"
+     "/* kMaxBatchChunks = INT32_MAX * kWarpSize was the old shape. */\n")
 set(_abi_ceiling_probes
     "frozen.h|"
     "width_derived.h|is derived from kWarpSize"
-    "no_definition.h|the rule is dead rather than satisfied")
+    "no_definition.h|the rule is dead rather than satisfied"
+    "commented_mention.h|the rule is dead rather than satisfied")
 foreach(_entry IN LISTS _abi_ceiling_probes)
   string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")
   string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\2" _expected "${_entry}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -394,6 +394,15 @@ cudec_add_test(batch_limit_parity SOURCES batch_limit_parity.cpp)
 target_include_directories(batch_limit_parity
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
+# The same limit against the OTHER failure: a ceiling re-derived from the wave
+# width the kernel launches at, which would make the accepted set twice as
+# large on a wave64 device (issue #242, masterplan section 15.5). Host-side for
+# the same reason as the parity test above, and it reads src/ for the same
+# reason.
+cudec_add_test(batch_limit_width_lock SOURCES batch_limit_width_lock.cpp)
+target_include_directories(batch_limit_width_lock
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+
 cudec_add_test(frame_host_negative SOURCES frame_host_negative.cpp)
 target_include_directories(frame_host_negative
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
@@ -761,6 +770,105 @@ cudec_check_batch_limit_sweep(${CMAKE_CURRENT_SOURCE_DIR}/../src
 if(_batch_limit_violations)
   message(FATAL_ERROR "a source under src/ builds its own batch launch bound "
                       "(issue #39):\n${_batch_limit_violations}")
+endif()
+
+# The ABI ceiling is frozen at the wave32 value on every backend and must not
+# be re-derived from the width the kernel launches at (issue #242, masterplan
+# section 15.5). A width-derived ceiling admits twice as many chunks on a
+# wave64 device, so the same call succeeds on one GPU and returns
+# CUDEC_ERR_INVALID_ARGUMENT on another.
+#
+# THIS IS A TEXT RULE BECAUSE THE VALUE CANNOT CARRY IT. On this backend the
+# two constants are both 32, so writing the ceiling in terms of the device
+# width produces exactly the same number and every arithmetic check stays
+# green - tests/batch_limit_width_lock.cpp included, which is why that file
+# says so and this rule sits beside it. What separates the right definition
+# from the wrong one here is which name it reads, and only the source says
+# that. A drift detector, not tamper-proofing: a copy that reaches the width
+# by some third name is not caught.
+function(cudec_check_abi_ceiling_derivation header_path out_violations)
+  set(_violations "")
+  if(NOT EXISTS ${header_path})
+    string(APPEND _violations
+           "  ${header_path} does not exist - the rule has nothing to read "
+           "(issue #242)\n")
+    set(${out_violations} "${_violations}" PARENT_SCOPE)
+    return()
+  endif()
+  file(READ ${header_path} _header_src)
+  # The initialiser, not the whole file: the ceiling's own definition is the
+  # subject, and the prose above it names both constants on purpose.
+  if(NOT _header_src MATCHES "kMaxBatchChunks[ \t\r\n]*=[^;]*;")
+    string(APPEND _violations
+           "  no definition of kMaxBatchChunks was found to read - the rule "
+           "is dead rather than satisfied (issue #242)\n")
+    set(${out_violations} "${_violations}" PARENT_SCOPE)
+    return()
+  endif()
+  set(_definition "${CMAKE_MATCH_0}")
+  if(_definition MATCHES "(^|[^A-Za-z_0-9])kWarpSize([^A-Za-z_0-9]|$)")
+    string(APPEND _violations
+           "  kMaxBatchChunks is derived from kWarpSize, the device's wave "
+           "width - the ABI ceiling is frozen at kAbiChunkLimitWaveSize on "
+           "every backend (issue #242)\n")
+  endif()
+  if(NOT _definition MATCHES
+     "(^|[^A-Za-z_0-9])kAbiChunkLimitWaveSize([^A-Za-z_0-9]|$)")
+    string(APPEND _violations
+           "  kMaxBatchChunks no longer reads kAbiChunkLimitWaveSize - the "
+           "constant naming the width the ABI ceiling is frozen at is what "
+           "keeps it out of the device's (issue #242)\n")
+  endif()
+  set(${out_violations} "${_violations}" PARENT_SCOPE)
+endfunction()
+
+# Three probes, planted first, for the reason the sweep above plants two: a
+# rule nobody has watched refuse anything is a rule nobody can show still
+# bites. The third is the dead-rule direction - a header the pattern stops
+# matching must report that it read nothing, never come back silent.
+set(_abi_ceiling_probe_root ${CMAKE_CURRENT_BINARY_DIR}/abi-ceiling-probes)
+file(REMOVE_RECURSE ${_abi_ceiling_probe_root})
+file(WRITE ${_abi_ceiling_probe_root}/frozen.h
+     "constexpr size_t kMaxBatchChunks =\n"
+     "    static_cast<size_t>(INT32_MAX) * kAbiChunkLimitWaveSize;\n")
+file(WRITE ${_abi_ceiling_probe_root}/width_derived.h
+     "constexpr size_t kMaxBatchChunks =\n"
+     "    static_cast<size_t>(INT32_MAX) * kWarpSize;\n")
+file(WRITE ${_abi_ceiling_probe_root}/no_definition.h
+     "constexpr unsigned kWarpSize = 32;\n")
+set(_abi_ceiling_probes
+    "frozen.h|"
+    "width_derived.h|is derived from kWarpSize"
+    "no_definition.h|the rule is dead rather than satisfied")
+foreach(_entry IN LISTS _abi_ceiling_probes)
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\2" _expected "${_entry}")
+  cudec_check_abi_ceiling_derivation(${_abi_ceiling_probe_root}/${_probe}
+                                     _probe_result)
+  if(_expected STREQUAL "")
+    # An empty needle is found at position 0 in every string, so the silent
+    # case is checked on emptiness rather than through string(FIND).
+    if(_probe_result)
+      message(FATAL_ERROR "the ABI-ceiling rule refuses a compliant probe: "
+                          "'${_probe}' must come back silent (issue #242). It "
+                          "reported:\n${_probe_result}")
+    endif()
+  else()
+    string(FIND "${_probe_result}" "${_expected}" _found_at)
+    if(_found_at EQUAL -1)
+      message(FATAL_ERROR "the ABI-ceiling rule is dead: probe '${_probe}' "
+                          "did not report \"${_expected}\" (issue #242). "
+                          "It reported:\n${_probe_result}")
+    endif()
+  endif()
+endforeach()
+
+# And now against the header the rule is for.
+cudec_check_abi_ceiling_derivation(${_limits_header} _abi_ceiling_violations)
+if(_abi_ceiling_violations)
+  message(FATAL_ERROR "the batch ABI's chunk-count ceiling has moved onto the "
+                      "device's wave width (issue "
+                      "#242):\n${_abi_ceiling_violations}")
 endif()
 
 # Reads a source and hands back its lines with C comments blanked in place,

--- a/tests/batch_limit_width_lock.cpp
+++ b/tests/batch_limit_width_lock.cpp
@@ -1,0 +1,79 @@
+/* The ABI's chunk-count ceiling does not move with the wave width (issue
+ * #242, masterplan section 15.5). Host-side and GPU-less: nothing here
+ * launches and nothing here calls into CUDA.
+ *
+ * WHY THIS TEST WRITES THE NUMBER OUT AGAIN WHEN batch_limit_parity.cpp
+ * DELIBERATELY DOES NOT. That test compares the two entry points against each
+ * other at the boundary and says in its own comment that it must not carry a
+ * third copy of the value, because a copy drifts silently against the header.
+ * The failure guarded here is the opposite one, and a copy is the only thing
+ * that catches it: the header's own constant being re-derived from the width
+ * the kernel launches at. Both sides of such a change move together, so every
+ * test that reads the value out of the header agrees with it afterwards and
+ * stays green. The digits below are the reference, not a duplicate of it.
+ *
+ * WHAT THE FAILURE LOOKS LIKE IF IT SHIPS. INT32_MAX * 64 is twice INT32_MAX *
+ * 32, so a width-derived ceiling accepts a chunk_count on a wave64 device that
+ * the same call is refused with CUDEC_ERR_INVALID_ARGUMENT on a wave32 one -
+ * a contract that varies by hardware, in a library whose claim is that the
+ * same input produces the same result on every path. The comment on kWarpSize
+ * used to name that derivation as the port's next step, which is why the
+ * refusal is executed here rather than left in prose.
+ *
+ * WHY THE PROOF IS COMPILE-TIME AND THERE IS NO BEHAVIOURAL LEG. Showing
+ * behaviourally that the accepted set has not GROWN means calling an entry
+ * point with a count inside the grown region - and when the defect is present
+ * that call passes validation and launches on the fake pointer arrays a
+ * host-side test has to use. batch_limit_parity.cpp refuses that for the same
+ * reason and stays on the reject side of the boundary throughout. So the
+ * comparison below is made where it costs nothing to make it: against digits
+ * this file owns, at compile time, before any call exists. */
+#include "batch_limits.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+namespace {
+
+/* The wave32 value, spelled from digits, so the assertions compare the header
+ * against something that does not move when the header does. */
+constexpr size_t kFrozenAbiChunkCeiling =
+    static_cast<size_t>(INT32_MAX) * 32u;
+
+/* What a ceiling derived from the launch width would be on a wave64 device.
+ * Named rather than written inline: it is the accepted set this test exists to
+ * keep out, not an arbitrary larger number. */
+constexpr size_t kWave64DerivedCeiling = static_cast<size_t>(INT32_MAX) * 64u;
+
+static_assert(kWave64DerivedCeiling > kFrozenAbiChunkCeiling,
+              "a width-derived ceiling is the LARGER accepted set; if these "
+              "two are equal the assertions below compare nothing");
+
+static_assert(cudec_detail::kMaxBatchChunks == kFrozenAbiChunkCeiling,
+              "the batch ABI's chunk-count ceiling is frozen at the wave32 "
+              "value on every backend (masterplan section 15.5)");
+
+static_assert(cudec_detail::kMaxBatchChunks != kWave64DerivedCeiling,
+              "the batch ABI's chunk-count ceiling has been re-derived from "
+              "the launch width; section 15.5 refuses that");
+
+static_assert(cudec_detail::kAbiChunkLimitWaveSize == 32u,
+              "the width the ABI ceiling is frozen at is an ABI constant, not "
+              "the device's width");
+
+/* The two constants coincide on this backend and must be free to differ: a
+ * static_assert tying them together would re-create the derivation above by
+ * another route. Asserted the only way that leaves them independent - each
+ * against its own reference. */
+static_assert(cudec_detail::kWarpSize == 32u,
+              "the CUDA build's wave width is 32");
+
+}  // namespace
+
+int main() {
+    std::printf("PASS: the batch ABI ceiling is %zu on every backend; the "
+                "wave64-derived %zu is not it\n",
+                cudec_detail::kMaxBatchChunks, kWave64DerivedCeiling);
+    return 0;
+}


### PR DESCRIPTION
# What & why

The batch ABI's chunk-count ceiling stops being a function of the device's wave
width. Refs #242 — this is that issue's ABI half; it does not close it, and the
residual is named at the bottom.

`src/batch_limits.h` read

```
constexpr size_t kMaxBatchChunks = static_cast<size_t>(INT32_MAX) * kWarpSize;
```

with the comment above `kWarpSize` saying the width port "turns this into the
WaveSize parameter (#241)". Carrying that promise out is the defect: a ceiling
derived from the launch width is twice as large on a wave64 device, so the same
`chunk_count` succeeds on one GPU and returns `CUDEC_ERR_INVALID_ARGUMENT` on
another — a contract that varies by hardware, in a library whose claim is that
the same input produces the same result on every path.

The design panel already refused it. `docs/MASTERPLAN.md` section 15.5, settled
via #110:

```
$ git show origin/main:docs/MASTERPLAN.md | sed -n '2415,2420p'
### 15.5 The ABI does not move with the wave width

`kMaxBatchChunks` in `src/batch_limits.h` is `INT32_MAX * kWarpSize`, so a
width-derived limit would be twice as large on wave64 as on wave32. The
panel refuses that: the accepted set stays the wave32 value on every
backend.
```

#241 landed the width parameter on the kernel side and left this half open;
#242 is where the issue says the ABI-visible answer lands.

## What changed

- `src/batch_limits.h`: the ceiling reads its own constant,
  `kAbiChunkLimitWaveSize`. It carries the same digits as `kWarpSize` on
  purpose, and the two must be free to differ — one is an ABI constant, the
  other is a device property. `kWarpSize`'s comment no longer promises a
  derivation section 15.5 refuses.
- `include/cudec.h`: the batch contract states the invariance where a caller
  reads it — the launch limit is the same number on every backend and every
  device, and does not widen on a 64-lane wave.
- `tests/batch_limit_width_lock.cpp`: the value, compared against digits the
  test owns.
- `tests/CMakeLists.txt`: the derivation, read at configure time.

The launch-shape refusal goes the other way and is untouched: a block that is
not a whole number of waves would leave a slice of a destination written by
nobody (`docs/DETERMINISM.md`), so that guard stays derived
from `WaveSize` in `src/chunk_decode.cuh`. There it is a statement about the
launch; in `batch_limits.h` it is a statement about the ABI.

## Why two guards rather than one

Neither reaches the other's failure, and that is the whole reason the second
one exists.

**The value cannot carry the derivation.** On this backend `kWarpSize` and
`kAbiChunkLimitWaveSize` are both 32, so writing the ceiling in terms of the
device width produces exactly the same number. Every arithmetic assertion stays
green, including the new one. Only the source says which name was read, so the
configure-time rule reads it.

**The derivation cannot carry the value.** A ceiling that keeps the right
constant and changes its digits passes the text rule and moves the accepted
set, which is what the compile-time comparison against independently written
digits catches.

**Why the value check is compile-time and there is no behavioural leg.**
Showing behaviourally that an accepted set has not _grown_ means calling an
entry point with a count inside the grown region — and when the defect is
present, that call passes validation and launches on the fake pointer arrays a
host-side test has to use. `tests/batch_limit_parity.cpp` refuses that for the
same reason and stays on the reject side of the boundary throughout. The
comparison is therefore made where it costs nothing: before any call exists.

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: no parse or decode path changed. The accepted set
      of `chunk_count` is byte-for-byte the one that shipped before this branch
      — 68719476704 either way — so no input that was refused is now admitted.
      The two new guards are both refusals and both are executed below.

```
$ ~/cudec-build/tests/batch_limit_parity
PASS: both entry points refuse chunk_count 0, 68719476705 and SIZE_MAX against the shared limit 68719476704
$ ~/cudec-build/tests/batch_limit_width_lock
PASS: the batch ABI ceiling is 68719476704 on every backend; the wave64-derived 137438953408 is not it
```

- [x] Oracle coverage: unchanged and re-run. The whole suite is green,
      `oracle_lz4`, `oracle_snappy` and `oracle_gdeflate` included.
- [x] Determinism preserved: `determinism_gpu` green; no device code changed.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      No CUDA call is added or removed by this branch.
- [x] An adversarial review was run — see **Review record** below, which also
      says plainly what form it took.
- [x] Review record below.

## Review record

**There is no second reader on this branch tonight, and this section is the
evidence in its place rather than a claim that one read it.** The review was a
single reading of the diff against the four standing lenses plus the C-ABI
question, and every verdict below names what was run rather than what was
concluded.

- **correctness — CONFIRMED 0 / PLAUSIBLE 0.** The produced value is unchanged:
  `INT32_MAX * 32` under both spellings. Asserted at compile time in the new
  test against digits that test owns, and printed at run time by both
  batch-limit tests, quoted above.
- **robustness — CONFIRMED 0 / PLAUSIBLE 0.** The configure-time rule is
  fail-closed in both of its own directions and both are planted probes: a
  header it cannot read reports that it read nothing, and a header whose only
  occurrence of the name sits in prose does the same rather than reporting a
  violation it did not see.
- **integration — CONFIRMED 0 / PLAUSIBLE 0.** `_limits_header` is the same
  variable the #39 lock above it already reads, the new function name collides
  with nothing, and the CUDA, host-only and sanitizer configures all pass. The
  public header gains prose and no declaration, so no symbol, size or layout
  moves; `conformance_c` resolves the ABI from C99 unchanged.
- **performance — not applicable and not measured.** No device code, no host
  hot path, and no constant's value changed, so there is nothing this branch
  could move. No number is claimed.
- **C-ABI lens — one finding, FIXED on this branch.** The first version of the
  configure-time rule matched the first `kMaxBatchChunks ... = ... ;` anywhere
  in the header, which is any mention of the name rather than the definition.
  The rules further down `tests/CMakeLists.txt` blank comments before reading a
  source; this one runs before that helper is defined, so a comment naming the
  old width-derived shape would have been read as the definition and refused,
  which is a rule refusing the prose that documents it. Latent rather than
  live — the header carries no such comment today — and fixed in `22892f5`
  anyway, with a fourth planted probe watching it.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

```
commit:    22892f5
gpu:       NVIDIA GeForce RTX 3080, driver 610.88
cuda:      release 13.3, V13.3.73
sanitizer: not run - no device code changed, and Compute Sanitizer cannot
           attach to the device on this machine (issue #258, unchanged by
           this branch)
```

## Performance checklist

Not on the hot path; no claim is made and no number is quoted.

## Quality checklist

- [x] Minimal: one constant, one comment correction, one prose sentence in the
      public header, one test, one configure-time rule.
- [x] Self-documenting: each constant's comment says which of the two questions
      it answers, and why the two must be free to differ.
- [x] The structural property this change establishes is locked in by both new
      guards, and each was watched refusing.

## Verification

All of it inside WSL Ubuntu-24.04 against the local device, at `22892f5`.

```
$ nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
NVIDIA GeForce RTX 3080, 610.88
$ /usr/local/cuda/bin/nvcc --version | tail -2
Cuda compilation tools, release 13.3, V13.3.73
```

- [x] Build clean.

```
$ cmake -S . -B ~/cudec-build -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86
-- Configuring done (19.5s)
-- Generating done (0.2s)
$ cmake --build ~/cudec-build -j
build exit: 0
```

- [x] `ctest` green, whole suite, GPU tests included.

```
$ ctest --test-dir ~/cudec-build --output-on-failure
100% tests passed, 0 tests failed out of 54

Label Time Summary:
gpu    =   8.95 sec*proc (9 tests)
```

Fifty-four rather than the fifty-three on `main`; the new one is
`batch_limit_width_lock`.

- [x] The sanitizer leg, over the set the workflow names.

```
$ cmake -B ~/cudec-san -DCUDEC_ENABLE_CUDA=ON -DCUDEC_SANITIZE=address,undefined
$ cmake --build ~/cudec-san -j
build exit: 0
$ ctest --test-dir ~/cudec-san --no-tests=error --output-on-failure -R \
    '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|zstd_frame_twin|zstd_exec_twin|zstd_blocks_twin|termination|batch_limit_parity|batch_limit_width_lock)$'
100% tests passed, 0 tests failed out of 15
```

The regex is the one in `.github/workflows/ci.yml` with the two batch-limit
tests appended, so the new one is shown clean under ASan+UBSan as well.

- [x] Prettier clean.

```
$ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

- [x] Docs synced: `docs/MASTERPLAN.md` section 15.5 already carries this
      decision and is quoted above rather than edited. No README, BENCHMARKS or
      methodology text describes the batch limit.

## The guards, watched refusing

Each mutant was applied to `src/batch_limits.h` alone, the guard that owes the
refusal was run, and the tree was restored before the next one.

**1. The ceiling re-derived from the device wave width** — the exact change the
old `kWarpSize` comment invited. Note that the produced value does not move on
this backend, which is why the compile-time comparison stays green here and the
configure-time rule is the one that bites.

```
constexpr size_t kMaxBatchChunks =
    static_cast<size_t>(INT32_MAX) * kWarpSize;

configure exit: 1
  the batch ABI's chunk-count ceiling has moved onto the device's wave width
  (issue #242):

    kMaxBatchChunks is derived from kWarpSize, the device's wave width - the ABI ceiling is frozen at kAbiChunkLimitWaveSize on every backend (issue #242)
    kMaxBatchChunks no longer reads kAbiChunkLimitWaveSize - the constant naming the width the ABI ceiling is frozen at is what keeps it out of the device's (issue #242)
```

**2. The frozen width changed to 64** — the value moves and the text rule sees
nothing wrong, so the compile-time comparison is the one that bites.

```
constexpr unsigned kAbiChunkLimitWaveSize = 64;

build exit: 2
tests/batch_limit_width_lock.cpp:53:45: error: static assertion failed: the batch ABI's chunk-count ceiling is frozen at the wave32 value on every backend (masterplan section 15.5)
tests/batch_limit_width_lock.cpp:57:45: error: static assertion failed: the batch ABI's chunk-count ceiling has been re-derived from the launch width; section 15.5 refuses that
tests/batch_limit_width_lock.cpp:61:52: error: static assertion failed: the width the ABI ceiling is frozen at is an ABI constant, not the device's width
```

**3. The definition renamed out from under the rule** — the dead-rule
direction, which has to report that it read nothing rather than passing.

```
constexpr size_t kRenamedCeiling = ...

configure exit: 1
    no definition of kMaxBatchChunks was found to read - the rule is dead rather than satisfied (issue #242)
```

The four planted probes run on every configure, before the rule judges the
tree: the compliant definition must come back silent, the width-derived one
must report the derivation, a header with no definition and a header whose only
occurrence of the name is inside a comment must both report that nothing was
read. A configure that reaches "Configuring done" has run all four.

## Notes

**This does not close #242, and the residual is one clause.** The issue's first
Done-when asks the host to select the 32- or 64-lane instantiation from the
width the device reports and to fail closed when that query fails. That query is
`hipDeviceProp_t::warpSize` on the backend where the answer can be 64, and there
is no HIP toolchain on this machine:

```
$ which hipcc amdclang++ clang++ g++ cmake
/usr/bin/clang++
/usr/bin/g++
/usr/bin/cmake
$ ls -d /opt/rocm*
(nothing)
```

`CMakeLists.txt` already refuses `-DCUDEC_ENABLE_HIP=ON` fail-closed for the
same reason. Landing the dispatch here would put a selection nothing can
execute behind a gate that cannot see it, which is the trade #240 records and
does not take. What this branch settles instead is the half of the issue that
section 15.5 actually decided and that this hardware can prove: the ABI answer.

**What the configure-time rule cannot do**, stated rather than left to be
found. It is a drift detector, not tamper-proofing — a definition that reaches
the device width under some third name is not caught, exactly as the #39 sweep
above it says of itself. And it reads one header; a second ceiling defined
elsewhere is the #39 sweep's subject, not this one's.
