### PR TITLE
Pin the block that ends on its own zero tail [#183]

### DIFF
--- a/tests/gdeflate_block_twin.cpp
+++ b/tests/gdeflate_block_twin.cpp
@@ -695,6 +695,100 @@ int RunMatchBeforeOutput() {
     return 0;
 }
 
+/* A block whose symbols simply STOP, which is where issue #183's enumerated
+ * "missing EOB" negative was expected to go and where it turns out there is no
+ * negative to write.
+ *
+ * ON THE STATIC CODE THE END-OF-BLOCK SYMBOL IS SEVEN ZERO BITS, and a page's
+ * tail is zeros. So a block that stops emitting is handed an end-of-block by
+ * its own padding: it decodes, it does not fail closed, and both this decoder
+ * and the reference produce exactly the literals that were written. That is
+ * asserted below rather than described, together with the codeword that causes
+ * it, so the two cannot drift apart.
+ *
+ * WHAT THAT MEANS FOR THE LADDER. A missing end-of-block is not a reject branch
+ * of this decoder. Where the symbols outlast the output instead, the literal
+ * and length paths each refuse against the capacity before writing, which is
+ * the branch RunCapacityBoundary above already sweeps; and the round-fuel arm
+ * in the block loop is a termination property rather than a reachable refusal.
+ * A fixture asserting a refusal here would therefore have been asserting
+ * something no page produces.
+ *
+ * THE PAIR IS THE PROOF, AND IT DIFFERS BY ONE SYMBOL. The same literals with
+ * the end-of-block written out explicitly must produce the same bytes as the
+ * page that leaves it to the tail. If they ever diverge, one of the two is
+ * being decoded through a different path than this file claims. The block is a
+ * static one so the fixture owes no dynamic header; what is under test is one
+ * symbol's absence. */
+int RunEndOfBlockFromTheTail() {
+    const std::vector<unsigned char> litlen_lens = StaticLitLenLengths();
+    cudec_detail::GDeflateLitLenTable litlen;
+    REQUIRE(cudec_detail::GDeflateBuildTable(litlen_lens.data(), 288, litlen));
+
+    uint32_t lit_code = 0;
+    uint32_t lit_bits = 0;
+    REQUIRE(cudec_test::CodewordOf(litlen, litlen_lens.data(),
+                                   static_cast<uint32_t>('a'), &lit_code,
+                                   &lit_bits));
+    uint32_t eob_code = 0;
+    uint32_t eob_bits = 0;
+    REQUIRE(cudec_test::CodewordOf(litlen, litlen_lens.data(),
+                                   cudec_detail::kGDeflateEndOfBlock,
+                                   &eob_code, &eob_bits));
+    /* The reason the page below needs no end-of-block, asserted rather than
+     * assumed: RFC 1951's static code gives symbol 256 the seven-bit codeword
+     * 0000000, and a page's tail is zeros. */
+    REQUIRE(eob_code == 0u && eob_bits == 7u);
+
+    /* One whole round of the 32 lanes, so the block is past the priming round
+     * rather than ending inside it, and the capacity is exactly what those
+     * literals produce - the two pages then differ by the end-of-block symbol
+     * and by nothing else. */
+    const size_t kCapacity = cudec_detail::kGDeflateNumStreams;
+
+    for (uint32_t with_eob = 0; with_eob < 2; with_eob++) {
+        GDeflatePageWriter w;
+        w.Reset();
+        w.Push(1, 1); /* BFINAL */
+        w.Push(2, cudec_detail::kGDeflateBlockStatic);
+        w.Ensure();
+        w.Reset();
+        for (size_t i = 0; i < kCapacity; i++) {
+            w.PushCode(lit_code, lit_bits);
+            w.Advance();
+        }
+        if (with_eob) {
+            /* The reference leaves the loop here without advancing, so the
+             * drain that follows starts on this lane. */
+            w.PushCode(eob_code, eob_bits);
+        }
+        for (uint32_t i = 0; i < cudec_detail::kGDeflateNumStreams; i++) {
+            w.Advance();
+        }
+        REQUIRE(w.ok());
+        const std::vector<unsigned char> page = w.Finish();
+
+        libdeflate_result status = LIBDEFLATE_BAD_DATA;
+        size_t produced = 0;
+        REQUIRE(OracleVerdictPadded(page, kCapacity, &status, &produced));
+
+        std::vector<unsigned char> out(kCapacity, 0);
+        GDeflatePageState st;
+        uint64_t got = 0;
+        const bool ok = GDeflateDecodePage(st, page.data(), page.size(),
+                                           out.data(), out.size(), &got);
+        REQUIRE_CTX(ok, "with_eob=%u was refused", with_eob);
+        REQUIRE_CTX(got == kCapacity, "with_eob=%u produced %llu", with_eob,
+                    static_cast<unsigned long long>(got));
+        REQUIRE_CTX(status == LIBDEFLATE_SUCCESS, "with_eob=%u status %d",
+                    with_eob, static_cast<int>(status));
+        REQUIRE(produced == kCapacity);
+        const std::vector<unsigned char> want(kCapacity, 'a');
+        REQUIRE(equal_bytes(out.data(), want.data(), kCapacity));
+    }
+    return 0;
+}
+
 /* A stored block whose declared length is more than the page can supply. It is
  * the one length in this format with nothing to cross-check it against - there
  * is no complement field (dossier 11.3, D3) - so the bytes still reachable are
@@ -882,6 +976,9 @@ int main() {
         return 1;
     }
     if (RunTruncatedPage() != 0) {
+        return 1;
+    }
+    if (RunEndOfBlockFromTheTail() != 0) {
         return 1;
     }
     std::printf("gdeflate_block_twin: ok\n");


### PR DESCRIPTION
Part of #183, and it does not close it.

## The negative this was meant to be does not exist

The ladder enumerates a missing end-of-block among its negatives. Building it
produced a page the decoder ACCEPTS, and the reason is the format rather than a
defect: RFC 1951's static code gives symbol 256 the seven-bit codeword 0000000,
and a page's tail is zeros, so a block whose symbols stop is handed an
end-of-block by its own padding.

    static end-of-block codeword: code=0 bits=7
    32 literals with no end-of-block written:
      ours     ok=1 produced=32
      reference status=0 produced=32

So this lands the pin instead of the negative. The two pages differ by the
end-of-block symbol and by nothing else and must produce the same bytes, and the
codeword that causes it is asserted beside them so the stated reason cannot
drift away from the behaviour.

Where the symbols outlast the output rather than stopping, the literal and
length paths each refuse against the capacity before writing anything, which is
the branch `RunCapacityBoundary` already sweeps. The round-fuel arm below the
block loop is a termination property rather than a reachable refusal, and its
own comment says so.

## What this is honest about

**It adds no guard.** No one-token mutant reds this fixture alone: a broken
static table is already caught by `RunMatchBeforeOutput`, and the decoder cannot
tell a tail-supplied end-of-block from a written one, which is the finding
rather than a gap in the fixture. What it buys is that a later session does not
spend a round building a negative for a refusal no page produces, and that a
page shape the corpus never generates - one completed by its own padding, which
a real stream can carry - is pinned as accepted by both sides rather than left
untested.

## Gate

    cmake --build build-af21-wsl -j8
    ctest --test-dir build-af21-wsl -LE gpu --output-on-failure
    100% tests passed, 0 tests failed out of 49

Through the WSL Ubuntu-24.04 CUDA toolkit (13.3), not the pinned
`nvidia/cuda:12.6.2` container CLAUDE.md names as the canonical gate.

**The nine GPU-labelled tests did NOT run and this is not a pass for them.**
`nvidia-smi` inside WSL reports `Failed to initialize NVML: GPU access blocked
by the operating system` and every GPU test fails at its first `cudaMalloc`;
the device is visible to the Windows host. This is one host-side test file and
no device code.

## Second reader

There was none tonight. The evidence above stands in place of one.
