### PR TITLE
Say that Snappy ships

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ Issue-driven, gate-driven:
   defined error code, never an out-of-bounds access, never a partial guess.
   Every reject path carries an explicit negative test.
 - **The oracles decide.** Decode output is diff-tested on real and fuzzed
-  corpora against the reference implementations - liblz4 today, with zlib and
-  libzstd joining as the DEFLATE and Zstd formats land.
+  corpora against the reference implementations - liblz4 and snappy today,
+  with zlib and libzstd joining as the DEFLATE and Zstd formats land.
 - **Format provenance.** Every format is implemented from its public
   specification only - the LZ4 block/frame spec, Snappy, DEFLATE (RFC 1951),
   the GDeflate spec, Zstd (RFC 8878). The reference decoders (liblz4, zlib,

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ properties a closed binary cannot offer:
 
 - **Auditability.** Decompressors are classic attack surface. Every bounds
   check in cudec is readable, tested, and fuzz-diffed against the reference
-  implementation - liblz4 today, with zlib and libzstd joining as the DEFLATE
-  and Zstd formats land.
+  implementations - liblz4 and snappy today, with zlib and libzstd joining as
+  the DEFLATE and Zstd formats land.
 - **Portability.** CUDA first; a HIP port is a planned milestone. What that
   milestone claims is one kernel family, single-source across both vendors
   behind the same C ABI, auditable and fail-closed on either - not a first on
@@ -42,14 +42,16 @@ one, and this README will never claim otherwise.
 
 ## Status
 
-**M0 through M2 are complete; M3 is next.** cudec decodes real LZ4 on an
-NVIDIA GPU today - batch block decode, the `.lz4` frame format
-(block-independent subset), and a pinned-host streaming path - all fail-closed
-and fuzz-diffed against liblz4. The design record is
-[docs/MASTERPLAN.md](docs/MASTERPLAN.md); the measured LZ4 block and streaming
+**M0 through M3 are complete; M4 is next.** cudec decodes real LZ4 and real
+Snappy on an NVIDIA GPU today - LZ4 batch block decode, the `.lz4` frame
+format (block-independent subset), a pinned-host LZ4 streaming path, and
+Snappy batch decode of raw streams - all fail-closed and fuzz-diffed against
+liblz4 and snappy. Snappy is batch-only by decision, not by omission: there is
+no Snappy streaming entry and no milestone carries one. The design record is
+[docs/MASTERPLAN.md](docs/MASTERPLAN.md); the measured LZ4 and Snappy
 baselines, each carrying its full methodology, are in
-[docs/BENCHMARKS.md](docs/BENCHMARKS.md). Snappy, GDeflate, Zstd, and the HIP
-port are planned, not yet implemented. Progress is tracked in the issues and
+[docs/BENCHMARKS.md](docs/BENCHMARKS.md). GDeflate, Zstd and the HIP port are
+planned, not yet implemented. Progress is tracked in the issues and
 milestones:
 
 | Milestone        | Deliverable                                         | Status  |
@@ -57,7 +59,7 @@ milestones:
 | M0 - Foundation  | Toolchain, CMake+CUDA skeleton, CI, test harness    | done    |
 | M1 - LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed      | done    |
 | M2 - LZ4 batch   | Frame format, batch API, streaming path, benchmarks | done    |
-| M3 - Snappy      | Snappy decode on the same kernel family             | planned |
+| M3 - Snappy      | Snappy decode on the same kernel family             | done    |
 | M4 - GDeflate    | GDeflate decode as an auditable CUDA library        | planned |
 | M5 - Zstd        | Zstd decode (FSE/Huffman sequences)                 | planned |
 | M6 - Portability | HIP port                                            | planned |


### PR DESCRIPTION
# What & why

Closes #393.

The README told a reader that Snappy is planned and not yet implemented, and
its milestone table carried M3 as `planned`. M3 closed. This is the project's
own front page understating what it ships, which is the one direction of error
a reader has no way to catch: nobody audits a claim that a project does LESS
than it does.

## What the tree says, against what the README said

    git show origin/main:include/cudec.h | sed -n '137p'
    cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,

    git ls-tree --name-only origin/main src/ fuzz/ cmake/ | grep -i snappy
    cmake/CudecSnappyOracle.cmake
    fuzz/fuzz_snappy_block.cpp
    src/snappy_block.h

    git ls-tree --name-only origin/main tests/ | grep -c snappy
    9

    git grep -n '^## M3\|^### M3' origin/main -- docs/BENCHMARKS.md
    origin/main:docs/BENCHMARKS.md:946:## M3: the Snappy CPU denominator (issue #164)
    origin/main:docs/BENCHMARKS.md:1009:## M3: the Snappy adversarial denominators (issue #119)
    origin/main:docs/BENCHMARKS.md:1087:## M3: first recorded Snappy GPU baselines and the ParseOnly ceiling (issue #167)
    origin/main:docs/BENCHMARKS.md:1231:### M3 perf lever (issue #161): the bounded 5-byte header window is rejected by both worst cases
    origin/main:docs/BENCHMARKS.md:1314:### M3 perf lever (issue #163): the short-copy predicated pass is not separable from noise
    origin/main:docs/BENCHMARKS.md:1403:### M3 perf lever (issue #165): the Snappy literal distribution, and the wide literal copy rejected a second time
    origin/main:docs/BENCHMARKS.md:1512:### M3 kernel shape (issue #292): the narrowed element buys occupancy and loses throughput

    gh issue list --repo iderex/cudec --state open --milestone "M3 - Snappy" --json number --jq 'length'
    0

## The oracle sentence, in both documents

    git grep -n 'liblz4 today' origin/main -- README.md CONTRIBUTING.md
    origin/main:CONTRIBUTING.md:20:  corpora against the reference implementations - liblz4 today, with zlib and
    origin/main:README.md:27:  implementation - liblz4 today, with zlib and libzstd joining as the DEFLATE

snappy 1.2.2 is vendored, pinned and in the build, and a shipped decode path is
diff-tested against it on real corpora, on the mutation corpus and under the
fuzzer, so naming liblz4 alone was refuted by the build. The forward-looking
half of the sentence is untouched: zlib and libzstd remain oracles for formats
that have not landed.

## What the new wording is careful about

**It says batch.** The Snappy streaming entry does not exist, and it was
decided out of scope rather than deferred:

    git grep -n 'no milestone carries one' origin/main -- docs/MASTERPLAN.md
    origin/main:docs/MASTERPLAN.md:817:Snappy streaming entry, and no milestone carries one.** Not "not in M3" - not

A bare "Snappy: done" would be read as including one, so the status line names
the surface the way the M2 line names its `.lz4` subset. `#120` is where that
was decided and it is closed.

**It claims nothing else.** GDeflate, Zstd and the HIP port stay `planned`,
because they are: `src/` holds one of the four GDeflate headers and no GDeflate
or Zstd kernel, and there is no HIP path.

**It changes no milestone state on the tracker.** This is the README catching
up with what merged, and nothing else.

## Type of change

- [x] Docs

## Engineering checklist

Not applicable: this change is two Markdown files and touches no code, no parse
path, no ABI and no workflow. Fail-closed behaviour, oracle coverage,
determinism and CUDA error checking are unchanged because nothing that
implements them was edited.

- [ ] An adversarial review (`/security-review`) was run for changes to
      kernels, format parsing, the C-ABI boundary, build/tools, or workflows.

This board had no second reader tonight, and the evidence stands in place of
one: every claim the new wording makes is quoted above from the file it is
about, at `origin/main`, with the command that returns it.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

## Performance checklist

Not applicable: no hot-path code is touched and no number moved.
`docs/BENCHMARKS.md` is not in the diff.

## Quality checklist

- [x] Minimal: one status paragraph, one table cell, two instances of one
      sentence.
- [x] Self-documenting: the status line names the delivered surface rather
      than a milestone label.
- [x] Conformance tests pass. This change establishes no new structural
      property. Nothing in this tree refuses a README status row that has gone
      stale against the milestone it describes, so this class recurs silently
      and was found by hand.

## Verification

Run in the Ubuntu-24.04 WSL distribution at the head commit of this branch.
This is CUDA 13.3, not the pinned `nvidia/cuda:12.6.2` container CONTRIBUTING
names as the canonical gate; for a documentation change nothing depends on the
compiler, and the container gate runs on this pull request in CI.

    ctest --test-dir build-af36-wsl --output-on-failure
    100% tests passed, 0 tests failed out of 55
    Label Time Summary:
    gpu    =   8.23 sec*proc (9 tests)

    nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
    NVIDIA GeForce RTX 3080, 610.88

Nine GPU-labelled tests executed on the device rather than being skipped.

    npx prettier@3 --check "**/*.{md,yml,yaml}"
    Checking formatting...
    All matched files use Prettier code style!

- [x] `cmake --build` - builds clean.
- [x] `ctest` - green.
- [x] Prettier - clean.
- [x] Docs synced: this change is the sync.

## Notes

    git diff --name-only origin/main...HEAD
    CONTRIBUTING.md
    README.md
