### PR TITLE
Decode a whole GDeflate page: blocks, DEFLATE64 tables, in-tile LZ77 [#182]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,7 @@ jobs:
           grep -E ': gdeflate_probes$' host-selected.txt &&
           grep -E ': gdeflate_schedule_twin$' host-selected.txt &&
           grep -E ': gdeflate_header_twin$' host-selected.txt &&
+          grep -E ': gdeflate_block_twin$' host-selected.txt &&
           echo "Deferred to the local GPU gate:" &&
           ctest --test-dir build-cuda -L gpu -N | tee gpu-deferred.txt &&
           grep -E ': smoke$' gpu-deferred.txt &&
@@ -440,6 +441,7 @@ jobs:
           test -x build-san/tests/gdeflate_schedule_twin &&
           test -x build-san/tests/gdeflate_tables_twin &&
           test -x build-san/tests/gdeflate_header_twin &&
+          test -x build-san/tests/gdeflate_block_twin &&
           test -x build-san/tests/zstd_exec_twin &&
           test -x build-san/tests/zstd_blocks_twin &&
           test -x build-san/tests/termination
@@ -463,7 +465,7 @@ jobs:
       - name: Run the untrusted-input decode path under ASan+UBSan
         run: >-
           ctest --test-dir build-san --no-tests=error --output-on-failure -R
-          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|gdeflate_tables_twin|gdeflate_header_twin|zstd_frame_twin|zstd_exec_twin|zstd_blocks_twin|termination)$'
+          '^(conformance_c|oracle_lz4|parser_twin|snappy_parser_twin|snappy_edge_sweep|snappy_upstream_negatives|frame_host_negative|tilestream_host_negative|gdeflate_schedule_twin|gdeflate_tables_twin|gdeflate_header_twin|gdeflate_block_twin|zstd_frame_twin|zstd_exec_twin|zstd_blocks_twin|termination)$'
           &&
           ctest --test-dir build-san -N | tee san-selected.txt &&
           grep -E ': conformance_c$' san-selected.txt &&
@@ -477,6 +479,7 @@ jobs:
           grep -E ': gdeflate_schedule_twin$' san-selected.txt &&
           grep -E ': gdeflate_tables_twin$' san-selected.txt &&
           grep -E ': gdeflate_header_twin$' san-selected.txt &&
+          grep -E ': gdeflate_block_twin$' san-selected.txt &&
           grep -E ': zstd_frame_twin$' san-selected.txt &&
           grep -E ': zstd_exec_twin$' san-selected.txt &&
           grep -E ': zstd_blocks_twin$' san-selected.txt &&

--- a/src/gdeflate_block.h
+++ b/src/gdeflate_block.h
@@ -1,0 +1,392 @@
+/* The GDeflate page decode (issue #182): the block loop over stored, static
+ * and dynamic blocks, the length and distance tables, and the in-tile LZ77
+ * execution. Single-source for host and device, the top of the stack whose
+ * lower rungs are src/gdeflate_schedule.h (#178) and src/gdeflate_tables.h
+ * (#175, #176). It assembles those rather than restating them: no second bit
+ * cursor, no second canonical construction, no second code-length read.
+ *
+ * THE TABLES HERE ARE NOT RFC 1951'S, AND THAT IS THE WHOLE REASON THIS FILE
+ * CARRIES THEM. The pinned fork defines DEFLATE64 unconditionally in
+ * deflate_constants.h, so its length and distance alphabets are the DEFLATE64
+ * ones: symbol 285 is base 3 with SIXTEEN extra bits, reaching 65538 rather
+ * than the fixed 258 of RFC 1951 section 3.2.5, and distance symbols 30 and 31
+ * exist with base 32769 and 49153 and fourteen extra bits, reaching 65536 -
+ * exactly the 64 KiB tile. A decoder that used the stock tables would decode
+ * most pages correctly and silently corrupt the ones that use those symbols,
+ * with no checksum anywhere to catch it (docs/MASTERPLAN.md section 11.4).
+ * Each of the three is pinned in tests/gdeflate_block_twin.cpp against the
+ * oracle AND against the stock reading, so the pin proves something.
+ *
+ * THE DEFERRED COPY IS THE FORMAT AND NOT AN OPTIMISATION. A length symbol and
+ * its distance symbol are decoded on the SAME lane in CONSECUTIVE rounds of
+ * that lane, which is thirty-two rounds apart in the page. The round that
+ * decodes the length reserves the output range and moves the write cursor past
+ * it; the round that decodes the distance performs the copy into that reserved
+ * range. So the output is written out of order, and a decoder that performed
+ * the copy immediately would consume the distance symbol from the wrong lane
+ * and decode a different page. Deferring is what the format says, and the
+ * thirty-two rounds after end-of-block exist to drain the copies still
+ * outstanding when the block ended.
+ *
+ * FAIL-CLOSED, AND WHERE THE BOUNDS COME FROM. Every length is checked against
+ * the output that remains before any byte is written, every distance is
+ * checked against the output already produced before any byte is read, and the
+ * stored block's declared length is checked against the bytes the page can
+ * still supply. None of the three is a bound derived from the stream. A match
+ * may never reach before the start of this page's output, which is what makes
+ * a tile independent of every other tile - the reference bounds it the same
+ * way and against the same origin, because it decompresses one page into one
+ * tile too.
+ *
+ * WHAT IT DOES NOT DO. It decodes ONE page. The tile stream that says where
+ * pages are is src/tilestream.h, and the batch surface that drives it is #216.
+ * Reject behaviour beyond the refusals named above is filed separately from
+ * this issue. */
+#ifndef CUDEC_GDEFLATE_BLOCK_H
+#define CUDEC_GDEFLATE_BLOCK_H
+
+#include "gdeflate_tables.h"
+
+#include <stdint.h>
+
+namespace cudec_detail {
+
+/* The reference's block types (deflate_constants.h). Type 3 is reserved and is
+ * the one BTYPE that carries no meaning at all, so it is refused by name. */
+constexpr uint32_t kGDeflateBlockStored = 0;
+constexpr uint32_t kGDeflateBlockStatic = 1;
+constexpr uint32_t kGDeflateBlockDynamic = 2;
+constexpr uint32_t kGDeflateBlockReserved = 3;
+
+/* The literal/length alphabet's first length symbol, and the end-of-block
+ * symbol below it. */
+constexpr uint32_t kGDeflateEndOfBlock = 256;
+constexpr uint32_t kGDeflateFirstLengthSym = 257;
+
+/* The shortest match the format can express. It is here because the distance
+ * check below is what stops a match reading before the page's output, and a
+ * reader wants the minimum beside it. */
+constexpr uint32_t kGDeflateMinMatchLen = 3;
+
+/* Length symbol 257 + i: its base, and how many extra bits follow it in the
+ * same round. Data from the pinned fork's `litlen_decode_results` under
+ * DEFLATE64, restated here because this is the thing that has to agree with
+ * it. The last three entries are where the format leaves RFC 1951: symbols
+ * 285, 286 and 287 all carry base 3 with sixteen extra bits. */
+CUDEC_HOST_DEVICE inline uint32_t GDeflateLengthBase(uint32_t index) {
+    const uint16_t kBase[31] = {3,  4,  5,  6,  7,  8,  9,   10,  11,  13, 15,
+                                17, 19, 23, 27, 31, 35, 43,  51,  59,  67, 83,
+                                99, 115, 131, 163, 195, 227, 3,   3,   3};
+    return kBase[index];
+}
+
+CUDEC_HOST_DEVICE inline uint32_t GDeflateLengthExtra(uint32_t index) {
+    const unsigned char kExtra[31] = {0, 0, 0, 0, 0, 0, 0, 0,  1,  1,  1,
+                                      1, 2, 2, 2, 2, 3, 3, 3,  3,  4,  4,
+                                      4, 4, 5, 5, 5, 5, 16, 16, 16};
+    return kExtra[index];
+}
+
+/* Distance symbol `sym`: its base and its extra-bit count. Symbols 30 and 31
+ * are the second divergence - RFC 1951 stops at 29 and 32768. */
+CUDEC_HOST_DEVICE inline uint32_t GDeflateDistBase(uint32_t sym) {
+    const uint32_t kBase[kGDeflateNumDistSyms] = {
+        1,    2,    3,    4,     5,     7,     9,     13,   17,    25,   33,
+        49,   65,   97,   129,   193,   257,   385,   513,  769,   1025, 1537,
+        2049, 3073, 4097, 6145,  8193,  12289, 16385, 24577, 32769, 49153};
+    return kBase[sym];
+}
+
+CUDEC_HOST_DEVICE inline uint32_t GDeflateDistExtra(uint32_t sym) {
+    const unsigned char kExtra[kGDeflateNumDistSyms] = {
+        0, 0, 0,  0,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  6,  6,
+        7, 7, 8,  8,  9,  9,  10, 10, 11, 11, 12, 12, 13, 13, 14, 14};
+    return kExtra[sym];
+}
+
+/* The static block's two codes (RFC 1951 section 3.2.6, unchanged by the
+ * DEFLATE64 divergences, which move bases and extra bits rather than codeword
+ * lengths). Built through the same construction every other table goes
+ * through, so a static block and a dynamic block share one decoder. */
+CUDEC_HOST_DEVICE inline bool GDeflateStaticTables(GDeflateLitLenTable& litlen,
+                                                   GDeflateDistTable& dist) {
+    unsigned char lens[kGDeflateNumLitLenSyms];
+    for (uint32_t i = 0; i < kGDeflateNumLitLenSyms; i++) {
+        if (i < 144) {
+            lens[i] = 8;
+        } else if (i < 256) {
+            lens[i] = 9;
+        } else if (i < 280) {
+            lens[i] = 7;
+        } else {
+            lens[i] = 8;
+        }
+    }
+    if (!GDeflateBuildTable(lens, kGDeflateNumLitLenSyms, litlen)) {
+        return false;
+    }
+    unsigned char dist_lens[kGDeflateNumDistSyms];
+    for (uint32_t i = 0; i < kGDeflateNumDistSyms; i++) {
+        dist_lens[i] = 5;
+    }
+    return GDeflateBuildTable(dist_lens, kGDeflateNumDistSyms, dist);
+}
+
+/* One lane's outstanding match: the length it reserved and where in the output
+ * that reservation starts. Held per lane for the reason GDeflateSchedule holds
+ * all 32 bit buffers - the CPU twin runs the lanes sequentially in one thread,
+ * while in the warp kernel each lane owns its own copy state in registers. The
+ * reference keeps the same thing as a rotating 32-bit mask beside a per-lane
+ * array; a mask and a flag per lane are the same set, and the flag is the
+ * shape that reads correctly in both residencies. */
+struct GDeflateDeferredCopy {
+    uint64_t out_pos;
+    uint32_t length;
+    bool pending;
+};
+
+/* Everything a page decode carries: the schedule, the two live tables, and the
+ * 32 deferred copies. */
+struct GDeflatePageState {
+    GDeflateSchedule s;
+    GDeflateLitLenTable litlen;
+    GDeflateDistTable dist;
+    GDeflateCodeLengths lens;
+    GDeflateDeferredCopy copies[kGDeflateNumStreams];
+    /* How many blocks the page turned out to hold. It is what the decode
+     * produced rather than bookkeeping: a page is one block or several and
+     * nothing outside says which, so without this the multi-block case cannot
+     * be told from the single-block one by anything that reads a decode. */
+    uint32_t blocks;
+};
+
+/* Perform the copy the current lane reserved: decode the distance symbol off
+ * this lane, add its extra bits, and move the bytes. */
+CUDEC_HOST_DEVICE inline bool GDeflateDoCopy(GDeflatePageState& st,
+                                             unsigned char* out) {
+    GDeflateSchedule& s = st.s;
+    GDeflateDeferredCopy& c = st.copies[s.idx];
+    const uint32_t sym = GDeflateDecodeSymbol(s, st.dist);
+    if (sym == kGDeflateNoSymbol) {
+        return false;
+    }
+    const uint32_t offset = GDeflateDistBase(sym) +
+                            GDeflatePop(s, GDeflateDistExtra(sym));
+    if (s.failed) {
+        return false;
+    }
+    /* The match source may not begin before this page's output. Compared in
+     * the 64-bit width the output position is carried in, so the comparison
+     * cannot be the place a narrowing hides: `offset` is at most 65536 and
+     * `c.out_pos` is where the reservation started. */
+    if (static_cast<uint64_t>(offset) > c.out_pos) {
+        s.failed = true;
+        return false;
+    }
+    const uint64_t src = c.out_pos - offset;
+    /* Byte by byte, forwards, which is what an overlapping match MEANS: a
+     * distance below the length is a run that repeats what this copy is itself
+     * writing. A word-at-a-time copy would have to special-case that; this
+     * does not, and it is the same order on both residencies, which is what
+     * makes the output bit-identical (docs/DETERMINISM.md). */
+    for (uint32_t n = 0; n < c.length; n++) {
+        out[c.out_pos + n] = out[src + n];
+    }
+    c.pending = false;
+    return true;
+}
+
+/* Decode one page into `out`, which is the tile it belongs to. Returns false
+ * with the schedule failed for every page this decoder refuses; `*out_len` is
+ * written only on success.
+ *
+ * `out_cap` is the caller's capacity and is the only bound the output is
+ * checked against. It is never derived from the page: the format states no
+ * uncompressed size anywhere inside a page, which is why the tile size lives
+ * in the stream header that src/tilestream.h parses. */
+CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
+                                                 const unsigned char* page,
+                                                 uint64_t page_bytes,
+                                                 unsigned char* out,
+                                                 uint64_t out_cap,
+                                                 uint64_t* out_len) {
+    GDeflateSchedule& s = st.s;
+    if (!GDeflateInit(s, page, page_bytes)) {
+        return false;
+    }
+    for (uint32_t n = 0; n < kGDeflateNumStreams; n++) {
+        st.copies[n].pending = false;
+        st.copies[n].length = 0;
+        st.copies[n].out_pos = 0;
+    }
+    uint64_t out_pos = 0;
+
+    /* A block costs lane 0 at least the three bits of its own header, and a
+     * lane holds at most kGDeflateMaxLaneBits, so at most that many thirds of
+     * a lane's worth of blocks can pass between two refills of lane 0 - and
+     * lane 0 can be refilled at most once per word the page holds. The cap is
+     * therefore generous by a wide margin and exists to make termination a
+     * property of the code rather than of an argument about the input. */
+    const uint64_t block_fuel =
+        (s.word_count + 1u) * (kGDeflateMaxLaneBits / kGDeflateMinMatchLen);
+    bool final_block = false;
+    uint32_t blocks_read = 0;
+    for (uint64_t block = 0; block < block_fuel && !final_block; block++) {
+        blocks_read++;
+        GDeflateReset(s);
+        final_block = GDeflatePop(s, 1) != 0;
+        const uint32_t block_type = GDeflatePop(s, 2);
+        if (s.failed) {
+            return false;
+        }
+        GDeflateEnsure(s, page);
+
+        if (block_type == kGDeflateBlockReserved) {
+            s.failed = true;
+            return false;
+        }
+
+        if (block_type == kGDeflateBlockStored) {
+            /* The bytes the page can still supply: whole words the cursor has
+             * not reached, plus whatever the lanes already hold. The reference
+             * computes exactly this, and it is the only bound a stored block's
+             * declared length has - there is no complement field to
+             * cross-check it against (dossier 11.3, D3).
+             *
+             * The reference guards its own sixteen-bit read with a second
+             * check that at least two bytes remain. That one is not carried
+             * here: it protects an unchecked read out of the input buffer,
+             * and GDeflatePop is bounded by the schedule already, so the same
+             * check on this side could not be reached by any page and a guard
+             * that cannot bite proves nothing. */
+            const uint64_t reachable =
+                (s.word_count - s.cursor) * (kGDeflateBitsPerPacket / 8u) +
+                (GDeflateBufferedBits(s) + 7u) / 8u;
+            const uint32_t len = GDeflatePop(s, 16);
+            if (s.failed) {
+                return false;
+            }
+            if (len > out_cap - out_pos || len > reachable) {
+                s.failed = true;
+                return false;
+            }
+            for (uint32_t n = 0; n < len; n++) {
+                out[out_pos] = static_cast<unsigned char>(GDeflatePop(s, 8));
+                out_pos++;
+                GDeflateAdvance(s, page);
+            }
+            if (s.failed) {
+                return false;
+            }
+        } else {
+            if (block_type == kGDeflateBlockStatic) {
+                if (!GDeflateStaticTables(st.litlen, st.dist)) {
+                    s.failed = true;
+                    return false;
+                }
+            } else if (!GDeflateReadDynamicTables(s, page, st.lens, st.litlen,
+                                                  st.dist)) {
+                return false;
+            }
+
+            GDeflateReset(s);
+            /* Every round either writes a byte, reserves a match of at least
+             * the minimum length, or retires a reservation an earlier round
+             * made - so the capacity bounds the reserving rounds and the
+             * retiring rounds alike, and the end-of-block round and the drain
+             * are the constant beside them. */
+            const uint64_t round_fuel = 2u * (out_cap + 1u) + kGDeflateNumStreams;
+            bool block_done = false;
+            for (uint64_t round = 0; round < round_fuel && !block_done;
+                 round++) {
+                if (st.copies[s.idx].pending) {
+                    if (!GDeflateDoCopy(st, out)) {
+                        return false;
+                    }
+                    GDeflateAdvance(s, page);
+                    if (s.failed) {
+                        return false;
+                    }
+                    continue;
+                }
+                const uint32_t sym = GDeflateDecodeSymbol(s, st.litlen);
+                if (sym == kGDeflateNoSymbol) {
+                    return false;
+                }
+                if (sym < kGDeflateEndOfBlock) {
+                    if (out_pos == out_cap) {
+                        s.failed = true;
+                        return false;
+                    }
+                    out[out_pos] = static_cast<unsigned char>(sym);
+                    out_pos++;
+                    GDeflateAdvance(s, page);
+                    if (s.failed) {
+                        return false;
+                    }
+                    continue;
+                }
+                if (sym == kGDeflateEndOfBlock) {
+                    /* The reference leaves the loop here WITHOUT advancing:
+                     * the drain below starts on this lane, not the next. */
+                    block_done = true;
+                    continue;
+                }
+                const uint32_t index = sym - kGDeflateFirstLengthSym;
+                const uint32_t length =
+                    GDeflateLengthBase(index) +
+                    GDeflatePop(s, GDeflateLengthExtra(index));
+                if (s.failed) {
+                    return false;
+                }
+                if (length > out_cap - out_pos) {
+                    s.failed = true;
+                    return false;
+                }
+                /* The reservation, not the copy. The distance symbol this
+                 * match needs arrives on this same lane one round of its own
+                 * later, and the output cursor moves past the hole now so the
+                 * rounds in between write after it. */
+                st.copies[s.idx].pending = true;
+                st.copies[s.idx].length = length;
+                st.copies[s.idx].out_pos = out_pos;
+                out_pos += length;
+                GDeflateAdvance(s, page);
+                if (s.failed) {
+                    return false;
+                }
+            }
+            if (!block_done) {
+                /* The round cap was reached with no end-of-block. A page that
+                 * ran that far has produced more rounds than its own capacity
+                 * admits, so it is refused rather than reported as a decode. */
+                s.failed = true;
+                return false;
+            }
+
+            /* The drain: one round per lane, retiring whatever is still
+             * outstanding. A block that ends with copies pending is the normal
+             * case rather than an error - up to 31 lanes can hold one. */
+            for (uint32_t n = 0; n < kGDeflateNumStreams; n++) {
+                if (st.copies[s.idx].pending && !GDeflateDoCopy(st, out)) {
+                    return false;
+                }
+                GDeflateAdvance(s, page);
+                if (s.failed) {
+                    return false;
+                }
+            }
+        }
+    }
+    if (!final_block) {
+        s.failed = true;
+        return false;
+    }
+    st.blocks = blocks_read;
+    *out_len = out_pos;
+    return true;
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_GDEFLATE_BLOCK_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,6 +178,18 @@ cudec_add_test(gdeflate_header_twin SOURCES gdeflate_header_twin.cpp LIBS
                gdeflate_oracle)
 target_include_directories(gdeflate_header_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The GDeflate page decode (issue #182), the top of the M4 CPU ladder: block
+# dispatch, the DEFLATE64 length and distance tables, and the deferred in-tile
+# LZ77. Unlike the three rungs below it this one asks the oracle directly - the
+# reference's compressor produces the corpus and its decompressor says what the
+# pages mean, both across the library's own boundary - so it is the test that
+# makes the schedule, the table construction and the code-length read checkable
+# end to end. GPU-less and linking gdeflate_oracle alone for the reasons
+# oracle_gdeflate gives above, reaching src/ for the header under test.
+cudec_add_test(gdeflate_block_twin SOURCES gdeflate_block_twin.cpp LIBS
+               gdeflate_oracle)
+target_include_directories(gdeflate_block_twin
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 # The reference's own decode behaviours, executed rather than read (issue
 # #155). Host-side and GPU-less on purpose: it is the oracle answering, and
 # the answers are what the M3 fail-closed matrix is allowed to lock against.

--- a/tests/gdeflate_block_twin.cpp
+++ b/tests/gdeflate_block_twin.cpp
@@ -1,0 +1,697 @@
+/* The GDeflate page decode, held against the reference (issue #182).
+ * src/gdeflate_block.h decodes a whole page - block dispatch, the DEFLATE64
+ * length and distance tables, and the deferred in-tile LZ77 - and this
+ * establishes that it produces the reference's bytes over a corpus the
+ * reference's own compressor generated.
+ *
+ * THIS IS THE ONE RUNG WHERE THE ORACLE ANSWERS DIRECTLY, AND THAT IS THE
+ * POINT. The rungs below it (#178, #175, #176) had to reach parity sideways,
+ * because the schedule's word cursor and the code-length vectors sit in the
+ * pinned fork's private state and no public name reaches them. A decoded page
+ * is different: `libdeflate_gdeflate_compress` produces the page and
+ * `libdeflate_gdeflate_decompress` says what it means, both across the
+ * library's own boundary. So the comparison here is the plain one - same page
+ * in, same bytes out, byte for byte and length for length - and it is what
+ * makes the three rungs below it checkable end to end, because a wrong word
+ * cursor or a wrong code-length vector cannot survive it.
+ *
+ * THE DIVERGENCES ARE THE PART A STOCK RFC 1951 DECODER GETS WRONG SILENTLY.
+ * Length symbol 285 with sixteen extra bits and distance symbols 30 and 31
+ * each get a fixture whose input can only be coded through them, and each is
+ * decoded to the byte. What shows that the pin proves something is the mutant
+ * pass rather than an assertion here: setting symbol 285 back to RFC 1951's
+ * base 258 with no extra bits, or either distance symbol back to a stock
+ * value, reds this file. A test that merely asserted the tables differ from
+ * RFC 1951's would pass against a decoder that never reached them.
+ *
+ * WHAT IS NOT COVERED. The reject ladder is filed separately from this issue,
+ * so the negatives here are the three this decoder owes on its own terms - a
+ * reserved block type, an output that does not fit its tile, and a page cut
+ * short - rather than a fail-closed matrix. Nothing here runs on a device;
+ * #214 is the kernel and #218 its gate set. */
+#include "gdeflate_block.h"
+#include "gdeflate_page_writer.h"
+#include "require.h"
+
+#include <libdeflate.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+using cudec_detail::GDeflateDecodePage;
+using cudec_detail::GDeflateInit;
+using cudec_detail::GDeflatePageState;
+using cudec_detail::GDeflatePop;
+using cudec_detail::GDeflateReset;
+using cudec_detail::GDeflateSchedule;
+using cudec_detail::kGDeflateBlockReserved;
+using cudec_test::GDeflatePageWriter;
+
+/* The tile a page decompresses into. The format fixes it and it is not read
+ * from anywhere inside a page (dossier 11.2), which is why every decode below
+ * is handed the capacity rather than discovering it. */
+constexpr size_t kTileBytes = 64u * 1024u;
+
+/* The deterministic source every fixture draws from. A named generator rather
+ * than a library one: the corpus has to be identical on every machine and in
+ * every run, or a parity failure is not reproducible. */
+class Lcg {
+   public:
+    explicit Lcg(unsigned seed) : state_(seed) {}
+    unsigned Next() {
+        state_ = state_ * 1103515245u + 12345u;
+        return (state_ >> 16) & 0xFFFFu;
+    }
+
+   private:
+    unsigned state_;
+};
+
+std::vector<unsigned char> Incompressible(unsigned seed, size_t n) {
+    Lcg lcg(seed);
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; i++) {
+        v[i] = static_cast<unsigned char>(lcg.Next() & 0xFFu);
+    }
+    return v;
+}
+
+/* A skewed alphabet with noise through it: worth describing with a code, not
+ * worth a static one, which is what draws a dynamic block. */
+std::vector<unsigned char> MixedEntropy(unsigned seed, size_t n) {
+    Lcg lcg(seed);
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; i++) {
+        const unsigned r = lcg.Next();
+        v[i] = static_cast<unsigned char>((r % 4u == 0u) ? (r & 0xFFu)
+                                                         : ('a' + (r % 5u)));
+    }
+    return v;
+}
+
+/* Short repeats, which is what puts ordinary matches - modest lengths, modest
+ * distances - into the corpus. */
+std::vector<unsigned char> ShortRepeats(unsigned seed, size_t n) {
+    Lcg lcg(seed);
+    std::vector<unsigned char> v;
+    v.reserve(n);
+    while (v.size() < n) {
+        const size_t run = 3u + (lcg.Next() % 60u);
+        const unsigned char b = static_cast<unsigned char>('a' + lcg.Next() % 6u);
+        for (size_t i = 0; i < run && v.size() < n; i++) {
+            v.push_back(b);
+        }
+        const size_t noise = lcg.Next() % 8u;
+        for (size_t i = 0; i < noise && v.size() < n; i++) {
+            v.push_back(static_cast<unsigned char>(lcg.Next() & 0xFFu));
+        }
+    }
+    return v;
+}
+
+/* Compress with the page split the reference itself chooses. Returns the pages
+ * as separate byte vectors, which is how a tile stream carries them and how
+ * this decoder consumes them. */
+bool CompressPages(int level, const std::vector<unsigned char>& in,
+                   std::vector<std::vector<unsigned char> >* pages) {
+    libdeflate_gdeflate_compressor* c =
+        libdeflate_alloc_gdeflate_compressor(level);
+    if (c == nullptr) {
+        return false;
+    }
+    size_t npages = 0;
+    const size_t bound =
+        libdeflate_gdeflate_compress_bound(c, in.size(), &npages);
+    if (bound == 0 || npages == 0) {
+        libdeflate_free_gdeflate_compressor(c);
+        return false;
+    }
+    std::vector<unsigned char> pool(bound * npages, 0);
+    std::vector<libdeflate_gdeflate_out_page> out(npages);
+    for (size_t i = 0; i < npages; i++) {
+        out[i].data = pool.data() + i * bound;
+        out[i].nbytes = bound;
+    }
+    const size_t total = libdeflate_gdeflate_compress(c, in.data(), in.size(),
+                                                      out.data(), npages);
+    libdeflate_free_gdeflate_compressor(c);
+    if (total == 0) {
+        return false;
+    }
+    pages->clear();
+    for (size_t i = 0; i < npages; i++) {
+        const unsigned char* p =
+            static_cast<const unsigned char*>(out[i].data);
+        pages->push_back(std::vector<unsigned char>(p, p + out[i].nbytes));
+    }
+    return true;
+}
+
+/* The reference's own answer for the whole page array, which is the second
+ * half of every parity claim: this decoder is compared against the input the
+ * corpus was built from AND against what the reference makes of the same
+ * bytes, so a corpus generator that silently produced something else cannot
+ * pass by agreeing with itself. */
+bool OracleDecompress(const std::vector<std::vector<unsigned char> >& pages,
+                      size_t out_cap, std::vector<unsigned char>* out) {
+    libdeflate_gdeflate_decompressor* d =
+        libdeflate_alloc_gdeflate_decompressor();
+    if (d == nullptr) {
+        return false;
+    }
+    std::vector<libdeflate_gdeflate_in_page> in(pages.size());
+    for (size_t i = 0; i < pages.size(); i++) {
+        in[i].data = pages[i].data();
+        in[i].nbytes = pages[i].size();
+    }
+    out->assign(out_cap, 0);
+    size_t produced = 0;
+    const libdeflate_result r = libdeflate_gdeflate_decompress(
+        d, in.data(), in.size(), out->data(), out_cap, &produced);
+    libdeflate_free_gdeflate_decompressor(d);
+    if (r != LIBDEFLATE_SUCCESS) {
+        return false;
+    }
+    out->resize(produced);
+    return true;
+}
+
+/* The block type of a page's first block, read with the schedule alone. Used
+ * to prove the corpus reaches all three types rather than assuming it does -
+ * which type a given input draws is the reference compressor's decision. */
+int FirstBlockType(const std::vector<unsigned char>& page) {
+    GDeflateSchedule s;
+    if (!GDeflateInit(s, page.data(), page.size())) {
+        return -1;
+    }
+    GDeflateReset(s);
+    GDeflatePop(s, 1);
+    const uint32_t t = GDeflatePop(s, 2);
+    if (s.failed) {
+        return -1;
+    }
+    return static_cast<int>(t);
+}
+
+/* What the corpus turned out to contain, accumulated across every fixture so
+ * the coverage claim is measured rather than asserted per case. */
+struct Coverage {
+    bool type_seen[4];
+    bool multi_block;
+    Coverage() : multi_block(false) {
+        for (uint32_t i = 0; i < 4; i++) {
+            type_seen[i] = false;
+        }
+    }
+};
+
+/* One corpus fixture: compress, decompress every page with the decoder under
+ * test, and require the concatenation to be the input byte for byte and the
+ * reference's own output byte for byte. */
+int CheckRoundTrip(const char* name, int level,
+                   const std::vector<unsigned char>& in, Coverage* cov) {
+    std::vector<std::vector<unsigned char> > pages;
+    REQUIRE_CTX(CompressPages(level, in, &pages), "%s at level %d", name,
+                level);
+
+    std::vector<unsigned char> oracle_out;
+    REQUIRE_CTX(OracleDecompress(pages, in.size(), &oracle_out),
+                "%s at level %d", name, level);
+    REQUIRE_CTX(oracle_out.size() == in.size(), "%s: oracle produced %zu",
+                name, oracle_out.size());
+    REQUIRE_CTX(equal_bytes(oracle_out.data(), in.data(), in.size()), "%s",
+                name);
+
+    std::vector<unsigned char> got;
+    for (size_t i = 0; i < pages.size(); i++) {
+        /* A page's tile is full unless it is the last one, and the last one
+         * holds exactly what is left. Nothing inside the page says so, which
+         * is why the caller has to. */
+        const size_t consumed = i * kTileBytes;
+        const size_t want = in.size() - consumed < kTileBytes
+                                ? in.size() - consumed
+                                : kTileBytes;
+        std::vector<unsigned char> tile(kTileBytes, 0);
+        GDeflatePageState st;
+        uint64_t produced = 0;
+        REQUIRE_CTX(GDeflateDecodePage(st, pages[i].data(), pages[i].size(),
+                                       tile.data(), want, &produced),
+                    "%s level %d page %zu", name, level, i);
+        REQUIRE_CTX(produced == want, "%s page %zu produced %llu want %zu",
+                    name, i, static_cast<unsigned long long>(produced), want);
+        REQUIRE_CTX(equal_bytes(tile.data(), in.data() + consumed, want),
+                    "%s level %d page %zu", name, level, i);
+
+        const int type = FirstBlockType(pages[i]);
+        REQUIRE_CTX(type >= 0 && type < 4, "%s page %zu type %d", name, i,
+                    type);
+        cov->type_seen[type] = true;
+        if (st.blocks > 1) {
+            cov->multi_block = true;
+        }
+        got.insert(got.end(), tile.begin(), tile.begin() + want);
+    }
+    REQUIRE_CTX(got.size() == in.size(), "%s: %zu bytes", name, got.size());
+    return 0;
+}
+
+/* The corpus. Levels are the reference's own range endpoints and its default,
+ * because which block type and which symbols an input draws is a function of
+ * the level as much as of the bytes. */
+int RunCorpus() {
+    Coverage cov;
+    const int levels[] = {1, 6, 9, 12};
+    for (uint32_t l = 0; l < 4; l++) {
+        const int level = levels[l];
+        if (CheckRoundTrip("incompressible-4k", level,
+                           Incompressible(1, 4096), &cov) != 0) {
+            return 1;
+        }
+        if (CheckRoundTrip("incompressible-60k", level,
+                           Incompressible(2, 60000), &cov) != 0) {
+            return 1;
+        }
+        if (CheckRoundTrip("mixed-4k", level, MixedEntropy(3, 4096), &cov) !=
+            0) {
+            return 1;
+        }
+        if (CheckRoundTrip("mixed-60k", level, MixedEntropy(4, 60000), &cov) !=
+            0) {
+            return 1;
+        }
+        if (CheckRoundTrip("short-repeats-60k", level,
+                           ShortRepeats(5, 60000), &cov) != 0) {
+            return 1;
+        }
+        /* Several pages, so the page split itself is exercised rather than
+         * only the single-page shape. */
+        if (CheckRoundTrip("mixed-multi-page", level,
+                           MixedEntropy(6, 3u * kTileBytes + 7u), &cov) != 0) {
+            return 1;
+        }
+        /* A page whose output hits the tile size exactly, which the issue asks
+         * for by name: the last page is full rather than short, so the
+         * capacity check and the last byte written coincide. */
+        if (CheckRoundTrip("exact-tile", level, ShortRepeats(7, kTileBytes),
+                           &cov) != 0) {
+            return 1;
+        }
+        if (CheckRoundTrip("exact-two-tiles", level,
+                           MixedEntropy(8, 2u * kTileBytes), &cov) != 0) {
+            return 1;
+        }
+        /* One byte, and the empty input, which are where a decode that
+         * assumed a block had a body would come apart. */
+        if (CheckRoundTrip("one-byte", level,
+                           std::vector<unsigned char>(1, 'q'), &cov) != 0) {
+            return 1;
+        }
+    }
+
+    /* The coverage claim, measured over everything above. All three block
+     * types have to have been decoded, and at least one page has to have held
+     * more than one block, or this file is testing less than it says. */
+    REQUIRE(cov.type_seen[cudec_detail::kGDeflateBlockStored]);
+    REQUIRE(cov.type_seen[cudec_detail::kGDeflateBlockStatic]);
+    REQUIRE(cov.type_seen[cudec_detail::kGDeflateBlockDynamic]);
+    REQUIRE(!cov.type_seen[kGDeflateBlockReserved]);
+    REQUIRE(cov.multi_block);
+    return 0;
+}
+
+/* D1: length symbol 285 is base 3 with sixteen extra bits and reaches 65538,
+ * where RFC 1951 fixes it at 258 with none. A whole tile of one byte is a
+ * single match under the format and 254 matches under the stock reading, so a
+ * decoder carrying the stock table walks the rest of the page from a bit
+ * position sixteen bits off - in every lane, with no checksum to catch it.
+ * That the pin bites is shown by the mutant that restores 258/0, not by an
+ * assertion here. */
+int RunLongMatch() {
+    Coverage cov;
+    const std::vector<unsigned char> run(kTileBytes, 'A');
+    if (CheckRoundTrip("tile-of-one-byte", 12, run, &cov) != 0) {
+        return 1;
+    }
+    /* The match this fixture rests on is longer than RFC 1951's ceiling, which
+     * is what makes it the D1 fixture rather than an ordinary run. */
+    REQUIRE(run.size() > 258u);
+    return CheckRoundTrip("tile-of-one-byte-level1", 1, run, &cov);
+}
+
+/* D2: distance symbols 30 and 31 exist, with base 32769 and 49153 and fourteen
+ * extra bits, reaching 65536 - the tile exactly. The fixture is the one
+ * tests/gdeflate_probes.cpp measures the divergence with: 20000 incompressible
+ * bytes repeated at offset 45000, so the only match that saves anything sits
+ * at a distance RFC 1951 cannot express. */
+int RunFarMatch() {
+    Coverage cov;
+    std::vector<unsigned char> v = Incompressible(11, 20000);
+    std::vector<unsigned char> page = Incompressible(12, 45000);
+    page.insert(page.end(), v.begin(), v.end());
+    for (size_t i = 0; i < 20000 && page.size() < kTileBytes; i++) {
+        page[i] = v[i];
+    }
+    REQUIRE(page.size() <= kTileBytes);
+    /* The repeat sits 45000 bytes after its source, past RFC 1951's 32768
+     * ceiling, which is what makes this the D2 fixture. */
+    REQUIRE(45000u > 32768u);
+    return CheckRoundTrip("far-match", 12, page, &cov);
+}
+
+/* An overlapping match: a distance below the match length, which is a run that
+ * repeats the bytes the copy is itself writing. It is the case a word-at-a-time
+ * copy has to special-case and this one does not, and it is where an
+ * implementation that copied backwards or in blocks produces different bytes. */
+int RunOverlappingMatch() {
+    Coverage cov;
+    std::vector<unsigned char> v;
+    v.reserve(kTileBytes);
+    /* A three-byte cycle repeated to fill the tile: every match after the
+     * first three bytes has distance 3 and a length far past it. */
+    while (v.size() < kTileBytes) {
+        v.push_back('x');
+        v.push_back('y');
+        v.push_back('z');
+    }
+    v.resize(kTileBytes);
+    if (CheckRoundTrip("distance-three-run", 12, v, &cov) != 0) {
+        return 1;
+    }
+    /* Distance one, the degenerate overlap. */
+    return CheckRoundTrip("distance-one-run", 6,
+                          std::vector<unsigned char>(40000, 0x5A), &cov);
+}
+
+/* A reserved block type, in front of a block that is otherwise entirely
+ * valid. That is the shape the refusal has to be tested with: a page carrying
+ * nothing but a reserved type is refused by any decoder that reaches the end
+ * of it, so such a page would pass against a decoder with no reserved check at
+ * all that merely fell through to the dynamic path. This takes a page the
+ * compressor produced, whose first block is dynamic, and turns its BTYPE into
+ * the reserved value - two bits, nothing else. The reference refuses it and so
+ * must this decoder, while a decoder without the check would decode the block
+ * behind those two bits perfectly. */
+int RunReservedBlockType() {
+    const std::vector<unsigned char> in = MixedEntropy(31, 20000);
+    std::vector<std::vector<unsigned char> > pages;
+    REQUIRE(CompressPages(6, in, &pages));
+    REQUIRE(pages.size() == 1);
+    REQUIRE(FirstBlockType(pages[0]) == cudec_detail::kGDeflateBlockDynamic);
+
+    /* BFINAL is bit 0 of the page's first word and BTYPE is bits 1 and 2,
+     * least significant first, because lane 0's first word is word 0 and the
+     * block header rides lane 0 (dossier 11.2). Setting both makes BTYPE 3. */
+    std::vector<unsigned char> page = pages[0];
+    page[0] = static_cast<unsigned char>(page[0] | 0x06u);
+    REQUIRE(FirstBlockType(page) == static_cast<int>(kGDeflateBlockReserved));
+
+    libdeflate_gdeflate_decompressor* d =
+        libdeflate_alloc_gdeflate_decompressor();
+    REQUIRE(d != nullptr);
+    libdeflate_gdeflate_in_page in_page;
+    in_page.data = page.data();
+    in_page.nbytes = page.size();
+    std::vector<unsigned char> out(kTileBytes, 0);
+    size_t produced = 0;
+    const libdeflate_result r = libdeflate_gdeflate_decompress(
+        d, &in_page, 1, out.data(), in.size(), &produced);
+    libdeflate_free_gdeflate_decompressor(d);
+    REQUIRE_CTX(r == LIBDEFLATE_BAD_DATA, "status %d", static_cast<int>(r));
+
+    std::vector<unsigned char> tile(kTileBytes, 0);
+    GDeflatePageState st;
+    uint64_t got = 0;
+    REQUIRE(!GDeflateDecodePage(st, page.data(), page.size(), tile.data(),
+                                in.size(), &got));
+    REQUIRE(st.s.failed);
+    return 0;
+}
+
+/* The RFC 1951 static code lengths, restated here rather than taken from the
+ * header under test. A fixture that computed its expected codewords with the
+ * code it is testing would agree with that code whatever either of them said,
+ * which is the one thing a twin may not do. */
+std::vector<unsigned char> StaticLitLenLengths() {
+    std::vector<unsigned char> lens(288, 0);
+    for (uint32_t i = 0; i < 288; i++) {
+        if (i < 144) {
+            lens[i] = 8;
+        } else if (i < 256) {
+            lens[i] = 9;
+        } else if (i < 280) {
+            lens[i] = 7;
+        } else {
+            lens[i] = 8;
+        }
+    }
+    return lens;
+}
+
+/* A match whose source begins before the page's output. The block's very first
+ * symbol is a length, so the reservation starts at output position zero and
+ * EVERY distance the format can express reaches before it - which makes this
+ * the smallest page that exercises the bound, and one whose refusal cannot be
+ * confused with running out of input. The reference refuses it at the same
+ * point and its verdict is asserted beside ours.
+ *
+ * The block is a static one so the fixture owes no dynamic header: what is
+ * under test is the distance bound, and a header between it and the page start
+ * would only add ways for the fixture itself to be wrong. */
+int RunMatchBeforeOutput() {
+    const std::vector<unsigned char> litlen_lens = StaticLitLenLengths();
+    const std::vector<unsigned char> dist_lens(32, 5);
+
+    cudec_detail::GDeflateLitLenTable litlen;
+    cudec_detail::GDeflateDistTable dist;
+    REQUIRE(cudec_detail::GDeflateBuildTable(litlen_lens.data(), 288, litlen));
+    REQUIRE(cudec_detail::GDeflateBuildTable(dist_lens.data(), 32, dist));
+
+    uint32_t len_code = 0;
+    uint32_t len_bits = 0;
+    REQUIRE(cudec_test::CodewordOf(litlen, litlen_lens.data(), 257u, &len_code,
+                                   &len_bits));
+    uint32_t lit_code = 0;
+    uint32_t lit_bits = 0;
+    REQUIRE(cudec_test::CodewordOf(litlen, litlen_lens.data(),
+                                   static_cast<uint32_t>('a'), &lit_code,
+                                   &lit_bits));
+    uint32_t dist_code = 0;
+    uint32_t dist_bits = 0;
+    REQUIRE(cudec_test::CodewordOf(dist, dist_lens.data(), 0u, &dist_code,
+                                   &dist_bits));
+
+    GDeflatePageWriter w;
+    w.Reset();
+    w.Push(1, 1); /* BFINAL */
+    w.Push(2, cudec_detail::kGDeflateBlockStatic);
+    w.Ensure();
+    w.Reset();
+    /* Lane 0 opens the block with a length symbol: three bytes reserved at
+     * output position zero, before a single byte exists. */
+    w.PushCode(len_code, len_bits);
+    w.Advance();
+    for (uint32_t i = 1; i < cudec_detail::kGDeflateNumStreams; i++) {
+        w.PushCode(lit_code, lit_bits);
+        w.Advance();
+    }
+    /* Back on lane 0, one round of its own later: the distance. Symbol 0 is
+     * distance 1, the nearest the format has, so a refusal here is a refusal
+     * for every distance there is. */
+    w.PushCode(dist_code, dist_bits);
+    w.Advance();
+    for (uint32_t i = 1; i < cudec_detail::kGDeflateNumStreams; i++) {
+        w.Advance();
+    }
+    REQUIRE(w.ok());
+    const std::vector<unsigned char> page = w.Finish();
+
+    libdeflate_gdeflate_decompressor* d =
+        libdeflate_alloc_gdeflate_decompressor();
+    REQUIRE(d != nullptr);
+    libdeflate_gdeflate_in_page in_page;
+    in_page.data = page.data();
+    in_page.nbytes = page.size();
+    std::vector<unsigned char> out(kTileBytes, 0);
+    size_t produced = 0;
+    const libdeflate_result r = libdeflate_gdeflate_decompress(
+        d, &in_page, 1, out.data(), out.size(), &produced);
+    libdeflate_free_gdeflate_decompressor(d);
+    REQUIRE_CTX(r == LIBDEFLATE_BAD_DATA, "status %d", static_cast<int>(r));
+
+    std::vector<unsigned char> tile(kTileBytes, 0);
+    GDeflatePageState st;
+    uint64_t got = 0;
+    REQUIRE(!GDeflateDecodePage(st, page.data(), page.size(), tile.data(),
+                                tile.size(), &got));
+    REQUIRE(st.s.failed);
+    return 0;
+}
+
+/* A stored block whose declared length is more than the page can supply. It is
+ * the one length in this format with nothing to cross-check it against - there
+ * is no complement field (dossier 11.3, D3) - so the bytes still reachable are
+ * the only bound, and this is that bound executed. The page is cut back to the
+ * words its own header needs, which the reference reads safely because it
+ * refuses on the declared length before touching the body. */
+int RunStoredLengthPastPage() {
+    GDeflatePageWriter w;
+    w.Reset();
+    w.Push(1, 1); /* BFINAL */
+    w.Push(2, cudec_detail::kGDeflateBlockStored);
+    w.Ensure();
+    w.Push(16, 0xFFFFu); /* LEN, far past anything this page holds */
+    REQUIRE(w.ok());
+    std::vector<unsigned char> page = w.Finish();
+    /* The priming round plus the one word lane 0 took for its header. Stated
+     * as that count rather than trimmed by a marker, because the writer's tail
+     * is slack for the reference's unchecked refill and not part of the page
+     * at all. */
+    const size_t real_words = cudec_detail::kGDeflateNumStreams + 1u;
+    REQUIRE(page.size() >= real_words * 4u);
+    page.resize(real_words * 4u);
+
+    libdeflate_gdeflate_decompressor* d =
+        libdeflate_alloc_gdeflate_decompressor();
+    REQUIRE(d != nullptr);
+    libdeflate_gdeflate_in_page in_page;
+    in_page.data = page.data();
+    in_page.nbytes = page.size();
+    std::vector<unsigned char> out(kTileBytes, 0);
+    size_t produced = 0;
+    const libdeflate_result r = libdeflate_gdeflate_decompress(
+        d, &in_page, 1, out.data(), out.size(), &produced);
+    libdeflate_free_gdeflate_decompressor(d);
+    REQUIRE_CTX(r == LIBDEFLATE_BAD_DATA, "status %d", static_cast<int>(r));
+
+    std::vector<unsigned char> tile(kTileBytes, 0);
+    GDeflatePageState st;
+    uint64_t got = 0;
+    REQUIRE(!GDeflateDecodePage(st, page.data(), page.size(), tile.data(),
+                                tile.size(), &got));
+    REQUIRE(st.s.failed);
+    return 0;
+}
+
+/* An output that does not fit the tile it was handed. Every capacity below the
+ * page's real output has to be refused, and the one that equals it has to be
+ * accepted - so the boundary is pinned rather than the fact that some small
+ * capacity failed. The literal path, the stored path and the match path each
+ * carry their own capacity check, and the sweep runs over a fixture that uses
+ * all three. */
+int CapacityBoundary(const char* name, const std::vector<unsigned char>& in,
+                     int level, bool want_stored) {
+    std::vector<std::vector<unsigned char> > pages;
+    REQUIRE_CTX(CompressPages(level, in, &pages), "%s", name);
+    REQUIRE_CTX(pages.size() == 1, "%s", name);
+    /* Which compressed type an input draws is the reference compressor's
+     * decision, so the fixture asserts the half it depends on - stored or not
+     * stored - rather than pinning a choice it does not control. */
+    const bool is_stored =
+        FirstBlockType(pages[0]) == cudec_detail::kGDeflateBlockStored;
+    REQUIRE_CTX(is_stored == want_stored, "%s: type %d", name,
+                FirstBlockType(pages[0]));
+
+    std::vector<unsigned char> tile(kTileBytes, 0);
+    for (size_t cap = 0; cap < in.size(); cap++) {
+        GDeflatePageState st;
+        uint64_t got = 0;
+        REQUIRE_CTX(!GDeflateDecodePage(st, pages[0].data(), pages[0].size(),
+                                        tile.data(), cap, &got),
+                    "%s: capacity %zu accepted", name, cap);
+        REQUIRE_CTX(st.s.failed, "%s: capacity %zu", name, cap);
+    }
+    GDeflatePageState st;
+    uint64_t got = 0;
+    REQUIRE(GDeflateDecodePage(st, pages[0].data(), pages[0].size(),
+                               tile.data(), in.size(), &got));
+    REQUIRE(got == in.size());
+    REQUIRE(equal_bytes(tile.data(), in.data(), in.size()));
+    return 0;
+}
+
+/* Both paths that write output carry their own capacity check, and a sweep
+ * over one block type leaves the other unread: a compressed block writes
+ * through the literal and the match path, a stored block through neither. */
+int RunCapacityBoundary() {
+    if (CapacityBoundary("compressed", ShortRepeats(21, 5000), 6, false) !=
+        0) {
+        return 1;
+    }
+    return CapacityBoundary("stored", Incompressible(23, 5000), 1, true);
+}
+
+/* A page cut short. Every length below the whole page is refused and the whole
+ * page is accepted, which is the same boundary shape the header twin pins one
+ * rung down.
+ *
+ * THE ORACLE IS NOT ASKED, AND NOT ASKING IT IS THE FINDING. ENSURE_BITS in
+ * the pinned fork reads a 32-bit word with no bound check against the end of
+ * the page, so handing the reference a truncated page is a heap out-of-bounds
+ * read: it would red the sanitizer gate with a defect in the oracle rather
+ * than a verdict on this decoder. src/gdeflate_schedule.h refuses the same
+ * read by an explicit bound, which is what this asserts. */
+int RunTruncatedPage() {
+    const std::vector<unsigned char> in = ShortRepeats(22, 20000);
+    std::vector<std::vector<unsigned char> > pages;
+    REQUIRE(CompressPages(6, in, &pages));
+    REQUIRE(pages.size() == 1);
+
+    std::vector<unsigned char> tile(kTileBytes, 0);
+    const size_t words = pages[0].size() / 4u;
+    uint32_t refusals = 0;
+    for (size_t cut = cudec_detail::kGDeflateNumStreams; cut < words; cut++) {
+        std::vector<unsigned char> shorter(pages[0].begin(),
+                                           pages[0].begin() + cut * 4u);
+        GDeflatePageState st;
+        uint64_t got = 0;
+        REQUIRE_CTX(!GDeflateDecodePage(st, shorter.data(), shorter.size(),
+                                        tile.data(), in.size(), &got),
+                    "%zu words accepted", cut);
+        REQUIRE_CTX(st.s.failed, "%zu words", cut);
+        refusals++;
+    }
+    REQUIRE(refusals != 0);
+    GDeflatePageState st;
+    uint64_t got = 0;
+    REQUIRE(GDeflateDecodePage(st, pages[0].data(), pages[0].size(),
+                               tile.data(), in.size(), &got));
+    REQUIRE(got == in.size());
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    if (RunCorpus() != 0) {
+        return 1;
+    }
+    if (RunLongMatch() != 0) {
+        return 1;
+    }
+    if (RunFarMatch() != 0) {
+        return 1;
+    }
+    if (RunOverlappingMatch() != 0) {
+        return 1;
+    }
+    if (RunReservedBlockType() != 0) {
+        return 1;
+    }
+    if (RunMatchBeforeOutput() != 0) {
+        return 1;
+    }
+    if (RunStoredLengthPastPage() != 0) {
+        return 1;
+    }
+    if (RunCapacityBoundary() != 0) {
+        return 1;
+    }
+    if (RunTruncatedPage() != 0) {
+        return 1;
+    }
+    std::printf("gdeflate_block_twin: ok\n");
+    return 0;
+}


### PR DESCRIPTION
# What & why

Closes #182.

`src/gdeflate_block.h` decodes a whole GDeflate page: the block loop over
stored, static and dynamic blocks, the DEFLATE64 length and distance tables,
and the deferred in-tile LZ77. It assembles the three rungs below it and adds
no second copy of any of them - no second bit cursor, no second canonical
construction, no second code-length read.

## Why this rung is different from the three below it

#178, #175 and #176 all had to reach parity sideways. The pinned fork compiles
`gdeflate_decompress.c` with `HIDE_INTERFACE`, so its word cursor, its precode
lengths and its length vectors are unreachable, and each of those issues had to
find an observable consequence to compare instead.

A decoded page is the first thing the oracle answers directly:
`libdeflate_gdeflate_compress` produces the page and
`libdeflate_gdeflate_decompress` says what it means, both across the library's
own boundary. So the comparison here is the plain one - same page in, same
bytes out, byte for byte and length for length - and it is what makes the
whole ladder checkable end to end. A wrong word cursor or a wrong code-length
vector one rung down cannot survive it.

## The DEFLATE64 divergences, which are the part a stock decoder gets wrong

The fork defines `DEFLATE64` unconditionally in `deflate_constants.h`, so its
alphabets are the DEFLATE64 ones:

```
$ git grep -n 'define DEFLATE64' lib/deflate_constants.h
14:#define DEFLATE64
```

- Length symbol 285 is base **3 with sixteen extra bits**, reaching 65538,
  where RFC 1951 section 3.2.5 fixes it at 258 with none.
- Distance symbols **30 and 31 exist**, base 32769 and 49153 with fourteen
  extra bits, reaching 65536 - the 64 KiB tile exactly. RFC 1951 stops at 29
  and 32768.

A decoder on the stock tables decodes most pages correctly and then walks the
rest of the page from the wrong bit position, in every lane, with no checksum
anywhere to catch it. Each divergence has a fixture whose input can only be
coded through it, and each is decoded to the byte. What shows the pin proves
something is the mutant pass: restoring symbol 285 to base 258, restoring it to
zero extra bits, moving either distance base by one, or giving both distance
symbols RFC 1951 extra widths all red this file.

## The deferred copy

A length symbol and its distance symbol are decoded on the SAME lane in
CONSECUTIVE rounds of that lane, which is thirty-two rounds apart in the page.
The round that reads the length reserves the output range and moves the write
cursor past it; the round that reads the distance fills it. So the output is
written out of order, and the thirty-two rounds after end-of-block exist to
drain what is still outstanding. Performing the copy immediately consumes the
distance from the wrong lane - mutant M6, red.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Build / CI / supply chain

## Engineering checklist

- [x] Fail-closed preserved. Every length is checked against the output that
      remains before a byte is written, every distance against the output
      already produced before a byte is read, and the stored block's declared
      length against the bytes the page can still supply. Nothing is sized from
      the stream. Negatives: a reserved block type in front of an otherwise
      valid block, a match whose source begins before the page's output, a
      stored length past the page, the capacity boundary swept byte by byte
      over both a compressed and a stored page, and the truncation boundary
      swept word by word.
- [x] Oracle coverage. Every positive fixture is compressed by the pinned
      NVIDIA/libdeflate fork, decompressed by it, and compared against BOTH the
      input and the reference's own output - so a corpus generator that
      silently produced something else cannot pass by agreeing with itself.
      Each negative carries the reference's own verdict beside ours except the
      truncation sweep, which is explained below.
- [x] Determinism preserved. The overlapping copy is byte by byte, forwards,
      which is the same order in both residencies; no floating point, no
      state outside the page state struct.
- [x] No CUDA API call and no exception crosses anything. The header is
      `__host__ __device__` single-source and no `.cu` includes it yet.
- [ ] An adversarial review was NOT run for this change. There is no second
      reader on this board tonight and the four-lens pass was not run, so this
      line stays negative and the mutant table below stands in place of one
      rather than being offered as equal to it.
- [ ] No review record: see above.

## What the corpus reaches

Compressed by `libdeflate_gdeflate_compress` at levels 1, 6, 9 and 12 over nine
input shapes: incompressible noise at two sizes, a skewed alphabet with noise
at two sizes, short repeats, a three-page input, a page whose output hits the
tile size exactly, an input of exactly two tiles, and one byte. Then, as their
own fixtures: a whole tile of one byte (D1), the far-match layout
`tests/gdeflate_probes.cpp` measures D2 with, a distance-three run and a
distance-one run for the overlapping copy.

The coverage claims are measured over that corpus rather than asserted per
case, and the test fails if any of them stops holding: all three block types
decoded, the reserved type never seen, and at least one page holding more than
one block.

## The mutant table, which is the evidence in place of a reviewer

Twenty-four mutants over `src/gdeflate_block.h`, built with ASan+UBSan so a
mutation that removes a bound reds as a diagnosed fault rather than by luck.
Twenty-two red.

```
M1  length symbol 285 back to RFC 1951 base 258         red
M2  length symbol 285 back to RFC 1951 zero extra bits  red
M3  distance symbol 30 base off by one                  red
M4  distance symbol 31 base off by one                  red
M5  distance 30/31 given RFC 1951 extra widths          red
M6  the copy performed immediately instead of deferred  red
M7  end-of-block advances before the drain              SURVIVED
M8  the drain shortened by one round                    red
M9  literal capacity check removed                      red (ASan heap overflow)
M10 match length capacity check removed                 red
M11 distance-before-output check removed                red (ASan heap overflow)
M12 the copy runs backwards                             red
M13 stored block length bound removed                   red
M14 reserved block type accepted                        red
M15 static literal/length code given a stock length     red
M16 static distance code width off by one               red
M17 ensure after BTYPE removed                          SURVIVED (equivalent)
M18 reset before the block body removed                 red
M19 BFINAL ignored, first block treated as the last     red
M20 pending copy tested after the literal decode        red
M21 length extra bits read after the advance            red
M22 distance extra bits dropped                         red
M23 the no-final-block refusal removed                  SURVIVED (unreachable)
M24 stored block byte round advance removed             red
```

The two survivors, stated rather than left to be found:

- **M17 is equivalent, and the arithmetic is the argument.** Without the
  `ENSURE_BITS` after BTYPE, lane 0 carries 29 bits instead of 61 into the
  fields that follow, and the refill it skipped happens at the first advance
  instead. No other lane consumes a word in between, so the same word reaches
  the same lane at the same cursor position either way. It is kept because
  mirroring the reference operation for operation is what a twin is for.
- **M23 cannot be reached by any page the cap admits.** The block cap is
  generous by construction: a block costs lane 0 at least three bits, a lane
  holds at most 63, and lane 0 can be refilled at most once per word, so no
  page can exhaust it. The refusal behind it is what stops an exhausted cap
  being reported as a successful decode, and there is no input that reaches it.
  The same is true of the round cap inside a block.

**M7 is neither, and it is a real gap in this corpus rather than a property of
the code.** With the extra advance the drain still visits all 32 lanes and the
refill order is provably unchanged - the extra advance re-ensures a lane that
was just refilled, so it takes no word - which is why nothing here separates
the two. What DOES change is the order in which the drain performs the
outstanding copies, and that is observable only on a page where one lane's
match source overlaps a range another lane has reserved and not yet filled. No
fixture in this corpus produces one. The code follows the reference (no advance
at end-of-block, drain starting on the end-of-block lane); the statement this
suite cannot make is that a decoder which did otherwise would be caught.

**One guard was deleted rather than left unproven.** The reference checks that
at least two bytes remain before its unchecked sixteen-bit read of a stored
block's length. That check has no counterpart here - `GDeflatePop` is bounded
by the schedule already - so on this side no page could reach it, and a guard
that cannot bite proves nothing. The `len <= reachable` bound it sat in front of
stays and is executed by `RunStoredLengthPastPage`.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. The header is
      compilable as device code and is included by host tests only; #214 is the
      kernel and #218 its gate set.

## Performance checklist

Not on the hot path: nothing here runs on a device yet. The one shape decision
made with the kernel in mind is stated in the diff - the deferred copy is a
per-lane flag and a per-lane reservation rather than the reference's rotating
32-bit mask, because a mask and a flag per lane are the same set and the flag
is what reads correctly in both residencies.

## Quality checklist

- [x] Minimal: no second bit cursor, no second table construction, no second
      code-length read; the static code goes through the same builder as every
      dynamic one. The test restates the RFC 1951 static lengths itself rather
      than importing them from the header under test, which is the one thing a
      twin may not do.
- [x] Self-documenting; the comments say why, including where the format leaves
      RFC 1951 and why the copy is deferred.
- [x] The new structural property is locked: `gdeflate_block_twin` is
      registered in the build job's host-side identity greps and in all three
      places the sanitize job pins its set by name, so the test silently losing
      its registration reds the gate.

## Verification

The container gate could not be run: the Docker daemon on this machine is not
up, and starting Docker Desktop is not something a session does at a machine
somebody is sitting at.

```
$ docker version --format '{{.Server.Version}}'
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
```

What was run instead is the same host-side compilation and the same binaries,
outside CMake, in the WSL Ubuntu-24.04 toolchain (g++ 13.3.0), against the same
pinned oracle sources, with the project's own flags
(`-std=c++17 -Wall -Wextra -Werror`):

```
gdeflate_block_twin PASS
gdeflate_header_twin PASS
gdeflate_tables_twin PASS
```

That is narrower than `ctest` in two ways, stated rather than left to be found:
it does not run the structural scanner in `tests/CMakeLists.txt`, and it does
not run the rest of the suite. Both are CI's, and CI is the gate here.

- [ ] `cmake --build build` - not run locally, see above. CI's build job is.
- [ ] `ctest --test-dir build` - not run locally, see above.
- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.
- [x] `scripts/check-doc-paths.sh` - passes.
- [x] Docs synced: no behaviour, API or performance claim in any document
      changes here.

## Notes

- What this issue's Done-when asks for and what is delivered line up as
  follows. Byte-and-size parity over the generated corpus, including stored,
  static and dynamic blocks, multi-block pages, multi-page streams and a page
  whose output hits the tile exactly: delivered, with the coverage measured
  rather than assumed. One pinned test per divergence, each asserted against
  the oracle and shown to produce a different answer under the stock RFC 1951
  reading: delivered, with the second half carried by mutants M1 to M5 rather
  than by an in-test assertion, because a test that merely compared the tables
  against RFC 1951's would pass against a decoder that never reached them.
  GPU-less: yes.
- The reject ladder is filed separately from this issue, so the negatives here
  are the ones this decoder owes on its own terms rather than a fail-closed
  matrix.
- This lands on top of #402 (issue #176), which is merged; the branch is
  rebased onto that mainline.
