### PR TITLE
Retire the single-stream literals lever on measured incidence [#237]

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -248,6 +248,18 @@ add_test(NAME bench_zstd_selfcheck COMMAND bench_zstd --selfcheck)
 add_test(NAME bench_zstd_coverage_selfcheck COMMAND bench_zstd --coverage
                                                     --selfcheck)
 
+# The literals-shape census (issue #237). Separate entry because it locks a
+# property neither of the two above touches: those rot on corpus shape and are
+# proven by a digest, this one rots on whether the walk can still TELL THE TWO
+# HUFFMAN LITERALS SPELLINGS APART. A census that stopped recognising the
+# single-stream form would report the same near-zero incidence as a corpus that
+# genuinely carries none, and the recorded result is a near-zero incidence - so
+# the selfcheck runs the census over the forced-mode corpus, which contains a
+# fixture of each spelling, and fails unless both were seen in sections and in
+# bytes. CPU-only, so it runs on the GPU-less runner.
+add_test(NAME bench_zstd_literals_selfcheck COMMAND bench_zstd --literals
+                                                    --selfcheck)
+
 # Every ctest entry carries a finite TIMEOUT (issue #72): the self-checks run
 # the same corpus construction and CPU decode the decoder is held to, so a
 # non-terminating decode must red them rather than stall the run. The
@@ -256,7 +268,8 @@ add_test(NAME bench_zstd_coverage_selfcheck COMMAND bench_zstd --coverage
 set_tests_properties(
   bench_selfcheck bench_worst4b_selfcheck bench_longmatch_selfcheck
   bench_assetlike_selfcheck bench_zstd_worst_selfcheck bench_zstd_selfcheck
-  bench_zstd_coverage_selfcheck bench_frame_selfcheck bench_snappy_selfcheck
+  bench_zstd_coverage_selfcheck bench_zstd_literals_selfcheck
+  bench_frame_selfcheck bench_snappy_selfcheck
   bench_snappy_worst_selfcheck bench_snappy_worstlit_selfcheck
   bench_gdeflate_selfcheck bench_gdeflate_assetlike_selfcheck
   bench_gdeflate_blocktypes_selfcheck

--- a/bench/bench_zstd.cpp
+++ b/bench/bench_zstd.cpp
@@ -1076,6 +1076,239 @@ bool RunForcedModeCoverage() {
     return true;
 }
 
+/* ------------------------------------------------------------------------
+ * The literals-shape census (issue #237): which literals spelling the
+ * compressor actually emits, over the recorded grid.
+ *
+ * The question is a TRIGGER RATE and not a duration. A decode shape dedicated
+ * to the single-stream Huffman literals form (Size_Format=00) puts the whole
+ * lane team on one stream instead of running the four-stream machinery over
+ * one real stream and three empty ones; what it costs is a branch every
+ * literals section pays, and what it buys is bounded by how much literal work
+ * sits in that form. cudec has measured and rejected a lever of exactly this
+ * shape once already - docs/BENCHMARKS.md "Perf pass 1 (issue #16)" killed the
+ * vectorized literal copy because the path rarely triggered - so the incidence
+ * is produced first and on its own, before any kernel exists to A/B.
+ *
+ * TWO STATISTICS, ALWAYS BOTH, which is bench/literal_hist.h's lesson from
+ * issue #165 carried across formats. The share of SECTIONS wearing a spelling
+ * and the share of literal BYTES sitting inside those sections answer
+ * different questions, and here they cannot agree even in principle:
+ * Size_Format=00 caps Regenerated_Size at 1023 bytes while the wider
+ * spellings reach 262143, so a form that is common by section can be
+ * negligible by work. A lever that moves decode time is argued from the byte
+ * share; the section share is what says how often the branch is paid.
+ *
+ * It reads headers only, through the walker tests/ already pins. No entropy
+ * stream is decoded here and no second walker enters the tree.
+ * ---------------------------------------------------------------------- */
+
+struct LiteralsCensus {
+    size_t frames = 0;
+    size_t blocks = 0;
+    size_t blocks_by_type[3] = {0, 0, 0};
+    /* Indexed by Literals_Block_Type: raw, rle, compressed, treeless. */
+    size_t sections[4] = {0, 0, 0, 0};
+    size_t regenerated[4] = {0, 0, 0, 0};
+    /* The Huffman forms (Compressed and Treeless) split by stream count:
+     * [0] is the single-stream spelling, [1] the four-stream ones. */
+    size_t huffman_sections[2] = {0, 0};
+    size_t huffman_regenerated[2] = {0, 0};
+    size_t largest_one_stream = 0;
+};
+
+/* Folds one frame's headers into the census. Returns false when the walker
+ * could not account for the frame, because a census taken over frames only
+ * partly understood reports an incidence that is really a parse failure. */
+bool CensusOfFrame(const std::vector<unsigned char>& frame,
+                   LiteralsCensus* census, std::string* why) {
+    ZstdFrameShape shape;
+    if (!ParseZstdFrameShape(frame, &shape, why)) {
+        return false;
+    }
+    census->frames++;
+    for (const ZstdBlockShape& block : shape.blocks) {
+        census->blocks++;
+        if (block.block_type < 3) {
+            census->blocks_by_type[block.block_type]++;
+        }
+        if (block.block_type != kZstdBlockCompressed) {
+            continue;
+        }
+        const unsigned type = block.literals_type;
+        if (type > 3) {
+            *why = "literals type out of range";
+            return false;
+        }
+        census->sections[type]++;
+        census->regenerated[type] += block.literals_regenerated_size;
+        if (type != kZstdLiteralsCompressed && type != kZstdLiteralsTreeless) {
+            continue;
+        }
+        /* The walker reports 1 or 4 and nothing else for these two types, so
+         * anything else is the walker having changed under this census rather
+         * than a stream count worth counting. */
+        if (block.literals_streams != 1 && block.literals_streams != 4) {
+            *why = "huffman literals section with neither 1 nor 4 streams";
+            return false;
+        }
+        const unsigned slot = block.literals_streams == 1 ? 0u : 1u;
+        census->huffman_sections[slot]++;
+        census->huffman_regenerated[slot] += block.literals_regenerated_size;
+        if (slot == 0 &&
+            block.literals_regenerated_size > census->largest_one_stream) {
+            census->largest_one_stream = block.literals_regenerated_size;
+        }
+    }
+    return true;
+}
+
+double SharePercent(size_t part, size_t whole) {
+    if (whole == 0) {
+        return 0.0;
+    }
+    return 100.0 * static_cast<double>(part) / static_cast<double>(whole);
+}
+
+void PrintLiteralsReport(const ZstdCorpus& corpus,
+                         const LiteralsCensus& census, size_t frame_bytes,
+                         int level) {
+    const size_t huffman_sections =
+        census.huffman_sections[0] + census.huffman_sections[1];
+    const size_t huffman_bytes =
+        census.huffman_regenerated[0] + census.huffman_regenerated[1];
+    const size_t all_sections = census.sections[0] + census.sections[1] +
+                                census.sections[2] + census.sections[3];
+
+    std::printf("## bench_zstd literals-shape report\n");
+    std::printf("- what this is: an incidence census over the literals "
+                "sections the pinned libzstd %s emits, read from the frame "
+                "headers by ParseZstdFrameShape in tests/zstd_corpus.h. NOT A "
+                "THROUGHPUT MEASUREMENT: nothing is timed and no entropy "
+                "stream is decoded, so no number here is a denominator\n",
+                ZSTD_versionString());
+    std::printf("- host CPU: %s\n", cudec_bench::HostCpuName().c_str());
+    std::printf("- corpus: %s, %zu frames, %.2f MB original, %.2f MB "
+                "compressed (ratio %.4f), %s\n",
+                corpus.name.c_str(), corpus.originals.size(),
+                static_cast<double>(corpus.original_bytes) / 1e6,
+                static_cast<double>(corpus.compressed_bytes) / 1e6,
+                static_cast<double>(corpus.compressed_bytes) /
+                    static_cast<double>(corpus.original_bytes),
+                corpus.provenance.c_str());
+    std::printf("- granularity: %zu KiB frames, compression level %d\n",
+                frame_bytes / 1024, level);
+    std::printf("- corpus digest: %016llx (XXH64 over per-frame length and "
+                "XXH64, little-endian, in corpus order)\n",
+                static_cast<unsigned long long>(CorpusDigest(corpus)));
+    std::printf("- blocks walked: %zu over %zu frames (raw %zu / rle %zu / "
+                "compressed %zu)\n",
+                census.blocks, census.frames, census.blocks_by_type[0],
+                census.blocks_by_type[1], census.blocks_by_type[2]);
+    std::printf("- literals sections: %zu (raw %zu / rle %zu / compressed %zu "
+                "/ treeless %zu)\n",
+                all_sections, census.sections[0], census.sections[1],
+                census.sections[2], census.sections[3]);
+    std::printf("- huffman sections by stream count: %zu total, 1-stream "
+                "(Size_Format=00) %zu (%.4f%%), 4-stream %zu (%.4f%%)\n",
+                huffman_sections, census.huffman_sections[0],
+                SharePercent(census.huffman_sections[0], huffman_sections),
+                census.huffman_sections[1],
+                SharePercent(census.huffman_sections[1], huffman_sections));
+    std::printf("- huffman literal bytes regenerated: %zu total, 1-stream %zu "
+                "(%.4f%%), 4-stream %zu (%.4f%%)\n",
+                huffman_bytes, census.huffman_regenerated[0],
+                SharePercent(census.huffman_regenerated[0], huffman_bytes),
+                census.huffman_regenerated[1],
+                SharePercent(census.huffman_regenerated[1], huffman_bytes));
+    std::printf("- largest 1-stream section seen: %zu bytes regenerated (the "
+                "spelling's own ceiling is 1023)\n",
+                census.largest_one_stream);
+}
+
+/* The census over one cell of the grid. The corpus is built and verified by
+ * exactly the path the timed run uses, so the frames counted here are the
+ * frames the recorded denominator was taken over rather than a second corpus
+ * that merely resembles it. */
+bool RunLiteralsCensus(const std::vector<unsigned char>& source,
+                       const std::string& name, size_t frame_bytes, int level,
+                       uint64_t* digest_out) {
+    ZstdCorpus corpus;
+    corpus.name = name;
+    corpus.provenance =
+        "cut into independent frames and compressed by the pinned libzstd "
+        "through the corpus generator in tests/zstd_corpus.h; every frame "
+        "decoded back by the reference and the concatenation compared "
+        "against the source before the walk";
+    if (!BuildStandardCorpus(source, frame_bytes, level, &corpus)) {
+        return false;
+    }
+    if (!StandardCorpusReconstructs(source, corpus)) {
+        return false;
+    }
+    LiteralsCensus census;
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        std::string why;
+        if (!CensusOfFrame(corpus.compressed[i], &census, &why)) {
+            std::fprintf(
+                stderr,
+                "the walker could not account for frame %zu of %s: %s\n", i,
+                corpus.name.c_str(), why.c_str());
+            return false;
+        }
+    }
+    PrintLiteralsReport(corpus, census, frame_bytes, level);
+    std::printf("\n");
+    *digest_out = CorpusDigest(corpus);
+    return true;
+}
+
+/* THE GUARD THIS CENSUS CANNOT SHIP WITHOUT, and the reason is the shape of
+ * the answer it is expected to give. A near-zero 1-stream incidence is the
+ * result this measurement exists to produce, and a census whose walk never
+ * recognises the single-stream spelling at all reports the identical number.
+ * The two have to be told apart by something that runs.
+ *
+ * The forced-mode corpus carries a fixture for each spelling on purpose -
+ * literals-compressed-one-stream and literals-compressed-four-stream, pinned
+ * as cells by tests/zstd_corpus_selfproof.cpp and listed in
+ * docs/ZSTD-CORPUS.md - so the census is run over it and required to have seen
+ * both, in sections and in bytes. Break the 1-stream arm of CensusOfFrame and
+ * this fails; leave the Silesia grid reporting 0.0000% and it passes, which is
+ * the separation that number needs in order to be read as a result. */
+bool LiteralsCensusSeesBothSpellings() {
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    if (fixtures.empty()) {
+        std::fprintf(stderr, "the forced-mode corpus generator produced "
+                             "nothing\n");
+        return false;
+    }
+    LiteralsCensus census;
+    for (const ZstdFixture& fixture : fixtures) {
+        std::string why;
+        if (!CensusOfFrame(fixture.compressed, &census, &why)) {
+            std::fprintf(stderr,
+                         "the walker could not account for forced-mode "
+                         "fixture %s: %s\n",
+                         fixture.name.c_str(), why.c_str());
+            return false;
+        }
+    }
+    bool ok = true;
+    for (unsigned slot = 0; slot < 2; slot++) {
+        if (census.huffman_sections[slot] == 0 ||
+            census.huffman_regenerated[slot] == 0) {
+            std::fprintf(stderr,
+                         "the census saw no %s huffman literals section with "
+                         "bytes in it over the forced-mode corpus, so a zero "
+                         "incidence reported elsewhere would be unreadable\n",
+                         slot == 0 ? "1-stream" : "4-stream");
+            ok = false;
+        }
+    }
+    return ok;
+}
+
 bool ParseCount(const char* text, size_t low, size_t high, size_t* out) {
     char* end = nullptr;
     const unsigned long long value = std::strtoull(text, &end, 10);
@@ -1089,7 +1322,7 @@ bool ParseCount(const char* text, size_t low, size_t high, size_t* out) {
 void Usage(const char* argv0) {
     std::fprintf(stderr,
                  "usage: %s [--runs N] [--warmup N] [--worst] [--coverage] "
-                 "[--selfcheck] [corpus files...]\n"
+                 "[--literals] [--selfcheck] [corpus files...]\n"
                  "  no flag and files given: the standard corpus path over "
                  "the recorded granularity and level set\n",
                  argv0);
@@ -1100,9 +1333,11 @@ void Usage(const char* argv0) {
 int main(int argc, char** argv) {
     bool worst = false;
     bool coverage = false;
+    bool literals = false;
     bool selfcheck = false;
     size_t warmup = 3;
     size_t runs = 30;
+    bool timing_flag_given = false;
     std::vector<std::string> files;
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
@@ -1110,6 +1345,8 @@ int main(int argc, char** argv) {
             worst = true;
         } else if (arg == "--coverage") {
             coverage = true;
+        } else if (arg == "--literals") {
+            literals = true;
         } else if (arg == "--selfcheck") {
             selfcheck = true;
         } else if (arg == "--runs" && i + 1 < argc) {
@@ -1117,12 +1354,14 @@ int main(int argc, char** argv) {
                 std::fprintf(stderr, "--runs must be in [1, %zu]\n", kMaxRuns);
                 return 2;
             }
+            timing_flag_given = true;
         } else if (arg == "--warmup" && i + 1 < argc) {
             if (!ParseCount(argv[++i], 0, kMaxRuns, &warmup)) {
                 std::fprintf(stderr, "--warmup must be in [0, %zu]\n",
                              kMaxRuns);
                 return 2;
             }
+            timing_flag_given = true;
         } else if (arg == "--runs" || arg == "--warmup") {
             std::fprintf(stderr, "%s needs a value\n", arg.c_str());
             return 2;
@@ -1133,9 +1372,75 @@ int main(int argc, char** argv) {
             files.push_back(arg);
         }
     }
-    if (worst && coverage) {
-        std::fprintf(stderr, "--worst and --coverage are separate runs\n");
+    if (static_cast<int>(worst) + static_cast<int>(coverage) +
+            static_cast<int>(literals) >
+        1) {
+        std::fprintf(stderr,
+                     "--worst, --coverage and --literals are separate runs\n");
         return 2;
+    }
+
+    if (literals) {
+        /* The same grid the recorded denominator was taken over, walked
+         * rather than timed. --runs and --warmup are refused here instead of
+         * ignored: a census accepting a timing flag reads as a run that was
+         * repeated, and this one is not repeated because there is nothing in
+         * it to vary. */
+        if (timing_flag_given) {
+            std::fprintf(stderr, "--literals is a census, not a timed run: it "
+                                 "takes neither --runs nor --warmup\n");
+            return 2;
+        }
+        if (files.empty() && !selfcheck) {
+            std::fprintf(stderr,
+                         "bench_zstd --literals needs corpus files (the "
+                         "recorded run uses bench/corpora/silesia/*); "
+                         "--selfcheck runs it on a generated source "
+                         "instead\n");
+            return 2;
+        }
+        std::vector<unsigned char> source;
+        std::string name;
+        if (selfcheck) {
+            source = MakeSelfcheckSource(kSelfcheckBytes);
+            name = "generated (selfcheck)";
+        } else {
+            for (const std::string& path : files) {
+                if (!AppendFile(path, &source)) {
+                    return 1;
+                }
+                const size_t slash = path.find_last_of("/\\");
+                name += (name.empty() ? "" : "+") +
+                        path.substr(slash == std::string::npos ? 0
+                                                               : slash + 1);
+            }
+        }
+        bool digests_hold = true;
+        for (size_t f = 0; f < sizeof(kFrameSizes) / sizeof(kFrameSizes[0]);
+             f++) {
+            for (size_t l = 0; l < sizeof(kLevels) / sizeof(kLevels[0]); l++) {
+                uint64_t digest = 0;
+                if (!RunLiteralsCensus(source, name, kFrameSizes[f], kLevels[l],
+                                       &digest)) {
+                    return 1;
+                }
+                if (selfcheck && !CheckDigest(digest, kFrameSizes[f],
+                                              kLevels[l],
+                                              kSelfcheckDigests[f][l])) {
+                    digests_hold = false;
+                }
+            }
+        }
+        if (!digests_hold) {
+            return 1;
+        }
+        if (selfcheck && !LiteralsCensusSeesBothSpellings()) {
+            return 1;
+        }
+        if (selfcheck) {
+            std::printf("PASS: selfcheck complete\n");
+        }
+        return 0;
     }
 
     if (coverage) {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1945,6 +1945,187 @@ decode surface each, so a throughput figure over them would measure the fixture
 list; the harness prints that in place of a number rather than leaving it to be
 inferred.
 
+## M5 perf lever: the single-stream literals shape, retired on incidence (issue #237)
+
+**The lever, and why it is answered here instead of on a device.** The
+single-stream Huffman literals form (`Size_Format=00`, RFC 8878 section
+3.1.1.3.1.1) is the one spelling that carries a single backward stream; the
+other three carry four. A decode shape dedicated to it would put the whole lane
+team on that stream instead of running the four-stream machinery over one real
+stream and three empty ones, and section 14.6 of the masterplan names it as one
+of the two levers that would be tried first if the literals phase turned out to
+dominate a frame's time. What it costs is a branch every literals section pays,
+whatever spelling it wears. So its ceiling is set by how much literal work sits
+in that form, and that is a property of what the compressor emits, not of any
+kernel: it is measurable now, and it decides the lever before a kernel exists.
+
+**The pre-registered rule this run was taken under**, written on #237 before the
+measurement: a form appearing in a negligible fraction of the real corpora
+retires the lever on the numbers alone, and that outcome is written up like any
+other. cudec has retired a lever of exactly this shape once before -- perf pass
+1 (issue #16) killed the vectorized literal copy because the path rarely
+triggered and only added setup and branch overhead -- and issue #165 is where
+the discipline of reading a trigger rate before writing the code was adopted.
+
+**Two statistics, always both.** The share of literals SECTIONS wearing a
+spelling and the share of literal BYTES sitting inside those sections answer
+different questions, and here they cannot agree even in principle:
+`Size_Format=00` caps `Regenerated_Size` at 1023 bytes while the wider
+spellings reach 262143. The section share says how often the branch is paid;
+the byte share bounds what it could buy. That separation is bench/literal_hist.h's
+lesson from issue #165 carried across formats.
+
+The census reads frame headers only, through the walker `tests/zstd_corpus.h`
+already pins, over the same six cells and the same frames the M5 CPU
+denominator above was taken on -- the six corpus digests below reproduce the six
+recorded in that entry byte for byte, which is what makes this a census of that
+corpus rather than of one resembling it. Recorded 2026-08-27. Reproduce with
+`bench_zstd --literals bench/corpora/silesia/*`; nothing is timed and no entropy
+stream is decoded, so no figure here is a denominator.
+
+| granularity | level | huffman sections | 1-stream | of sections | huffman literal bytes | 1-stream bytes | of bytes |
+| ----------- | ----- | ---------------- | -------- | ----------- | --------------------- | -------------- | -------- |
+| 64 KiB      | 1     | 3149             | 0        | 0.0000%     | 63586548              | 0              | 0.0000%  |
+| 64 KiB      | 3     | 3149             | 0        | 0.0000%     | 48451864              | 0              | 0.0000%  |
+| 64 KiB      | 19    | 3096             | 0        | 0.0000%     | 26666688              | 0              | 0.0000%  |
+| 512 KiB     | 1     | 1889             | 0        | 0.0000%     | 61165017              | 0              | 0.0000%  |
+| 512 KiB     | 3     | 2173             | 6        | 0.2761%     | 34179495              | 1010           | 0.0030%  |
+| 512 KiB     | 19    | 3621             | 174      | 4.8053%     | 17000854              | 28296          | 0.1664%  |
+
+The table is a reading aid. The six blocks below are the record.
+
+```
+## bench_zstd literals-shape report
+- what this is: an incidence census over the literals sections the pinned libzstd 1.5.7 emits, read from the frame headers by ParseZstdFrameShape in tests/zstd_corpus.h. NOT A THROUGHPUT MEASUREMENT: nothing is timed and no entropy stream is decoded, so no number here is a denominator
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 frames, 211.94 MB original, 76.70 MB compressed (ratio 0.3619), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before the walk
+- granularity: 64 KiB frames, compression level 1
+- corpus digest: f95ac5fe65483030 (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- blocks walked: 3234 over 3234 frames (raw 21 / rle 0 / compressed 3213)
+- literals sections: 3213 (raw 64 / rle 0 / compressed 3149 / treeless 0)
+- huffman sections by stream count: 3149 total, 1-stream (Size_Format=00) 0 (0.0000%), 4-stream 3149 (100.0000%)
+- huffman literal bytes regenerated: 63586548 total, 1-stream 0 (0.0000%), 4-stream 63586548 (100.0000%)
+- largest 1-stream section seen: 0 bytes regenerated (the spelling's own ceiling is 1023)
+```
+
+```
+## bench_zstd literals-shape report
+- what this is: an incidence census over the literals sections the pinned libzstd 1.5.7 emits, read from the frame headers by ParseZstdFrameShape in tests/zstd_corpus.h. NOT A THROUGHPUT MEASUREMENT: nothing is timed and no entropy stream is decoded, so no number here is a denominator
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 frames, 211.94 MB original, 73.52 MB compressed (ratio 0.3469), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before the walk
+- granularity: 64 KiB frames, compression level 3
+- corpus digest: c7171e665a1888c6 (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- blocks walked: 3234 over 3234 frames (raw 15 / rle 0 / compressed 3219)
+- literals sections: 3219 (raw 70 / rle 0 / compressed 3149 / treeless 0)
+- huffman sections by stream count: 3149 total, 1-stream (Size_Format=00) 0 (0.0000%), 4-stream 3149 (100.0000%)
+- huffman literal bytes regenerated: 48451864 total, 1-stream 0 (0.0000%), 4-stream 48451864 (100.0000%)
+- largest 1-stream section seen: 0 bytes regenerated (the spelling's own ceiling is 1023)
+```
+
+```
+## bench_zstd literals-shape report
+- what this is: an incidence census over the literals sections the pinned libzstd 1.5.7 emits, read from the frame headers by ParseZstdFrameShape in tests/zstd_corpus.h. NOT A THROUGHPUT MEASUREMENT: nothing is timed and no entropy stream is decoded, so no number here is a denominator
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 frames, 211.94 MB original, 65.04 MB compressed (ratio 0.3069), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before the walk
+- granularity: 64 KiB frames, compression level 19
+- corpus digest: 748220fb33f7ee01 (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- blocks walked: 3234 over 3234 frames (raw 1 / rle 0 / compressed 3233)
+- literals sections: 3233 (raw 137 / rle 0 / compressed 3096 / treeless 0)
+- huffman sections by stream count: 3096 total, 1-stream (Size_Format=00) 0 (0.0000%), 4-stream 3096 (100.0000%)
+- huffman literal bytes regenerated: 26666688 total, 1-stream 0 (0.0000%), 4-stream 26666688 (100.0000%)
+- largest 1-stream section seen: 0 bytes regenerated (the spelling's own ceiling is 1023)
+```
+
+```
+## bench_zstd literals-shape report
+- what this is: an incidence census over the literals sections the pinned libzstd 1.5.7 emits, read from the frame headers by ParseZstdFrameShape in tests/zstd_corpus.h. NOT A THROUGHPUT MEASUREMENT: nothing is timed and no entropy stream is decoded, so no number here is a denominator
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 405 frames, 211.94 MB original, 73.95 MB compressed (ratio 0.3489), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before the walk
+- granularity: 512 KiB frames, compression level 1
+- corpus digest: ed6b1bc51f66d81f (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- blocks walked: 1940 over 405 frames (raw 6 / rle 0 / compressed 1934)
+- literals sections: 1934 (raw 45 / rle 0 / compressed 1681 / treeless 208)
+- huffman sections by stream count: 1889 total, 1-stream (Size_Format=00) 0 (0.0000%), 4-stream 1889 (100.0000%)
+- huffman literal bytes regenerated: 61165017 total, 1-stream 0 (0.0000%), 4-stream 61165017 (100.0000%)
+- largest 1-stream section seen: 0 bytes regenerated (the spelling's own ceiling is 1023)
+```
+
+```
+## bench_zstd literals-shape report
+- what this is: an incidence census over the literals sections the pinned libzstd 1.5.7 emits, read from the frame headers by ParseZstdFrameShape in tests/zstd_corpus.h. NOT A THROUGHPUT MEASUREMENT: nothing is timed and no entropy stream is decoded, so no number here is a denominator
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 405 frames, 211.94 MB original, 68.23 MB compressed (ratio 0.3219), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before the walk
+- granularity: 512 KiB frames, compression level 3
+- corpus digest: 4983cbc86cd8255b (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- blocks walked: 2506 over 405 frames (raw 88 / rle 0 / compressed 2418)
+- literals sections: 2418 (raw 245 / rle 0 / compressed 1956 / treeless 217)
+- huffman sections by stream count: 2173 total, 1-stream (Size_Format=00) 6 (0.2761%), 4-stream 2167 (99.7239%)
+- huffman literal bytes regenerated: 34179495 total, 1-stream 1010 (0.0030%), 4-stream 34178485 (99.9970%)
+- largest 1-stream section seen: 227 bytes regenerated (the spelling's own ceiling is 1023)
+```
+
+```
+## bench_zstd literals-shape report
+- what this is: an incidence census over the literals sections the pinned libzstd 1.5.7 emits, read from the frame headers by ParseZstdFrameShape in tests/zstd_corpus.h. NOT A THROUGHPUT MEASUREMENT: nothing is timed and no entropy stream is decoded, so no number here is a denominator
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 405 frames, 211.94 MB original, 58.65 MB compressed (ratio 0.2767), cut into independent frames and compressed by the pinned libzstd through the corpus generator in tests/zstd_corpus.h; every frame decoded back by the reference and the concatenation compared against the source before the walk
+- granularity: 512 KiB frames, compression level 19
+- corpus digest: 4242734974b3b0d5 (XXH64 over per-frame length and XXH64, little-endian, in corpus order)
+- blocks walked: 4378 over 405 frames (raw 1 / rle 0 / compressed 4377)
+- literals sections: 4377 (raw 735 / rle 21 / compressed 3213 / treeless 408)
+- huffman sections by stream count: 3621 total, 1-stream (Size_Format=00) 174 (4.8053%), 4-stream 3447 (95.1947%)
+- huffman literal bytes regenerated: 17000854 total, 1-stream 28296 (0.1664%), 4-stream 16972558 (99.8336%)
+- largest 1-stream section seen: 255 bytes regenerated (the spelling's own ceiling is 1023)
+```
+
+**The lever is retired: no kernel code ships.** Across the whole recorded grid
+the single-stream form carries at most **0.1664% of the Huffman literal bytes**,
+and four of the six cells carry none at all. The branch that would select the
+dedicated shape is taken by every literals section, so the trade is a cost paid
+on up to 100% of sections against a ceiling of one part in six hundred of the
+literal work -- and that ceiling is generous twice over, because it assumes the
+dedicated shape decodes those bytes in zero time and because literal decode is
+only one phase of a frame's cost. That is the pre-registered retirement
+condition met on the numbers.
+
+**The section share and the byte share diverge by a factor of thirty, and only
+one of them is the argument.** At 512 KiB and level 19 the form is 4.8053% of
+sections but 0.1664% of bytes, because the largest single-stream section in the
+entire grid regenerates 255 bytes against a 262143-byte ceiling on the wide
+spellings. A reader who took the section share for the size of the prize would
+be reading the wrong statistic; issue #165 is where that mistake was made
+visible on LZ4 and Snappy, and the census prints both figures on every run so it
+cannot be made silently here.
+
+**What drives the form is block splitting, not frame size,** and that is the
+opposite of what the lever's framing assumed. Incidence is zero at 64 KiB
+granularity across the whole level set and non-zero only at 512 KiB, where the
+compressor emits many blocks per frame instead of one: 4378 blocks over 405
+frames at level 19 against 3234 blocks over 3234 frames at 64 KiB. The form is
+the tail of a block split small, so shrinking the frame -- which produces fewer,
+larger blocks per frame here -- does not raise it. No cause is claimed beyond
+what those counts show.
+
+**What this does not cover, stated as a bound rather than left to be assumed.**
+One corpus (Silesia), one compressor (the pinned libzstd 1.5.7), the two frame
+granularities and three levels the M5 batch model names, and nothing below 64
+KiB. A different compressor, a dictionary, or a producer emitting deliberately
+tiny blocks could carry a materially higher share, and none of those was
+measured. The forced-mode corpus does emit the form on demand, so the fallback
+#237 named -- reach for the #185 fixtures if the natural corpora never exercise
+it -- was not needed: the natural corpora exercise it, and the answer is that
+they barely do.
+
+**The census cannot report a zero it cannot see, and that is checked by
+something that runs.** A near-zero incidence and a walk that stopped
+recognising the single-stream spelling produce the identical table, so
+`bench_zstd_literals_selfcheck` runs the census over the forced-mode corpus --
+which carries a fixture of each spelling -- and fails unless both were counted,
+in sections and in bytes. Removing the one-stream arm of the census turns that
+ctest entry red with the reason named; the Silesia grid reporting 0.0000% leaves
+it green. That is the separation the zeroes above need in order to be read as a
+result.
+
 ## Community AMD results
 
 **No community results yet.** Nothing in this section is a measurement; it

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -2042,6 +2042,22 @@ them by naming where the literals live.
   is idle, and warp per frame's ten resident frames stop being the worse
   trade. That is the one measurement that reopens 14.2, and #236 and #237
   are the levers that would be tried first.
+
+  **Measured outcome (issue #237, 2026-08-27): the `Size_Format` of zero half
+  of that bullet is retired before the kernel exists, and the other half is
+  untouched.** An incidence census over the recorded M5 corpus - the same six
+  cells and the same frames the CPU denominator was taken on, proved by the
+  six corpus digests reproducing - finds the single-stream form carrying at
+  most 0.1664% of the Huffman literal bytes, and none at all at 64 KiB
+  granularity across the whole level set. So the 124-of-128-idle case is real
+  but rare enough that a dedicated shape for it cannot pay for the branch
+  every literals section would take, and #237 is closed with no kernel code.
+  What that does NOT settle is whether the four-stream literals phase
+  dominates a frame's time: that is a device measurement, it stays open on
+  #236, and it is still the one that would reopen 14.2. `docs/BENCHMARKS.md`
+  carries the table, the bounds of the corpus it was taken over, and the guard
+  that separates a measured zero from a blind one.
+
 - **Achieved registers above 64 per thread.** The whole of 14.2 is derived
   from 32 resident warps at 64 registers. Above it the block count falls
   and the shared-memory headroom the four-warp block relies on stops being

--- a/tests/zstd_corpus.cpp
+++ b/tests/zstd_corpus.cpp
@@ -187,6 +187,7 @@ bool ReadLiteralsSection(Reader* r, ZstdBlockShape* shape) {
             regenerated = (*head >> 4) | (static_cast<size_t>(rest[0]) << 4) |
                           (static_cast<size_t>(rest[1]) << 12);
         }
+        shape->literals_regenerated_size = regenerated;
         /* An RLE literals section stores exactly one byte whatever it
          * regenerates; a Raw one stores every byte it regenerates. */
         return r->Skip(type == kZstdLiteralsRle ? 1u : regenerated);
@@ -195,6 +196,7 @@ bool ReadLiteralsSection(Reader* r, ZstdBlockShape* shape) {
     /* Compressed and Treeless carry a compressed size as well, and the
      * stream count is the Size_Format: 00 is the only single-stream form. */
     size_t compressed = 0;
+    size_t regenerated = 0;
     if (size_format == 0 || size_format == 1) {
         const unsigned char* rest = nullptr;
         if (!r->Take(2, &rest)) {
@@ -203,6 +205,7 @@ bool ReadLiteralsSection(Reader* r, ZstdBlockShape* shape) {
         const uint32_t packed = (static_cast<uint32_t>(*head) >> 4) |
                                 (static_cast<uint32_t>(rest[0]) << 4) |
                                 (static_cast<uint32_t>(rest[1]) << 12);
+        regenerated = packed & 0x3ffu;
         compressed = (packed >> 10) & 0x3ffu;
     } else if (size_format == 2) {
         const unsigned char* rest = nullptr;
@@ -213,6 +216,7 @@ bool ReadLiteralsSection(Reader* r, ZstdBlockShape* shape) {
                                 (static_cast<uint32_t>(rest[0]) << 4) |
                                 (static_cast<uint32_t>(rest[1]) << 12) |
                                 (static_cast<uint32_t>(rest[2]) << 20);
+        regenerated = packed & 0x3fffu;
         compressed = (packed >> 14) & 0x3fffu;
     } else {
         const unsigned char* rest = nullptr;
@@ -224,8 +228,10 @@ bool ReadLiteralsSection(Reader* r, ZstdBlockShape* shape) {
                                 (static_cast<uint64_t>(rest[1]) << 12) |
                                 (static_cast<uint64_t>(rest[2]) << 20) |
                                 (static_cast<uint64_t>(rest[3]) << 28);
+        regenerated = static_cast<size_t>(packed & 0x3ffffu);
         compressed = static_cast<size_t>((packed >> 18) & 0x3ffffu);
     }
+    shape->literals_regenerated_size = regenerated;
     shape->literals_streams = size_format == 0 ? 1u : 4u;
     shape->literals_payload_offset = r->pos;
     shape->literals_payload_size = compressed;

--- a/tests/zstd_corpus.h
+++ b/tests/zstd_corpus.h
@@ -76,6 +76,16 @@ struct ZstdBlockShape {
      * only for those two literals types. */
     size_t literals_payload_offset = 0;
     size_t literals_payload_size = 0;
+    /* What the literals section regenerates, for every literals type. The
+     * walk reads it in order to step over a Raw section and carries it in the
+     * same packed word as the compressed size for the other two, so it is
+     * reported for the reason the three fields above are. It is the
+     * denominator any statement about how much literal WORK sits in a given
+     * section shape has to be taken over: the section count answers a
+     * different question and the two diverge sharply, because the
+     * single-stream spelling caps regenerated size at 1023 bytes while the
+     * four-stream ones reach 262143. */
+    size_t literals_regenerated_size = 0;
 };
 
 struct ZstdFrameShape {


### PR DESCRIPTION
Closes #237.

## What this decides

The dedicated `Size_Format=00` literals decode shape is **retired on the
numbers, before any kernel exists to A/B it**. #237 pre-registered exactly that
route: the trigger rate is the primary measurement, and a form appearing in a
negligible fraction of the real corpora retires the lever on its own. The rate
is a property of what the compressor emits rather than of any kernel, so it was
producible now, and it is decisive.

`bench_zstd --literals` walks the literals sections of the recorded M5 grid and
reports two shares: how many SECTIONS wear each spelling, and how many literal
BYTES sit inside them. Both, always, because here they cannot agree -
`Size_Format=00` caps `Regenerated_Size` at 1023 bytes while the wider
spellings reach 262143. Reading the section share as the size of the prize is
the mistake issue #165 made visible on LZ4 and Snappy.

| granularity | level | huffman sections | 1-stream | of sections | huffman literal bytes | 1-stream bytes | of bytes |
| ----------- | ----- | ---------------- | -------- | ----------- | --------------------- | -------------- | -------- |
| 64 KiB      | 1     | 3149             | 0        | 0.0000%     | 63586548              | 0              | 0.0000%  |
| 64 KiB      | 3     | 3149             | 0        | 0.0000%     | 48451864              | 0              | 0.0000%  |
| 64 KiB      | 19    | 3096             | 0        | 0.0000%     | 26666688              | 0              | 0.0000%  |
| 512 KiB     | 1     | 1889             | 0        | 0.0000%     | 61165017              | 0              | 0.0000%  |
| 512 KiB     | 3     | 2173             | 6        | 0.2761%     | 34179495              | 1010           | 0.0030%  |
| 512 KiB     | 19    | 3621             | 174      | 4.8053%     | 17000854              | 28296          | 0.1664%  |

At most **0.1664% of the Huffman literal bytes**, and four of six cells carry
none at all. The branch that would select the dedicated shape is taken by every
literals section. That is a cost on up to 100% of sections against a ceiling of
one part in six hundred of the literal work, and the ceiling is generous twice
over: it assumes the dedicated shape decodes those bytes in zero time, and
literal decode is one phase of a frame's cost. No kernel code ships.

Two things the table says that the framing of the lever did not expect. The
section share and the byte share diverge by a factor of thirty, because the
largest single-stream section in the whole grid regenerates 255 bytes. And
incidence is zero at 64 KiB and non-zero only at 512 KiB, where the compressor
emits many blocks per frame rather than one - the form is the tail of a block
split small, so shrinking the frame does not raise it.

## The corpus is the recorded one, and that is proved rather than asserted

The census runs the same construction the M5 CPU denominator was taken on. All
six corpus digests reproduce the six recorded at `docs/BENCHMARKS.md` for issue
#227 byte for byte - `f95ac5fe65483030`, `c7171e665a1888c6`, `748220fb33f7ee01`,
`ed6b1bc51f66d81f`, `4983cbc86cd8255b`, `4242734974b3b0d5` - so this is a census
of that corpus and not of one resembling it.

## The guard, and the proof that it bites

A near-zero incidence and a walk that stopped recognising the single-stream
spelling print the identical table, so the zeroes above need something that can
tell them apart. `bench_zstd_literals_selfcheck` runs the census over the
forced-mode corpus, which carries a fixture of each spelling, and fails unless
both were counted in sections and in bytes.

Proven by deleting it. With the one-stream arm of `CensusOfFrame` removed
(`const unsigned slot = 1u;`):

```
MUTANT selfcheck exit=1
the census saw no 1-stream huffman literals section with bytes in it over the forced-mode corpus, so a zero incidence reported elsewhere would be unreadable
```

Restored, the entry is green and the Silesia grid still reports 0.0000% on four
cells - which is the separation the result needs.

## Gate

Built and run at the head commit of this branch. The host carries no Docker
daemon tonight, and starting the stopped Windows service would raise a consent
prompt, so the CUDA toolchain in the WSL Ubuntu-24.04 distro was used instead of
the container `CLAUDE.md` documents. Same source, same flags, different
toolchain version - stated rather than glossed: nvcc 13.3.73 against the
container's 12.6.77, on the RTX 3080, driver 610.88.

```
cmake -S . -B ~/build-af19 -DCUDEC_ENABLE_CUDA=ON
cmake --build ~/build-af19 -j
ctest --test-dir ~/build-af19 --output-on-failure

100% tests passed, 0 tests failed out of 55
Label Time Summary:
gpu    =  10.19 sec*proc (9 tests)
Total Test time (real) =  26.65 sec
```

55, up from 54: `bench_zstd_literals_selfcheck` is the entry this adds. The
build is clean under the project's `-Wall -Wextra -Werror`.

Format:

```
npx prettier@3 --check "**/*.{md,yml,yaml}"
Checking formatting...
All matched files use Prettier code style!
```

## Bounds, stated rather than left to be assumed

One corpus (Silesia), one compressor (the pinned libzstd 1.5.7), the two frame
granularities and three levels the M5 batch model names, and nothing below 64
KiB. A different compressor, a dictionary, or a producer emitting deliberately
tiny blocks could carry a materially higher share, and none of those was
measured. The fallback #237 named - reach for the #185 forced-mode fixtures if
the natural corpora never exercise the form - was not needed: they do exercise
it, and the answer is that they barely do.

Nothing here says whether the four-stream literals phase dominates a frame's
time. That is a device measurement, it stays open on #236, and it is still the
one that would reopen masterplan 14.2.

## Means

Markdown for the record and C++17 in the existing bench harness, both already
in the tree: the census reads frame headers through the walker `tests/` pins
rather than adding a second one, and it adds no language, runtime or
dependency. `ParseZstdFrameShape` now reports the regenerated size it already
reads in order to step over a section, for the reason it reports the three
offsets beside it - every consumer would otherwise re-derive it.

## Review

This change had no second reader. The evidence above stands in place of one:
the mutant run for the guard, the six reproduced digests for the corpus, and
the full ctest transcript for the gate.
