### PR TITLE
Census the GDeflate block-type mix and retire the specialisation lever [#206]

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -194,6 +194,23 @@ add_test(NAME bench_gdeflate_assetlike_selfcheck COMMAND bench_gdeflate
 add_test(NAME bench_gdeflate_blocktypes_selfcheck COMMAND bench_gdeflate
                                                   --blocktypes --selfcheck)
 
+# The whole-page block-type census (issue #206). Separate entry from the one
+# above because it proves the opposite property: that one asserts a corpus
+# still OPENS with the block type its family is named for, this one asserts
+# the walk REACHES PAST that opening. A stored block's length field is sixteen
+# bits, so a full page of stored data is at least two blocks, and a census
+# that had collapsed back to reading openings would report one block per page
+# and red here while the entry above stayed green. It also holds the census to
+# the one block-type guarantee the reference's own header gives - level 0
+# emits uncompressed blocks - so a misattributed type reds against the
+# compressor rather than against an expectation.
+#
+# CPU-only, like the entries above: the census reads cudec's own page decoder
+# from src/gdeflate_block.h, which is host/device single-source and needs no
+# device to run on the host side.
+add_test(NAME bench_gdeflate_blockmix_selfcheck COMMAND bench_gdeflate
+                                                 --blockmix --selfcheck)
+
 # The Zstd worst-case corpus (issue #229). No CUDA in it at all: the frames
 # are constructed on the host, emitted through the reference's own
 # sequence-compression entry point and decoded by the reference, so the
@@ -272,6 +289,6 @@ set_tests_properties(
   bench_frame_selfcheck bench_snappy_selfcheck
   bench_snappy_worst_selfcheck bench_snappy_worstlit_selfcheck
   bench_gdeflate_selfcheck bench_gdeflate_assetlike_selfcheck
-  bench_gdeflate_blocktypes_selfcheck
+  bench_gdeflate_blocktypes_selfcheck bench_gdeflate_blockmix_selfcheck
   PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 cudec_assert_test_timeouts()

--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -57,6 +57,7 @@
 
 #include <libdeflate.h>
 
+#include "gdeflate_block.h"
 #include "gdeflate_schedule.h"
 #include "xxhash64.h"
 
@@ -792,7 +793,8 @@ bool ParseCount(const char* text, size_t lo, size_t hi, size_t* out) {
 void Usage(const char* argv0) {
     std::fprintf(stderr,
                  "usage: %s [--warmup N] [--runs N] [--assetlike] "
-                 "[--blocktypes] [--selfcheck] [corpus files...]\n",
+                 "[--blocktypes] [--blockmix] [--selfcheck] "
+                 "[corpus files...]\n",
                  argv0);
 }
 
@@ -820,6 +822,235 @@ int RunBlocktypes(size_t warmup, size_t runs, bool selfcheck) {
     return ok ? 0 : 1;
 }
 
+/* THE BLOCK-TYPE MIX (issue #206), and what makes it a census rather than a
+ * histogram of openings.
+ *
+ * The specialisation lever this feeds asks whether a second decode path for
+ * stored and static blocks pays, and the evidence it rests on is how many
+ * blocks of each type the reference actually emits and how many bytes each
+ * type produces. A block boundary inside a page is not findable by scanning
+ * (masterplan 11.3), so the walk over first block headers that --blocktypes
+ * performs stops after one block per page and cannot answer that. Worse, it
+ * is biased AGAINST the type this lever cares about most: a stored block's
+ * length field is sixteen bits, 65535 is one byte short of a page, so a page
+ * of stored data is at least two blocks every time while a page that uses a
+ * table can be one. Counting openings undercounts stored blocks by
+ * construction.
+ *
+ * What reaches the second block is a decode, so this walks every page with
+ * cudec's own page decoder and reads the census it produces. That census is
+ * only worth what the decode is worth, so every page is required to decode
+ * to exactly its source bytes here, on top of the reference round trip the
+ * corpus already passed - a walk that drifted off the block structure would
+ * produce different bytes long before it produced a wrong count.
+ *
+ * IT REPORTS AND LOCKS NOTHING ABOUT ADVERSARIALITY. This is a measurement of
+ * what a compressor emits, not a corpus with a shape to defend, so it carries
+ * no density floor and no throughput number. */
+struct BlockMix {
+    size_t pages = 0;
+    uint64_t blocks = 0;
+    uint64_t out_bytes = 0;
+    uint64_t type_blocks[cudec_detail::kGDeflateBlockTypeCount] = {0, 0, 0};
+    uint64_t type_bytes[cudec_detail::kGDeflateBlockTypeCount] = {0, 0, 0};
+};
+
+/* Decode every page and fold its census in. Three things are required of each
+ * page, and each of them is a different way for the walk to be wrong:
+ *
+ *  - it decodes to exactly the source bytes, so the walk followed the real
+ *    block structure and not a plausible-looking wrong one;
+ *  - the per-type counts sum to the page's block count, so no block escaped
+ *    the accounting or was counted twice;
+ *  - the per-type byte counts sum to the page's output, so every produced
+ *    byte is attributed to exactly one block type.
+ *
+ * The last two are what separate a census from a tally that happens to add
+ * up to something. */
+bool CensusCorpus(const std::vector<unsigned char>& source,
+                  const Corpus& corpus, BlockMix* mix) {
+    size_t offset = 0;
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        const std::vector<unsigned char>& page = corpus.compressed[i];
+        const size_t want = corpus.originals[i].size();
+        std::vector<unsigned char> out(want == 0 ? 1 : want);
+        cudec_detail::GDeflatePageState st;
+        uint64_t produced = 0;
+        if (!cudec_detail::GDeflateDecodePage(st, page.data(), page.size(),
+                                              out.data(), want, &produced)) {
+            std::fprintf(stderr,
+                         "page %zu of %s was refused by the page decoder, so "
+                         "no block census can be read out of it\n",
+                         i, corpus.name.c_str());
+            return false;
+        }
+        if (produced != want ||
+            std::memcmp(out.data(), source.data() + offset, want) != 0) {
+            std::fprintf(stderr,
+                         "page %zu of %s decoded to bytes that are not its "
+                         "source, so the block walk behind the census did not "
+                         "follow this page\n",
+                         i, corpus.name.c_str());
+            return false;
+        }
+        uint64_t blocks_seen = 0;
+        uint64_t bytes_seen = 0;
+        for (uint32_t t = 0; t < cudec_detail::kGDeflateBlockTypeCount; t++) {
+            blocks_seen += st.type_blocks[t];
+            bytes_seen += st.type_bytes[t];
+            mix->type_blocks[t] += st.type_blocks[t];
+            mix->type_bytes[t] += st.type_bytes[t];
+        }
+        if (blocks_seen != st.blocks || bytes_seen != produced) {
+            std::fprintf(stderr,
+                         "page %zu of %s censused %llu blocks and %llu bytes "
+                         "against %u blocks and %llu bytes decoded - the "
+                         "attribution does not cover the page\n",
+                         i, corpus.name.c_str(),
+                         static_cast<unsigned long long>(blocks_seen),
+                         static_cast<unsigned long long>(bytes_seen),
+                         st.blocks,
+                         static_cast<unsigned long long>(produced));
+            return false;
+        }
+        mix->blocks += st.blocks;
+        mix->out_bytes += produced;
+        mix->pages++;
+        offset += want;
+    }
+    return true;
+}
+
+double Share(uint64_t part, uint64_t whole) {
+    return whole == 0 ? 0.0
+                      : 100.0 * static_cast<double>(part) /
+                            static_cast<double>(whole);
+}
+
+void PrintBlockMix(const Corpus& corpus, int level, const BlockMix& mix) {
+    std::printf("## bench_gdeflate block-type mix\n");
+    std::printf("- corpus: %s, %zu pages, %.2f MB original, ratio %.4f, %s\n",
+                corpus.name.c_str(), corpus.originals.size(),
+                static_cast<double>(corpus.original_bytes) / 1e6,
+                static_cast<double>(corpus.compressed_bytes) /
+                    static_cast<double>(corpus.original_bytes),
+                corpus.provenance.c_str());
+    std::printf("- compressor: the pinned NVIDIA/libdeflate gdeflate fork, "
+                "commit %s, compression level %d\n",
+                CUDEC_GDEFLATE_COMMIT, level);
+    std::printf("- corpus digest: %016llx\n",
+                static_cast<unsigned long long>(CorpusDigest(corpus)));
+    std::printf("- read by: cudec's own page decoder "
+                "(src/gdeflate_block.h), every page required to decode to its "
+                "source bytes and every block and byte attributed to a type; "
+                "this is a whole-page census and not a walk over openings\n");
+    std::printf("- blocks: %llu over %zu pages (%.3f per page), %llu output "
+                "bytes\n",
+                static_cast<unsigned long long>(mix.blocks), mix.pages,
+                mix.pages == 0 ? 0.0
+                               : static_cast<double>(mix.blocks) /
+                                     static_cast<double>(mix.pages),
+                static_cast<unsigned long long>(mix.out_bytes));
+    std::printf("| type    | blocks | share of blocks | output bytes | share "
+                "of bytes |\n");
+    std::printf("| ------- | ------ | --------------- | ------------ | "
+                "-------------- |\n");
+    for (uint32_t t = 0; t < cudec_detail::kGDeflateBlockTypeCount; t++) {
+        std::printf("| %-7s | %6llu | %14.4f%% | %12llu | %13.4f%% |\n",
+                    BlockTypeName(t),
+                    static_cast<unsigned long long>(mix.type_blocks[t]),
+                    Share(mix.type_blocks[t], mix.blocks),
+                    static_cast<unsigned long long>(mix.type_bytes[t]),
+                    Share(mix.type_bytes[t], mix.out_bytes));
+    }
+}
+
+/* The selfcheck's two anchors, and they are anchors rather than restatements
+ * of what the census just produced.
+ *
+ * The first is the only block-type guarantee the reference's own header
+ * gives: level 0 emits uncompressed blocks by construction. A census that
+ * misattributed a type would have to misattribute it here too, where the
+ * answer is known from outside this harness.
+ *
+ * The second is what proves the walk REACHES PAST THE FIRST BLOCK, which is
+ * the whole reason this path exists beside --blocktypes. A stored block's
+ * length field is sixteen bits and its maximum is one byte short of a page,
+ * so a full page of stored data is at least two stored blocks, always. A
+ * census that stopped at the opening would report exactly one block per page
+ * and fail here. */
+bool CheckLevelZeroAnchors(const Corpus& corpus, const BlockMix& mix) {
+    const uint64_t stored = mix.type_blocks[cudec_detail::kGDeflateBlockStored];
+    if (stored != mix.blocks ||
+        mix.type_bytes[cudec_detail::kGDeflateBlockStored] != mix.out_bytes) {
+        std::fprintf(stderr,
+                     "level 0 censused %llu of %llu blocks as stored and %llu "
+                     "of %llu bytes - the reference emits uncompressed blocks "
+                     "at level 0 by construction, so the census disagrees "
+                     "with the compressor rather than with an expectation\n",
+                     static_cast<unsigned long long>(stored),
+                     static_cast<unsigned long long>(mix.blocks),
+                     static_cast<unsigned long long>(
+                         mix.type_bytes[cudec_detail::kGDeflateBlockStored]),
+                     static_cast<unsigned long long>(mix.out_bytes));
+        return false;
+    }
+    size_t full_pages = 0;
+    for (size_t i = 0; i < corpus.originals.size(); i++) {
+        if (corpus.originals[i].size() > kStoredBlockMaxBytes) {
+            full_pages++;
+        }
+    }
+    if (mix.blocks < 2 * static_cast<uint64_t>(full_pages)) {
+        std::fprintf(stderr,
+                     "level 0 censused %llu blocks over %zu pages that each "
+                     "hold more than the %zu bytes a stored block's length "
+                     "field can express - such a page cannot be one block, so "
+                     "this walk is not reaching past the first one\n",
+                     static_cast<unsigned long long>(mix.blocks), full_pages,
+                     kStoredBlockMaxBytes);
+        return false;
+    }
+    return true;
+}
+
+/* The census path. It is handed the corpus source the level sweep would have
+ * used, so the two paths cannot disagree about what a corpus is, and it times
+ * nothing: what it produces is a table, and a timing beside it would invite
+ * the table to be read as a throughput result. */
+int RunBlockmix(const std::vector<unsigned char>& source,
+                const std::string& name, const std::string& provenance,
+                bool selfcheck, const uint64_t* expected) {
+    bool ok = true;
+    for (size_t i = 0; i < kLevelCount; i++) {
+        Corpus corpus;
+        corpus.name = name;
+        corpus.provenance = provenance;
+        corpus.composition = kCompositionNotAsserted;
+        if (!BuildCorpus(source, kLevels[i], &corpus)) {
+            return 1;
+        }
+        if (!CorpusRoundTrips(source, corpus)) {
+            return 1;
+        }
+        if (selfcheck &&
+            !CheckDigest(CorpusDigest(corpus), name, kLevels[i], expected[i])) {
+            ok = false;
+        }
+        BlockMix mix;
+        if (!CensusCorpus(source, corpus, &mix)) {
+            return 1;
+        }
+        if (selfcheck && kLevels[i] == 0 &&
+            !CheckLevelZeroAnchors(corpus, mix)) {
+            ok = false;
+        }
+        PrintBlockMix(corpus, kLevels[i], mix);
+        std::printf("\n");
+    }
+    return ok ? 0 : 1;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -828,6 +1059,7 @@ int main(int argc, char** argv) {
     bool selfcheck = false;
     bool assetlike = false;
     bool blocktypes = false;
+    bool blockmix = false;
     std::vector<std::string> files;
 
     for (int i = 1; i < argc; i++) {
@@ -836,6 +1068,8 @@ int main(int argc, char** argv) {
             assetlike = true;
         } else if (arg == "--blocktypes") {
             blocktypes = true;
+        } else if (arg == "--blockmix") {
+            blockmix = true;
         } else if (arg == "--selfcheck") {
             selfcheck = true;
         } else if (arg == "--runs" && i + 1 < argc) {
@@ -867,6 +1101,15 @@ int main(int argc, char** argv) {
                      "--blocktypes builds its own corpora, one per forced "
                      "block type; do not pass corpus files or --assetlike "
                      "with it\n");
+        return 2;
+    }
+
+    if (blockmix && blocktypes) {
+        std::fprintf(stderr,
+                     "--blockmix censuses the level sweep's corpora and "
+                     "--blocktypes builds forced-type corpora of its own; "
+                     "they answer different questions and cannot be asked "
+                     "for at once\n");
         return 2;
     }
 
@@ -924,6 +1167,11 @@ int main(int argc, char** argv) {
 
     const uint64_t* expected =
         assetlike ? kAssetlikeSelfcheckDigests : kSelfcheckDigests;
+
+    if (blockmix) {
+        return RunBlockmix(source, name, provenance, selfcheck, expected);
+    }
+
     bool ok = true;
     for (size_t i = 0; i < kLevelCount; i++) {
         uint64_t digest = 0;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1782,6 +1782,222 @@ carries the methodology its own numbers were taken under.
 - decode throughput: p50 0.335 GB/s / p90 0.315 GB/s / p99 0.307 GB/s
 ```
 
+## M4 perf lever: the block-type mix, retired on the census (issue #206)
+
+**The lever, and why it is answered here instead of on a device.** Stored and
+static-Huffman blocks are the cheap block types: a stored block carries no
+table and a static one uses the fixed code. A decode path specialised for them
+would be a second route through a security-critical round loop, and every
+branch of it would have to be re-covered by the validation ladder. What it
+could buy is bounded by how much of a real corpus is made of those blocks, and
+that is a property of what the compressor emits rather than of any kernel. So
+the count decides the lever before a kernel exists, which is the order #206
+fixed: count first, then decide.
+
+**The pre-registered rule this run was taken under**, written on #206 before
+the measurement: only if the mix is materially non-trivial is the
+specialisation implemented and measured, and "the mix does not justify a second
+path" is a full result to be recorded as one. The forced stored/static corpora
+in the M4 corpus set are decode-path coverage and are excluded from the
+argument by the same rule, because they are synthetic by construction.
+
+**Counting the openings would have answered the wrong question, and it would
+have answered it in the direction that flatters the lever.** A GDeflate block
+boundary is not findable by scanning (section 11.3), so the walk in
+`bench_gdeflate --blocktypes` reads the first block header of each page and
+stops. A stored block's length field is sixteen bits, and 65535 is one byte
+short of a page, so a full page of stored data is at least two stored blocks,
+always, while a page that uses a table can be one. A histogram of openings
+therefore undercounts exactly the block type the lever is about. What reaches a
+page's second block is a decode, so this census walks every page with cudec's
+own page decoder (`src/gdeflate_block.h`) and reads the per-type counts it
+produces.
+
+The census is taken over the same corpora and the same compressor pin as the M4
+CPU denominator above -- the eight corpus digests below reproduce the eight
+recorded in that entry byte for byte, which is what makes this a census of that
+corpus rather than of one resembling it. Recorded 2026-08-30. Reproduce with
+`bench_gdeflate --blockmix bench/corpora/silesia/*` and
+`bench_gdeflate --blockmix --assetlike`; nothing is timed and no figure here is
+a denominator.
+
+| corpus     | level | pages | blocks | blocks/page | stored blocks | static blocks | dynamic blocks | stored bytes | static bytes | dynamic bytes |
+| ---------- | ----- | ----- | ------ | ----------- | ------------- | ------------- | -------------- | ------------ | ------------ | ------------- |
+| Silesia    | 0     | 3234  | 6467   | 2.000       | 100.0000%     | 0.0000%       | 0.0000%        | 100.0000%    | 0.0000%      | 0.0000%       |
+| Silesia    | 1     | 3234  | 6742   | 2.085       | 0.0148%       | 0.0148%       | 99.9703%       | 0.0057%      | 0.0059%      | 99.9883%      |
+| Silesia    | 6     | 3234  | 6767   | 2.092       | 0.0296%       | 0.0443%       | 99.9261%       | 0.0115%      | 0.0255%      | 99.9630%      |
+| Silesia    | 12    | 3234  | 7308   | 2.260       | 0.0137%       | 0.0137%       | 99.9726%       | 0.0057%      | 0.0096%      | 99.9847%      |
+| asset-like | 0     | 3200  | 6400   | 2.000       | 100.0000%     | 0.0000%       | 0.0000%        | 100.0000%    | 0.0000%      | 0.0000%       |
+| asset-like | 1     | 3200  | 9600   | 3.000       | 0.0000%       | 0.0000%       | 100.0000%      | 0.0000%      | 0.0000%      | 100.0000%     |
+| asset-like | 6     | 3200  | 9600   | 3.000       | 0.0000%       | 0.0000%       | 100.0000%      | 0.0000%      | 0.0000%      | 100.0000%     |
+| asset-like | 12    | 3200  | 9600   | 3.000       | 0.0000%       | 0.0000%       | 100.0000%      | 0.0000%      | 0.0000%      | 100.0000%     |
+
+The table is a reading aid. The eight blocks below are the record.
+
+```
+## bench_gdeflate block-type mix
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, ratio 1.0021, cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- compressor: the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05, compression level 0
+- corpus digest: 88ed82d5ec9df3ad
+- read by: cudec's own page decoder (src/gdeflate_block.h), every page required to decode to its source bytes and every block and byte attributed to a type; this is a whole-page census and not a walk over openings
+- blocks: 6467 over 3234 pages (2.000 per page), 211938580 output bytes
+| type    | blocks | share of blocks | output bytes | share of bytes |
+| ------- | ------ | --------------- | ------------ | -------------- |
+| stored  |   6467 |       100.0000% |    211938580 |      100.0000% |
+| static  |      0 |         0.0000% |            0 |        0.0000% |
+| dynamic |      0 |         0.0000% |            0 |        0.0000% |
+```
+
+```
+## bench_gdeflate block-type mix
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, ratio 0.3581, cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- compressor: the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05, compression level 1
+- corpus digest: 131124d155e6672b
+- read by: cudec's own page decoder (src/gdeflate_block.h), every page required to decode to its source bytes and every block and byte attributed to a type; this is a whole-page census and not a walk over openings
+- blocks: 6742 over 3234 pages (2.085 per page), 211938580 output bytes
+| type    | blocks | share of blocks | output bytes | share of bytes |
+| ------- | ------ | --------------- | ------------ | -------------- |
+| stored  |      1 |         0.0148% |        12100 |        0.0057% |
+| static  |      1 |         0.0148% |        12604 |        0.0059% |
+| dynamic |   6740 |        99.9703% |    211913876 |       99.9883% |
+```
+
+```
+## bench_gdeflate block-type mix
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, ratio 0.3343, cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- compressor: the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05, compression level 6
+- corpus digest: 042b2473240db0b0
+- read by: cudec's own page decoder (src/gdeflate_block.h), every page required to decode to its source bytes and every block and byte attributed to a type; this is a whole-page census and not a walk over openings
+- blocks: 6767 over 3234 pages (2.092 per page), 211938580 output bytes
+| type    | blocks | share of blocks | output bytes | share of bytes |
+| ------- | ------ | --------------- | ------------ | -------------- |
+| stored  |      2 |         0.0296% |        24378 |        0.0115% |
+| static  |      3 |         0.0443% |        53991 |        0.0255% |
+| dynamic |   6762 |        99.9261% |    211860211 |       99.9630% |
+```
+
+```
+## bench_gdeflate block-type mix
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, ratio 0.3198, cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- compressor: the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05, compression level 12
+- corpus digest: 4b88e13a215ed884
+- read by: cudec's own page decoder (src/gdeflate_block.h), every page required to decode to its source bytes and every block and byte attributed to a type; this is a whole-page census and not a walk over openings
+- blocks: 7308 over 3234 pages (2.260 per page), 211938580 output bytes
+| type    | blocks | share of blocks | output bytes | share of bytes |
+| ------- | ------ | --------------- | ------------ | -------------- |
+| stored  |      1 |         0.0137% |        12092 |        0.0057% |
+| static  |      1 |         0.0137% |        20300 |        0.0096% |
+| dynamic |   7306 |        99.9726% |    211906188 |       99.9847% |
+```
+
+```
+## bench_gdeflate block-type mix
+- corpus: asset-like, 3200 pages, 209.72 MB original, ratio 1.0021, generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- compressor: the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05, compression level 0
+- corpus digest: 08ac6ec118b60189
+- read by: cudec's own page decoder (src/gdeflate_block.h), every page required to decode to its source bytes and every block and byte attributed to a type; this is a whole-page census and not a walk over openings
+- blocks: 6400 over 3200 pages (2.000 per page), 209715200 output bytes
+| type    | blocks | share of blocks | output bytes | share of bytes |
+| ------- | ------ | --------------- | ------------ | -------------- |
+| stored  |   6400 |       100.0000% |    209715200 |      100.0000% |
+| static  |      0 |         0.0000% |            0 |        0.0000% |
+| dynamic |      0 |         0.0000% |            0 |        0.0000% |
+```
+
+```
+## bench_gdeflate block-type mix
+- corpus: asset-like, 3200 pages, 209.72 MB original, ratio 0.7105, generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- compressor: the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05, compression level 1
+- corpus digest: 45690d97a5d3b054
+- read by: cudec's own page decoder (src/gdeflate_block.h), every page required to decode to its source bytes and every block and byte attributed to a type; this is a whole-page census and not a walk over openings
+- blocks: 9600 over 3200 pages (3.000 per page), 209715200 output bytes
+| type    | blocks | share of blocks | output bytes | share of bytes |
+| ------- | ------ | --------------- | ------------ | -------------- |
+| stored  |      0 |         0.0000% |            0 |        0.0000% |
+| static  |      0 |         0.0000% |            0 |        0.0000% |
+| dynamic |   9600 |       100.0000% |    209715200 |      100.0000% |
+```
+
+```
+## bench_gdeflate block-type mix
+- corpus: asset-like, 3200 pages, 209.72 MB original, ratio 0.7029, generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- compressor: the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05, compression level 6
+- corpus digest: 47dad3ea983dc577
+- read by: cudec's own page decoder (src/gdeflate_block.h), every page required to decode to its source bytes and every block and byte attributed to a type; this is a whole-page census and not a walk over openings
+- blocks: 9600 over 3200 pages (3.000 per page), 209715200 output bytes
+| type    | blocks | share of blocks | output bytes | share of bytes |
+| ------- | ------ | --------------- | ------------ | -------------- |
+| stored  |      0 |         0.0000% |            0 |        0.0000% |
+| static  |      0 |         0.0000% |            0 |        0.0000% |
+| dynamic |   9600 |       100.0000% |    209715200 |      100.0000% |
+```
+
+```
+## bench_gdeflate block-type mix
+- corpus: asset-like, 3200 pages, 209.72 MB original, ratio 0.6995, generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- compressor: the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05, compression level 12
+- corpus digest: cb272ab3765d8378
+- read by: cudec's own page decoder (src/gdeflate_block.h), every page required to decode to its source bytes and every block and byte attributed to a type; this is a whole-page census and not a walk over openings
+- blocks: 9600 over 3200 pages (3.000 per page), 209715200 output bytes
+| type    | blocks | share of blocks | output bytes | share of bytes |
+| ------- | ------ | --------------- | ------------ | -------------- |
+| stored  |      0 |         0.0000% |            0 |        0.0000% |
+| static  |      0 |         0.0000% |            0 |        0.0000% |
+| dynamic |   9600 |       100.0000% |    209715200 |      100.0000% |
+```
+
+**The verdict: the mix does not justify a second path, and the corpus splits
+into two populations rather than one.** Where the compressor compresses --
+levels 1, 6 and 12, on both corpora -- stored and static blocks together are at
+most **0.0740% of blocks and 0.0370% of the produced bytes**, and on the
+asset-like corpus they are exactly zero at every one of those levels. A
+specialised path acting on one part in two thousand seven hundred of the output
+cannot pay for a second route through the round loop, and the accept rule #206
+pre-registered asks for a recorded improvement on a non-synthetic corpus, which
+that share cannot produce.
+
+**Level 0 is 100% stored on both corpora and it is not the counter-example it
+looks like.** It is the one block-type guarantee the reference's own header
+gives -- level 0 emits uncompressed blocks by construction -- so that cell is
+the compressor declining to compress rather than a workload with cheap blocks
+in it. Two readings say it does not reopen the lever. First, the M4 CPU
+denominator above records level 0 as the FASTEST family on both corpora, 0.692
+and 0.678 GB/s against 0.292 to 0.373 for every compressed level, so a
+specialisation there would accelerate the case that is already fastest and
+leave the binding one untouched. Second, the stored block is not on the round
+loop to begin with: `src/gdeflate_block.h` dispatches it to its own byte loop
+that builds no table and enters no round, so the "cheap block paying the full
+round-loop machinery" the lever is named for is not what the decoder does. What
+the census leaves for a specialisation to act on is therefore the static blocks
+alone, and they are 0.0137% to 0.0443% of blocks.
+
+**What this closes and what it does not.** It closes #206: no kernel code ships
+and the second decode path is not built. It does NOT relieve the M4 kernel of
+giving stored and static blocks their own arms -- those arms are the format's
+block-type dispatch and are mandatory, not a specialisation -- and it says
+nothing about the round loop's cost on dynamic blocks, which is where 99.9% of
+the work is and which #204, #205 and #207 measure.
+
+**What this does not cover, stated as a bound rather than left to be assumed.**
+Two corpora (Silesia and the asset-like model), one compressor (the pinned
+NVIDIA/libdeflate gdeflate fork at the commit named in every block below), the
+four levels the M4 corpus set names, and the 64 KiB page granularity the format
+fixes. A different compressor, or a producer emitting stored blocks
+deliberately, could carry a materially higher share, and neither was measured.
+
+**A census that had collapsed back into a walk over openings would print the
+same shape, so something that runs separates the two.**
+`bench_gdeflate_blockmix_selfcheck` holds every page to decoding to its source
+bytes, holds the per-type counts to summing to the page's own block count and
+the per-type byte counts to summing to the page's output, and then holds the
+level-0 cell to two things it cannot satisfy by accident: every block stored,
+which is the compressor's own guarantee, and at least two blocks for every page
+larger than a stored block's length field can express, which no walk over
+openings can produce. Attributing every block to one type reds it on the first;
+attributing bytes from the page start rather than the block start reds it on
+the sum; counting one block per page -- the opening-walk reading -- reds it on
+the second.
+
 ## M5: the Zstd CPU denominator (issue #227)
 
 There is no Zstd kernel yet. This entry is the denominator a later device

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1949,7 +1949,9 @@ The table is a reading aid. The eight blocks below are the record.
 **The verdict: the mix does not justify a second path, and the corpus splits
 into two populations rather than one.** Where the compressor compresses --
 levels 1, 6 and 12, on both corpora -- stored and static blocks together are at
-most **0.0740% of blocks and 0.0370% of the produced bytes**, and on the
+most **0.0739% of blocks and 0.0370% of the produced bytes**, which is five
+blocks of 6767 and 78369 bytes of 211938580 at Silesia level 6, the worst of
+the six cells. On the
 asset-like corpus they are exactly zero at every one of those levels. A
 specialised path acting on one part in two thousand seven hundred of the output
 cannot pay for a second route through the round loop, and the accept rule #206

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1790,8 +1790,9 @@ second path, and the question is closed before the kernel exists.** A
 whole-page block-type census over the recorded M4 corpora - the same eight
 cells the CPU denominator was taken on, proved by the eight corpus digests
 reproducing - finds that at every level where the reference actually
-compresses, stored and static blocks together are at most 0.0740% of blocks
-and 0.0370% of the produced bytes, and exactly zero of both on the
+compresses, stored and static blocks together are at most 0.0739% of blocks
+and 0.0370% of the produced bytes - five blocks of 6767 at the worst of the
+six cells - and exactly zero of both on the
 asset-like corpus. Level 0 is 100% stored on both corpora and does not
 reopen it: that is the compressor declining to compress, it is already the
 fastest family in the denominator table, and the stored block is not on the

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1785,6 +1785,24 @@ it an entropy-shaped path like any other, and whether it deserves a fast
 path is a measurement question that belongs to the perf pass, filed as #206
 against a measured block-type mix.
 
+**Measured outcome (issue #206, 2026-08-30): the mix does not justify a
+second path, and the question is closed before the kernel exists.** A
+whole-page block-type census over the recorded M4 corpora - the same eight
+cells the CPU denominator was taken on, proved by the eight corpus digests
+reproducing - finds that at every level where the reference actually
+compresses, stored and static blocks together are at most 0.0740% of blocks
+and 0.0370% of the produced bytes, and exactly zero of both on the
+asset-like corpus. Level 0 is 100% stored on both corpora and does not
+reopen it: that is the compressor declining to compress, it is already the
+fastest family in the denominator table, and the stored block is not on the
+round loop in the first place - `src/gdeflate_block.h` dispatches it to its
+own byte loop that builds no table and enters no round. So #206 closes with
+no kernel code. What that does NOT settle is the round loop's cost on
+dynamic blocks, where 99.9% of the work is; that stays with #204, #205 and
+#207. `docs/BENCHMARKS.md` carries the table, the bounds of the corpora it
+was taken over, and the guard that separates this census from a walk over
+page openings, which would have undercounted stored blocks by construction.
+
 ### 13.3 The validation ladder
 
 Every value read from the stream is checked before its first use as an

--- a/src/gdeflate_block.h
+++ b/src/gdeflate_block.h
@@ -58,6 +58,12 @@ constexpr uint32_t kGDeflateBlockStatic = 1;
 constexpr uint32_t kGDeflateBlockDynamic = 2;
 constexpr uint32_t kGDeflateBlockReserved = 3;
 
+/* The block types a decoded page can be made OF, which is one fewer than the
+ * BTYPE field can spell. The reserved type is refused before anything is
+ * accounted for it, so it never indexes the census below and the census array
+ * is deliberately too short to hold it. */
+constexpr uint32_t kGDeflateBlockTypeCount = 3;
+
 /* The literal/length alphabet's first length symbol, and the end-of-block
  * symbol below it. */
 constexpr uint32_t kGDeflateEndOfBlock = 256;
@@ -158,6 +164,16 @@ struct GDeflatePageState {
      * nothing outside says which, so without this the multi-block case cannot
      * be told from the single-block one by anything that reads a decode. */
     uint32_t blocks;
+    /* What the page turned out to be MADE OF, in the same sense `blocks` is
+     * what it turned out to hold: how many blocks of each type it carried and
+     * how many output bytes each type produced, indexed by the BTYPE
+     * constants above. A block boundary inside a page is not findable by
+     * scanning (docs/MASTERPLAN.md section 11.3), so a decode that walked to
+     * a block is the only thing that can attribute a byte to its type, and
+     * without this the attribution is unreadable from outside (issue #206).
+     * Written only on a successful decode, like `blocks`. */
+    uint32_t type_blocks[kGDeflateBlockTypeCount];
+    uint64_t type_bytes[kGDeflateBlockTypeCount];
 };
 
 /* Perform the copy the current lane reserved: decode the distance symbol off
@@ -231,8 +247,11 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
         (s.word_count + 1u) * (kGDeflateMaxLaneBits / kGDeflateMinMatchLen);
     bool final_block = false;
     uint32_t blocks_read = 0;
+    uint32_t type_blocks[kGDeflateBlockTypeCount] = {0, 0, 0};
+    uint64_t type_bytes[kGDeflateBlockTypeCount] = {0, 0, 0};
     for (uint64_t block = 0; block < block_fuel && !final_block; block++) {
         blocks_read++;
+        const uint64_t block_out_start = out_pos;
         GDeflateReset(s);
         final_block = GDeflatePop(s, 1) != 0;
         const uint32_t block_type = GDeflatePop(s, 2);
@@ -377,12 +396,25 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
                 }
             }
         }
+
+        /* BTYPE is two bits and the reserved value returned above, so the
+         * index is inside the census by construction rather than by a bound
+         * checked here. The byte count is the output cursor's movement across
+         * the whole block, drain included: a match reserved inside this block
+         * moved the cursor when it was reserved, and the copy that retires it
+         * writes into the range that move already claimed. */
+        type_blocks[block_type]++;
+        type_bytes[block_type] += out_pos - block_out_start;
     }
     if (!final_block) {
         s.failed = true;
         return false;
     }
     st.blocks = blocks_read;
+    for (uint32_t n = 0; n < kGDeflateBlockTypeCount; n++) {
+        st.type_blocks[n] = type_blocks[n];
+        st.type_bytes[n] = type_bytes[n];
+    }
     *out_len = out_pos;
     return true;
 }


### PR DESCRIPTION
# What & why

Closes #206.

The lever asks whether stored and static blocks deserve a second decode path
through the round loop, and its own rule is **count first, then decide**:
"Only if that mix is materially non-trivial, implement the specialisation and
measure it", and "the mix does not justify a second path" is a full result that
must be recorded as one. This is the count, and the answer is the second one.

**Nothing in the tree could do the counting, and the reading that was available
points the wrong way.** A GDeflate block boundary is not findable by scanning
(masterplan 11.3), so `bench_gdeflate --blocktypes` reads each page's FIRST
block header and stops - a bound that file already states about itself. That
reading is biased against exactly the block type this lever is about: a stored
block's length field is sixteen bits and 65535 is one byte short of a page, so
a full page of stored data is at least two stored blocks, always, while a page
that uses a table can be one. A histogram of openings undercounts stored
blocks by construction. That trap was written on this issue on 2026-08-27 and
is what this change pays.

## What is here

- `src/gdeflate_block.h`: `GDeflatePageState` already carries what a page
  turned out to HOLD (`blocks`); this adds what it turned out to be made OF -
  blocks and produced bytes per block type. Accumulated in locals and stored
  into the state only on a successful decode, the same discipline `blocks`
  has. The index is BTYPE, two bits with the reserved value refused above the
  accounting site, so it is inside the census by construction rather than by a
  bound checked there. No decode branch is added and no bound moves.
- `bench/bench_gdeflate.cpp`: `--blockmix`, which walks the level sweep's own
  corpora with that decoder. Every page must decode to its source bytes, the
  per-type counts must sum to the page's block count, and the per-type byte
  counts must sum to its output - so an attribution that does not cover the
  page is a failure rather than a smaller table.
- `bench/CMakeLists.txt`: `bench_gdeflate_blockmix_selfcheck`, CPU-only, with
  the mandatory finite `TIMEOUT`.
- `docs/BENCHMARKS.md`: the table, the eight report blocks, the corpus bounds,
  the verdict and the guard.
- `docs/MASTERPLAN.md`: the measured outcome recorded at 13.2, in the
  paragraph that filed the question.

## The measurement

Taken over Silesia and the asset-like corpus at levels 0, 1, 6 and 12. **All
eight corpus digests reproduce the eight recorded for the M4 CPU denominator**,
which is what makes this a census of that corpus rather than of one resembling
it.

| corpus     | level | pages | blocks | blocks/page | stored blocks | static blocks | dynamic blocks | stored bytes | static bytes | dynamic bytes |
| ---------- | ----- | ----- | ------ | ----------- | ------------- | ------------- | -------------- | ------------ | ------------ | ------------- |
| Silesia    | 0     | 3234  | 6467   | 2.000       | 100.0000%     | 0.0000%       | 0.0000%        | 100.0000%    | 0.0000%      | 0.0000%       |
| Silesia    | 1     | 3234  | 6742   | 2.085       | 0.0148%       | 0.0148%       | 99.9703%       | 0.0057%      | 0.0059%      | 99.9883%      |
| Silesia    | 6     | 3234  | 6767   | 2.092       | 0.0296%       | 0.0443%       | 99.9261%       | 0.0115%      | 0.0255%      | 99.9630%      |
| Silesia    | 12    | 3234  | 7308   | 2.260       | 0.0137%       | 0.0137%       | 99.9726%       | 0.0057%      | 0.0096%      | 99.9847%      |
| asset-like | 0     | 3200  | 6400   | 2.000       | 100.0000%     | 0.0000%       | 0.0000%        | 100.0000%    | 0.0000%      | 0.0000%       |
| asset-like | 1     | 3200  | 9600   | 3.000       | 0.0000%       | 0.0000%       | 100.0000%      | 0.0000%      | 0.0000%      | 100.0000%     |
| asset-like | 6     | 3200  | 9600   | 3.000       | 0.0000%       | 0.0000%       | 100.0000%      | 0.0000%      | 0.0000%      | 100.0000%     |
| asset-like | 12    | 3200  | 9600   | 3.000       | 0.0000%       | 0.0000%       | 100.0000%      | 0.0000%      | 0.0000%      | 100.0000%     |

**The verdict.** Where the reference actually compresses, stored and static
together are at most 0.0739% of blocks and 0.0370% of the produced bytes -
five blocks of 6767 and 78369 bytes of 211938580, at Silesia level 6, the worst
of the six cells - and exactly zero of both on the asset-like corpus. A specialised path acting on one
part in two thousand seven hundred of the output cannot produce the recorded
improvement on a non-synthetic corpus that this issue's accept rule asks for.

**Level 0 is 100% stored on both corpora and does not reopen it**, for two
reasons that are readings rather than arguments. The M4 denominator records
level 0 as the fastest family on both corpora (0.692 and 0.678 GB/s against
0.292 to 0.373 for every compressed level), so a specialisation there
accelerates the case that is already fastest. And the stored block is not on
the round loop to begin with: `src/gdeflate_block.h` dispatches it to its own
byte loop that builds no table and enters no round, so the "cheap block paying
the full round-loop machinery" the lever is named for is not what the decoder
does. What is left for a specialisation to act on is the static blocks alone,
at 0.0137% to 0.0443% of blocks.

## Type of change

- [x] Performance (a measured negative; no kernel code ships)
- [x] Format support (GDeflate)

## Engineering checklist

- [x] Fail-closed preserved: no decode branch is added, no bound is changed,
      and nothing new is read from the stream. The census is accounting over
      values the decode had already produced and refused on.
- [x] Oracle coverage: the corpora are built and round-tripped by the vendored
      reference before the census runs, exactly as the level sweep does, and
      every page is additionally required to decode to its source bytes
      through cudec's own decoder before its census is folded in.
- [x] Determinism preserved: the census is a function of the page, computed in
      the order the decode already runs in.
- [x] No CUDA API call is added and no exception crosses the ABI.
- [ ] An adversarial review (`/security-review`) was run, `cuda-reviewer`
      included. **It was not, and that box stays unticked.** No second reader
      was available for this change. What stands in place of one is the three
      mutants below and the per-lens reading recorded here.
- [x] Review record: below, with counts.

## Review record

Read against the four lenses this repository names plus the CUDA-domain
questions the mandatory lens would ask, by the author of the change and by
nobody else. **CONFIRMED 0 / PLAUSIBLE 0.**

- **Correctness.** `block_type` is the two-bit BTYPE field and the reserved
  value returns before the accounting site, so the census index is `0..2` and
  `kGDeflateBlockTypeCount` is deliberately 3. The byte figure is the output
  cursor's movement across the whole block, drain included, which is right
  because a match reserved inside a block moved the cursor at reservation and
  the copy that retires it writes into the range that move already claimed;
  the per-page sum check is what proves that rather than argues it.
- **Robustness.** No stream value bounds anything here. The accumulators are
  written after the last refusal, so a page the decoder rejects produces no
  census at all rather than a partial one.
- **Integration / device.** The header is `__host__ __device__`
  single-source and stays so; six locals and 36 bytes on `GDeflatePageState`
  (`3 x uint32_t` + `3 x uint64_t`) are what it costs the future kernel, which
  is small against the two Huffman tables that set that kernel's residency
  (masterplan 13.1). If the occupancy arithmetic ever disagrees, #214 can put
  the census behind a template parameter without moving anything else. The
  bench binary carries no CUDA and needs no device.
- **Performance.** No hot path is touched. The census is one increment and one
  add per block.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code path that runs on a
      device today. `src/gdeflate_block.h` is host/device single-source, and
      there is no GDeflate kernel; everything here executes on the host.

```
commit:    8170396 (the tree the gate below ran on is de35d5f plus a documented figure correction)
gpu:       no route to a device the sanitizer could attach to
cuda:      13.3 (V13.3.73)
sanitizer: not run
```

No container runtime was reachable while this was built, and the WSL
distribution the build ran in has no device:

```
$ docker version --format '{{.Server.Version}}'
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine

$ nvidia-smi --query-gpu=name --format=csv,noheader
Failed to initialize NVML: GPU access blocked by the operating system
```

Everything this change adds runs in the GPU-less subset, so the missing device
costs it no coverage of its own; it costs the rest of the suite its on-device
run, which is why the paste below is labelled as the host-side subset.

## Performance checklist

- [x] The claim is measured, not reasoned: the census above, with the corpus
      digests that tie it to the recorded M4 denominator.
- [x] No regression against the recorded baseline: no kernel code ships and no
      recorded number moves. This entry is a measured negative, which is the
      outcome the issue pre-registered as a full result.

## Verification

Built with nvcc 13.3 rather than the pinned 12.6.2 container, because no
container runtime was reachable (above). The pinned container is what CI runs,
and CI's verdict on this branch is the one that counts.

```
$ sh scripts/check-doc-paths.sh
PASS: every path a tense-present document names resolves, and every declared
forward reference names an open issue

$ rm -rf $HOME/bc216 && cmake -B $HOME/bc216 -S . -DCUDEC_ENABLE_CUDA=ON \
    && cmake --build $HOME/bc216 -j
warnings: 0

$ ctest --test-dir $HOME/bc216 -LE gpu --no-tests=error --output-on-failure
100% tests passed, 0 tests failed out of 50
Total Test time (real) =  14.72 sec

$ cmake -B $HOME/bh216 -S . && cmake --build $HOME/bh216 -j     # host-only
host-only exit=0
```

- [x] Builds clean, both configurations, zero warnings.
- [x] `ctest -LE gpu` green: 50/50, including the new
      `bench_gdeflate_blockmix_selfcheck`.
- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.
- [x] Docs synced: BENCHMARKS.md carries the entry, MASTERPLAN 13.2 carries
      the outcome where it filed the question.

### The guards, each watched refusing

```
----- MUTANT 1: every block attributed to dynamic -----
level 0 censused 0 of 8 blocks as stored and 0 of 262144 bytes - the reference
emits uncompressed blocks at level 0 by construction, so the census disagrees
with the compressor rather than with an expectation
0% tests passed, 1 tests failed out of 1

----- MUTANT 2: the per-block start is not reset, so bytes are attributed from
      the page start -----
page 0 of selfcheck censused 2 blocks and 131071 bytes against 2 blocks and
65536 bytes decoded - the attribution does not cover the page
0% tests passed, 1 tests failed out of 1

----- MUTANT 3: the census counts one block per page (the opening-walk
      reading) -----
level 0 censused 8 of 4 blocks as stored and 262144 of 262144 bytes - the
reference emits uncompressed blocks at level 0 by construction, so the census
disagrees with the compressor rather than with an expectation
0% tests passed, 1 tests failed out of 1

----- restored -----
100% tests passed, 0 tests failed out of 1
```

Mutant 3 is the one the entry exists for: it is exactly what a walk over
openings produces, and it fails against the arithmetic that a page larger than
a stored block's length field cannot be one block. Mutant 1 fails against the
compressor's own guarantee rather than against an expectation written here.

## Notes

**What this closes and what it does not.** It closes #206 on the measured mix:
no second decode path is built. It does not relieve the M4 kernel of giving
stored and static blocks their own arms - those are the format's block-type
dispatch and are mandatory, not a specialisation - and it says nothing about
the round loop's cost on dynamic blocks, where 99.9% of the work is and which
#204, #205 and #207 measure.

**One thing noticed and deliberately not changed**, because it is pre-existing
and touching it would be a second topic: `blocks_read` in `GDeflateDecodePage`
is a `uint32_t` counting a loop bounded by a `uint64_t` fuel, so a page large
enough to hold more than 2^32 blocks would wrap that counter. The new per-type
counters have exactly the same exposure and no more. Nothing is indexed by
either, so no bound depends on it; the field is diagnostic. Reaching it needs a
single "page" on the order of a gigabyte and a half.

**Not covered by this change:** the sibling corpus issue #226 is still waiting
on a scope call between rounds-per-decoded-byte and refills-per-decoded-byte
for its density lock; nothing here takes that call.
