### PR TITLE
Build the GDeflate canonical Huffman table, held against the reference [#175]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,6 +437,7 @@ jobs:
           test -x build-san/tests/frame_host_negative &&
           test -x build-san/tests/tilestream_host_negative &&
           test -x build-san/tests/gdeflate_schedule_twin &&
+          test -x build-san/tests/gdeflate_tables_twin &&
           test -x build-san/tests/zstd_exec_twin &&
           test -x build-san/tests/zstd_blocks_twin &&
           test -x build-san/tests/termination
@@ -460,7 +461,7 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|zstd_frame_twin|zstd_exec_twin|zstd_blocks_twin|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|gdeflate_tables_twin|zstd_frame_twin|zstd_exec_twin|zstd_blocks_twin|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
@@ -472,6 +473,7 @@ jobs:
           grep -E ': frame_host_negative$' san-selected.txt &&
           grep -E ': tilestream_host_negative$' san-selected.txt &&
           grep -E ': gdeflate_schedule_twin$' san-selected.txt &&
+          grep -E ': gdeflate_tables_twin$' san-selected.txt &&
           grep -E ': zstd_frame_twin$' san-selected.txt &&
           grep -E ': zstd_exec_twin$' san-selected.txt &&
           grep -E ': zstd_blocks_twin$' san-selected.txt &&

--- a/src/gdeflate_tables.h
+++ b/src/gdeflate_tables.h
@@ -196,15 +196,20 @@ CUDEC_HOST_DEVICE inline bool GDeflateBuildTable(
         t.first_index[len] = static_cast<uint16_t>(next);
         next += t.count[len];
     }
-    uint32_t fill[kMaxLen + 1];
-    for (uint32_t len = 0; len <= kMaxLen; len++) {
-        fill[len] = t.first_index[len];
-    }
+    /* first_index doubles as the fill cursor and is wound back by each
+     * length's own count afterwards. A separate scratch array would be
+     * per-thread local memory in the kernel, in the one place where occupancy
+     * is the binding resource (section 13.1), for a value the table already
+     * holds. */
     for (uint32_t sym = 0; sym < num_syms; sym++) {
         const uint32_t len = lens[sym];
         if (len != 0) {
-            t.sorted[fill[len]++] = static_cast<uint16_t>(sym);
+            t.sorted[t.first_index[len]++] = static_cast<uint16_t>(sym);
         }
+    }
+    for (uint32_t len = 1; len <= kMaxLen; len++) {
+        t.first_index[len] =
+            static_cast<uint16_t>(t.first_index[len] - t.count[len]);
     }
 
     /* Cleared before the completeness question rather than after it, so no

--- a/src/gdeflate_tables.h
+++ b/src/gdeflate_tables.h
@@ -1,0 +1,331 @@
+/* Canonical Huffman table construction for GDeflate (issue #175): a code
+ * length vector in, a decode table out, and a refusal for every vector the
+ * reference refuses. Single-sourced for host and device, the sibling of
+ * src/gdeflate_schedule.h, src/lz4_block.h and src/snappy_block.h. It reads no
+ * bits of its own beyond the decode helper at the bottom and knows nothing
+ * about block headers: where a length vector comes from is #176's, what a
+ * decoded symbol means is #182's.
+ *
+ * WHY THIS IS THE PIECE THAT GETS ITS OWN REVIEW. A decode table is the one
+ * place in a DEFLATE-family decoder where attacker-chosen numbers become an
+ * index. The vector is read from the stream, so its length distribution is
+ * chosen by whoever wrote the page, and every historical DEFLATE memory-safety
+ * defect lives in the gap between "these lengths describe a code" and "these
+ * lengths describe something, so let us index with it". GDeflate carries no
+ * checksum anywhere (docs/MASTERPLAN.md section 11.4), so a table built from a
+ * vector that is not a code produces plausible bytes rather than a caught
+ * error.
+ *
+ * THE LAYOUT IS THE ONE SECTION 13.1 SETTLED, AND ITS SHAPE IS THE ARGUMENT.
+ * A canonical decoder over per-length counts, first codes and first indices is
+ * complete on its own and its size is fixed by the alphabet rather than by the
+ * lengths, so no input can change how much memory a warp holds - which is what
+ * killed the two-level table, whose worst legal case needs 2504 lit/len
+ * entries. The root arrays here are accelerators over that decoder and not a
+ * second decoder: a code no longer than the root resolves in one lookup, a
+ * longer one falls back to the length-by-length walk, and both paths return
+ * the same symbol by construction because both read the same three arrays.
+ *
+ * WHAT IT COSTS AGAINST 13.1'S BUDGET, because the table there was computed
+ * for 318 symbols and this holds 320. The draft says up to 286 literal/length
+ * symbols (dossier 11.2); the reference reads HLIT as five bits and adds 257,
+ * so it admits up to 288 and builds a table over all of them. Parity with the
+ * reference is the rule the whole M4 ladder rests on, so the capacity follows
+ * the reference. Two extra symbols are four bytes, and the two `kind` fields
+ * are two more each: 3144 bytes per warp against the 3200-byte budget, where
+ * 13.1 computed 3132. The margin narrows from 68 bytes to 56 and the occupancy
+ * arithmetic is unmoved.
+ *
+ * FAIL-CLOSED, AND EXACTLY WHERE THE REFERENCE IS. `build_decode_table` in the
+ * pinned fork refuses an over-subscribed vector, refuses an incomplete one,
+ * and admits two named exceptions to incompleteness: the empty code, and a
+ * code whose whole codespace is one symbol at length 1. Both exceptions are
+ * reachable in a valid stream, so both are accepted here rather than tightened
+ * away - a distance code with one distance is what a page full of one match
+ * distance produces. The empty code is where this header is STRICTER than the
+ * reference and says so: the reference fills its table with a synthetic
+ * "symbol 0, length 1" entry so that a malformed stream reading from the
+ * unused codespace still lands on an initialised entry, which means a match in
+ * a block whose distance code is empty decodes to a distance symbol that the
+ * stream never encoded. Here that table refuses on use instead. A block that
+ * declares no distances and uses none is unaffected, which is the only shape a
+ * compressor produces. */
+#ifndef CUDEC_GDEFLATE_TABLES_H
+#define CUDEC_GDEFLATE_TABLES_H
+
+#include "gdeflate_schedule.h"
+
+#include <stdint.h>
+
+namespace cudec_detail {
+
+/* The reference's own constants (deflate_constants.h in the pinned
+ * NVIDIA/libdeflate fork), restated here because this header is the thing that
+ * has to agree with them. The literal/length capacity is the reference's 288
+ * rather than the draft's 286, for the reason the file comment gives. */
+constexpr uint32_t kGDeflateMaxCodeLen = 15;
+constexpr uint32_t kGDeflateNumLitLenSyms = 288;
+constexpr uint32_t kGDeflateNumDistSyms = 32;
+
+/* Root widths from docs/MASTERPLAN.md section 13.1: 10 bits over the
+ * literal/length alphabet and 7 over the distance alphabet, which is the pair
+ * that fits the per-warp budget. They are accelerator widths, so moving one
+ * changes a footprint and never an answer - #204 is where that is measured. */
+constexpr uint32_t kGDeflateLitLenRootBits = 10;
+constexpr uint32_t kGDeflateDistRootBits = 7;
+
+/* A root slot packs the symbol above the codeword length. Length 0 is the miss
+ * marker rather than a legal answer: a zero-length codeword does not exist, so
+ * no symbol can collide with the sentinel. The widest symbol index is 287, so
+ * the shifted field needs nine bits above the four length bits and the entry
+ * stays 16 bits wide, which is what the section 13.1 footprint is costed at. */
+constexpr uint32_t kGDeflateRootLenBits = 4;
+constexpr uint32_t kGDeflateRootLenMask = (1u << kGDeflateRootLenBits) - 1u;
+static_assert(kGDeflateMaxCodeLen <= kGDeflateRootLenMask,
+              "the packed length field must hold the longest legal codeword");
+static_assert((kGDeflateNumLitLenSyms - 1) <=
+                  (0xFFFFu >> kGDeflateRootLenBits),
+              "the packed symbol field must hold the highest symbol index");
+
+/* What a vector turned out to be. `kGDeflateTableComplete` is the only kind
+ * that decodes through the arrays; the other two are the reference's two named
+ * exceptions to completeness and are handled at their own branch in the decode
+ * helper, because neither has a codespace to walk. */
+enum GDeflateTableKind {
+    kGDeflateTableComplete = 0,
+    kGDeflateTableSingle = 1,
+    kGDeflateTableEmpty = 2
+};
+
+/* `kCapSyms` is the alphabet the table is sized for and `kMaxLen` is the
+ * longest codeword the code admits, which is 15 for the literal/length and
+ * distance codes and 7 for the precode. The codespace comparison is against
+ * `kMaxLen`, so the two are not interchangeable: a vector that is a complete
+ * code under one is over-subscribed or incomplete under the other. */
+template <uint32_t kCapSyms, uint32_t kRootBits, uint32_t kMaxLen>
+struct GDeflateHuffTable {
+    /* Symbols in canonical order - by increasing codeword length, then by
+     * increasing symbol value - with the zero-length symbols left out. */
+    uint16_t sorted[kCapSyms];
+    /* Indexed by codeword length, 0 through kMaxLen. `count[0]` is the number
+     * of unused symbols and is not part of any code. */
+    uint16_t count[kMaxLen + 1];
+    uint16_t first_code[kMaxLen + 1];
+    uint16_t first_index[kMaxLen + 1];
+    uint16_t root[1u << kRootBits];
+    uint16_t kind;
+};
+
+using GDeflateLitLenTable =
+    GDeflateHuffTable<kGDeflateNumLitLenSyms, kGDeflateLitLenRootBits,
+                      kGDeflateMaxCodeLen>;
+using GDeflateDistTable =
+    GDeflateHuffTable<kGDeflateNumDistSyms, kGDeflateDistRootBits,
+                      kGDeflateMaxCodeLen>;
+
+/* Reverse the low `len` bits of `code`. DEFLATE packs a codeword so that its
+ * most significant bit arrives first, and the lane bit buffer hands bits back
+ * least significant first, so the value a root lookup is indexed by is the
+ * codeword read backwards. This is the one place the two orders meet; the
+ * length-by-length walk below never needs it because it rebuilds the codeword
+ * one arriving bit at a time. */
+CUDEC_HOST_DEVICE inline uint32_t GDeflateReverseBits(uint32_t code,
+                                                      uint32_t len) {
+    uint32_t out = 0;
+    for (uint32_t i = 0; i < len; i++) {
+        out = (out << 1) | ((code >> i) & 1u);
+    }
+    return out;
+}
+
+/* Build the decode table for `num_syms` code lengths. Returns false and leaves
+ * the table unusable for every vector the reference refuses, and for the two
+ * it refuses that the format cannot produce (a length past `kMaxLen`, an
+ * alphabet past the capacity) - both are caller errors rather than bad input,
+ * and refusing is the answer that cannot be mistaken for a decode. */
+template <uint32_t kCapSyms, uint32_t kRootBits, uint32_t kMaxLen>
+CUDEC_HOST_DEVICE inline bool GDeflateBuildTable(
+    const unsigned char* lens, uint32_t num_syms,
+    GDeflateHuffTable<kCapSyms, kRootBits, kMaxLen>& t) {
+    static_assert(kRootBits <= kMaxLen,
+                  "a root wider than the longest codeword would index slots "
+                  "no code can reach");
+    if (num_syms > kCapSyms) {
+        return false;
+    }
+    for (uint32_t len = 0; len <= kMaxLen; len++) {
+        t.count[len] = 0;
+        t.first_code[len] = 0;
+        t.first_index[len] = 0;
+    }
+    t.kind = kGDeflateTableComplete;
+    for (uint32_t sym = 0; sym < num_syms; sym++) {
+        const uint32_t len = lens[sym];
+        if (len > kMaxLen) {
+            /* The format cannot deliver this - explicit lengths arrive as
+             * precode symbols below 16 and the precode's own lengths are three
+             * bits - so it is a caller error, and it is refused rather than
+             * truncated because a truncated length silently describes a
+             * different code. */
+            return false;
+        }
+        t.count[len] = static_cast<uint16_t>(t.count[len] + 1u);
+    }
+
+    /* Codespace out of 2^kMaxLen, accumulated the way the reference
+     * accumulates it: shift the running total left once per length instead of
+     * summing `count[len] << (kMaxLen - len)`, so the widest intermediate is
+     * bounded by the alphabet size rather than by the shift. */
+    uint32_t codespace = 0;
+    for (uint32_t len = 1; len <= kMaxLen; len++) {
+        codespace = (codespace << 1) + t.count[len];
+    }
+    const uint32_t full = 1u << kMaxLen;
+    if (codespace > full) {
+        /* Over-subscribed: the lengths claim more of the codespace than
+         * exists, so at least two symbols share a prefix and no assignment
+         * exists. */
+        return false;
+    }
+
+    /* Canonical order, and the first index of each length. Both are needed by
+     * every branch below, including the two degenerate ones, so they are
+     * filled before the completeness question is answered. */
+    uint32_t next = 0;
+    for (uint32_t len = 1; len <= kMaxLen; len++) {
+        t.first_index[len] = static_cast<uint16_t>(next);
+        next += t.count[len];
+    }
+    uint32_t fill[kMaxLen + 1];
+    for (uint32_t len = 0; len <= kMaxLen; len++) {
+        fill[len] = t.first_index[len];
+    }
+    for (uint32_t sym = 0; sym < num_syms; sym++) {
+        const uint32_t len = lens[sym];
+        if (len != 0) {
+            t.sorted[fill[len]++] = static_cast<uint16_t>(sym);
+        }
+    }
+
+    /* Cleared before the completeness question rather than after it, so no
+     * accepted table ever carries an uninitialised root - the degenerate kinds
+     * do not read it, and a struct with a live field nothing wrote is the
+     * thing a later reader has to reason about instead of trust. */
+    for (uint32_t i = 0; i < (1u << kRootBits); i++) {
+        t.root[i] = 0;
+    }
+
+    if (codespace < full) {
+        /* Incomplete, which the reference admits in exactly two shapes and
+         * refuses otherwise. Both are pinned against the reference in
+         * tests/gdeflate_tables_twin.cpp rather than read out of its source. */
+        if (codespace == 0) {
+            t.kind = kGDeflateTableEmpty;
+            return true;
+        }
+        if (codespace != (full >> 1) || t.count[1] != 1) {
+            return false;
+        }
+        /* One symbol at length 1. The reference gives it both codewords, 0 and
+         * 1, so a single bit resolves it whichever way that bit falls; the
+         * decode helper does the same, which is why no root entry is written
+         * for this kind. */
+        t.kind = kGDeflateTableSingle;
+        return true;
+    }
+
+    /* Complete. First codes are the canonical recurrence, and they are what
+     * the walk compares against. */
+    uint32_t code = 0;
+    for (uint32_t len = 1; len <= kMaxLen; len++) {
+        t.first_code[len] = static_cast<uint16_t>(code);
+        code = (code + t.count[len]) << 1;
+    }
+
+    /* The root accelerator. A codeword of length L owns every slot whose low L
+     * bits are its reversed codeword, which is 2^(kRootBits - L) slots spaced
+     * 2^L apart - the same spacing the reference's own table has, and for the
+     * same reason. Slots left at zero are the misses that fall through to the
+     * walk. */
+    for (uint32_t len = 1; len <= kRootBits; len++) {
+        for (uint32_t n = 0; n < t.count[len]; n++) {
+            const uint32_t sym = t.sorted[t.first_index[len] + n];
+            const uint32_t rev =
+                GDeflateReverseBits(t.first_code[len] + n, len);
+            const uint16_t entry = static_cast<uint16_t>(
+                (sym << kGDeflateRootLenBits) | len);
+            for (uint32_t i = rev; i < (1u << kRootBits); i += (1u << len)) {
+                t.root[i] = entry;
+            }
+        }
+    }
+    return true;
+}
+
+/* The one sentinel a decode may return. 0xFFFF is outside every alphabet this
+ * header sizes for, and every caller of the helper below is required to test
+ * for it: the schedule's own failure flag is set at the same moment, so a
+ * caller that checks either one is correct and a caller that checks neither is
+ * caught by the flag on its next operation. */
+constexpr uint32_t kGDeflateNoSymbol = 0xFFFFu;
+
+/* Decode one symbol from the current lane. The accelerator is a peek, so a
+ * miss has consumed nothing and the walk starts at length 1 rather than
+ * part-way through a codeword.
+ *
+ * EVERY EXIT THAT IS NOT A SYMBOL SETS THE SCHEDULE'S FAILURE FLAG. A lane
+ * that cannot supply the bits a resolved codeword needs is refused by
+ * GDeflateRemove rather than allowed to shift a buffer it does not hold, and a
+ * walk that reaches the maximum length without matching has read a codeword
+ * that the code does not contain, which on a complete code means the bits were
+ * not produced by this table. */
+template <uint32_t kCapSyms, uint32_t kRootBits, uint32_t kMaxLen>
+CUDEC_HOST_DEVICE inline uint32_t GDeflateDecodeSymbol(
+    GDeflateSchedule& s,
+    const GDeflateHuffTable<kCapSyms, kRootBits, kMaxLen>& t) {
+    if (s.failed) {
+        return kGDeflateNoSymbol;
+    }
+    if (t.kind == kGDeflateTableEmpty) {
+        /* Stricter than the reference, deliberately: it hands back a symbol
+         * the stream never encoded, and a distance built from that symbol is
+         * indistinguishable from one the page asked for. */
+        s.failed = true;
+        return kGDeflateNoSymbol;
+    }
+    if (t.kind == kGDeflateTableSingle) {
+        GDeflateRemove(s, 1);
+        if (s.failed) {
+            return kGDeflateNoSymbol;
+        }
+        return t.sorted[0];
+    }
+    const uint32_t probe = GDeflatePeek(s, kRootBits);
+    const uint16_t entry = t.root[probe];
+    const uint32_t hit_len = entry & kGDeflateRootLenMask;
+    if (hit_len != 0) {
+        GDeflateRemove(s, hit_len);
+        if (s.failed) {
+            return kGDeflateNoSymbol;
+        }
+        return entry >> kGDeflateRootLenBits;
+    }
+    uint32_t code = 0;
+    for (uint32_t len = 1; len <= kMaxLen; len++) {
+        const uint32_t bit = GDeflatePop(s, 1);
+        if (s.failed) {
+            return kGDeflateNoSymbol;
+        }
+        code = (code << 1) | bit;
+        if (t.count[len] != 0 && code >= t.first_code[len] &&
+            (code - t.first_code[len]) < t.count[len]) {
+            return t.sorted[t.first_index[len] + (code - t.first_code[len])];
+        }
+    }
+    s.failed = true;
+    return kGDeflateNoSymbol;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_GDEFLATE_TABLES_H */

--- a/src/gdeflate_tables.h
+++ b/src/gdeflate_tables.h
@@ -173,9 +173,15 @@ CUDEC_HOST_DEVICE inline bool GDeflateBuildTable(
     }
 
     /* Codespace out of 2^kMaxLen, accumulated the way the reference
-     * accumulates it: shift the running total left once per length instead of
-     * summing `count[len] << (kMaxLen - len)`, so the widest intermediate is
-     * bounded by the alphabet size rather than by the shift. */
+     * accumulates it: the running total shifted left once per length. An
+     * over-subscribed vector overshoots deliberately - that overshoot is the
+     * refusal below - so the accumulator has to hold more than a full
+     * codespace without wrapping, and the worst case is every symbol at length
+     * 1, which reaches `num_syms << (kMaxLen - 1)`. The reference carries the
+     * same bound as a static assertion and so does this. */
+    static_assert(kCapSyms <= (0xFFFFFFFFu >> (kMaxLen - 1)),
+                  "the codespace accumulator must not wrap on the most "
+                  "over-subscribed vector the alphabet admits");
     uint32_t codespace = 0;
     for (uint32_t len = 1; len <= kMaxLen; len++) {
         codespace = (codespace << 1) + t.count[len];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -156,6 +156,16 @@ cudec_add_test(gdeflate_schedule_twin SOURCES gdeflate_schedule_twin.cpp LIBS
                gdeflate_oracle)
 target_include_directories(gdeflate_schedule_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The GDeflate canonical table construction (issue #175), the rung above the
+# schedule. GPU-less for the same reason and linking gdeflate_oracle alone for
+# the reason oracle_gdeflate gives above. It emits whole GDeflate pages to ask
+# the reference its verdict, because the fork compiles its decompressor with
+# HIDE_INTERFACE and its table builder is reachable through nothing else -
+# tests/gdeflate_page_writer.h is that emitter and carries the argument.
+cudec_add_test(gdeflate_tables_twin SOURCES gdeflate_tables_twin.cpp LIBS
+               gdeflate_oracle)
+target_include_directories(gdeflate_tables_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 # The reference's own decode behaviours, executed rather than read (issue
 # #155). Host-side and GPU-less on purpose: it is the oracle answering, and
 # the answers are what the M3 fail-closed matrix is allowed to lock against.

--- a/tests/gdeflate_page_writer.h
+++ b/tests/gdeflate_page_writer.h
@@ -1,0 +1,194 @@
+/* A GDeflate page writer, for tests only (issue #175). It exists because the
+ * reference's answer to "is this a code?" is not callable: the pinned fork
+ * compiles `gdeflate_decompress.c` with `HIDE_INTERFACE` defined, so
+ * `build_decode_table` is static inside that translation unit and the plain
+ * DEFLATE entry points are not compiled at all. The only door into the
+ * reference's table construction is a whole GDeflate page, so a test that
+ * wants the reference's verdict on a chosen code-length vector has to emit
+ * one.
+ *
+ * WHAT MAKES THIS SAFE TO TRUST. A writer that is wrong produces pages the
+ * reference rejects, and a reject is exactly what a negative test is looking
+ * for - so a broken writer reads as a passing suite. Two things stop that.
+ * Every negative below is paired with a positive that differs in one field and
+ * must DECODE, so a writer that emitted nothing usable fails the pair rather
+ * than passing it. And the positive pages carry a symbol sequence chosen by
+ * the test and are required to come back byte-identical, which no accidental
+ * bit layout produces.
+ *
+ * IT IS THE MIRROR OF src/gdeflate_schedule.h AND NOT A SECOND SCHEDULE. The
+ * decoder's rules are: one shared word cursor; a lane is refilled when it
+ * falls below the 32-bit watermark and only ever by the operation that is
+ * looking at it; ADVANCE refills the current lane and then rotates; RESET
+ * returns to lane 0 consuming nothing. A page is therefore 32 independent
+ * least-significant-bit-first streams plus the order in which their words were
+ * handed out, and this writer builds exactly those two things: bits go into
+ * the current lane's stream, and every refill the decoder will perform appends
+ * that lane to the word order. Assembly at the end is mechanical.
+ *
+ * THE TAIL IS FOR THE REFERENCE, NOT FOR THE FORMAT. `ENSURE_BITS` in the
+ * fork's `gdeflate_decompress_template.h` reads a 32-bit word with no bound
+ * check against the end of the page, so a page whose emission this writer got
+ * wrong by one refill would have the reference read off the end of a heap
+ * buffer, and the sanitized CI job would report a writer bug as an
+ * out-of-bounds read in the oracle. The zero tail below turns that into a read
+ * of zeros. cudec's own schedule refuses the same read by an explicit bound
+ * (`GDeflateEnsure`), which is the distinction docs/MASTERPLAN.md draws
+ * between a padding convention and a check. */
+#ifndef CUDEC_TESTS_GDEFLATE_PAGE_WRITER_H
+#define CUDEC_TESTS_GDEFLATE_PAGE_WRITER_H
+
+#include "gdeflate_tables.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace cudec_test {
+
+/* One byte per bit while the page is being built. A page here is a few hundred
+ * symbols, so the shape that is easiest to reason about wins over the shape
+ * that is compact. */
+using LaneBits = std::vector<unsigned char>;
+
+class GDeflatePageWriter {
+   public:
+    GDeflatePageWriter() {
+        for (uint32_t n = 0; n < kStreams; n++) {
+            bitsleft_[n] = 0;
+        }
+        idx_ = 0;
+        ok_ = true;
+        /* The priming round the format opens with: one word into each lane, in
+         * lane order (src/gdeflate_schedule.h, draft section 5.3). It is the
+         * decoder's own opening loop of 32 ADVANCEs, mirrored. */
+        for (uint32_t n = 0; n < kStreams; n++) {
+            Advance();
+        }
+    }
+
+    /* RESET(): back to lane 0, nothing consumed. */
+    void Reset() { idx_ = 0; }
+
+    /* ENSURE_BITS(LOW_WATERMARK_BITS): the current lane takes the next word if
+     * it has fallen below the watermark. */
+    void Ensure() {
+        if (bitsleft_[idx_] >= kWatermark) {
+            return;
+        }
+        order_.push_back(idx_);
+        bitsleft_[idx_] += kPacket;
+    }
+
+    /* ADVANCE(): ensure, then rotate. */
+    void Advance() {
+        Ensure();
+        idx_ = (idx_ + 1u) % kStreams;
+    }
+
+    /* POP_BITS(n) seen from the other side: n bits of `value`, least
+     * significant first, into the current lane. A lane that does not hold n
+     * bits at this point means the emission sequence has drifted from the
+     * decoder's, which is a bug in the test rather than in anything under
+     * test - so it is recorded and asserted on, never silently corrected. */
+    void Push(uint32_t n, uint32_t value) {
+        if (n > bitsleft_[idx_]) {
+            ok_ = false;
+            return;
+        }
+        for (uint32_t i = 0; i < n; i++) {
+            lane_[idx_].push_back(static_cast<unsigned char>((value >> i) & 1u));
+        }
+        bitsleft_[idx_] -= n;
+    }
+
+    /* A Huffman codeword: the canonical code most significant bit first, which
+     * is the order the decoder rebuilds it in, so the value handed to Push is
+     * the codeword reversed. */
+    void PushCode(uint32_t code, uint32_t len) {
+        Push(len, cudec_detail::GDeflateReverseBits(code, len));
+    }
+
+    bool ok() const { return ok_; }
+
+    /* Lane streams padded to whole words, then interleaved in the order the
+     * decoder took them. */
+    std::vector<unsigned char> Finish() const {
+        std::vector<std::vector<uint32_t>> words(kStreams);
+        for (uint32_t n = 0; n < kStreams; n++) {
+            const LaneBits& b = lane_[n];
+            for (size_t i = 0; i < b.size(); i += kPacket) {
+                uint32_t w = 0;
+                for (uint32_t k = 0; k < kPacket && i + k < b.size(); k++) {
+                    w |= static_cast<uint32_t>(b[i + k]) << k;
+                }
+                words[n].push_back(w);
+            }
+        }
+        std::vector<size_t> taken(kStreams, 0);
+        std::vector<unsigned char> page;
+        page.reserve((order_.size() + kTailWords) * 4u);
+        for (size_t i = 0; i < order_.size(); i++) {
+            const uint32_t lane = order_[i];
+            const uint32_t w =
+                taken[lane] < words[lane].size() ? words[lane][taken[lane]] : 0u;
+            taken[lane]++;
+            page.push_back(static_cast<unsigned char>(w & 0xFFu));
+            page.push_back(static_cast<unsigned char>((w >> 8) & 0xFFu));
+            page.push_back(static_cast<unsigned char>((w >> 16) & 0xFFu));
+            page.push_back(static_cast<unsigned char>((w >> 24) & 0xFFu));
+        }
+        page.resize(page.size() + kTailWords * 4u, 0);
+        return page;
+    }
+
+   private:
+    static constexpr uint32_t kStreams = 32;
+    static constexpr uint32_t kPacket = 32;
+    static constexpr uint32_t kWatermark = 32;
+    /* See the file comment: slack for the reference's unchecked refill, not a
+     * property of the format. Sized for the fixture that deliberately drives
+     * the reference past the emitted words - an all-zero literal/length vector
+     * is an empty code, which the reference resolves to a synthetic literal
+     * that consumes one bit and produces one byte until the output buffer is
+     * full, so the words it asks for are bounded by the output cap and not by
+     * anything the page said. 16 KiB of zeros covers that cap with room, and a
+     * page here is still a quarter of the 64 KiB the format allows. */
+    static constexpr uint32_t kTailWords = 4096;
+
+    LaneBits lane_[kStreams];
+    uint32_t bitsleft_[kStreams];
+    uint32_t idx_;
+    std::vector<uint32_t> order_;
+    bool ok_;
+};
+
+/* Code lengths for a complete canonical code over `n` symbols, the shape every
+ * fixture here needs and none of them should invent twice. Two lengths suffice:
+ * with b = ceil(log2(n)), giving 2^b - n symbols length b-1 and the rest length
+ * b spends exactly the whole codespace, since 2(2^b - n) + (2n - 2^b) = 2^b.
+ * n = 1 is the degenerate single-symbol code the reference admits at length 1,
+ * and it is returned rather than refused because a fixture that needs it is
+ * pinning that admission. */
+inline std::vector<unsigned char> CompleteLengths(uint32_t n) {
+    std::vector<unsigned char> lens;
+    if (n == 0) {
+        return lens;
+    }
+    if (n == 1) {
+        lens.push_back(1);
+        return lens;
+    }
+    uint32_t b = 0;
+    while ((1u << b) < n) {
+        b++;
+    }
+    const uint32_t short_count = (1u << b) - n;
+    for (uint32_t i = 0; i < n; i++) {
+        lens.push_back(static_cast<unsigned char>(i < short_count ? b - 1 : b));
+    }
+    return lens;
+}
+
+}  // namespace cudec_test
+
+#endif /* CUDEC_TESTS_GDEFLATE_PAGE_WRITER_H */

--- a/tests/gdeflate_tables_twin.cpp
+++ b/tests/gdeflate_tables_twin.cpp
@@ -570,10 +570,18 @@ int RunAllZeroLitLen() {
  * surface. They are refused rather than clamped because a clamped length
  * describes a different code, silently. */
 int RunUnreachableByFormat() {
+    /* The fixture is a vector that is a COMPLETE code over the first 257
+     * symbols with one extra symbol at length 16, and it is that shape for a
+     * reason worth keeping. A vector whose over-long length replaced a coded
+     * one is refused either way - the code it leaves behind is incomplete - so
+     * it cannot tell the length check from the completeness check. This one
+     * can: without the length check the over-long symbol is counted in a slot
+     * one past the end of the per-length array, the fifteen lengths that
+     * remain still spend the whole codespace, and the vector is accepted. */
     std::vector<unsigned char> too_long = CompleteLengths(257);
-    too_long[0] = 16;
+    too_long.push_back(16);
     GDeflateLitLenTable lt;
-    REQUIRE(!GDeflateBuildTable(too_long.data(), 257u, lt));
+    REQUIRE(!GDeflateBuildTable(too_long.data(), 258u, lt));
 
     const std::vector<unsigned char> lens = CompleteLengths(257);
     GDeflateDistTable dt;

--- a/tests/gdeflate_tables_twin.cpp
+++ b/tests/gdeflate_tables_twin.cpp
@@ -1,0 +1,610 @@
+/* The GDeflate canonical table construction, held against the reference
+ * (issue #175). src/gdeflate_tables.h turns a code-length vector into a decode
+ * table or refuses it; this file establishes that it assigns the same codeword
+ * to every symbol the reference does, and that it refuses every vector the
+ * reference refuses.
+ *
+ * HOW PARITY IS ESTABLISHED HERE, AND WHY IT IS NOT A TABLE COMPARISON. The
+ * reference's table is not reachable. The pinned fork compiles
+ * `gdeflate_decompress.c` with `HIDE_INTERFACE`, so `build_decode_table` is
+ * static in that translation unit and the plain DEFLATE entry points are not
+ * compiled at all; the only door is `libdeflate_gdeflate_decompress` and a
+ * whole page. So parity is established in the direction that door opens: the
+ * test builds a table with the header under test, ENCODES a chosen symbol
+ * sequence with the codewords that table assigns, and requires the reference
+ * to hand back exactly the bytes those symbols name. A single wrong codeword
+ * anywhere in the alphabet produces a different byte or a refusal, and cannot
+ * produce the expected output. That is a stronger statement than comparing two
+ * tables field by field, because it runs through the reference's real decode
+ * path rather than through a copy of it.
+ *
+ * WHAT IS NOT COVERED, AND IT IS THE ISSUE'S FIRST BULLET. The corpus half -
+ * "for every dynamic block in the oracle-generated corpus" - needs the code
+ * length vectors that sit inside blocks the reference's own compressor
+ * produced, and reading one out of a page IS the dynamic block header decode,
+ * which is #176 and does not exist. Nothing in this file reads a
+ * compressor-produced page. The alphabet is covered by construction instead:
+ * the fixtures below encode every literal and the end-of-block symbol, and
+ * codeword lengths from 1 to 15, which is both sides of the root accelerator.
+ *
+ * WHAT THE LENGTH AND DISTANCE SYMBOLS ARE NOT. Emitting a length symbol means
+ * emitting its extra bits and the distance symbol that follows it in the next
+ * round, and then the in-tile LZ77 copy that pair names - the block loop,
+ * which is #182. The distance code is therefore exercised here through its
+ * TABLE (built, accepted, refused) and never through a decoded match. Said
+ * plainly so the gap is not read as coverage. */
+#include "gdeflate_page_writer.h"
+#include "gdeflate_tables.h"
+#include "require.h"
+
+#include <libdeflate.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+using cudec_detail::GDeflateBuildTable;
+using cudec_detail::GDeflateDecodeSymbol;
+using cudec_detail::GDeflateDistTable;
+using cudec_detail::GDeflateInit;
+using cudec_detail::GDeflateLitLenTable;
+using cudec_detail::GDeflateSchedule;
+using cudec_detail::kGDeflateNoSymbol;
+using cudec_detail::kGDeflateTableEmpty;
+using cudec_detail::kGDeflateTableSingle;
+using cudec_test::CompleteLengths;
+using cudec_test::GDeflatePageWriter;
+
+/* The precode alphabet and the order its lengths are stored in, both from the
+ * reference (`deflate_precode_lens_permutation` in
+ * gdeflate_decompress_template.h). The permutation is data the writer has to
+ * agree with, so it is here rather than derived. */
+constexpr uint32_t kNumPrecodeSyms = 19;
+constexpr uint32_t kMaxPrecodeLen = 7;
+const unsigned char kPrecodePermutation[kNumPrecodeSyms] = {
+    16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
+
+using PrecodeTable =
+    cudec_detail::GDeflateHuffTable<kNumPrecodeSyms, kMaxPrecodeLen,
+                                    kMaxPrecodeLen>;
+
+/* The codeword a built table assigns to `sym`, recovered from the same three
+ * arrays the decoder walks. Returns false for a symbol the vector left out. */
+template <typename Table>
+bool CodewordOf(const Table& t, const unsigned char* lens, uint32_t sym,
+                uint32_t* code, uint32_t* len) {
+    const uint32_t l = lens[sym];
+    if (l == 0) {
+        return false;
+    }
+    if (t.kind == kGDeflateTableSingle) {
+        /* The reference gives the one symbol both codewords, 0 and 1, so
+         * either bit resolves it; 0 is the one zlib's decompressor assumes and
+         * the one the reference's comment names. */
+        *code = 0;
+        *len = 1;
+        return true;
+    }
+    for (uint32_t i = 0; i < t.count[l]; i++) {
+        if (t.sorted[t.first_index[l] + i] == sym) {
+            *code = t.first_code[l] + i;
+            *len = l;
+            return true;
+        }
+    }
+    return false;
+}
+
+/* One dynamic block, emitted whole. `litlen_lens` and `dist_lens` are the
+ * vectors under test; `symbols` is what the block's body encodes, which the
+ * caller ends with 256 when it wants a block the reference can finish. An
+ * empty `symbols` emits the header alone, which is all a vector the reference
+ * refuses at table-build time ever gets read. */
+bool EmitDynamicBlock(const std::vector<unsigned char>& litlen_lens,
+                      const std::vector<unsigned char>& dist_lens,
+                      const std::vector<uint32_t>& symbols,
+                      std::vector<unsigned char>* page) {
+    if (litlen_lens.size() < 257 || litlen_lens.size() > 288 ||
+        dist_lens.empty() || dist_lens.size() > 32) {
+        return false;
+    }
+
+    /* The precode encodes the concatenated vector with explicit lengths only:
+     * no repeat codes. Run-length encoding of the vector is the header's
+     * business (#176), and a fixture that leaned on it would be pinning that
+     * decode rather than this construction. */
+    std::vector<unsigned char> all = litlen_lens;
+    all.insert(all.end(), dist_lens.begin(), dist_lens.end());
+
+    unsigned char used[16];
+    std::memset(used, 0, sizeof(used));
+    for (size_t i = 0; i < all.size(); i++) {
+        used[all[i]] = 1;
+    }
+    uint32_t n_used = 0;
+    for (uint32_t v = 0; v < 16; v++) {
+        n_used += used[v];
+    }
+    const std::vector<unsigned char> shape = CompleteLengths(n_used);
+    unsigned char precode_lens[kNumPrecodeSyms];
+    std::memset(precode_lens, 0, sizeof(precode_lens));
+    uint32_t k = 0;
+    for (uint32_t v = 0; v < 16; v++) {
+        if (used[v]) {
+            precode_lens[v] = shape[k++];
+        }
+    }
+    PrecodeTable precode;
+    if (!GDeflateBuildTable(precode_lens, kNumPrecodeSyms, precode)) {
+        return false;
+    }
+
+    GDeflateLitLenTable litlen;
+    GDeflateDistTable dist;
+    const bool litlen_ok =
+        GDeflateBuildTable(litlen_lens.data(),
+                           static_cast<uint32_t>(litlen_lens.size()), litlen);
+    const bool dist_ok = GDeflateBuildTable(
+        dist_lens.data(), static_cast<uint32_t>(dist_lens.size()), dist);
+
+    GDeflatePageWriter w;
+    w.Reset();
+    w.Push(1, 1); /* BFINAL: one block per page here. */
+    w.Push(2, 2); /* BTYPE = DEFLATE_BLOCKTYPE_DYNAMIC_HUFFMAN. */
+    w.Ensure();
+    w.Push(5, static_cast<uint32_t>(litlen_lens.size()) - 257u); /* HLIT */
+    w.Push(5, static_cast<uint32_t>(dist_lens.size()) - 1u);     /* HDIST */
+    w.Push(4, kNumPrecodeSyms - 4u);                             /* HCLEN */
+    w.Ensure();
+    /* All 19 precode lengths, in the permuted order the format stores them,
+     * one per round. */
+    for (uint32_t i = 0; i < kNumPrecodeSyms; i++) {
+        w.Push(3, precode_lens[kPrecodePermutation[i]]);
+        w.Advance();
+    }
+    w.Reset();
+    for (size_t i = 0; i < all.size(); i++) {
+        uint32_t code = 0;
+        uint32_t len = 0;
+        if (!CodewordOf(precode, precode_lens, all[i], &code, &len)) {
+            return false;
+        }
+        w.PushCode(code, len);
+        w.Advance();
+    }
+
+    if (!symbols.empty()) {
+        if (!litlen_ok || !dist_ok) {
+            return false;
+        }
+        w.Reset();
+        for (size_t i = 0; i < symbols.size(); i++) {
+            uint32_t code = 0;
+            uint32_t len = 0;
+            if (!CodewordOf(litlen, litlen_lens.data(), symbols[i], &code,
+                            &len)) {
+                return false;
+            }
+            w.PushCode(code, len);
+            if (symbols[i] == 256) {
+                /* The reference leaves the decode loop on the end-of-block
+                 * symbol without advancing, then runs 32 rounds to drain the
+                 * deferred copies. Those rounds refill, so the writer owes
+                 * their words. */
+                break;
+            }
+            w.Advance();
+        }
+        for (uint32_t i = 0; i < 32; i++) {
+            w.Advance();
+        }
+    }
+
+    if (!w.ok()) {
+        return false;
+    }
+    *page = w.Finish();
+    return true;
+}
+
+/* The reference's verdict on one page, plus what it produced. */
+struct OracleAnswer {
+    int status;
+    std::vector<unsigned char> out;
+};
+
+OracleAnswer AskOracle(const std::vector<unsigned char>& page,
+                       size_t out_cap) {
+    OracleAnswer a;
+    a.status = LIBDEFLATE_BAD_DATA;
+    libdeflate_gdeflate_decompressor* d =
+        libdeflate_alloc_gdeflate_decompressor();
+    if (d == nullptr) {
+        return a;
+    }
+    libdeflate_gdeflate_in_page in;
+    in.data = page.data();
+    in.nbytes = page.size();
+    a.out.assign(out_cap, 0);
+    size_t produced = 0;
+    a.status = libdeflate_gdeflate_decompress(d, &in, 1, a.out.data(), out_cap,
+                                              &produced);
+    libdeflate_free_gdeflate_decompressor(d);
+    a.out.resize(a.status == LIBDEFLATE_SUCCESS ? produced : 0);
+    return a;
+}
+
+/* A literal/length vector over 257 symbols, every one of 0..256 coded. This is
+ * the alphabet fixture: every literal the format has, plus end-of-block. */
+std::vector<unsigned char> AllLiteralsLens() {
+    return CompleteLengths(257);
+}
+
+/* A literal/length vector whose codeword lengths run 1, 2, ... 15, 15 over
+ * symbols 0..14 and 256. The lengths spend the codespace exactly, and they are
+ * the fixture that reaches both sides of the root accelerator: 1 through 10
+ * resolve in one lookup, 11 through 15 fall through to the length-by-length
+ * walk. A vector of uniform lengths would exercise one of the two and read
+ * exactly like a vector that exercised both. */
+std::vector<unsigned char> DeepCodeLens() {
+    std::vector<unsigned char> lens(257, 0);
+    for (uint32_t i = 0; i < 15; i++) {
+        lens[i] = static_cast<unsigned char>(i + 1);
+    }
+    lens[256] = 15;
+    return lens;
+}
+
+int RunAlphabetParity() {
+    /* Every literal, in order, then end-of-block. */
+    std::vector<uint32_t> symbols;
+    for (uint32_t b = 0; b < 256; b++) {
+        symbols.push_back(b);
+    }
+    symbols.push_back(256);
+
+    std::vector<unsigned char> page;
+    /* HDIST is at least one symbol; a block with no matches declares a
+     * distance code with nothing in it, which is the reference's empty-code
+     * admission and is pinned again below on its own. */
+    const std::vector<unsigned char> no_dist(1, 0);
+    REQUIRE(EmitDynamicBlock(AllLiteralsLens(), no_dist, symbols, &page));
+
+    const OracleAnswer a = AskOracle(page, 4096);
+    REQUIRE_CTX(a.status == LIBDEFLATE_SUCCESS, "status %d", a.status);
+    REQUIRE(a.out.size() == 256);
+    std::vector<unsigned char> want(256);
+    for (uint32_t b = 0; b < 256; b++) {
+        want[b] = static_cast<unsigned char>(b);
+    }
+    REQUIRE(equal_bytes(a.out.data(), want.data(), want.size()));
+    return 0;
+}
+
+int RunDeepCodeParity() {
+    std::vector<uint32_t> symbols;
+    for (uint32_t b = 0; b < 15; b++) {
+        symbols.push_back(b);
+    }
+    symbols.push_back(256);
+
+    std::vector<unsigned char> page;
+    const std::vector<unsigned char> no_dist(1, 0);
+    REQUIRE(EmitDynamicBlock(DeepCodeLens(), no_dist, symbols, &page));
+
+    const OracleAnswer a = AskOracle(page, 4096);
+    REQUIRE_CTX(a.status == LIBDEFLATE_SUCCESS, "status %d", a.status);
+    REQUIRE(a.out.size() == 15);
+    std::vector<unsigned char> want(15);
+    for (uint32_t b = 0; b < 15; b++) {
+        want[b] = static_cast<unsigned char>(b);
+    }
+    REQUIRE(equal_bytes(a.out.data(), want.data(), want.size()));
+
+    /* And the same lengths through the header under test, so the claim that
+     * the walk was reached is a fact about this table rather than about the
+     * fixture's intent: symbol 14 carries a 15-bit codeword, which is five
+     * bits past the 10-bit root. */
+    GDeflateLitLenTable t;
+    const std::vector<unsigned char> lens = DeepCodeLens();
+    REQUIRE(GDeflateBuildTable(lens.data(), 257u, t));
+    uint32_t code = 0;
+    uint32_t len = 0;
+    REQUIRE(CodewordOf(t, lens.data(), 14u, &code, &len));
+    REQUIRE(len == 15);
+    REQUIRE(CodewordOf(t, lens.data(), 0u, &code, &len));
+    REQUIRE(len == 1);
+    return 0;
+}
+
+/* The length-by-length walk, written independently of the header under test so
+ * that the root accelerator has something to be compared against. `bits` is a
+ * probe as the lane hands it over: least significant bit first, which is the
+ * most significant bit of the codeword. */
+template <typename Table>
+uint32_t WalkSymbol(const Table& t, uint32_t bits, uint32_t nbits,
+                    uint32_t* used_len) {
+    uint32_t code = 0;
+    for (uint32_t len = 1; len <= nbits; len++) {
+        code = (code << 1) | ((bits >> (len - 1)) & 1u);
+        if (t.count[len] != 0 && code >= t.first_code[len] &&
+            (code - t.first_code[len]) < t.count[len]) {
+            *used_len = len;
+            return t.sorted[t.first_index[len] + (code - t.first_code[len])];
+        }
+    }
+    return kGDeflateNoSymbol;
+}
+
+/* The root accelerator is only an accelerator: a slot it fails to fill falls
+ * through to the walk and still answers correctly, so nothing that decodes can
+ * see an under-filled root. That is exactly why it needs its own check. Both
+ * halves are asserted - every filled slot agrees with the walk, and the number
+ * of filled slots is the closed form the layout claims, which is what an
+ * under-filled root fails. */
+template <typename Table>
+int CheckRoot(const char* what, const Table& t, uint32_t root_bits) {
+    uint32_t filled = 0;
+    for (uint32_t i = 0; i < (1u << root_bits); i++) {
+        const uint32_t entry = t.root[i];
+        const uint32_t hit_len = entry & cudec_detail::kGDeflateRootLenMask;
+        if (hit_len == 0) {
+            continue;
+        }
+        filled++;
+        uint32_t walk_len = 0;
+        const uint32_t walk = WalkSymbol(t, i, root_bits, &walk_len);
+        REQUIRE_CTX(walk == (entry >> cudec_detail::kGDeflateRootLenBits),
+                    "%s: slot %u names %u, the walk says %u", what, i,
+                    entry >> cudec_detail::kGDeflateRootLenBits, walk);
+        REQUIRE_CTX(walk_len == hit_len, "%s: slot %u length %u vs %u", what, i,
+                    hit_len, walk_len);
+    }
+    uint32_t expect = 0;
+    for (uint32_t len = 1; len <= root_bits; len++) {
+        expect += static_cast<uint32_t>(t.count[len]) << (root_bits - len);
+    }
+    REQUIRE_CTX(filled == expect, "%s: %u slots filled, %u owed", what, filled,
+                expect);
+    return 0;
+}
+
+int RunRootAccelerator() {
+    GDeflateLitLenTable flat;
+    const std::vector<unsigned char> flat_lens = AllLiteralsLens();
+    REQUIRE(GDeflateBuildTable(flat_lens.data(), 257u, flat));
+    /* Every codeword here is 8 or 9 bits, so the 10-bit root resolves the whole
+     * alphabet and no slot may be left over. */
+    if (CheckRoot("all-literals", flat, cudec_detail::kGDeflateLitLenRootBits) !=
+        0) {
+        return 1;
+    }
+
+    GDeflateLitLenTable deep;
+    const std::vector<unsigned char> deep_lens = DeepCodeLens();
+    REQUIRE(GDeflateBuildTable(deep_lens.data(), 257u, deep));
+    /* Here five of the sixteen codewords are longer than the root, so the root
+     * is deliberately incomplete and the closed form is what says by how much.
+     */
+    if (CheckRoot("deep-code", deep, cudec_detail::kGDeflateLitLenRootBits) !=
+        0) {
+        return 1;
+    }
+    return 0;
+}
+
+/* A vector the reference refuses, and the one-field neighbour it accepts. The
+ * pair is the point: a writer that emitted nothing usable would fail the
+ * accepting half, so a refusal here cannot be read as agreement by accident. */
+int RequireRejectedPair(const char* what,
+                        const std::vector<unsigned char>& bad_litlen,
+                        const std::vector<unsigned char>& bad_dist,
+                        const std::vector<unsigned char>& good_litlen,
+                        const std::vector<unsigned char>& good_dist) {
+    /* The header under test refuses at least one of the two vectors. */
+    GDeflateLitLenTable lt;
+    GDeflateDistTable dt;
+    const bool twin_litlen = GDeflateBuildTable(
+        bad_litlen.data(), static_cast<uint32_t>(bad_litlen.size()), lt);
+    const bool twin_dist = GDeflateBuildTable(
+        bad_dist.data(), static_cast<uint32_t>(bad_dist.size()), dt);
+    REQUIRE_CTX(!twin_litlen || !twin_dist, "%s: the twin accepted it", what);
+
+    /* The reference refuses the page carrying them. The body is left out: a
+     * vector rejected at table-build time is never read past the header. */
+    std::vector<unsigned char> bad_page;
+    REQUIRE_CTX(EmitDynamicBlock(bad_litlen, bad_dist, std::vector<uint32_t>(),
+                                 &bad_page),
+                "%s: could not emit", what);
+    const OracleAnswer bad = AskOracle(bad_page, 4096);
+    REQUIRE_CTX(bad.status != LIBDEFLATE_SUCCESS, "%s: the oracle accepted it",
+                what);
+
+    /* The neighbour decodes, which is what makes the refusal above evidence.
+     * It is a full block, so it exercises the same writer end to end. */
+    std::vector<uint32_t> symbols;
+    symbols.push_back(65);
+    symbols.push_back(256);
+    std::vector<unsigned char> good_page;
+    REQUIRE_CTX(EmitDynamicBlock(good_litlen, good_dist, symbols, &good_page),
+                "%s: could not emit the neighbour", what);
+    const OracleAnswer good = AskOracle(good_page, 4096);
+    REQUIRE_CTX(good.status == LIBDEFLATE_SUCCESS, "%s: neighbour status %d",
+                what, good.status);
+    REQUIRE(good.out.size() == 1 && good.out[0] == 'A');
+    return 0;
+}
+
+int RunRejects() {
+    const std::vector<unsigned char> good_litlen = AllLiteralsLens();
+    const std::vector<unsigned char> no_dist(1, 0);
+
+    /* Over-subscribed: one codeword shortened by a bit, so the lengths claim
+     * more codespace than exists. */
+    std::vector<unsigned char> over = good_litlen;
+    over[0] = static_cast<unsigned char>(over[0] - 1);
+    if (RequireRejectedPair("over-subscribed lit/len", over, no_dist,
+                            good_litlen, no_dist) != 0) {
+        return 1;
+    }
+
+    /* Incomplete: one codeword lengthened by a bit, so part of the codespace
+     * is unreachable and the vector is neither empty nor the single-symbol
+     * shape the reference admits. */
+    std::vector<unsigned char> under = good_litlen;
+    under[0] = static_cast<unsigned char>(under[0] + 1);
+    if (RequireRejectedPair("incomplete lit/len", under, no_dist, good_litlen,
+                            no_dist) != 0) {
+        return 1;
+    }
+
+    /* Incomplete distance code that is not one of the two admitted shapes:
+     * two symbols at length 2 spend half the codespace, and count[1] is 0. */
+    std::vector<unsigned char> half_dist(2, 2);
+    if (RequireRejectedPair("incomplete distance", good_litlen, half_dist,
+                            good_litlen, no_dist) != 0) {
+        return 1;
+    }
+    return 0;
+}
+
+/* The two incomplete vectors the reference admits, pinned as admissions rather
+ * than assumed, and the one place this header is deliberately stricter. */
+int RunAdmittedIncomplete() {
+    const std::vector<unsigned char> good_litlen = AllLiteralsLens();
+    std::vector<uint32_t> symbols;
+    symbols.push_back(65);
+    symbols.push_back(256);
+
+    /* The empty distance code: one symbol, length 0. Both sides accept the
+     * vector, and a block that declares no distance and uses none decodes. */
+    const std::vector<unsigned char> empty_dist(1, 0);
+    GDeflateDistTable dt;
+    REQUIRE(GDeflateBuildTable(empty_dist.data(), 1u, dt));
+    REQUIRE(dt.kind == kGDeflateTableEmpty);
+    std::vector<unsigned char> page;
+    REQUIRE(EmitDynamicBlock(good_litlen, empty_dist, symbols, &page));
+    OracleAnswer a = AskOracle(page, 4096);
+    REQUIRE_CTX(a.status == LIBDEFLATE_SUCCESS, "empty distance: status %d",
+                a.status);
+
+    /* And the strictness that is this header's own: the reference resolves
+     * every codeword of an empty table to a synthetic symbol 0 so that a
+     * malformed stream still lands on an initialised entry. Decoding from one
+     * here refuses instead, which is only reachable by a page that uses a
+     * distance it never declared. */
+    GDeflateSchedule s;
+    const std::vector<unsigned char> probe(256, 0xFF);
+    REQUIRE(GDeflateInit(s, probe.data(), probe.size()));
+    const uint32_t before = s.bitsleft[0];
+    REQUIRE(GDeflateDecodeSymbol(s, dt) == kGDeflateNoSymbol);
+    REQUIRE(s.failed);
+    /* And it refuses without moving the lane. Every other refusal in this
+     * family reaches the same verdict by exhausting the length walk, which
+     * costs the lane fifteen bits first; a table with nothing in it is known
+     * to be unusable before a single bit is read, and the refusal that reads
+     * nothing is the one that keeps "once failed, nothing moves" (the sticky
+     * flag rule in src/gdeflate_schedule.h) literally true here. */
+    REQUIRE(s.bitsleft[0] == before);
+
+    /* The single-symbol distance code: one symbol at length 1, which spends
+     * half the codespace. The reference admits it by name and assigns the
+     * symbol both codewords; this pins the admission. Reading the symbol back
+     * out needs a decoded match, which is #182. */
+    const std::vector<unsigned char> single_dist(1, 1);
+    GDeflateDistTable st;
+    REQUIRE(GDeflateBuildTable(single_dist.data(), 1u, st));
+    REQUIRE(st.kind == kGDeflateTableSingle);
+    REQUIRE(EmitDynamicBlock(good_litlen, single_dist, symbols, &page));
+    a = AskOracle(page, 4096);
+    REQUIRE_CTX(a.status == LIBDEFLATE_SUCCESS, "single distance: status %d",
+                a.status);
+    REQUIRE(a.out.size() == 1 && a.out[0] == 'A');
+
+    /* One bit resolves it whichever way the bit falls, which is what "both
+     * codewords" means where a decoder is concerned. */
+    GDeflateSchedule z;
+    const std::vector<unsigned char> zeros(256, 0x00);
+    REQUIRE(GDeflateInit(z, zeros.data(), zeros.size()));
+    REQUIRE(GDeflateDecodeSymbol(z, st) == 0u);
+    GDeflateSchedule o;
+    const std::vector<unsigned char> ones(256, 0xFF);
+    REQUIRE(GDeflateInit(o, ones.data(), ones.size()));
+    REQUIRE(GDeflateDecodeSymbol(o, st) == 0u);
+    return 0;
+}
+
+/* An all-zero literal/length vector is the empty code again, in the one place
+ * it can never be right: the reference admits the TABLE and then resolves
+ * every codeword to a synthetic literal, so the page runs until the output
+ * buffer is full and is refused there. Both sides refuse the page, by
+ * different routes, and the route matters enough to say which is which. */
+int RunAllZeroLitLen() {
+    const std::vector<unsigned char> zero_litlen(257, 0);
+    const std::vector<unsigned char> no_dist(1, 0);
+
+    GDeflateLitLenTable lt;
+    REQUIRE(GDeflateBuildTable(zero_litlen.data(), 257u, lt));
+    REQUIRE(lt.kind == kGDeflateTableEmpty);
+    GDeflateSchedule s;
+    const std::vector<unsigned char> probe(256, 0x5A);
+    REQUIRE(GDeflateInit(s, probe.data(), probe.size()));
+    REQUIRE(GDeflateDecodeSymbol(s, lt) == kGDeflateNoSymbol);
+    REQUIRE(s.failed);
+
+    std::vector<unsigned char> page;
+    REQUIRE(EmitDynamicBlock(zero_litlen, no_dist, std::vector<uint32_t>(),
+                             &page));
+    const OracleAnswer a = AskOracle(page, 64);
+    REQUIRE_CTX(a.status != LIBDEFLATE_SUCCESS, "all-zero lit/len: status %d",
+                a.status);
+    return 0;
+}
+
+/* Two refusals the format cannot deliver, so the reference cannot be asked
+ * about them and is not. Explicit code lengths arrive as precode symbols below
+ * 16 and an alphabet size is five bits plus a constant, so neither shape can
+ * be written into a page at all; both are caller errors on the header's own
+ * surface. They are refused rather than clamped because a clamped length
+ * describes a different code, silently. */
+int RunUnreachableByFormat() {
+    std::vector<unsigned char> too_long = CompleteLengths(257);
+    too_long[0] = 16;
+    GDeflateLitLenTable lt;
+    REQUIRE(!GDeflateBuildTable(too_long.data(), 257u, lt));
+
+    const std::vector<unsigned char> lens = CompleteLengths(257);
+    GDeflateDistTable dt;
+    REQUIRE(!GDeflateBuildTable(lens.data(), 257u, dt));
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    if (RunAlphabetParity() != 0) {
+        return 1;
+    }
+    if (RunDeepCodeParity() != 0) {
+        return 1;
+    }
+    if (RunRootAccelerator() != 0) {
+        return 1;
+    }
+    if (RunRejects() != 0) {
+        return 1;
+    }
+    if (RunAdmittedIncomplete() != 0) {
+        return 1;
+    }
+    if (RunAllZeroLitLen() != 0) {
+        return 1;
+    }
+    if (RunUnreachableByFormat() != 0) {
+        return 1;
+    }
+    std::printf("gdeflate_tables_twin: ok\n");
+    return 0;
+}


### PR DESCRIPTION
Part of #175. The canonical Huffman table construction for GDeflate, and the
route that lets the reference answer for it.

## What lands

`src/gdeflate_tables.h`, single-sourced host and device on the
`src/gdeflate_schedule.h` pattern, is the layout the #94 panel settled in
`docs/MASTERPLAN.md` section 13.1: per-length counts, first codes, first
indices and the canonical symbol order - a complete decoder whose size is
fixed by the alphabet rather than by the code lengths - plus a 10-bit root
accelerator over the literal/length alphabet and a 7-bit one over the
distance alphabet. A codeword no longer than its root resolves in one
lookup; a longer one falls through to the length-by-length walk, and both
read the same three arrays, so the accelerator cannot disagree with the
decoder it accelerates.

It refuses an over-subscribed vector and an incomplete one, and admits the
two incomplete shapes the reference admits by name - the empty code, and one
symbol at length 1 - because both are reachable in a valid stream: a
distance code with one distance is what a page full of one match distance
produces.

## Two decisions worth reading before the diff

**The capacity is 288 literal/length symbols, not the draft's 286.** The
dossier (section 11.2) says up to 286; the reference reads HLIT as five bits
and adds 257, so it admits up to 288 and builds a table over all of them.
Parity with the reference is what the whole M4 ladder rests on, so the
capacity follows the reference. Against section 13.1's arithmetic that is
four bytes for the two extra symbols and two more for each table's `kind`
field: 3144 bytes per warp where 13.1 computed 3132, against the 3200-byte
budget. The margin narrows from 68 bytes to 56 and the occupancy plan is
unmoved.

**One place is stricter than the reference, and it is stated at the branch.**
An empty table resolves every codeword to a synthetic "symbol 0, length 1"
entry in the reference, so a match in a block whose distance code is empty
decodes to a distance the stream never encoded. Here that table refuses on
use, and refuses without consuming a bit. A block that declares no distances
and uses none is unaffected, which is the only shape a compressor produces,
and the test pins that it still decodes.

## How parity is established, and why not by comparing tables

The reference's table is not reachable. The pinned fork compiles
`gdeflate_decompress.c` with `HIDE_INTERFACE`, so `build_decode_table` is
static inside that translation unit and the plain DEFLATE entry points are
not compiled at all:

```
$ grep -n 'HIDE_INTERFACE' build/_deps/gdeflate-src/lib/gdeflate_decompress.c \
    build/_deps/gdeflate-src/lib/deflate_decompress.c
gdeflate_decompress.c:32:#define HIDE_INTERFACE
deflate_decompress.c:957:#ifndef HIDE_INTERFACE
```

The only door is `libdeflate_gdeflate_decompress` and a whole page, so
`tests/gdeflate_page_writer.h` emits one. It is the mirror of the schedule
header and not a second schedule: a page is 32 least-significant-bit-first
lane streams plus the order their words were handed out in, so the writer
records the refills the decoder will perform and interleaves accordingly.

Parity then runs in the direction that door opens. The test builds a table
with the header under test, encodes a chosen symbol sequence with the
codewords that table assigns, and requires the reference to hand back exactly
the bytes those symbols name. One wrong codeword anywhere produces a
different byte or a refusal. Every negative is paired with a one-field
neighbour that must decode, so a writer that emitted nothing usable fails the
pair rather than passing it.

## The proof that the guards bite

Each mutant is one character or one condition, applied to a copy of the tree,
and the suite is required to go red:

```
$ bash mutants.sh
baseline: green
M1 codeword not reversed: red (guard bites)
M2 over-subscription accepted: red (guard bites)
M3 incomplete accepted: red (guard bites)
M4 empty-table decode allowed: red (guard bites)
M5 over-long code length accepted: red (guard bites)
M6 single-code symbol off by one: red (guard bites)
M7 root slot spacing wrong: red (guard bites)
M8 first_code recurrence off by one: red (guard bites)
```

M4 and M7 survived the first pass and the tests were sharpened until they did
not. M4 survived because the length walk refuses an empty table anyway, so
the branch was only observable in what it does NOT consume - the test now
asserts the lane is untouched. M7 survived because an under-filled root falls
through to the walk and still answers correctly, so the test now checks every
filled slot against an independently written walk and checks the filled count
against the closed form the layout claims.

## The means

C++ in a `__host__ __device__` header, which is the means the three sibling
parsers in `src/` already use and the only one that lets the kernel compile
the same arithmetic the CPU twin is tested through. It adds no language, no
runtime and no dependency, and it is testable by the ctest net that exists.

## What is NOT covered

The issue's first bullet - table-build parity "for every dynamic block in the
oracle-generated corpus" - is not covered here, and the test file says so at
the top rather than in a commit message. Reading a code-length vector out of
a page the reference's compressor produced IS the dynamic block header
decode, which is #176 and does not exist. The alphabet is covered by
construction instead: the fixtures encode every literal and the end-of-block
symbol, and codeword lengths from 1 to 15, which is both sides of the root.

Length and distance symbols are exercised through their tables and never
through a decoded match: emitting a length symbol means emitting its extra
bits, the distance symbol in the next round and the LZ77 copy that pair
names, which is #182.

So #175 stays open on its corpus bullet after this merge.

## Second commit, and why it is here rather than folded away

Re-running the mutant table after the first commit found two things, and both
are corrections rather than polish.

The canonical fill used a scratch array indexed by codeword length. In the
kernel that is per-thread local memory, in the one place where occupancy is
the binding resource, for a value the table already holds - `first_index`
doubles as the fill cursor and is wound back by each length's own count.

The over-long-length negative could not tell the length check from the
completeness check. It set a CODED symbol's length to 16, and a vector whose
over-long length replaced a coded one is refused either way, because the code
left behind is incomplete. With the length check removed the suite stayed
green, and the reason M5 had read as red in the first table is worse than the
gap it hid: the removed scratch array happened to sit next on the stack, so
the mutant crashed rather than being caught. The fixture is now a complete
code over 257 symbols plus one extra at length 16, which without the check is
counted one slot past the end of the per-length array while the remaining
lengths still spend the whole codespace - so it is ACCEPTED, and the test
reds on the accept.

The mutant table quoted above is the one taken after both changes.

## Two further commits, both corrections

`c24ff58` - the codespace accumulator's comment claimed the shift-accumulate
form kept the widest intermediate bounded by the alphabet size. It does not:
an over-subscribed vector overshoots on purpose, that overshoot is what the
refusal reads, and the worst case is every symbol at length 1, which reaches
`num_syms << (kMaxLen - 1)`. Both formulations of the sum reach it, so the
sentence was a reason written for a choice made for a different one. The
bound is now stated as it is and carried by a static assertion in the shape
the reference carries it.

`e888619` - the twin was outside the sanitizer gate. That job's regex and its
per-name greps enumerate the host tests that read untrusted input, and this
one reads exactly that; its sibling over the same surface,
`gdeflate_schedule_twin`, is already listed. Left out, the M4 table
construction would have sat outside the one gate that runs it under ASan and
UBSan while the job stayed green. Verified rather than assumed:

```
$ cmake -B build-san -DCUDEC_ENABLE_CUDA=ON -DCUDEC_SANITIZE=address,undefined
$ cmake --build build-san -j 12
$ ldd build-san/tests/gdeflate_tables_twin | grep -c -E 'libasan|libubsan'
2
$ ctest --test-dir build-san --no-tests=error --output-on-failure -R '^(...)$'
100% tests passed, 0 tests failed out of 14
Total Test time (real) =  15.59 sec
```

## Verification

Configured and built with the CUDA toolchain, then the host-side subset,
which is the gate CI runs:

```
$ cmake -B build -S . -DCUDEC_ENABLE_CUDA=ON && cmake --build build -j 12
$ ctest --test-dir build -LE gpu --no-tests=error     | grep -E "gdeflate_tables_twin|tests passed|Total Test time"
      Start  7: gdeflate_tables_twin
 7/47 Test  #7: gdeflate_tables_twin ..................   Passed    0.01 sec
100% tests passed, 0 tests failed out of 47
Total Test time (real) =  70.87 sec
```

nvcc V13.3.73 on Ubuntu 24.04. The twin was additionally built and run under
`-fsanitize=address,undefined` and is clean; that matters here because the
reference's `ENSURE_BITS` refills with no bound check against the end of the
page, so a writer that got a refill wrong would read off the end of a heap
buffer. The writer's zero tail is documented as slack for that reference
behaviour and not as a property of the format - cudec's own schedule refuses
the same read by an explicit bound.

```
$ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
All matched files use Prettier code style!
```

No GPU test is added or changed by this PR; the header is host-testable by
design and the device instantiation arrives with the kernel (#214).

There is no second reader for this change tonight. The evidence above stands
in place of one: the mutant table is what a reviewer would otherwise be asked
to take on trust, and the two surviving mutants are recorded rather than
tidied away.
