### PR TITLE
Freeze the GDeflate batch entry and answer an accepted batch [#216]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,17 @@ write (#82). Everything in it is in the tree today.
 - **A defined status for every outcome.** `cudec_status` covers argument
   rejects, corrupt input, an output buffer too small, and CUDA faults, with
   `CUDEC_ERR_UNSUPPORTED` for a stream cudec understands and will not decode and
-  `CUDEC_ERR_NOT_IMPLEMENTED` reserved for entry points that do not exist yet.
-  No exception crosses the ABI and every CUDA call's error is checked.
+  `CUDEC_ERR_NOT_IMPLEMENTED` for an entry point that is declared here and not
+  built in this configuration. No exception crosses the ABI and every CUDA
+  call's error is checked.
+- **The GDeflate batch entry, frozen ahead of its kernel.**
+  `cudec_gdeflate_decompress_batch` takes the same arguments as the LZ4 and
+  Snappy entries and refuses the same argument classes; its surface is the raw
+  GDeflate page with a caller-supplied size and capacity, and no container is
+  parsed. This build carries no GDeflate kernel, so a batch the entry accepts
+  is answered `CUDEC_ERR_NOT_IMPLEMENTED` and no CUDA call is made. The symbol
+  and the signature do not move when the kernel lands; only the answer to an
+  accepted batch does.
 - **`cudec_version()`** and the `CUDEC_VERSION_*` macros, single-sourced: the
   build system reads the version out of the public header, and a conformance
   test refuses a mismatch between the two.

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -31,10 +31,13 @@ typedef enum cudec_status {
     CUDEC_ERR_CORRUPT_INPUT = 2,
     CUDEC_ERR_OUTPUT_TOO_SMALL = 3,
     CUDEC_ERR_CUDA = 4,
-    /* Reserved for an API entry point or decode path declared here but not
-     * yet implemented (e.g. a future format). No current entry point
-     * returns it; kept at this fixed value so a caller's switch stays
-     * exhaustive once it is wired up. */
+    /* An API entry point or decode path declared here but not implemented
+     * in this build. It is what a declared-but-unbuilt entry answers a
+     * batch it has already accepted, so the freeze on that entry's symbol
+     * and signature never depends on a build configuration:
+     * cudec_gdeflate_decompress_batch returns it today, and the value is
+     * fixed so a caller's switch stays exhaustive across the build that
+     * stops returning it. */
     CUDEC_ERR_NOT_IMPLEMENTED = 5,
     /* A well-formed frame that uses a feature cudec does not decode, or a
      * legal frame type it declines (block-linked mode, a dictionary id, a
@@ -141,6 +144,46 @@ cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
                                            size_t chunk_count,
                                            cudec_chunk_result* d_results,
                                            cudec_stream_t stream);
+
+/* Batch GDeflate page decode. The batch contract above holds argument for
+ * argument: the same device-side arrays of chunk_count entries holding
+ * device pointers, the same 16-byte-aligned d_results, the same per-chunk
+ * result semantics, the same synchronous CUDEC_ERR_INVALID_ARGUMENT reject
+ * classes against the same launch limit, and the same asynchronous launch
+ * on `stream`. Nothing about the batch contract varies by format.
+ *
+ * The supported surface is the RAW GDeflate page - the unit the format
+ * decompresses into one 64 KiB tile - with its compressed size in
+ * d_src_sizes and its output capacity in d_dst_capacities, both supplied
+ * by the caller. No container is parsed here and none ever will be: the
+ * TileStream envelope that records where a file's pages are is a
+ * caller-side layer, so a whole TileStream handed to this entry is a
+ * malformed page and is rejected as CUDEC_ERR_CORRUPT_INPUT rather than
+ * stepped into. The bound on every write is that page's
+ * d_dst_capacities entry and never a length read out of the page.
+ *
+ * Per page, and isolated to that page: CUDEC_ERR_CORRUPT_INPUT for a
+ * malformed page, CUDEC_ERR_OUTPUT_TOO_SMALL when the decode would pass
+ * the supplied capacity, bytes_written == 0 on either, and the
+ * destination contents then unspecified but never presented as a valid
+ * decode.
+ *
+ * THIS BUILD CARRIES NO GDEFLATE KERNEL, AND THAT IS A DEFINED STATUS
+ * RATHER THAN AN ABSENT SYMBOL. A batch that passes the validation above
+ * returns CUDEC_ERR_NOT_IMPLEMENTED, having made no CUDA call at all - so
+ * this entry, unlike the two above, also leaves the thread's pending CUDA
+ * error state untouched on a call it accepts. The symbol, the signature
+ * and every reject class above are frozen now and do not move when the
+ * kernel lands; only the answer to an accepted batch does. A symbol that
+ * was absent instead would make the freeze conditional on a build
+ * configuration, which is two contracts wearing one name. */
+cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
+                                             const size_t* d_src_sizes,
+                                             void* const* d_dst_ptrs,
+                                             const size_t* d_dst_capacities,
+                                             size_t chunk_count,
+                                             cudec_chunk_result* d_results,
+                                             cudec_stream_t stream);
 
 /* Decode a single LZ4 frame (the .lz4 container: magic, frame descriptor,
  * data blocks, end mark, optional checksums) from host memory into host

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -63,3 +63,35 @@ cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
         d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
         d_results, stream);
 }
+
+/* The GDeflate entry is the frozen contract without the kernel behind it
+ * yet (issue #216). It shares the validator with the two above rather than
+ * growing its own, so the reject classes cannot drift apart while they are
+ * being frozen, and then stops: no launch, and deliberately no
+ * cudaGetLastError() drain either. Draining is how the entries above buy a
+ * post-launch check that reports their own submission; with nothing
+ * submitted there is nothing to report, and consuming a caller's pending
+ * error on the way to answering "not built here" would be this entry
+ * altering CUDA state it never used.
+ *
+ * That absence is what tests/launch_fail.cpp reads: with no visible device
+ * an entry that made any CUDA call would answer CUDEC_ERR_CUDA, so the
+ * not-implemented answer there is the evidence that this path touches the
+ * runtime at all only through the validator, which touches it not at
+ * all. */
+cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
+                                             const size_t* d_src_sizes,
+                                             void* const* d_dst_ptrs,
+                                             const size_t* d_dst_capacities,
+                                             size_t chunk_count,
+                                             cudec_chunk_result* d_results,
+                                             cudec_stream_t stream) {
+    (void)stream;
+    const cudec_status valid = cudec_detail::validate_batch_args(
+        d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
+        d_results);
+    if (valid != CUDEC_OK) {
+        return valid;
+    }
+    return CUDEC_ERR_NOT_IMPLEMENTED;
+}

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -4,9 +4,12 @@
  * the header's layout check through the pre-C11 negative-array-size
  * fallback, which no other translation unit compiles.
  *
- * Every path exercised here is a documented synchronous reject that makes
- * no CUDA call (see cudec.h), so this test runs green on the GPU-less CI
- * runner - the pointers below are host memory and are never dereferenced. */
+ * Every path exercised here returns synchronously without making a CUDA
+ * call (see cudec.h): the documented argument rejects, and the one
+ * documented ACCEPT that answers CUDEC_ERR_NOT_IMPLEMENTED because this
+ * build carries no GDeflate kernel. So this test runs green on the
+ * GPU-less CI runner - the pointers below are host memory and are never
+ * dereferenced. */
 #include "cudec.h"
 
 #include <stdint.h>
@@ -101,6 +104,42 @@ int main(void) {
     REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, SIZE_MAX,
                                           aligned,
                                           0) == CUDEC_ERR_INVALID_ARGUMENT);
+
+    /* The same eight classes on the GDeflate entry (issue #216), written
+     * out call for call for the reason the Snappy block above is: a future
+     * entry wired to its own validator, or to none, would pass a test that
+     * only counted on the sharing. */
+    REQUIRE(cudec_gdeflate_decompress_batch(0, sizes, dsts, caps, 1, aligned,
+                                            0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, 0, dsts, caps, 1, aligned,
+                                            0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, 0, caps, 1, aligned,
+                                            0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, 0, 1, aligned,
+                                            0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 1, 0,
+                                            0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 1,
+                                            misaligned,
+                                            0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 0,
+                                            aligned,
+                                            0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, SIZE_MAX,
+                                            aligned,
+                                            0) == CUDEC_ERR_INVALID_ARGUMENT);
+
+    /* The ninth class, which exists on this entry and on neither of the
+     * others: a batch that PASSES validation while this build carries no
+     * GDeflate kernel is answered with the defined not-implemented status.
+     * Safe here for the same reason every call above is - the entry makes
+     * no CUDA call and dereferences none of these host pointers - and it is
+     * what freezes the contract: the day the kernel lands this line becomes
+     * an assertion about output, and until then it refuses both a silent
+     * CUDEC_OK over a batch nothing decoded and an absent symbol. */
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 1,
+                                            aligned,
+                                            0) == CUDEC_ERR_NOT_IMPLEMENTED);
 
     /* The frame entry point resolves its own C linkage here. Every call
      * below is a documented argument reject that returns before any CUDA

--- a/tests/launch_fail.cpp
+++ b/tests/launch_fail.cpp
@@ -50,7 +50,26 @@ int main() {
     REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, 1, results,
                                           nullptr) == CUDEC_ERR_CUDA);
 
-    std::printf("PASS: launch-failure branch reports CUDEC_ERR_CUDA with "
-                "zero visible devices, on both batch entries\n");
+    /* The GDeflate entry, whose second half is the OPPOSITE assertion and
+     * is why it belongs in this file at all (issue #216). With no visible
+     * device, any CUDA call this entry made would fail, so an entry that
+     * launched, or merely drained the pending error state, would answer
+     * CUDEC_ERR_CUDA here. Answering the defined not-implemented status
+     * instead is the evidence that a batch it accepts reaches the CUDA
+     * runtime not at all. Twice, for the reason the calls above are twice:
+     * a first-touch context init failing once would look the same. */
+    REQUIRE(cudec_gdeflate_decompress_batch(nullptr, sizes, dsts, caps, 1,
+                                            results, nullptr) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 1,
+                                            results, nullptr) ==
+            CUDEC_ERR_NOT_IMPLEMENTED);
+    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 1,
+                                            results, nullptr) ==
+            CUDEC_ERR_NOT_IMPLEMENTED);
+
+    std::printf("PASS: with zero visible devices the two kernel-backed batch "
+                "entries report CUDEC_ERR_CUDA and the GDeflate entry "
+                "reports CUDEC_ERR_NOT_IMPLEMENTED\n");
     return 0;
 }


### PR DESCRIPTION
# What & why

Closes #216.

The GDeflate batch surface is designed (masterplan 13.4) and its host-side page
decode is in the tree, but no symbol existed. This freezes the entry.

**The open question this issue carried, and the answer taken:** what
`cudec_gdeflate_decompress_batch` returns for a batch that PASSES validation
while no kernel stands behind it. The answer is a defined runtime status per
entry, never a link error. A frozen contract that sometimes fails to link is two
contracts wearing one name, selected by build configuration; the freeze is only
worth its word if the symbol always stands. So the entry validates, and where no
kernel stands behind the batch it returns `CUDEC_ERR_NOT_IMPLEMENTED` - the
status the header already reserved for exactly this shape and that no entry
point returned. That answer is also the testable one: the day the kernel lands,
two assertions flip from expecting not-implemented to expecting output, which is
the cleanest record of the landing.

**It makes no CUDA call on any path**, including the `cudaGetLastError()` drain
the two kernel-backed entries perform. With nothing submitted there is nothing
to report, and consuming a caller's pending error on the way to answering "not
built here" would be this entry altering CUDA state it never used. That absence
is asserted rather than argued: see mutant 3 below.

## What is here

- `include/cudec.h`: the entry declared beside the LZ4 and Snappy entries, same
  arguments, same reject classes, same launch limit; the raw 64 KiB page surface
  stated so a caller cannot mistake a container for input; the not-implemented
  state stated as a state of this build rather than a second interface. The
  `CUDEC_ERR_NOT_IMPLEMENTED` comment said no entry point returns it and now
  says which one does.
- `src/batch.cu`: the entry, sharing `validate_batch_args` with the two above
  rather than growing its own validation.
- `tests/conformance_c.c`: the eight documented reject classes written out call
  for call from C99, plus the ninth class this entry has and the others do not -
  the accepted batch.
- `tests/launch_fail.cpp`: the same two halves the LZ4 and Snappy entries have,
  with the second half inverted. With zero visible devices any CUDA call answers
  `CUDEC_ERR_CUDA`, so the not-implemented answer there is what proves the path
  reaches the runtime not at all.
- `CHANGELOG.md`: the entry under Unreleased, and the status list corrected.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] API surface

## Engineering checklist

- [x] Fail-closed preserved: the entry adds no parse and no decode. Every
      documented reject class is a synchronous refusal through the shared
      validator, each with an assertion in two tests, and a batch it accepts is
      refused with a defined status rather than reported as decoded.
- [x] Oracle coverage: not applicable, and stated rather than ticked away - this
      change decodes nothing, so there is no output to diff against a reference.
- [x] Determinism preserved: the entry is a pure function of its arguments and
      touches no device state.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      There is no CUDA call on this path at all, which mutant 3 below is the
      evidence for.
- [ ] An adversarial review (`/security-review`) was run. **It was not, and that
      box stays unticked.** No second reader was available for this change. What
      stands in place of one is below: the three mutants, each watched refusing,
      and the reading of the diff recorded per lens.
- [x] Review record: below, with counts.

## Review record

Read against the four lenses this repository names, by the author of the change
and by nobody else. **CONFIRMED 0 / PLAUSIBLE 0.**

- **Correctness.** The entry's whole body is the shared validator and a
  constant. `stream` is the only argument it does not pass on, and it is
  discarded explicitly. No arithmetic, no dereference.
- **Robustness.** No pointer this entry receives is dereferenced on any path,
  which is what makes the tests safe to drive with host memory on a GPU-less
  runner. The reject set is the frozen one, taken from the same function the
  other two entries call, so it cannot drift from them while it is being frozen.
- **Integration.** The declaration compiles as C99 and resolves with C linkage,
  proven by `conformance_c`. The host-only build is unaffected: `src/batch.cu`
  is compiled only under `CUDEC_ENABLE_CUDA`, exactly as the other two entries
  are. Both example programs already switch exhaustively over `cudec_status`
  including `CUDEC_ERR_NOT_IMPLEMENTED`, and both still build.
- **Performance.** No hot path is touched and no number moves.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. The kernel behind this
      entry is a sibling step (#214) and nothing here launches one.

```
commit:    319acc13ce40877d6f3e8058abb730600369aae3
gpu:       no route to a device the sanitizer could attach to
cuda:      13.3 (V13.3.73)
sanitizer: not run
```

The container path this repository's gate uses was not reachable while this was
built:

```
$ docker version --format '{{.Server.Version}}'
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
```

and the WSL distribution the build below ran in has no device either:

```
$ nvidia-smi --query-gpu=name --format=csv,noheader
Failed to initialize NVML: GPU access blocked by the operating system
```

Every test this change adds is in the GPU-less subset by construction, so the
missing device costs this change no coverage. It costs the rest of the suite its
on-device run, which is why the paste below is the host-side subset and is
labelled as one.

## Performance checklist

Not applicable: no hot path, no numbers.

## Verification

Built with nvcc 13.3 rather than the pinned 12.6.2 container, because no
container runtime was reachable (the command and its output are above). Stated
rather than glossed: the pinned container is what CI runs, and CI's verdict on
this branch is the one that counts.

```
$ nvcc --version | tail -2
Cuda compilation tools, release 13.3, V13.3.73
Build cuda_13.3.r13.3/compiler.38244171_0

$ cmake -B $HOME/bh216 -S . && cmake --build $HOME/bh216 -j       # host-only
exit=0

$ cmake -B $HOME/bc216 -S . -DCUDEC_ENABLE_CUDA=ON && cmake --build $HOME/bc216 -j
$ grep -ci warning build.log
0

$ ctest --test-dir $HOME/bc216 -LE gpu --no-tests=error --output-on-failure
100% tests passed, 0 tests failed out of 49
Total Test time (real) =  16.80 sec
```

- [x] Builds clean, both configurations, zero warnings.
- [x] `ctest -LE gpu` green: 49/49, `conformance_c` and `launch_fail` among them.
- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.
- [x] Docs synced: masterplan 13.4 already describes this entry and needed no
      edit; the changelog did and has it.

### The guards, each watched refusing

Three mutants, one per property this change claims, built and run over the same
subset:

```
----- MUTANT 1: validation removed -----
conformance_c.c:112 FAIL ... == CUDEC_ERR_INVALID_ARGUMENT
launch_fail.cpp:61  FAIL ... == CUDEC_ERR_INVALID_ARGUMENT
0% tests passed, 2 tests failed out of 2

----- MUTANT 2: accepted batch answered CUDEC_OK -----
conformance_c.c:140 FAIL ... == CUDEC_ERR_NOT_IMPLEMENTED
launch_fail.cpp:64  FAIL ... == CUDEC_ERR_NOT_IMPLEMENTED
0% tests passed, 2 tests failed out of 2

----- MUTANT 3: entry launches the LZ4 kernel instead of answering -----
conformance_c.c:140 FAIL ... == CUDEC_ERR_NOT_IMPLEMENTED
launch_fail.cpp:64  FAIL ... == CUDEC_ERR_NOT_IMPLEMENTED
0% tests passed, 2 tests failed out of 2

----- restored -----
100% tests passed, 0 tests failed out of 2
```

Mutant 3 is the one worth reading twice: it is the only evidence that "makes no
CUDA call" is a tested property rather than a sentence in a comment.

## Notes

Out of scope, deliberately: the kernel behind this entry (#214), the on-device
hostile-input and determinism gates (#218), and the TileStream envelope that
would drive it (#177). None of them can move this entry's signature - that is
what freezing it now buys.

One thing this change does NOT fix, noticed while editing the file and left
alone because it is a different subject: `CHANGELOG.md` still says under
"Supported subset" that Snappy has "no code in this release", while
`cudec_snappy_decompress_batch` has been in the tree since #152.
