### PR TITLE
Name the decode kernel's source and say what shipped in it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ container command for the maintained path (build directory `build-cuda`,
 ### The tests that allocate over 4 GiB
 
 Some arms of the decoder are selected by a capacity test and nothing smaller
-reaches them: `src/lz4_decode.cuh` picks a 64-bit overlap gather for a match
+reaches them: `src/chunk_decode.cuh` picks a 64-bit overlap gather for a match
 longer than 2^32, and no ordinary fixture is that large. `huge_match_gpu`
 reaches that one with a single 4 GiB decode. It is built by every CUDA
 configure, so it cannot rot, and it is registered as a ctest entry only under

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -411,14 +411,18 @@ wrong. "Exactly once" holds for a supported launch geometry, which the
 kernel enforces rather than assumes: the copy loops stride by the warp
 size, so a block that is not a whole number of warps would leave a fixed
 slice of every destination written by nobody, and that geometry returns
-without decoding ([DETERMINISM.md](DETERMINISM.md)). The shipped inner loop computes that `i mod off` directly - one
-64-bit modulo per output byte, so every lane pays a division per
-iteration (`dst[seq.match_dst + i] = dst[seq.match_src + (i % offset)]`
-in `src/lz4_decode.cuh`). Cutting that cost is deferred, measurement-gated
-perf work, not a present property: eliding the modulo when the match
-cannot wrap (`off >= len`, #36) and narrowing it to 32-bit (#58), neither
-merged. The fully incremental `r += step; if (r >= off) r -= off` scheme
-was itself tried and rejected by measurement - see perf pass 1 below.
+without decoding ([DETERMINISM.md](DETERMINISM.md)). The shipped inner loop
+computes that `i mod off` directly, at two arithmetic widths behind one
+warp-uniform test in `src/chunk_decode.cuh`: a 32-bit modulo where the match
+length fits in `uint32_t`, and the 64-bit one above it, so a match longer
+than 2^32 still decodes through the other arm. That narrowing is #58 and it
+is merged - perf pass 4 in [BENCHMARKS.md](BENCHMARKS.md) is the measurement
+it was accepted on, and the offset stays 64-bit in the stored sequence, so no
+field is narrowed. Eliding the modulo altogether when the match cannot wrap
+(`off >= len`) was measured and rejected rather than deferred: perf pass 3
+there records the worst-case regression that decided it (#36). The fully
+incremental `r += step; if (r >= off) r -= off` scheme was itself tried and
+rejected by measurement - see perf pass 1 below.
 
 **The validation ladder** (fail-closed; every stream-decoded value checked
 before first use as address, length, or offset): token existence before
@@ -536,15 +540,15 @@ percentage points"; batches under ~2,000 chunks underfill the machine and
 land near CPU speed (documented, not hidden); warp-synchronous discipline
 is load-bearing - every `__syncwarp` is reviewed as such.
 
-**M3/M4 seam:** the chunk decoder is to become
-`template<class Parser, bool ParseOnly>` - Snappy (M3) swaps the parser and
-keeps everything else; GDeflate (M4) keeps the copy engine, validation
-posture, and result contract while bringing its format-native 32-substream
-parse model. Written as a commitment rather than as a present property,
-because it is one: `src/lz4_decode.cuh` is `template <bool ParseOnly>` with
-`Lz4Parser` named directly in the kernel body, and no `Parser` template
-parameter exists under `src/` today. Section 10 fixes the contract the seam
-must carry; the M3 kernel rung materializes it.
+**M3/M4 seam:** the chunk decoder is
+`template <class Parser, bool ParseOnly, int WaveSize>` - Snappy (M3) swaps
+the parser and keeps everything else; GDeflate (M4) keeps the copy engine,
+validation posture, and result contract while bringing its format-native
+32-substream parse model. This was written as a commitment rather than as a
+present property, and it is a present property now: `src/chunk_decode.cuh`
+carries the `Parser` parameter and the M3 kernel rung materialized it (#150),
+and the wave-width parameter beside it is #241. Section 10 fixes the contract
+the seam carries; GDeflate is the instantiation still owed.
 
 **The M1 PR ladder** (each independently gated): (1) this design section -
 closes the design issue; (2) the sequence parser + validation ladder as a


### PR DESCRIPTION
# What & why

Closes #391.

`src/lz4_decode.cuh` became `src/chunk_decode.cuh` on 2026-08-25 (`7e5949c`,
issue #150). Three present-tense sentences across two documents kept naming
the old path, and two of them are wrong about the kernel and not only about
the file. Both fail in the same direction - they tell a reader that work is
unmerged when it is merged - which is the direction that costs someone a
re-implementation.

## What the tree says, against what the documents said

**The gather.** `docs/MASTERPLAN.md` said the shipped inner loop is "one
64-bit modulo per output byte" and that narrowing it to 32 bits (#58) was
deferred, unmerged perf work.

    git show origin/main:src/chunk_decode.cuh | sed -n '207,216p'
                    if (seq.match_len <= UINT32_MAX) {
                        const uint32_t off32 = static_cast<uint32_t>(offset);
                        for (uint64_t i = lane; i < seq.match_len;
                             i += kWaveSize) {
                            dst[seq.match_dst + i] =
                                dst[seq.match_src +
                                    (static_cast<uint32_t>(i) % off32)];
                        }
                    } else {

    git grep -n 'Perf pass 4 (issue #58)' origin/main -- docs/BENCHMARKS.md
    origin/main:docs/BENCHMARKS.md:190:### Perf pass 4 (issue #58): narrowing the gather modulo to 32 bits is accepted

So the masterplan contradicted `docs/BENCHMARKS.md` inside one tree. The same
sentence called #36 deferred work; perf pass 3 records it as measured and
rejected on the worst case.

**The seam.** `docs/MASTERPLAN.md` said "no `Parser` template parameter exists
under `src/` today".

    git show origin/main:src/chunk_decode.cuh | sed -n '91,93p'
    template <class Parser, bool ParseOnly, int WaveSize>
    __global__ void __launch_bounds__(kBlockThreadsFor<WaveSize>)
        chunk_decode_batch(const void* const* src_ptrs, const size_t* src_sizes,

#150 is closed as completed and is the commit that put it there; #241 added
the width parameter beside it.

**The path.** `CONTRIBUTING.md` was right about the behaviour - the `else` arm
above is the 64-bit gather it describes - and wrong about the file. Only the
path moved there.

## How it was found

By resolving the paths the M4 and M5 perf-lever issues cite as their
implementation reference. #214, #218, #228, #234 and #238 all point a reader
at `src/lz4_decode.cuh`, with line numbers, and it is not in the tree.

## What this deliberately does not change

**The three mentions in `docs/BENCHMARKS.md`.** Two name the kernel symbol
`lz4_decode_batch` inside perf pass 2's pinned profile, one describes the fuel
cap's cost at the file's name on the day it was measured. Those are records of
runs, and renaming a path inside a past measurement would misstate the run.

**The mention in `.github/workflows/codeql.yml`.** It sits inside a reading
explicitly pinned to `ab133e0468841fa3c2c1ca3b55ae1ee40f3ae173` and is still
true at that commit. What that comment owes is the re-run its own last line
asks for, since files have moved into `src/` since; that needs a CodeQL
database from a workflow run and is separate work.

**The masterplan's section-9 outcome list stops at perf pass 3.** Pass 4 (#58)
shipped and has no outcome paragraph beside passes 1-3. The sentence corrected
here cites `docs/BENCHMARKS.md` for it rather than summarising it a second
time; writing that paragraph is a different topic and is not taken on here.

**Nothing refuses the next one.** No check in this tree reads a tracked
document for a `src/` path that does not resolve, so this class recurs
silently. It was found by hand, and it would be found by hand again.

## Type of change

- [x] Docs

## Engineering checklist

Not applicable: this change is two Markdown files and touches no code, no
parse path, no ABI and no workflow. Fail-closed behaviour, oracle coverage,
determinism and CUDA error checking are unchanged because nothing that
implements them was edited.

- [ ] An adversarial review (`/security-review`) was run for changes to
      kernels, format parsing, the C-ABI boundary, build/tools, or workflows.

This board had no second reader tonight, and the evidence stands in place of
one: every claim the change adds is quoted above from the file it is about, at
`origin/main`, with the command that returns it.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

## Performance checklist

Not applicable: no hot-path code is touched and no number moved. The
`docs/BENCHMARKS.md` figures are untouched, which is checkable from the diff -
that file is not in it.

## Quality checklist

- [x] Minimal: three sentences corrected, nothing else edited.
- [x] Self-documenting: each corrected sentence now names the file it is about
      and states which issue shipped the property it describes.
- [x] Conformance tests pass. This change establishes no new structural
      property, so it locks none in; the guard that would refuse the next stale
      path is named above as absent rather than implied.

## Verification

Run in the Ubuntu-24.04 WSL distribution at the head commit of this branch.
This is CUDA 13.3, not the pinned `nvidia/cuda:12.6.2` container CONTRIBUTING
names as the canonical gate; for a documentation change nothing depends on the
compiler, and the container gate runs on this pull request in CI.

    ctest --test-dir build-af36-wsl --output-on-failure
    100% tests passed, 0 tests failed out of 55
    Label Time Summary:
    gpu    =   8.84 sec*proc (9 tests)

    nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
    NVIDIA GeForce RTX 3080, 610.88
    nvcc --version | tail -2
    Cuda compilation tools, release 13.3, V13.3.73

Nine GPU-labelled tests executed on the device rather than being skipped.

    npx prettier@3 --check "**/*.{md,yml,yaml}"
    Checking formatting...
    All matched files use Prettier code style!

- [x] `cmake --build` - builds clean.
- [x] `ctest` - green.
- [x] Prettier - clean.
- [x] Docs synced: this change is the sync.

## Notes

The paths this branch touches are `CONTRIBUTING.md` and `docs/MASTERPLAN.md`
and nothing else:

    git diff --name-only origin/main...HEAD
    CONTRIBUTING.md
    docs/MASTERPLAN.md
