### PR TITLE
Split the changelog's format limits into one statement per format [#411]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ write (#82). Everything in it is in the tree today.
   asynchronous: its return value covers argument validation and launch
   submission, and the per-chunk statuses are valid once the stream reaches the
   end of the launch.
+- **Snappy raw-stream batch decode on the GPU.**
+  `cudec_snappy_decompress_batch` decodes N independent raw Snappy streams -
+  the varint-prefixed block `google/snappy`'s own `Compress` produces - in one
+  launch on a caller-provided stream, and the batch contract holds argument for
+  argument against the LZ4 entry above: the same device-side arrays, the same
+  per-chunk `cudec_chunk_result`, the same synchronous argument rejects, the
+  same launch limit, and the same asynchronous launch. The Snappy FRAMING
+  format - stream identifier, framed chunks, masked CRC-32C - is not decoded
+  here and no entry point decodes it, so a framed stream is a malformed raw one
+  and is refused with `CUDEC_ERR_CORRUPT_INPUT` rather than partially decoded.
+  The declared uncompressed length that opens every raw stream is
+  attacker-controlled and sizes nothing: it is checked against that chunk's
+  capacity before an element is parsed, a declaration above the capacity reports
+  `CUDEC_ERR_OUTPUT_TOO_SMALL`, and every later overrun of it reports
+  `CUDEC_ERR_CORRUPT_INPUT`. There is no Snappy streaming entry point and no
+  milestone carries one: Snappy is batch-only by decision, not by omission.
 - **`.lz4` frame decode.** `cudec_lz4f_decompress` decodes the frame format's
   block-independent subset, host memory to host memory, driving the batch
   decoder internally. The header, block and content checksums and the optional
@@ -85,9 +101,25 @@ write (#82). Everything in it is in the tree today.
 
 ### Supported subset, stated as limits rather than implied
 
-- LZ4 only. Snappy, GDeflate, Zstd and the HIP port are planned milestones with
-  no code in this release; the milestone table in
-  [README.md](README.md) is the current state.
+- **Formats, stated one at a time.** One sentence covering four formats is read
+  as a promise in the direction that costs a consumer the most, so each format
+  states its own limit and none of them can be refuted by resolving a symbol out
+  of `include/cudec.h`.
+  - **LZ4** decodes on the GPU: block batch, the `.lz4` frame subset bounded
+    below, and the pinned-host streaming path.
+  - **Snappy** decodes on the GPU, raw streams only, through the batch entry and
+    nothing else. The framing format is not decoded by any entry point.
+  - **GDeflate** has a declared entry point whose contract is frozen and no
+    kernel behind it. A batch it accepts is answered
+    `CUDEC_ERR_NOT_IMPLEMENTED`, and no CUDA call is made.
+  - **Zstd** has host-side format parsers under `src/` and no public surface at
+    all: `include/cudec.h` names no Zstd entry point, on any build.
+  - **The HIP port** carries no device sources. `CUDEC_ENABLE_HIP` exists to
+    fail the configure rather than to produce a build.
+
+  The milestone table in [README.md](README.md) carries the same list against
+  the milestones that own each one.
+
 - Frames must be block-independent and carry no dictionary id.
 - Decode only. Nothing here compresses.
 - NVIDIA GPUs. The default architecture list is `80` plus `86-real`, and the
@@ -103,9 +135,11 @@ write (#82). Everything in it is in the tree today.
 
 - **Fail-closed decode.** A malformed, truncated or hostile chunk produces a
   defined error with `bytes_written == 0`, never an out-of-bounds access and
-  never partial output presented as success. Held to liblz4 1.10.0 as the
-  authority on validity over the fixture corpus, its mutants and hand-crafted
-  negatives; the parser twin runs that comparison on the GPU-less CI runner and
+  never partial output presented as success. Each format is held to its own
+  reference as the authority on validity - liblz4 1.10.0 for LZ4, google/snappy
+  1.2.2 for Snappy, including the three malformed streams snappy's own test
+  suite carries - over the fixture corpus, its mutants and hand-crafted
+  negatives; the parser twins run that comparison on the GPU-less CI runner and
   the device twins repeat it on hardware.
 - **Determinism.** Same input, bit-identical output. The levels this holds at,
   and what each one is measured against, are in


### PR DESCRIPTION
Closes #411.

## What was wrong

`CHANGELOG.md`'s "Supported subset, stated as limits rather than implied" is the
file's negative disclosure - the place a consumer reads to find out what cudec
will NOT do - and it said this:

    git show origin/main:CHANGELOG.md | sed -n '88,90p'
    - LZ4 only. Snappy, GDeflate, Zstd and the HIP port are planned milestones with
      no code in this release; the milestone table in
      [README.md](README.md) is the current state.

One sentence covering four formats, and the Snappy quarter of it is refuted by
resolving a symbol:

    git show origin/main:include/cudec.h | grep -n '^cudec_status cudec_.*_decompress_batch'
    110:cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
    140:cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
    180:cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,

    git log --format='%h %ad %s' --date=short -1 origin/main \
      -S'cudec_snappy_decompress_batch' -- include/cudec.h
    7e5949c 2026-08-25 Materialize the chunk-decoder seam and instantiate Snappy on it [#150]

    git show origin/main:CHANGELOG.md | grep -c 'cudec_snappy_decompress_batch'
    0

So the file understated the surface in the Added section and misstated it in the
limits section, in the one direction where a wrong entry is read as a promise.

## What changed

**The Added section gains the Snappy batch entry**, in the shape the LZ4 batch
entry's paragraph already sets: the raw varint-prefixed stream it takes, the
framing format no entry point decodes and how a framed stream is therefore
refused, the attacker-controlled declared length that sizes nothing, and the
absence of a Snappy streaming entry as a decision rather than an omission. Every
clause is the header's own contract, at `include/cudec.h:117-139`.

**The limits section states each format separately.** Five statements, each
refutable only by the tree and none of them by a symbol lookup:

- LZ4 decodes - block batch, the `.lz4` frame subset, the pinned-host streaming
  path.
- Snappy decodes, raw streams only, batch entry only.
- GDeflate has a declared entry point with a frozen contract and no kernel; an
  accepted batch is answered `CUDEC_ERR_NOT_IMPLEMENTED` (`src/batch.cu:67-92`).
- Zstd has host parsers under `src/` and no public surface: `grep -c -i zstd
  include/cudec.h` returns `0`.
- The HIP port has no device sources; `CUDEC_ENABLE_HIP` fails the configure
  (`CMakeLists.txt:265-284`).

**One sentence outside the issue's three bullets moved with them**, and it is
the same defect rather than a second topic: the fail-closed guarantee said the
release was "Held to liblz4 1.10.0 as the authority on validity", naming one
reference for a release that decodes two formats. It now names the reference
each format is actually held to - liblz4 1.10.0 and google/snappy 1.2.2,
including the three malformed streams snappy's own suite carries
(`tests/snappy_upstream_negatives.cpp`, pinned at
`cmake/CudecSnappyOracle.cmake:23`). Fixing the neighbours and leaving a
known-understating sentence in the same section would have left the file wrong
for the reason this change exists.

## The third Done-when: the README table was read, and it agrees

It needed no edit, which is a reading rather than an omission:

    git show origin/main:README.md | sed -n '57,65p'
    | Milestone        | Deliverable                                         | Status  |
    | ---------------- | --------------------------------------------------- | ------- |
    | M0 - Foundation  | Toolchain, CMake+CUDA skeleton, CI, test harness    | done    |
    | M1 - LZ4 block   | Warp-cooperative LZ4 block decode, fuzz-diffed      | done    |
    | M2 - LZ4 batch   | Frame format, batch API, streaming path, benchmarks | done    |
    | M3 - Snappy      | Snappy decode on the same kernel family             | done    |
    | M4 - GDeflate    | GDeflate decode as an auditable CUDA library        | planned |
    | M5 - Zstd        | Zstd decode (FSE/Huffman sequences)                 | planned |
    | M6 - Portability | HIP port                                            | planned |

LZ4 and Snappy done, GDeflate/Zstd/HIP planned - the same list the new limits
section carries, against the milestones that own each one. The pointer at the
table survives; what changed is that it is no longer the only place the state is
stated correctly.

## Means

Markdown prose in `CHANGELOG.md`, which is not a choice: the artefact under
change IS that file, in the Keep a Changelog format the file's own header
declares. Nothing here adds a language, a runtime or a dependency, and the check
that judges it is the same Prettier gate the rest of the tracked Markdown passes.

## Verification

    npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
    Checking formatting...
    All matched files use Prettier code style!

No code, build or test file is touched:

    git diff --name-only origin/main...HEAD
    CHANGELOG.md

## Scope

Nothing about the released heading: no version is tagged and the entry stays
under Unreleased, which is #82's.

## Second reader

This board has no second reader tonight. The claims above are each backed by the
command beside them rather than by a review, and every statement the change adds
was checked against `include/cudec.h`, `src/batch.cu`, `CMakeLists.txt` and
`tests/` at this head.
