### PR TITLE
Say that the M3 bench rung and perf pass landed

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -584,12 +584,14 @@ crafted negative in the twin asserts the reference's verdict on the same
 bytes as well as cudec's, so a reject branch is demonstrably in parity
 rather than merely present.
 
-**Where this section is a commitment and where it is a description.** The
-parser core, the seam, the batch entry and the device gate set have all
-landed; what has not is the bench rung and the measured pass. Each
-subsection below says which it is, so the document cannot be read as a
-report of shipped code. The tree is the authority for the second kind and
-the commands that read it are given inline.
+**Where this section is a commitment and where it is a description.** Every
+rung of the ladder below has landed - the parser core, the seam, the batch
+entry, the device gate set, the bench rung and the measured perf pass, whose
+numbers are in [BENCHMARKS.md](BENCHMARKS.md). Each subsection below still
+says which it is, because a subsection marked landed keeps the wording it was
+committed to rather than being rewritten into a report of the result, so the
+document cannot be read as a report of shipped code. The tree is the
+authority for the second kind and the commands that read it are given inline.
 
 ### The seam: what a parser owes the chunk decoder
 


### PR DESCRIPTION
# What & why

Closes #395.

Section 10's marker separating what the section commits to from what it
reports named two rungs as not landed. Both landed, so a reader was told the
M3 numbers do not exist while the same tree carries them.

## What it said, against what the tree holds

    git show origin/main:docs/MASTERPLAN.md | sed -n '587,589p'
    **Where this section is a commitment and where it is a description.** The
    parser core, the seam, the batch entry and the device gate set have all
    landed; what has not is the bench rung and the measured pass. Each

    git grep -n '^## M3\|^### M3' origin/main -- docs/BENCHMARKS.md
    origin/main:docs/BENCHMARKS.md:946:## M3: the Snappy CPU denominator (issue #164)
    origin/main:docs/BENCHMARKS.md:1009:## M3: the Snappy adversarial denominators (issue #119)
    origin/main:docs/BENCHMARKS.md:1087:## M3: first recorded Snappy GPU baselines and the ParseOnly ceiling (issue #167)
    origin/main:docs/BENCHMARKS.md:1231:### M3 perf lever (issue #161): the bounded 5-byte header window is rejected by both worst cases
    origin/main:docs/BENCHMARKS.md:1314:### M3 perf lever (issue #163): the short-copy predicated pass is not separable from noise
    origin/main:docs/BENCHMARKS.md:1403:### M3 perf lever (issue #165): the Snappy literal distribution, and the wide literal copy rejected a second time
    origin/main:docs/BENCHMARKS.md:1512:### M3 kernel shape (issue #292): the narrowed element buys occupancy and loses throughput

    git ls-tree --name-only origin/main bench/ | grep snappy
    bench/bench_snappy.cpp

## What is deliberately not rewritten

The `**Landed**` and `**A commitment**` markers on the subsections below are
untouched. Section 10 keeps the wording each subsection was committed to
rather than rewriting it into a report of the result, which is why the seam
subsection still spells the template without the wave-width parameter #241
later added. That is the convention working, not drift. This change states
the convention in the marker instead of leaving it implied, because the
clause that made the distinction readable was the one that had gone stale.

This is the third correction of this shape tonight, after #391 (the kernel
source's name and two claims about it) and #393 (the README's M3 status).
Nothing in this tree refuses any of them: no check reads a tracked document
against the code it describes, so the class recurs silently and all three were
found by hand.

## Type of change

- [x] Docs

## Engineering checklist

Not applicable: this change is one Markdown paragraph and touches no code, no
parse path, no ABI and no workflow.

- [ ] An adversarial review (`/security-review`) was run for changes to
      kernels, format parsing, the C-ABI boundary, build/tools, or workflows.

This board had no second reader tonight, and the evidence stands in place of
one: every claim the new wording makes is quoted above from the file it is
about, at `origin/main`, with the command that returns it.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

## Performance checklist

Not applicable: no hot-path code is touched and no number moved.
`docs/BENCHMARKS.md` is not in the diff.

## Quality checklist

- [x] Minimal: one paragraph.
- [x] Self-documenting: the marker now names the convention it relies on.
- [x] Conformance tests pass. This change establishes no new structural
      property, and the guard that would refuse the next stale sentence does
      not exist, which is said above rather than implied.

## Verification

Run in the Ubuntu-24.04 WSL distribution at the head commit of this branch.
This is CUDA 13.3, not the pinned `nvidia/cuda:12.6.2` container CONTRIBUTING
names as the canonical gate; for a documentation change nothing depends on the
compiler, and the container gate runs on this pull request in CI.

    ctest --test-dir build-af36-wsl --output-on-failure
    100% tests passed, 0 tests failed out of 55
    Label Time Summary:
    gpu    =   8.34 sec*proc (9 tests)

    nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
    NVIDIA GeForce RTX 3080, 610.88

Nine GPU-labelled tests executed on the device rather than being skipped.

    npx prettier@3 --check "**/*.{md,yml,yaml}"
    Checking formatting...
    All matched files use Prettier code style!

- [x] `cmake --build` - builds clean.
- [x] `ctest` - green.
- [x] Prettier - clean.
- [x] Docs synced: this change is the sync.

## Notes

    git diff --name-only origin/main...HEAD
    docs/MASTERPLAN.md
