### PR TITLE
Say how much of a page the block-type walk covered [#206]

### DIFF
--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -130,6 +130,15 @@ constexpr uint32_t kBlockStored = 0;
 constexpr uint32_t kBlockStatic = 1;
 constexpr uint32_t kBlockDynamic = 2;
 
+/* The most bytes one stored block can carry, from the 16-bit length field
+ * tests/gdeflate_probes.cpp measures against the reference rather than
+ * carrying over from RFC 1951 (probe 7, dossier D3/D4). It is one byte short
+ * of a page, which is why a page of stored data is never one block. */
+constexpr size_t kStoredBlockMaxBytes = 0xFFFF;
+static_assert(kStoredBlockMaxBytes < kPageBytes,
+              "a full page of stored data would fit in one stored block, and "
+              "the composition claim below assumes it cannot");
+
 /* What a corpus path that did not walk the pages says about itself. A
  * sentence rather than an empty string: an empty composition field printed
  * as an empty line reads as a claim nobody made. */
@@ -159,18 +168,20 @@ const char* BlockTypeName(uint32_t type) {
  * Returns false when the page is too short to prime or the schedule went
  * sticky, which is a corpus this harness must not go on to time rather than
  * a block type to report. */
-bool FirstBlockType(const std::vector<unsigned char>& page, uint32_t* out) {
+bool FirstBlockHeader(const std::vector<unsigned char>& page, uint32_t* type,
+                      bool* is_final) {
     cudec_detail::GDeflateSchedule s;
     if (!cudec_detail::GDeflateInit(s, page.data(), page.size())) {
         return false;
     }
     cudec_detail::GDeflateReset(s);
-    cudec_detail::GDeflatePop(s, 1); /* BFINAL, not read here */
-    const uint32_t type = cudec_detail::GDeflatePop(s, 2);
+    const uint32_t bfinal = cudec_detail::GDeflatePop(s, 1);
+    const uint32_t block_type = cudec_detail::GDeflatePop(s, 2);
     if (s.failed) {
         return false;
     }
-    *out = type;
+    *type = block_type;
+    *is_final = bfinal != 0;
     return true;
 }
 
@@ -179,9 +190,12 @@ bool FirstBlockType(const std::vector<unsigned char>& page, uint32_t* out) {
  * first disagreement names the page and what was read there, because "some
  * page in this corpus is wrong" is not a thing anyone can act on. */
 bool AssertComposition(Corpus* corpus, uint32_t want) {
-    for (size_t i = 0; i < corpus->compressed.size(); i++) {
+    const size_t pages = corpus->compressed.size();
+    size_t whole_page_blocks = 0;
+    for (size_t i = 0; i < pages; i++) {
         uint32_t got = 0;
-        if (!FirstBlockType(corpus->compressed[i], &got)) {
+        bool is_final = false;
+        if (!FirstBlockHeader(corpus->compressed[i], &got, &is_final)) {
             std::fprintf(stderr,
                          "page %zu of %s carries no readable block header - "
                          "the schedule refused it before any type was read\n",
@@ -197,13 +211,71 @@ bool AssertComposition(Corpus* corpus, uint32_t want) {
                          BlockTypeName(want));
             return false;
         }
+        /* A stored block carries at most kStoredBlockMaxBytes, so a page
+         * holding more than that cannot be one stored block and its first
+         * block cannot be final. Reading BFINAL set there would mean the
+         * length field is wider than probe 7 measured or that the walk is
+         * reading the wrong bit, and both are ladder facts rather than corpus
+         * accidents - so it is a refusal rather than a smaller claim. */
+        if (want == kBlockStored && is_final &&
+            corpus->originals[i].size() > kStoredBlockMaxBytes) {
+            std::fprintf(stderr,
+                         "page %zu of %s holds %zu bytes and its first stored "
+                         "block is final, so one stored block would have to "
+                         "carry more than the %zu bytes its length field can "
+                         "hold\n",
+                         i, corpus->name.c_str(), corpus->originals[i].size(),
+                         kStoredBlockMaxBytes);
+            return false;
+        }
+        if (is_final) {
+            whole_page_blocks++;
+        }
+    }
+    /* What the walk covered, not merely what it looked at. BFINAL on the
+     * first block says the page has no second block, so for those pages the
+     * opening block IS the page and the claim is complete; for the rest it is
+     * a lower bound, because reaching a page's second block means decoding to
+     * it. Reporting the split is what keeps a lower bound from being read as
+     * a census (issues #206, #225).
+     *
+     * ONE SIDE OF THIS IS A REFUSAL AND THE OTHER IS A REPORT, and the
+     * asymmetry is deliberate rather than unfinished. A walk that read BFINAL
+     * as set where it is clear reds on the stored refusal above. A walk that
+     * read it as clear everywhere - a dead read, the usual failure - turns
+     * every whole-page claim below into a lower bound, which is the harness
+     * claiming LESS than it covered. There is no structural fact that decides
+     * how many blocks a table-using page holds, so nothing here can refuse
+     * that direction, and a check that goes dead towards a weaker claim is
+     * not a fail-open. */
+    /* The parenthetical belongs only where a later block can exist. Carrying
+     * it onto a page proved whole would deny a claim the walk has just
+     * earned. */
+    const char* const kUnreached =
+        " (a later block in the same page is neither asserted nor denied, "
+        "because reaching one means decoding to it)";
+    std::string covered;
+    if (whole_page_blocks == pages) {
+        covered = "and BFINAL is set on it in every page, so each page is that "
+                  "one block and this is the page's whole composition rather "
+                  "than its opening";
+    } else if (whole_page_blocks == 0) {
+        covered = std::string(
+                      "and BFINAL is clear on it in every page, so every page "
+                      "carries at least one more block that this walk does "
+                      "not reach - a lower bound on the count, never a "
+                      "census") +
+                  kUnreached;
+    } else {
+        covered = "and BFINAL is set on it in " +
+                  std::to_string(whole_page_blocks) + " of " +
+                  std::to_string(pages) +
+                  " pages, which are whole; the rest carry at least one more "
+                  "block that this walk does not reach" +
+                  kUnreached;
     }
     corpus->composition = std::string("every page opens with a ") +
-                          BlockTypeName(want) +
-                          " block, asserted by walking each page's first "
-                          "block header (the first block only - a later "
-                          "block in the same page is neither asserted nor "
-                          "denied, because reaching one means decoding to it)";
+                          BlockTypeName(want) + " block, " + covered;
     return true;
 }
 


### PR DESCRIPTION
# What & why

The GDeflate block-type composition lock says how much of a page it covered.
Refs #206 — this is groundwork for that issue's step 1 and does not close it;
what step 1 still needs is at the bottom.

`bench/bench_gdeflate.cpp` walks each page's first block header and throws away
the bit that decides whether that block is the whole page:

```
$ git show origin/main:bench/bench_gdeflate.cpp | grep -n 'BFINAL, not read here'
168:    cudec_detail::GDeflatePop(s, 1); /* BFINAL, not read here */
```

so the report carried the weaker sentence for every corpus, including the ones
where the stronger one is true. The static family's pages are each a single
block and the report said only that they open with one.

## What the bit buys, in both directions

**Upwards, for table-using pages.** BFINAL set on the first block means the page
has no second block, so the type just named is the page's whole composition
rather than its opening. The static family now reads that way.

**Downwards, for stored pages, and this is the part worth reading.** A stored
block's length field is sixteen bits, measured against the reference rather than
carried over from RFC 1951:

```
$ git show origin/main:tests/gdeflate_probes.cpp | sed -n '638,640p'
     *   - LEN is the 16 bits immediately after BFINAL and BTYPE, and it equals
     *     the bytes the compressor was given. Unaligned by construction: those
     *     three bits are not padded out to a byte.
$ git show origin/main:bench/bench_gdeflate.cpp | grep -n 'kPageBytes = '
80:constexpr size_t kPageBytes = 65536;
```

65535 is one byte short of a page, so a full page of stored data is **at least
two blocks, every time**. A first-block histogram therefore undercounts stored
blocks specifically, while counting table-using pages at their true number —
a bias against exactly the block type #206's lever is deciding about. Both
stored families now say so on their own line instead of leaving a reader to
work it out.

## What changed

- `FirstBlockType` becomes `FirstBlockHeader` and hands back BFINAL beside the
  type.
- `AssertComposition` counts the pages whose first block is final and writes the
  claim it earned: whole page, lower bound, or the split.
- The arithmetic above becomes a refusal: a page holding more than a stored
  block can carry, whose first stored block is final, fails the family.
- `kStoredBlockMaxBytes`, with a `static_assert` that it is below the page size
   — the whole argument rests on that inequality, so it is refused rather than
  assumed.

No corpus, no digest, no timing and no number moves. The three selfcheck corpus
digests are unchanged, which is the harness saying the bytes it measured are the
same bytes.

## Type of change

- [ ] Decode kernel / device code
- [ ] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [ ] API surface
- [ ] Performance
- [ ] Bug fix
- [ ] Refactor / code quality
- [x] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved: this is a bench-side corpus lock, not a decode
      path. It gains one refusal and loses none.
- [x] Oracle coverage: unchanged. Every page is still round-trip-verified
      against the vendored reference before timing.
- [x] Determinism preserved: the corpus digests are byte-identical, printed
      below.
- [x] No CUDA call added or removed; nothing crosses the C ABI here.
- [x] Adversarial review — see **Review record**, which says what form it took.
- [x] Review record below.

## Review record

**There is no second reader on this branch tonight, and this section is the
evidence in its place rather than a claim that one read it.** A single reading
of the diff against the standing lenses; each verdict names what was run.

- **correctness — CONFIRMED 0 / PLAUSIBLE 0.** The bit read is the one the
  format puts first: `GDeflatePop(s, 1)` then `GDeflatePop(s, 2)`, which is the
  order the file already used and the order `tests/gdeflate_probes.cpp` pins.
  The three families report stored/stored/static exactly as before, so the type
  half is unmoved.
- **robustness — CONFIRMED 0 / PLAUSIBLE 0.** The new refusal is bounded by the
  page's own uncompressed size rather than by anything read out of the stream,
  and the inequality it rests on is a `static_assert`. A page the schedule
  refuses still fails ahead of it, unchanged.
- **integration — CONFIRMED 0 / PLAUSIBLE 0.** The composition string is
  consumed at one print site and by nothing else; no document quotes the
  blocktypes families' composition line, so nothing goes out of sync.
- **performance — not applicable.** The walk was already run once per page at
  corpus build time and is outside every timed region.
- **the report-versus-refusal question — one finding, DISCLOSED rather than
  fixed.** The whole-page direction cannot be refused: no structural fact
  decides how many blocks a table-using page holds. A dead BFINAL read
  therefore stays green and downgrades every claim. That is measured below,
  the direction is towards claiming less, and the code says so where it is
  decided rather than in this body alone.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

## Performance checklist

No hot path, no claim, no number. Timings are printed by this harness and none
of them is quoted here or recorded anywhere by this branch.

## Quality checklist

- [x] Minimal: one bit read, one counter, one refusal, one sentence chosen from
      three.
- [x] Self-documenting: the asymmetry between the refusal and the report is
      written at the place that decides it.
- [x] The property this establishes — a page of stored data is never one block
      — is locked by the refusal, watched failing below.

## Verification

WSL Ubuntu-24.04, RTX 3080, driver 610.88, CUDA 13.3 (V13.3.73), `sm_86`.

```
$ cmake -S . -B ~/cudec-build -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86
$ cmake --build ~/cudec-build -j
build exit: 0
$ ctest --test-dir ~/cudec-build --output-on-failure
100% tests passed, 0 tests failed out of 54
```

- [x] Prettier clean (`All matched files use Prettier code style!`); no
      markdown or YAML changed.
- [x] Docs synced: nothing in `docs/` quotes these families' composition line.

What the three forced families report on this branch:

```
$ ~/cudec-build/bench/bench_gdeflate --blocktypes --selfcheck | grep 'block-type composition'
- block-type composition: every page opens with a stored block, and BFINAL is clear on it in every page, so every page carries at least one more block that this walk does not reach - a lower bound on the count, never a census (a later block in the same page is neither asserted nor denied, because reaching one means decoding to it)
- block-type composition: every page opens with a stored block, and BFINAL is clear on it in every page, so every page carries at least one more block that this walk does not reach - a lower bound on the count, never a census (a later block in the same page is neither asserted nor denied, because reaching one means decoding to it)
- block-type composition: every page opens with a static block, and BFINAL is set on it in every page, so each page is that one block and this is the page's whole composition rather than its opening
```

## The guards, watched

Each mutant was applied to the source alone, the selfcheck was rebuilt and run,
and the tree was restored.

**A. The refusal inverted** — a stored page is required to be final instead of
required not to be. This is the near-miss: the one-character version of a walk
that read the wrong bit.

```
220:        if (want == kBlockStored && !is_final &&

selfcheck exit: 1
page 0 of stored-by-level holds 65536 bytes and its first stored block is final, so one stored block would have to carry more than the 65535 bytes its length field can hold
```

**B. The BFINAL read replaced by a constant zero** — the dead-read failure. It
does **not** red, and that is disclosed rather than repaired:

```
184:    *is_final = false; (void)bfinal;

selfcheck exit: 0
- block-type composition: every page opens with a static block, and BFINAL is clear on it in every page, so every page carries at least one more block that this walk does not reach - a lower bound on the count, never a census (...)
```

Every line downgrades to the weaker claim, which is the harness covering less
than it says rather than claiming more than it proved. Refusing that direction
would need a structural bound on the block count of a table-using page, and no
such bound exists.

## Notes

**This leaves #206 open, and the gap is written on that issue.** Step 1 wants
the block-type mix as counts and output bytes per corpus and level. What this
branch adds is the population that walk can honestly count — single-block pages
— and a name for the rest. The rest are the stored-heavy pages, by the
arithmetic above, so the missing half of the census is the half the lever cares
about most, and reaching it means walking past the first block header: #175 for
the canonical construction, #176 for the code-length decode, #182 for the block
dispatch.

**One trap met while building this, recorded because it cost a red gate that
was not real.** A mutant restored by copying the original file back over
`bench/bench_gdeflate.cpp` on the `/mnt/g` DrvFs mount left the build system
seeing an object newer than the restored source, so the next `ctest` ran the
mutant's binary and reported a failure the tree did not have. The numbers above
were re-taken after forcing the rebuild, and each mutant was run in isolation
rather than in sequence.
