### PR TITLE
Assert the table's canonical order, not only the codewords it produces [#175]

### DIFF
--- a/tests/gdeflate_tables_twin.cpp
+++ b/tests/gdeflate_tables_twin.cpp
@@ -371,6 +371,84 @@ int CheckRoot(const char* what, const Table& t, uint32_t root_bits) {
     return 0;
 }
 
+/* Canonical ORDER, asserted directly rather than inferred from the codewords
+ * that were decoded through it. A table can hand back the right symbol for
+ * every codeword the fixtures happen to emit and still order `sorted` by
+ * something else, because the first-index arithmetic and the fill walk the
+ * same array - so an ordering defect hides behind exactly the evidence the
+ * parity fixtures produce. The property is the reference's own: primarily by
+ * increasing codeword length, secondarily by increasing symbol value, with the
+ * uncoded symbols left out entirely. */
+template <typename Table>
+int CheckCanonicalOrder(const char* what, const Table& t,
+                        const std::vector<unsigned char>& lens,
+                        uint32_t max_len) {
+    uint32_t n = 0;
+    for (size_t sym = 0; sym < lens.size(); sym++) {
+        n += (lens[sym] != 0) ? 1u : 0u;
+    }
+    uint32_t placed = 0;
+    for (uint32_t len = 1; len <= max_len; len++) {
+        REQUIRE_CTX(t.first_index[len] == placed, "%s: length %u starts at %u, "
+                    "%u symbols placed before it", what, len,
+                    static_cast<uint32_t>(t.first_index[len]), placed);
+        uint32_t previous = 0;
+        for (uint32_t i = 0; i < t.count[len]; i++) {
+            const uint32_t sym = t.sorted[placed + i];
+            REQUIRE_CTX(sym < lens.size(), "%s: symbol %u is outside the "
+                        "alphabet", what, sym);
+            REQUIRE_CTX(lens[sym] == len, "%s: symbol %u sits at length %u and "
+                        "its length is %u", what, sym, len,
+                        static_cast<uint32_t>(lens[sym]));
+            REQUIRE_CTX(i == 0 || sym > previous, "%s: symbol %u follows %u at "
+                        "length %u", what, sym, previous, len);
+            previous = sym;
+        }
+        placed += t.count[len];
+    }
+    REQUIRE_CTX(placed == n, "%s: %u symbols placed, %u coded", what, placed, n);
+    return 0;
+}
+
+int RunCanonicalOrder() {
+    const std::vector<unsigned char> flat_lens = AllLiteralsLens();
+    GDeflateLitLenTable flat;
+    REQUIRE(GDeflateBuildTable(flat_lens.data(), 257u, flat));
+    if (CheckCanonicalOrder("all-literals", flat, flat_lens,
+                            cudec_detail::kGDeflateMaxCodeLen) != 0) {
+        return 1;
+    }
+
+    const std::vector<unsigned char> deep_lens = DeepCodeLens();
+    GDeflateLitLenTable deep;
+    REQUIRE(GDeflateBuildTable(deep_lens.data(), 257u, deep));
+    if (CheckCanonicalOrder("deep-code", deep, deep_lens,
+                            cudec_detail::kGDeflateMaxCodeLen) != 0) {
+        return 1;
+    }
+
+    /* A vector whose coded symbols are scattered rather than leading, so that
+     * an implementation ordering by symbol index alone, or filling in input
+     * order, produces a different array. Symbols 200, 5, 91 and 3 all carry
+     * length 2, which spends the codespace exactly. */
+    std::vector<unsigned char> scattered(257, 0);
+    scattered[200] = 2;
+    scattered[5] = 2;
+    scattered[91] = 2;
+    scattered[3] = 2;
+    GDeflateLitLenTable mixed;
+    REQUIRE(GDeflateBuildTable(scattered.data(), 257u, mixed));
+    REQUIRE(mixed.sorted[0] == 3);
+    REQUIRE(mixed.sorted[1] == 5);
+    REQUIRE(mixed.sorted[2] == 91);
+    REQUIRE(mixed.sorted[3] == 200);
+    if (CheckCanonicalOrder("scattered", mixed, scattered,
+                            cudec_detail::kGDeflateMaxCodeLen) != 0) {
+        return 1;
+    }
+    return 0;
+}
+
 int RunRootAccelerator() {
     GDeflateLitLenTable flat;
     const std::vector<unsigned char> flat_lens = AllLiteralsLens();
@@ -592,6 +670,9 @@ int RunUnreachableByFormat() {
 }  // namespace
 
 int main() {
+    if (RunCanonicalOrder() != 0) {
+        return 1;
+    }
     if (RunAlphabetParity() != 0) {
         return 1;
     }


### PR DESCRIPTION
Part of #175, and the second half of what the scope ruling of 2026-08-28 asks
for on this side.

That ruling rewrites Done-when bullet one into two things: observable parity at
the contract edge over the corpus, and "the canonical table construction gets
its own invariant tests on our side (canonical ordering, the oversubscribed and
incomplete fixtures rejecting as the spec demands)". #400 landed the
construction, the two reject fixtures and the parity route. Canonical ORDERING
was not among them, and this is why that matters rather than being pedantry.

## The property was implied, not checked

Every fixture in #400 reads the order back through the codewords the table
produces: a table that ordered `sorted` by something else assigns different
codewords, the encoded page decodes to different bytes, and the parity fixture
reds. So the property held - it was just never stated, and what a reader got
when it broke was a byte mismatch six functions away from the fill that caused
it.

`CheckCanonicalOrder` states the reference's own property directly: primarily
by increasing codeword length, secondarily by increasing symbol value, uncoded
symbols left out entirely, with each length group starting exactly where the
counts say it does.

## One case the parity fixtures cannot reach

They code contiguous runs - literals 0 through 255, or 0 through 14 - so an
ordering that happened to agree with input order agrees with canonical order
there too. The new `scattered` fixture codes symbols 3, 5, 91 and 200 at one
length and asserts the four slots by name, which is the shape where the two
orders could diverge and no page is emitted for it.

## The proof that it bites

Two mutants added to the table, both one token on the fill machinery:

```
$ bash mutants.sh
baseline: green
M1 codeword not reversed: red (guard bites)
M2 over-subscription accepted: red (guard bites)
M3 incomplete accepted: red (guard bites)
M4 empty-table decode allowed: red (guard bites)
M5 over-long code length accepted: red (guard bites)
M6 single-code symbol off by one: red (guard bites)
M7 root slot spacing wrong: red (guard bites)
M8 first_code recurrence off by one: red (guard bites)
M9 fill cursor not wound back: red (guard bites)
M10 fill cursor never advances: red (guard bites)
```

The check runs first, so the defect names itself. M9 reports

```
FAIL gdeflate_tables_twin.cpp:392: t.first_index[len] == placed
| all-literals: length 8 starts at 255, 0 symbols placed before it
```

where against #400's suite the same mutant reported a failed page emission and
said nothing about which array was wrong.

WHAT THIS CHECK DOES NOT BUY, so the addition is not read as coverage it does
not have: it catches no ordering defect that the parity fixtures would let
through for a symbol those fixtures encode. Its value is the scattered case and
the diagnostic, and the mutants above red on both routes rather than only on
this one.

## The means

The same C++ test net as its neighbours, in the file that already owns this
header. Nothing added to the tree, no new target, no new dependency.

## Verification

```
$ cmake -B build -S . -DCUDEC_ENABLE_CUDA=ON && cmake --build build -j 12
$ ctest --test-dir build -LE gpu --no-tests=error
100% tests passed, 0 tests failed out of 47
Total Test time (real) =  15.46 sec
$ npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
All matched files use Prettier code style!
```

nvcc V13.3.73 on Ubuntu 24.04. The twin is in the sanitizer gate as of #400 and
its ASan+UBSan run is clean.

## What is still open on #175

The corpus half of the rewritten bullet one - "the decoded output of every
dynamic block in the corpus matches the oracle byte for byte at the block
boundary" - needs a block decode to produce that output, which is #182. Nothing
here reaches it, and #175 stays open on it.

There is no second reader for this change tonight. The mutant table is what a
reviewer would otherwise be asked to take on trust.
