### PR TITLE
Route the host layer's device runtime through one vendor seam [#240]

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -768,7 +768,7 @@ which is what let the `is_copy` flag go rather than be carried across the
 seam. The copy engine runs both halves unconditionally and has nothing to
 branch on, which is the "copy engine checks nothing" rule with one contract
 behind it instead of two. `tests/CMakeLists.txt` locks the single source the
-way it already locks `cuda_raii.h` and the batch limit.
+way it already locks `vendor_raii.h` and the batch limit.
 
 ### The batch entry
 
@@ -2382,14 +2382,27 @@ uses onto their HIP spellings, keyed on `__HIP_PLATFORM_AMD__`, and the
 kernel sources stay one set of files.
 
 The surface that shim has to carry is small and is readable rather than
-guessed. The host layer's CUDA runtime use is concentrated in
-`src/cuda_raii.h`, which touches `cudaMalloc`, `cudaFree`, `cudaHostAlloc`,
-`cudaFreeHost`, `cudaEventCreate`, `cudaEventDestroy`,
-`cudaStreamCreateWithFlags` and `cudaStreamDestroy`, plus the error type and
-the two flag constants those calls take. That header is therefore the
-ownership boundary the panel adopts, which is where #240 already assumed it
-would land. Anything outside it that reaches for the runtime directly is a
-finding against this design rather than a case for widening the shim.
+guessed. The host layer's runtime use was concentrated in the shared RAII
+owners, which touch the two allocation pairs, the stream and event owners,
+the error type and the two flag constants those calls take.
+
+**Landed** (#240) as `src/vendor_rt.h`, and the boundary moved one step out
+from where this section put it. The owners are still the concentration, but
+`src/frame.cpp` and `src/stream.cpp` reach the runtime directly as well, so a
+shim owned by the owners' header would have left those two outside it. The
+seam is its own header instead: it names the backend, every other file under
+`src/` - the owners in `src/vendor_raii.h` included - goes through
+`cudec_rt::`, and a configure-time rule in `tests/CMakeLists.txt` reds the
+build on a `cuda`- or `hip`-prefixed spelling anywhere else. Anything outside
+the seam that reaches for the runtime directly is now a red configure rather
+than a finding.
+
+The mapping is proven consistent and is not proven correct. A second
+configure-time rule refuses a table whose two arms carry different operation
+sets, which is the failure that would otherwise build clean here and red only
+under ROCm; whether each HIP name is the right partner for its CUDA name is
+what no reading of this tree can answer, and #210's compile-only job is the
+route to a compiler that can.
 
 ### 15.2 The wave width is a template parameter, and the reason is a platform fact
 

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -3,7 +3,7 @@
 #include "lz4_block.h"
 #include "snappy_block.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt.h"
 
 namespace {
 
@@ -28,14 +28,15 @@ cudec_status submit_batch(const void* const* d_src_ptrs,
     /* Drain any error already pending on this thread so the post-launch
      * check reports this submission alone; the header documents that the
      * call consumes the pending error state. */
-    (void)cudaGetLastError();
+    (void)cudec_rt::get_last_error();
 
     cudec_detail::chunk_decode_batch<Parser, false, cudec_detail::kCudaWaveSize>
         <<<cudec_detail::decode_grid_blocks(chunk_count),
            cudec_detail::kBlockThreads, 0, stream>>>(
             d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
             d_results);
-    return cudaGetLastError() == cudaSuccess ? CUDEC_OK : CUDEC_ERR_CUDA;
+    return cudec_rt::get_last_error() == cudec_rt::success ? CUDEC_OK
+                                                           : CUDEC_ERR_CUDA;
 }
 
 }  // namespace
@@ -68,7 +69,8 @@ cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
  * yet (issue #216). It shares the validator with the two above rather than
  * growing its own, so the reject classes cannot drift apart while they are
  * being frozen, and then stops: no launch, and deliberately no
- * cudaGetLastError() drain either. Draining is how the entries above buy a
+ * cudec_rt::get_last_error() drain either. Draining is how the entries above
+ * buy a
  * post-launch check that reports their own submission; with nothing
  * submitted there is nothing to report, and consuming a caller's pending
  * error on the way to answering "not built here" would be this entry

--- a/src/chunk_decode.cuh
+++ b/src/chunk_decode.cuh
@@ -56,7 +56,7 @@
 #include "cudec.h"
 #include "decode_sequence.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt.h"
 
 namespace cudec_detail {
 

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -6,10 +6,10 @@
  * optional declared content size are verified fail-closed. Frame spec
  * (public): lz4_Frame_format.md. */
 #include "cudec.h"
-#include "cuda_raii.h"
+#include "vendor_raii.h"
 #include "lz4_frame.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt.h"
 
 #include <cstring>
 #include <vector>
@@ -28,9 +28,9 @@ using cudec_detail::Lz4FrameDescriptor;
  * to *total_out. Every CUDA failure maps to a defined status; a block the
  * decoder rejects makes the whole frame CORRUPT_INPUT.
  *
- * Staging is a single source buffer and a single destination buffer (not a
- * cudaMalloc per block): device memory stays bounded, an oversized hostile
- * frame fails fast and cleanly on one allocation instead of a per-block
+ * Staging is a single source buffer and a single destination buffer (not one
+ * device allocation per block): device memory stays bounded, an oversized
+ * hostile frame fails fast and cleanly on one allocation instead of a per-block
  * allocation storm, and the shape is closer to what the pinned-host
  * streaming path (issue #24) needs. #24 still supersedes it (overlap,
  * pinned memory, per-block dst sizing). */
@@ -38,7 +38,7 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
                                const std::vector<Lz4FrameBlock>& blocks,
                                size_t block_max, unsigned char* out,
                                size_t dst_capacity, size_t* total_out) {
-#define FRAME_CUDA(call) CUDEC_CUDA_CHECK(call, return CUDEC_ERR_CUDA)
+#define FRAME_RT(call) CUDEC_RT_CHECK(call, return CUDEC_ERR_CUDA)
 
     std::vector<size_t> cidx;
     size_t total_src = 0;
@@ -56,16 +56,17 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
     /* One-shot owners: each buffer is allocated once here and freed on every
      * scope exit. The shared grow-only DevBuf serves this by a single ensure()
      * from cap 0 - every size below is non-zero (guarded by n != 0), so the
-     * first ensure allocates exactly once, identical to a bare cudaMalloc. */
-    cudec_cuda::DevBuf d_src, d_dst, dd_meta, dd_res;
+     * first ensure allocates exactly once, identical to a bare device
+     * allocation. */
+    cudec_rt::DevBuf d_src, d_dst, dd_meta, dd_res;
     if (n != 0) {
         /* One destination slot of block_max per compressed block. Guard the
          * product against size_t overflow before asking the driver. */
         if (block_max != 0 && n > SIZE_MAX / block_max) {
             return CUDEC_ERR_CORRUPT_INPUT;
         }
-        FRAME_CUDA(d_src.ensure(total_src));
-        FRAME_CUDA(d_dst.ensure(n * block_max));
+        FRAME_RT(d_src.ensure(total_src));
+        FRAME_RT(d_dst.ensure(n * block_max));
 
         std::vector<const void*> h_src(n);
         std::vector<void*> h_dst(n);
@@ -84,8 +85,8 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
                 h_dcp[k] = block_max;
                 so += b.src_len;
             }
-            FRAME_CUDA(cudaMemcpy(d_src.p, stage.data(), total_src,
-                                  cudaMemcpyHostToDevice));
+            FRAME_RT(cudec_rt::memcpy(d_src.p, stage.data(), total_src,
+                                  cudec_rt::memcpy_h2d));
         }
 
         /* The four metadata arrays go up in ONE transfer out of one packed
@@ -107,8 +108,8 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
             return CUDEC_ERR_CORRUPT_INPUT;
         }
         const size_t meta_stride = n * sizeof(void*);
-        FRAME_CUDA(dd_meta.ensure(4 * meta_stride));
-        FRAME_CUDA(dd_res.ensure(n * sizeof(cudec_chunk_result)));
+        FRAME_RT(dd_meta.ensure(4 * meta_stride));
+        FRAME_RT(dd_res.ensure(n * sizeof(cudec_chunk_result)));
 
         /* One host staging buffer in the same layout, filled section by
          * section, so the upload is a straight copy of it. */
@@ -119,8 +120,8 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
                     meta_stride);
         std::memcpy(h_meta.data() + 3 * meta_stride, h_dcp.data(),
                     meta_stride);
-        FRAME_CUDA(cudaMemcpy(dd_meta.p, h_meta.data(), 4 * meta_stride,
-                              cudaMemcpyHostToDevice));
+        FRAME_RT(cudec_rt::memcpy(dd_meta.p, h_meta.data(), 4 * meta_stride,
+                              cudec_rt::memcpy_h2d));
 
         unsigned char* const d_meta = static_cast<unsigned char*>(dd_meta.p);
         const cudec_status launched = cudec_lz4_decompress_batch(
@@ -132,12 +133,12 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
         if (launched != CUDEC_OK) {
             return launched;
         }
-        FRAME_CUDA(cudaDeviceSynchronize());
+        FRAME_RT(cudec_rt::device_synchronize());
 
         std::vector<cudec_chunk_result> res(n);
-        FRAME_CUDA(cudaMemcpy(res.data(), dd_res.p,
+        FRAME_RT(cudec_rt::memcpy(res.data(), dd_res.p,
                               n * sizeof(cudec_chunk_result),
-                              cudaMemcpyDeviceToHost));
+                              cudec_rt::memcpy_d2h));
         for (size_t k = 0; k < n; k++) {
             /* Any per-block failure means the frame's block data is corrupt.
              * The per-block dst capacity is our internal block_max, never the
@@ -168,7 +169,7 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
     /* Place each block at its prefix offset: uncompressed blocks copied from
      * the frame, compressed blocks copied from the device.
      *
-     * Each compressed block used to cost its own blocking cudaMemcpy, which is
+     * Each compressed block used to cost its own blocking copy, which is
      * one host stall per block; the block-count sweep in docs/BENCHMARKS.md is
      * what made that visible, at roughly 34 microseconds a block. The copies
      * are now issued on one stream and drained once, and consecutive blocks
@@ -195,15 +196,15 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
      * freed device memory is a use-after-free that does not fail loudly - so
      * the guard below runs it on EVERY exit path from here on, including the
      * error returns, and the ordinary path checks its status as well. */
-    cudec_cuda::StreamOwner asm_stream;
+    cudec_rt::StreamOwner asm_stream;
     if (n != 0) {
-        FRAME_CUDA(asm_stream.create());
+        FRAME_RT(asm_stream.create());
     }
     struct AsmDrain {
-        cudaStream_t s;
+        cudec_rt::stream_t s;
         ~AsmDrain() {
             if (s != nullptr) {
-                (void)cudaStreamSynchronize(s);
+                (void)cudec_rt::stream_synchronize(s);
             }
         }
     } asm_drain{asm_stream.s};
@@ -234,10 +235,10 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
                 run_len += len;
             } else {
                 if (run_len != 0) {
-                    FRAME_CUDA(cudaMemcpyAsync(
+                    FRAME_RT(cudec_rt::memcpy_async(
                         out + run_out,
                         static_cast<unsigned char*>(d_dst.p) + run_dev, run_len,
-                        cudaMemcpyDeviceToHost, asm_stream.s));
+                        cudec_rt::memcpy_d2h, asm_stream.s));
                 }
                 run_dev = dev;
                 run_out = off;
@@ -248,17 +249,17 @@ cudec_status DecodeAndAssemble(const unsigned char* frame,
         }
     }
     if (run_len != 0) {
-        FRAME_CUDA(cudaMemcpyAsync(
+        FRAME_RT(cudec_rt::memcpy_async(
             out + run_out, static_cast<unsigned char*>(d_dst.p) + run_dev,
-            run_len, cudaMemcpyDeviceToHost, asm_stream.s));
+            run_len, cudec_rt::memcpy_d2h, asm_stream.s));
     }
     if (n != 0) {
-        FRAME_CUDA(cudaStreamSynchronize(asm_stream.s));
+        FRAME_RT(cudec_rt::stream_synchronize(asm_stream.s));
     }
 
     *total_out = total;
     return CUDEC_OK;
-#undef FRAME_CUDA
+#undef FRAME_RT
 }
 
 /* The frame decode proper; wrapped by the extern "C" entry point in a

--- a/src/lz4_frame.h
+++ b/src/lz4_frame.h
@@ -10,7 +10,8 @@
  * LZ4 surface arbitrary bytes reach before anything else, and it is the gate
  * that decides which blocks the device decoder is asked about at all - so a
  * fail-open here admits a stream to the kernel rather than only to this rung.
- * src/frame.cpp includes <cuda_runtime.h> and joins the CUDA library, which
+ * src/frame.cpp reaches the device runtime through src/vendor_rt.h and joins
+ * the vendor runtime library, which
  * puts it out of reach of the one runner that could drive arbitrary bytes
  * into it: fuzz/ links no cudec archive and builds with Clang on a machine
  * with no CUDA at all. Header-only and CUDA-free is what lets the parser and

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -29,9 +29,9 @@
 #include "batch_limits.h"
 #include "cudec.h"
 
-#include "cuda_raii.h"
+#include "vendor_raii.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt.h"
 
 #include <cstdint>
 #include <cstring>
@@ -127,15 +127,15 @@ cudec_status CopyWaveToHost(cudec_chunk_result* wr, const unsigned char* d_dst,
  * namespace, not an anonymous one) so this ABI-visible struct triggers no
  * subobject-linkage diagnostic. */
 struct cudec_stream_ctx {
-    cudec_cuda::StreamOwner stream;
-    cudec_cuda::EventOwner reuse_ev;
-    cudec_cuda::PinnedBuf p_src;
-    cudec_cuda::DevBuf d_src;
-    cudec_cuda::PinnedBuf p_meta;
-    cudec_cuda::DevBuf d_meta;
-    cudec_cuda::DevBuf d_dst; /* host-output staging only */
-    cudec_cuda::DevBuf d_results;
-    cudec_cuda::PinnedBuf p_results;
+    cudec_rt::StreamOwner stream;
+    cudec_rt::EventOwner reuse_ev;
+    cudec_rt::PinnedBuf p_src;
+    cudec_rt::DevBuf d_src;
+    cudec_rt::PinnedBuf p_meta;
+    cudec_rt::DevBuf d_meta;
+    cudec_rt::DevBuf d_dst; /* host-output staging only */
+    cudec_rt::DevBuf d_results;
+    cudec_rt::PinnedBuf p_results;
     bool poisoned = false;
 };
 
@@ -174,8 +174,8 @@ cudec_status CopyWaveToHost(cudec_chunk_result* wr, const unsigned char* d_dst,
             return CUDEC_ERR_CUDA;
         }
         if (bw != 0 && dst_ptrs[i] != nullptr &&
-            cudaMemcpy(dst_ptrs[i], d_dst + off, bw,
-                       cudaMemcpyDeviceToHost) != cudaSuccess) {
+            cudec_rt::memcpy(dst_ptrs[i], d_dst + off, bw,
+                       cudec_rt::memcpy_d2h) != cudec_rt::success) {
             return CUDEC_ERR_CUDA;
         }
         off += dst_caps[i];
@@ -287,7 +287,8 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
         }
     }
     if (max_wave_src == 0) {
-        max_wave_src = 1; /* cudaMalloc(0) is legal but avoid the corner */
+        /* A zero-size device allocation is legal but avoid the corner. */
+        max_wave_src = 1;
     }
     if (host_out && max_wave_dst == 0) {
         max_wave_dst = 1;
@@ -298,12 +299,12 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
     }
     const size_t results_bytes = chunk_count * sizeof(cudec_chunk_result);
 
-    /* Grow-only staging. A grow allocation failure (e.g. an oversized
-     * cudaMalloc) leaves the context's buffers partially grown; poison so only
+    /* Grow-only staging. A grow allocation failure (e.g. an oversized device
+     * allocation) leaves the context's buffers partially grown; poison so only
      * destruction is valid afterwards. This is a DEFINED failure, reachable
      * through the public API without any undefined behavior. */
 #define GROW(call) \
-    CUDEC_CUDA_CHECK(call, { ctx.poisoned = true; return CUDEC_ERR_CUDA; })
+    CUDEC_RT_CHECK(call, { ctx.poisoned = true; return CUDEC_ERR_CUDA; })
     GROW(ctx.p_src.ensure(max_wave_src));
     GROW(ctx.d_src.ensure(max_wave_src));
     GROW(ctx.p_meta.ensure(meta_bytes));
@@ -315,8 +316,8 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
     GROW(ctx.p_results.ensure(results_bytes));
 #undef GROW
 
-    cudaStream_t stream = ctx.stream.s;
-    cudaEvent_t reuse = ctx.reuse_ev.e;
+    cudec_rt::stream_t stream = ctx.stream.s;
+    cudec_rt::event_t reuse = ctx.reuse_ev.e;
 
     /* Seed the pinned result mirror with a DEFINED not-produced status: any wave
      * that does not complete before an error return then publishes CUDEC_ERR_CUDA
@@ -351,7 +352,7 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
          * runs the previous wave's decode and result readback. The first wave
          * never recorded the event. */
         if (have_pending_src &&
-            cudaEventSynchronize(reuse) != cudaSuccess) {
+            cudec_rt::event_synchronize(reuse) != cudec_rt::success) {
             WAVE_FAIL(CUDEC_ERR_CUDA);
         }
 
@@ -400,22 +401,24 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
             reinterpret_cast<const size_t*>(dm + 3 * meta_stride);
 
         if (src_off != 0 &&
-            cudaMemcpyAsync(d_src, p_src, src_off, cudaMemcpyHostToDevice,
-                            stream) != cudaSuccess) {
+            cudec_rt::memcpy_async(d_src, p_src, src_off, cudec_rt::memcpy_h2d,
+                            stream) != cudec_rt::success) {
             WAVE_FAIL(CUDEC_ERR_CUDA);
         }
-        if (cudaMemcpyAsync(ctx.d_meta.p, ctx.p_meta.p, meta_bytes,
-                            cudaMemcpyHostToDevice, stream) != cudaSuccess) {
+        if (cudec_rt::memcpy_async(ctx.d_meta.p, ctx.p_meta.p, meta_bytes,
+                                   cudec_rt::memcpy_h2d,
+                                   stream) != cudec_rt::success) {
             WAVE_FAIL(CUDEC_ERR_CUDA);
         }
         /* Record after both H2D copies so the next wave's reuse gate waits for
          * the pinned source AND metadata reads to complete. */
-        if (cudaEventRecord(reuse, stream) != cudaSuccess) {
+        if (cudec_rt::event_record(reuse, stream) != cudec_rt::success) {
             WAVE_FAIL(CUDEC_ERR_CUDA);
         }
         have_pending_src = true;
 
-        /* The per-wave result slice is offset*16 into a cudaMalloc base, so it
+        /* The per-wave result slice is offset*16 into a device-allocation
+         * base, so it
          * satisfies the batch entry's 16-byte-alignment requirement. */
         cudec_chunk_result* d_res =
             static_cast<cudec_chunk_result*>(ctx.d_results.p) + begin;
@@ -426,10 +429,10 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
         }
 
         /* Result readback into the pinned mirror (async). */
-        if (cudaMemcpyAsync(
+        if (cudec_rt::memcpy_async(
                 static_cast<cudec_chunk_result*>(ctx.p_results.p) + begin,
-                d_res, wn * sizeof(cudec_chunk_result), cudaMemcpyDeviceToHost,
-                stream) != cudaSuccess) {
+                d_res, wn * sizeof(cudec_chunk_result), cudec_rt::memcpy_d2h,
+                stream) != cudec_rt::success) {
             WAVE_FAIL(CUDEC_ERR_CUDA);
         }
 
@@ -441,7 +444,7 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
              * the D2H targets pageable caller memory and is therefore
              * synchronous, so host-output does not overlap (device-output is
              * the overlapped path). */
-            if (cudaStreamSynchronize(stream) != cudaSuccess) {
+            if (cudec_rt::stream_synchronize(stream) != cudec_rt::success) {
                 WAVE_FAIL(CUDEC_ERR_CUDA);
             }
             cudec_chunk_result* wr =
@@ -459,10 +462,11 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
      * (the entry is synchronous), and surface any async fault as a defined
      * error. */
     cudec_status drain = wave_status;
-    if (cudaStreamSynchronize(stream) != cudaSuccess && drain == CUDEC_OK) {
+    if (cudec_rt::stream_synchronize(stream) != cudec_rt::success &&
+        drain == CUDEC_OK) {
         drain = CUDEC_ERR_CUDA;
     }
-    if (cudaGetLastError() != cudaSuccess && drain == CUDEC_OK) {
+    if (cudec_rt::get_last_error() != cudec_rt::success && drain == CUDEC_OK) {
         drain = CUDEC_ERR_CUDA;
     }
 
@@ -501,8 +505,8 @@ cudec_status cudec_stream_ctx_create(cudec_stream_ctx** out_ctx) {
     /* The only create-time device resources are the single stream and the
      * reuse event; the staging is allocated lazily on first decode (grow-only,
      * so create takes no sizing parameters). */
-    if (ctx->stream.create() != cudaSuccess ||
-        ctx->reuse_ev.create() != cudaSuccess) {
+    if (ctx->stream.create() != cudec_rt::success ||
+        ctx->reuse_ev.create() != cudec_rt::success) {
         delete ctx; /* RAII frees whichever of the two succeeded */
         return CUDEC_ERR_CUDA;
     }
@@ -553,7 +557,7 @@ void cudec_stream_ctx_destroy(cudec_stream_ctx* ctx) {
      * surfaces the fault, which is ignored) and guarantees no async work
      * touches the buffers the destructor is about to free. */
     if (ctx->stream.s != nullptr) {
-        (void)cudaStreamSynchronize(ctx->stream.s);
+        (void)cudec_rt::stream_synchronize(ctx->stream.s);
     }
     delete ctx;
 }

--- a/src/vendor_raii.h
+++ b/src/vendor_raii.h
@@ -1,41 +1,41 @@
-/* Shared host-side CUDA RAII owners and the cudaSuccess-check macro for the
- * CUDA host-orchestration translation units (frame.cpp, stream.cpp, and the
+/* Shared host-side device-runtime RAII owners and the success-check macro for
+ * the host-orchestration translation units (frame.cpp, stream.cpp, and the
  * Snappy/GDeflate host paths to come). INTERNAL - device-independent host glue,
  * never part of the public C ABI in include/cudec.h.
  *
- * Each owner owns exactly one CUDA handle, is non-copyable, and frees it on
- * EVERY scope exit - including the hostile-input reject paths, not just on
- * success. A leak on the expected corrupt-input path is a device/pinned-memory
- * exhaustion DoS in a library entry point. Cleanup errors are discarded
- * deliberately: they are not actionable and must not mask the real decode
- * status. On an allocation failure the owner holds nothing (null, cap 0), so
- * the destructor never double-frees; the enclosing caller decides whether the
- * failure poisons a reusable context.
+ * Each owner owns exactly one device-runtime handle, is non-copyable, and
+ * frees it on EVERY scope exit - including the hostile-input reject paths,
+ * not just on success. A leak on the expected corrupt-input path is a
+ * device/pinned-memory exhaustion DoS in a library entry point. Cleanup
+ * errors are discarded deliberately: they are not actionable and must not
+ * mask the real decode status. On an allocation failure the owner holds
+ * nothing (null, cap 0), so the destructor never double-frees; the enclosing
+ * caller decides whether the failure poisons a reusable context.
  *
  * The member types have external linkage (this is a named namespace, not an
  * anonymous one) so an ABI-visible struct built from them - cudec_stream_ctx -
  * triggers no subobject-linkage diagnostic. */
-#ifndef CUDEC_CUDA_RAII_H
-#define CUDEC_CUDA_RAII_H
+#ifndef CUDEC_VENDOR_RAII_H
+#define CUDEC_VENDOR_RAII_H
 
-#include <cuda_runtime.h>
+#include "vendor_rt.h"
 
 #include <cstddef>
 
-/* Evaluate a CUDA runtime `call` exactly once; if it did not return
- * cudaSuccess, run `on_failure`. `on_failure` maps the fault to a defined
+/* Evaluate a device-runtime `call` exactly once; if it did not return
+ * cudec_rt::success, run `on_failure`. `on_failure` maps the fault to a defined
  * cudec_status return (and, for the reusable stream context, poisons it first
  * so only destruction is valid afterwards). The single expansion is why `call`
  * is never evaluated twice - the failure policy is the caller's, the check is
  * single-sourced here. */
-#define CUDEC_CUDA_CHECK(call, on_failure) \
+#define CUDEC_RT_CHECK(call, on_failure)   \
     do {                                   \
-        if ((call) != cudaSuccess) {       \
+        if ((call) != cudec_rt::success) { \
             on_failure;                    \
         }                                  \
     } while (0)
 
-namespace cudec_cuda {
+namespace cudec_rt {
 
 /* Grow-only device buffer. ensure() reuses the existing allocation when it is
  * already large enough (the amortization); otherwise it frees the old one and
@@ -53,25 +53,25 @@ struct DevBuf {
     DevBuf& operator=(const DevBuf&) = delete;
     ~DevBuf() {
         if (p != nullptr) {
-            (void)cudaFree(p);
+            (void)cudec_rt::device_free(p);
         }
     }
-    cudaError_t ensure(size_t bytes) {
+    cudec_rt::error_t ensure(size_t bytes) {
         if (bytes <= cap) {
-            return cudaSuccess;
+            return cudec_rt::success;
         }
         if (p != nullptr) {
-            (void)cudaFree(p);
+            (void)cudec_rt::device_free(p);
             p = nullptr;
             cap = 0;
         }
-        const cudaError_t e = cudaMalloc(&p, bytes);
-        if (e != cudaSuccess) {
+        const cudec_rt::error_t e = cudec_rt::device_malloc(&p, bytes);
+        if (e != cudec_rt::success) {
             p = nullptr;
             return e;
         }
         cap = bytes;
-        return cudaSuccess;
+        return cudec_rt::success;
     }
 };
 
@@ -84,59 +84,59 @@ struct PinnedBuf {
     PinnedBuf& operator=(const PinnedBuf&) = delete;
     ~PinnedBuf() {
         if (p != nullptr) {
-            (void)cudaFreeHost(p);
+            (void)cudec_rt::host_free(p);
         }
     }
-    cudaError_t ensure(size_t bytes) {
+    cudec_rt::error_t ensure(size_t bytes) {
         if (bytes <= cap) {
-            return cudaSuccess;
+            return cudec_rt::success;
         }
         if (p != nullptr) {
-            (void)cudaFreeHost(p);
+            (void)cudec_rt::host_free(p);
             p = nullptr;
             cap = 0;
         }
-        const cudaError_t e = cudaHostAlloc(&p, bytes, cudaHostAllocDefault);
-        if (e != cudaSuccess) {
+        const cudec_rt::error_t e = cudec_rt::host_alloc(&p, bytes);
+        if (e != cudec_rt::success) {
             p = nullptr;
             return e;
         }
         cap = bytes;
-        return cudaSuccess;
+        return cudec_rt::success;
     }
 };
 
 struct StreamOwner {
-    cudaStream_t s = nullptr;
+    cudec_rt::stream_t s = nullptr;
     StreamOwner() = default;
     StreamOwner(const StreamOwner&) = delete;
     StreamOwner& operator=(const StreamOwner&) = delete;
     ~StreamOwner() {
         if (s != nullptr) {
-            (void)cudaStreamDestroy(s);
+            (void)cudec_rt::stream_destroy(s);
         }
     }
-    cudaError_t create() {
+    cudec_rt::error_t create() {
         /* Non-blocking so a wave does not depend on the legacy default stream
          * staying idle (a caller with default-stream work in the same context
          * would otherwise serialize every wave). */
-        return cudaStreamCreateWithFlags(&s, cudaStreamNonBlocking);
+        return cudec_rt::stream_create_nonblocking(&s);
     }
 };
 
 struct EventOwner {
-    cudaEvent_t e = nullptr;
+    cudec_rt::event_t e = nullptr;
     EventOwner() = default;
     EventOwner(const EventOwner&) = delete;
     EventOwner& operator=(const EventOwner&) = delete;
     ~EventOwner() {
         if (e != nullptr) {
-            (void)cudaEventDestroy(e);
+            (void)cudec_rt::event_destroy(e);
         }
     }
-    cudaError_t create() { return cudaEventCreate(&e); }
+    cudec_rt::error_t create() { return cudec_rt::event_create(&e); }
 };
 
-}  // namespace cudec_cuda
+}  // namespace cudec_rt
 
-#endif  // CUDEC_CUDA_RAII_H
+#endif  // CUDEC_VENDOR_RAII_H

--- a/src/vendor_rt.h
+++ b/src/vendor_rt.h
@@ -1,0 +1,147 @@
+/* The vendor runtime seam: the ONE translation unit in src/ that names a
+ * backend runtime. Every other file under src/ reaches the device runtime
+ * through cudec_rt:: and never spells cudaXxx or hipXxx, so the host
+ * orchestration (frame.cpp, stream.cpp, the RAII owners in vendor_raii.h) is
+ * one set of sources compiled for either backend - masterplan section 15.
+ *
+ * WHY A MAPPING TABLE AND NOT A SET OF #defines OVER THE CALL SITES. The
+ * llama.cpp vendors/hip.h pattern redefines the CUDA names to the HIP ones and
+ * leaves the callers spelling cudaMalloc on both backends. That reads as CUDA
+ * source that secretly is not, and it makes "which calls does the port owe?"
+ * unanswerable without compiling. Here the two arms are two columns of the
+ * same table: what the port owes is the length of the table, a reader compares
+ * the columns by eye, and a configure-time rule (tests/CMakeLists.txt, issue
+ * #240) reds the build when one column grows an entry the other does not.
+ *
+ * WHAT THIS HEADER DOES NOT CLAIM. No hipcc has ever compiled the HIP arm: no
+ * ROCm toolchain exists on the machine this landed from, and CMakeLists.txt
+ * refuses CUDEC_ENABLE_HIP fail-closed for the same reason. The mapping is
+ * proven CONSISTENT (both arms define the same operations, the CUDA arm builds
+ * and passes the whole gate) and is NOT proven CORRECT: a name mapped to the
+ * wrong HIP entry point compiles clean on CUDA and reds only under a compiler
+ * nobody here has. Issue #210 is the route to that compiler.
+ *
+ * INTERNAL - never part of the public C ABI in include/cudec.h. The public
+ * status CUDEC_ERR_CUDA keeps its name on both backends: it is an ABI
+ * constant a caller compiled against, not a spelling this seam may move. */
+#ifndef CUDEC_VENDOR_RT_H
+#define CUDEC_VENDOR_RT_H
+
+#include <cstddef>
+
+/* __HIP_PLATFORM_AMD__ is defined by hipcc when it targets AMD, and by nothing
+ * else - so the CUDA arm is the default and a host compiler that knows about
+ * neither backend still lands on a real runtime header rather than on an empty
+ * shim. Fail-closed: there is no third arm that stubs the calls out. */
+#if defined(__HIP_PLATFORM_AMD__)
+#include <hip/hip_runtime.h>
+
+#define CUDEC_RT_ERROR_T hipError_t
+#define CUDEC_RT_STREAM_T hipStream_t
+#define CUDEC_RT_EVENT_T hipEvent_t
+#define CUDEC_RT_MEMCPY_KIND_T hipMemcpyKind
+#define CUDEC_RT_SUCCESS hipSuccess
+#define CUDEC_RT_MEMCPY_H2D hipMemcpyHostToDevice
+#define CUDEC_RT_MEMCPY_D2H hipMemcpyDeviceToHost
+#define CUDEC_RT_STREAM_NONBLOCKING hipStreamNonBlocking
+#define CUDEC_RT_HOST_ALLOC_DEFAULT hipHostMallocDefault
+#define CUDEC_RT_MALLOC hipMalloc
+#define CUDEC_RT_FREE hipFree
+#define CUDEC_RT_HOST_ALLOC hipHostMalloc
+#define CUDEC_RT_HOST_FREE hipHostFree
+#define CUDEC_RT_MEMCPY hipMemcpy
+#define CUDEC_RT_MEMCPY_ASYNC hipMemcpyAsync
+#define CUDEC_RT_STREAM_CREATE_WITH_FLAGS hipStreamCreateWithFlags
+#define CUDEC_RT_STREAM_DESTROY hipStreamDestroy
+#define CUDEC_RT_STREAM_SYNCHRONIZE hipStreamSynchronize
+#define CUDEC_RT_EVENT_CREATE hipEventCreate
+#define CUDEC_RT_EVENT_DESTROY hipEventDestroy
+#define CUDEC_RT_EVENT_RECORD hipEventRecord
+#define CUDEC_RT_EVENT_SYNCHRONIZE hipEventSynchronize
+#define CUDEC_RT_DEVICE_SYNCHRONIZE hipDeviceSynchronize
+#define CUDEC_RT_GET_LAST_ERROR hipGetLastError
+
+#else
+#include <cuda_runtime.h>
+
+#define CUDEC_RT_ERROR_T cudaError_t
+#define CUDEC_RT_STREAM_T cudaStream_t
+#define CUDEC_RT_EVENT_T cudaEvent_t
+#define CUDEC_RT_MEMCPY_KIND_T cudaMemcpyKind
+#define CUDEC_RT_SUCCESS cudaSuccess
+#define CUDEC_RT_MEMCPY_H2D cudaMemcpyHostToDevice
+#define CUDEC_RT_MEMCPY_D2H cudaMemcpyDeviceToHost
+#define CUDEC_RT_STREAM_NONBLOCKING cudaStreamNonBlocking
+#define CUDEC_RT_HOST_ALLOC_DEFAULT cudaHostAllocDefault
+#define CUDEC_RT_MALLOC cudaMalloc
+#define CUDEC_RT_FREE cudaFree
+#define CUDEC_RT_HOST_ALLOC cudaHostAlloc
+#define CUDEC_RT_HOST_FREE cudaFreeHost
+#define CUDEC_RT_MEMCPY cudaMemcpy
+#define CUDEC_RT_MEMCPY_ASYNC cudaMemcpyAsync
+#define CUDEC_RT_STREAM_CREATE_WITH_FLAGS cudaStreamCreateWithFlags
+#define CUDEC_RT_STREAM_DESTROY cudaStreamDestroy
+#define CUDEC_RT_STREAM_SYNCHRONIZE cudaStreamSynchronize
+#define CUDEC_RT_EVENT_CREATE cudaEventCreate
+#define CUDEC_RT_EVENT_DESTROY cudaEventDestroy
+#define CUDEC_RT_EVENT_RECORD cudaEventRecord
+#define CUDEC_RT_EVENT_SYNCHRONIZE cudaEventSynchronize
+#define CUDEC_RT_DEVICE_SYNCHRONIZE cudaDeviceSynchronize
+#define CUDEC_RT_GET_LAST_ERROR cudaGetLastError
+
+#endif
+
+namespace cudec_rt {
+
+using error_t = CUDEC_RT_ERROR_T;
+using stream_t = CUDEC_RT_STREAM_T;
+using event_t = CUDEC_RT_EVENT_T;
+using memcpy_kind_t = CUDEC_RT_MEMCPY_KIND_T;
+
+inline constexpr error_t success = CUDEC_RT_SUCCESS;
+inline constexpr memcpy_kind_t memcpy_h2d = CUDEC_RT_MEMCPY_H2D;
+inline constexpr memcpy_kind_t memcpy_d2h = CUDEC_RT_MEMCPY_D2H;
+
+/* One thin inline per operation, so the seam costs nothing at run time and a
+ * call site cannot pass a flag the port has not mapped. The two allocation
+ * pairs hide their flag argument on purpose: the pinned flag is the only one
+ * this library ever wants, and the backends spell it differently. */
+inline error_t device_malloc(void** p, size_t bytes) {
+    return CUDEC_RT_MALLOC(p, bytes);
+}
+inline error_t device_free(void* p) { return CUDEC_RT_FREE(p); }
+inline error_t host_alloc(void** p, size_t bytes) {
+    return CUDEC_RT_HOST_ALLOC(p, bytes, CUDEC_RT_HOST_ALLOC_DEFAULT);
+}
+inline error_t host_free(void* p) { return CUDEC_RT_HOST_FREE(p); }
+inline error_t memcpy(void* dst, const void* src, size_t bytes,
+                      memcpy_kind_t kind) {
+    return CUDEC_RT_MEMCPY(dst, src, bytes, kind);
+}
+inline error_t memcpy_async(void* dst, const void* src, size_t bytes,
+                            memcpy_kind_t kind, stream_t s) {
+    return CUDEC_RT_MEMCPY_ASYNC(dst, src, bytes, kind, s);
+}
+inline error_t stream_create_nonblocking(stream_t* s) {
+    return CUDEC_RT_STREAM_CREATE_WITH_FLAGS(s, CUDEC_RT_STREAM_NONBLOCKING);
+}
+inline error_t stream_destroy(stream_t s) {
+    return CUDEC_RT_STREAM_DESTROY(s);
+}
+inline error_t stream_synchronize(stream_t s) {
+    return CUDEC_RT_STREAM_SYNCHRONIZE(s);
+}
+inline error_t event_create(event_t* e) { return CUDEC_RT_EVENT_CREATE(e); }
+inline error_t event_destroy(event_t e) { return CUDEC_RT_EVENT_DESTROY(e); }
+inline error_t event_record(event_t e, stream_t s) {
+    return CUDEC_RT_EVENT_RECORD(e, s);
+}
+inline error_t event_synchronize(event_t e) {
+    return CUDEC_RT_EVENT_SYNCHRONIZE(e);
+}
+inline error_t device_synchronize() { return CUDEC_RT_DEVICE_SYNCHRONIZE(); }
+inline error_t get_last_error() { return CUDEC_RT_GET_LAST_ERROR(); }
+
+}  // namespace cudec_rt
+
+#endif  // CUDEC_VENDOR_RT_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -619,39 +619,226 @@ foreach(_probe host_warning device_warning)
   endif()
 endforeach()
 
-# Single-source lock (issue #40): the host-side CUDA RAII owners live once, in
-# src/cuda_raii.h, and every CUDA host translation unit reuses them instead of
-# carrying its own copy. This detector reds the build if the header stops
+# Single-source lock (issue #40): the host-side device-runtime RAII owners live
+# once, in src/vendor_raii.h, and every host translation unit reuses them
+# instead of carrying its own copy. This detector reds the build if the header stops
 # defining an owner, or if a host TU drops the include or re-introduces a local
 # owner definition. Honest limit (as with the checks above): it catches a
 # re-copy under the SAME struct names, not one smuggled in under a fresh name -
 # a drift detector, not tamper-proofing.
-set(_raii_header ${CMAKE_CURRENT_SOURCE_DIR}/../src/cuda_raii.h)
+set(_raii_header ${CMAKE_CURRENT_SOURCE_DIR}/../src/vendor_raii.h)
 if(NOT EXISTS ${_raii_header})
-  message(FATAL_ERROR "src/cuda_raii.h is missing: the shared CUDA RAII owners "
+  message(FATAL_ERROR "src/vendor_raii.h is missing: the shared RAII owners "
                       "must be single-sourced there (issue #40)")
 endif()
 file(READ ${_raii_header} _raii_src)
 foreach(_owner DevBuf PinnedBuf StreamOwner EventOwner)
   if(NOT _raii_src MATCHES "struct ${_owner}")
-    message(FATAL_ERROR "src/cuda_raii.h no longer defines the shared owner "
+    message(FATAL_ERROR "src/vendor_raii.h no longer defines the shared owner "
                         "'${_owner}' (issue #40)")
   endif()
 endforeach()
 foreach(_tu frame.cpp stream.cpp)
   file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_tu} _tu_src)
-  if(NOT _tu_src MATCHES "#include \"cuda_raii.h\"")
-    message(FATAL_ERROR "src/${_tu} no longer includes cuda_raii.h: it must "
-                        "reuse the shared CUDA RAII owners (issue #40)")
+  if(NOT _tu_src MATCHES "#include \"vendor_raii.h\"")
+    message(FATAL_ERROR "src/${_tu} no longer includes vendor_raii.h: it must "
+                        "reuse the shared RAII owners (issue #40)")
   endif()
   foreach(_owner DevBuf PinnedBuf StreamOwner EventOwner DevPtr)
     if(_tu_src MATCHES "struct ${_owner}")
       message(FATAL_ERROR "src/${_tu} defines a local 'struct ${_owner}': the "
-                          "CUDA RAII owners are single-sourced in cuda_raii.h "
+                          "RAII owners are single-sourced in vendor_raii.h "
                           "(issue #40)")
     endif()
   endforeach()
 endforeach()
+
+# ---- The vendor seam (issue #240). Two rules, and they fail for different
+# reasons, which is why neither is folded into the other.
+#
+# Both are functions over a STRING rather than passes over the tree, so each
+# one is watched refusing a planted violation and watched staying silent on a
+# planted near-miss before it is pointed at a real file. A rule that has only
+# ever run against a clean tree has not been shown to bite.
+
+# RULE ONE: src/vendor_rt.h is the only file under src/ that may name a
+# backend runtime. The port's whole claim is that frame.cpp, stream.cpp and
+# the RAII owners are ONE set of sources for both backends; a single
+# cudaMemcpy left anywhere else is a translation unit that compiles on exactly
+# one of them - and it compiles clean on the backend this machine can build,
+# which is the direction nothing else here would catch.
+#
+# The pattern matches a vendor prefix followed by an upper-case letter or an
+# underscore - cudaMalloc, hipMemcpy, cuda_runtime.h, hip_runtime.h - and is
+# deliberately narrower than the word "cuda". It must not fire on the public
+# status CUDEC_ERR_CUDA (a caller compiled against that name and this seam may
+# not move it), on the cudec_rt:: spellings the seam introduces, on prose that
+# says CUDA, or on an English word that merely contains "hip".
+function(cudec_scan_vendor_spelling _text _label _out)
+  set(_hits "")
+  # A leading space so a match at offset zero still has a left context to
+  # test; the class before the prefix is what keeps "chip" and "cudec" out.
+  if(" ${_text}" MATCHES "[^A-Za-z0-9_]((cuda|hip)[A-Z_][A-Za-z0-9_]*)")
+    string(APPEND _hits "${_label}: names a backend runtime directly "
+           "('${CMAKE_MATCH_1}'); every file under src/ except src/vendor_rt.h "
+           "reaches the runtime through cudec_rt:: (issue #240)\n")
+  endif()
+  set(${_out} "${_hits}" PARENT_SCOPE)
+endfunction()
+
+# The violating probes and the three near-misses. The near-misses are the ones
+# worth reading: each is a spelling that legitimately survives in this tree
+# today, and a rule that reddened on any of them would be switched off within
+# a week rather than repaired.
+foreach(_violating "    return cudaMalloc(&p, bytes);"
+                   "    return hipMemcpyAsync(d, s, n, k, st);"
+                   "#include <cuda_runtime.h>")
+  cudec_scan_vendor_spelling("${_violating}" "probe" _probe_hit)
+  if(NOT _probe_hit)
+    message(FATAL_ERROR "the vendor-seam rule is dead: the planted violation "
+                        "'${_violating}' was not reported (issue #240)")
+  endif()
+endforeach()
+foreach(_near "return CUDEC_ERR_CUDA;" "return cudec_rt::device_malloc(&p, n);"
+              "/* Every CUDA API error is checked, on chip and off. */")
+  cudec_scan_vendor_spelling("${_near}" "probe" _near_hit)
+  if(_near_hit)
+    message(FATAL_ERROR "the vendor-seam rule is over-wide: it reported the "
+                        "legitimate spelling '${_near}' (issue #240)")
+  endif()
+endforeach()
+
+set(_vendor_rt ${CMAKE_CURRENT_SOURCE_DIR}/../src/vendor_rt.h)
+if(NOT EXISTS ${_vendor_rt})
+  message(FATAL_ERROR "src/vendor_rt.h is missing: it is the one place a "
+                      "backend runtime is named (issue #240)")
+endif()
+# Opt-out by one path rather than opt-in by a list, for the reason the
+# termination rule states about its own glob: a new file under src/ must be
+# covered on the day it lands, not on the day somebody remembers to add it.
+file(GLOB_RECURSE _vendor_scan_sources RELATIVE
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src CONFIGURE_DEPENDS
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cc
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cu
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cuh
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.h
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.hpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.inl)
+if(NOT _vendor_scan_sources)
+  message(FATAL_ERROR "the vendor-seam scan found no sources under src/ - the "
+                      "glob has stopped matching (issue #240)")
+endif()
+if(NOT vendor_rt.h IN_LIST _vendor_scan_sources)
+  message(FATAL_ERROR "src/vendor_rt.h is outside the vendor-seam glob, so the "
+                      "one file the rule exempts is a file it never saw "
+                      "(issue #240)")
+endif()
+list(REMOVE_ITEM _vendor_scan_sources vendor_rt.h)
+set(_vendor_violations "")
+foreach(_source IN LISTS _vendor_scan_sources)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source} _vsrc)
+  cudec_scan_vendor_spelling("${_vsrc}" "src/${_source}" _found)
+  string(APPEND _vendor_violations "${_found}")
+endforeach()
+if(_vendor_violations)
+  message(FATAL_ERROR "the vendor seam has leaked:\n${_vendor_violations}")
+endif()
+
+# RULE TWO: the two arms of the mapping table carry the same operations.
+#
+# This is the part of the mapping that can be judged here at all. No ROCm
+# toolchain exists on the machine this landed from, so nothing local compiles
+# the HIP arm and no reading of this tree can say whether hipHostMalloc is the
+# right partner for cudaHostAlloc - that is the compile job in #210, and until
+# it runs the mapping is proven CONSISTENT and is not proven CORRECT. What IS
+# decidable is the failure that costs most and looks like nothing: an entry
+# added to the CUDA arm and forgotten in the HIP arm, which builds and passes
+# every gate here and reds only under a compiler nobody has.
+function(cudec_vendor_arms_agree _text _out)
+  set(_why "")
+  string(FIND "${_text}" "#if defined(__HIP_PLATFORM_AMD__)" _p_if)
+  string(FIND "${_text}" "\n#else" _p_else)
+  string(FIND "${_text}" "\n#endif" _p_endif)
+  if(_p_if LESS 0
+     OR _p_else LESS 0
+     OR _p_endif LESS 0
+     OR NOT _p_if LESS _p_else
+     OR NOT _p_else LESS _p_endif)
+    set(${_out} "the mapping table's #if/#else/#endif shape was not found; "
+        PARENT_SCOPE)
+    return()
+  endif()
+  math(EXPR _hip_len "${_p_else} - ${_p_if}")
+  math(EXPR _cuda_len "${_p_endif} - ${_p_else}")
+  string(SUBSTRING "${_text}" ${_p_if} ${_hip_len} _hip_arm)
+  string(SUBSTRING "${_text}" ${_p_else} ${_cuda_len} _cuda_arm)
+  string(REGEX MATCHALL "#define CUDEC_RT_[A-Z0-9_]+" _hip_names "${_hip_arm}")
+  string(REGEX MATCHALL "#define CUDEC_RT_[A-Z0-9_]+" _cuda_names "${_cuda_arm}")
+  list(TRANSFORM _hip_names REPLACE "#define " "")
+  list(TRANSFORM _cuda_names REPLACE "#define " "")
+  if(NOT _hip_names OR NOT _cuda_names)
+    set(${_out} "one arm defines no mapping at all; " PARENT_SCOPE)
+    return()
+  endif()
+  foreach(_n IN LISTS _cuda_names)
+    if(NOT _n IN_LIST _hip_names)
+      string(APPEND _why "${_n} is mapped for CUDA and not for HIP; ")
+    endif()
+  endforeach()
+  foreach(_n IN LISTS _hip_names)
+    if(NOT _n IN_LIST _cuda_names)
+      string(APPEND _why "${_n} is mapped for HIP and not for CUDA; ")
+    endif()
+  endforeach()
+  set(${_out} "${_why}" PARENT_SCOPE)
+endfunction()
+
+# Watched refusing in both directions and watched silent on a balanced table.
+# The two one-sided probes are one entry away from the balanced one: the
+# mistake somebody actually makes is adding a line to the arm they can
+# compile.
+set(_probe_balanced
+    "#if defined(__HIP_PLATFORM_AMD__)\n#define CUDEC_RT_MALLOC hipMalloc\n#define CUDEC_RT_FREE hipFree\n#else\n#define CUDEC_RT_MALLOC cudaMalloc\n#define CUDEC_RT_FREE cudaFree\n#endif\n"
+)
+set(_probe_cuda_only
+    "#if defined(__HIP_PLATFORM_AMD__)\n#define CUDEC_RT_MALLOC hipMalloc\n#else\n#define CUDEC_RT_MALLOC cudaMalloc\n#define CUDEC_RT_FREE cudaFree\n#endif\n"
+)
+set(_probe_hip_only
+    "#if defined(__HIP_PLATFORM_AMD__)\n#define CUDEC_RT_MALLOC hipMalloc\n#define CUDEC_RT_FREE hipFree\n#else\n#define CUDEC_RT_MALLOC cudaMalloc\n#endif\n"
+)
+set(_probe_shapeless "#define CUDEC_RT_MALLOC cudaMalloc\n")
+cudec_vendor_arms_agree("${_probe_balanced}" _arms_why)
+if(_arms_why)
+  message(FATAL_ERROR "the mapping-table rule is over-wide: it reported a "
+                      "balanced table (${_arms_why}) (issue #240)")
+endif()
+cudec_vendor_arms_agree("${_probe_cuda_only}" _arms_why)
+if(NOT _arms_why MATCHES "CUDEC_RT_FREE is mapped for CUDA and not for HIP")
+  message(FATAL_ERROR "the mapping-table rule is dead: a CUDA-only entry was "
+                      "not reported (issue #240)")
+endif()
+cudec_vendor_arms_agree("${_probe_hip_only}" _arms_why)
+if(NOT _arms_why MATCHES "CUDEC_RT_FREE is mapped for HIP and not for CUDA")
+  message(FATAL_ERROR "the mapping-table rule is dead: a HIP-only entry was "
+                      "not reported (issue #240)")
+endif()
+# A table whose two arms cannot be located must report that it read nothing,
+# never come back silent: a shape change is the one edit that would otherwise
+# turn this rule off while leaving it green.
+cudec_vendor_arms_agree("${_probe_shapeless}" _arms_why)
+if(NOT _arms_why MATCHES "shape was not found")
+  message(FATAL_ERROR "the mapping-table rule passes vacuously on a header it "
+                      "could not parse (issue #240)")
+endif()
+
+file(READ ${_vendor_rt} _vendor_rt_src)
+cudec_vendor_arms_agree("${_vendor_rt_src}" _arms_why)
+if(_arms_why)
+  message(FATAL_ERROR "src/vendor_rt.h maps the two backends unevenly: "
+                      "${_arms_why}(issue #240)")
+endif()
 
 # Single-source lock for the shared decode element (issue #150): the one
 # struct every format parser hands the chunk decoder lives once, in
@@ -1018,7 +1205,7 @@ endfunction()
 # Rule 1, single source. src/snappy_block.h exists and defines the parser
 # types; no other source under src/ defines them, and a source that names
 # SnappyParser includes the header rather than restating the ladder. This is
-# the cuda_raii.h lock (issue #40) applied to the format core: the M3 kernel
+# the vendor_raii.h lock (issue #40) applied to the format core: the M3 kernel
 # instantiates this parser, and a kernel-local copy of a validation ladder is
 # a fail-open the moment the two stop agreeing.
 #
@@ -2047,7 +2234,7 @@ file(WRITE ${_probe_dir}/scan_wrapped_after_mask.cu
 # element carries the loop and its condition. The idiom must come back silent
 # and a real loop wearing the same wrapper must not, or the clause that
 # forgives the wrapper has turned the rule off for every macro in the tree -
-# which is what the file exemption on src/cuda_raii.h was doing.
+# which is what the file exemption on src/vendor_raii.h was doing.
 #
 # Both put the #define on line 1, and the violating one asserts that line
 # number: the report lands on the macro's own line only while the join still


### PR DESCRIPTION
# What & why

`src/vendor_rt.h` becomes the one file under `src/` that names a backend
runtime. It holds a mapping table with one arm per backend, keyed on
`__HIP_PLATFORM_AMD__`, and exports a neutral `cudec_rt::` surface. The RAII
owners (`src/cuda_raii.h` renamed to `src/vendor_raii.h`), `src/frame.cpp`,
`src/stream.cpp`, `src/batch.cu` and `src/chunk_decode.cuh` reach the runtime
through that surface and spell no `cudaXxx` of their own.

The failure this prevents is a host translation unit that compiles on exactly
one backend. Before this change every device-runtime call site was a CUDA
name, so the port's "one set of sources" claim could be checked only by
compiling under both compilers, and only one of them exists on any machine
reachable from here.

This leaves #240 open. Three of its four Done-when clauses are met and two of
them are now mechanised; the residual is written into the issue.

**The mapping is proven consistent and is NOT proven correct.** No `hipcc` has
ever read the HIP arm. Probed at this commit:

```
$ command -v hipcc || echo MISSING-hipcc
MISSING-hipcc
$ ls -d /opt/rocm 2>/dev/null || echo MISSING-rocm
MISSING-rocm
```

`CMakeLists.txt` still refuses `CUDEC_ENABLE_HIP` fail-closed for the same
reason, and this change does not touch that refusal: the port carries no HIP
device sources yet, which is the second of the two refusals that option makes.
A name mapped to the wrong HIP entry point compiles clean on CUDA and reds
only under a compiler nobody here has. That is what the compile-only ROCm job
in #210 is for, and this body claims nothing it would decide.

## Why a mapping table rather than the llama.cpp `vendors/hip.h` spelling

`vendors/hip.h` redefines the CUDA names to the HIP ones and leaves the
callers spelling `cudaMalloc` on both backends. That reads as CUDA source
which secretly is not, and it makes "which calls does the port owe?"
unanswerable without compiling. Here the two arms are two columns of one
table: what the port owes is the length of the table, a reader compares the
columns by eye, and a configure-time rule reds the build when one column grows
an entry the other does not.

`CUDEC_ERR_CUDA` keeps its name on both backends. It is an ABI constant a
caller compiled against, not a spelling this seam may move.

## Type of change

- [x] Refactor / code quality
- [x] Build / CI / supply chain
- [x] Docs

## Engineering checklist

- [x] Fail-closed preserved: no parse or decode path changed. Every mapped
      call still goes through the single-expansion check macro (renamed
      `CUDEC_CUDA_CHECK` to `CUDEC_RT_CHECK`), every failure still maps to the
      same defined `cudec_status`, and the reusable stream context still
      poisons before returning. The change is name-for-name; no branch, no
      bound and no status was added, removed or reordered.
- [x] Oracle coverage: unchanged and re-run. The host-side oracle diffs
      (`oracle_lz4`, `oracle_gdeflate`, the twins) are in the 50/50 below.
- [x] Determinism preserved: the seam is the identity on CUDA - every wrapper
      is an `inline` one-liner onto the same runtime entry point the call site
      used before.
- [x] Every runtime call's error is checked; no exceptions cross the C ABI.
      Now mechanised: a `cuda`- or `hip`-prefixed spelling outside the seam
      reds the configure, so a call added around the check macro cannot enter
      `src/` unnoticed.
- [ ] **An adversarial review was NOT run for this change, and there was no
      second reader.** The mutant table below is what stands in its place, and
      it is weaker than a review: it proves the two new rules refuse what they
      name, not that the change is right.

## The two new configure-time rules, and the proof that each bites

Both are functions over a string rather than passes over the tree, so each is
watched refusing a planted violation and watched staying silent on a planted
near-miss on **every** configure, before it is pointed at a real file.

Rule one - the seam is the only file that may name a backend runtime.
Near-misses that must stay green, and do: `CUDEC_ERR_CUDA`, the `cudec_rt::`
spellings, prose that says CUDA, and an English word containing "hip".

Rule two - the two arms carry the same operation set. Watched refusing a
CUDA-only entry, a HIP-only entry, and a header whose `#if`/`#else`/`#endif`
shape cannot be found (that last one must report that it read nothing rather
than passing silently).

Two live mutants against the real tree, each run through a full configure:

| mutant                                                        | verdict |
| ------------------------------------------------------------- | ------- |
| `cudec_rt::device_synchronize()` -> `cudaDeviceSynchronize()` in `src/frame.cpp` | red     |
| `#define CUDEC_RT_EVENT_SYNCHRONIZE hipEventSynchronize` deleted from the HIP arm | red     |

```
CMake Error at tests/CMakeLists.txt:746 (message):
  the vendor seam has leaked:

  src/frame.cpp: names a backend runtime directly ('cudaDeviceSynchronize');
  every file under src/ except src/vendor_rt.h reaches the runtime through
  cudec_rt:: (issue #240)
```

```
CMake Error at tests/CMakeLists.txt:839 (message):
  src/vendor_rt.h maps the two backends unevenly: CUDEC_RT_EVENT_SYNCHRONIZE
  is mapped for CUDA and not for HIP; (issue #240)
```

Both mutants were reverted before the commit; the tree here is the unmutated
one.

The existing single-source lock (issue #40) follows the renamed header rather
than being weakened: it now requires `src/vendor_raii.h` to exist, to define
all four owners, and both host translation units to include it. It was watched
refusing during this work, unintentionally - restoring `src/frame.cpp` from
the index mid-mutation dropped the include, and the lock reported exactly that:

```
CMake Error at tests/CMakeLists.txt:644 (message):
  src/frame.cpp no longer includes vendor_raii.h: it must reuse the shared
  RAII owners (issue #40)
```

## GPU sanitizer gate

- [ ] Not applicable: this change touches device code (`src/batch.cu`,
      `src/chunk_decode.cuh`), so the gate applies and could not be run.

```
commit:    83a6bed
gpu:       none reachable
cuda:      Build cuda_13.3.r13.3/compiler.38244171_0
sanitizer: not attempted - no device to attach to
```

There was no route to a device tonight. The toolchain and the device are
separate questions and only the first one answers:

```
$ nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
Failed to initialize NVML: GPU access blocked by the operating system
Failed to properly shut down NVML: GPU access blocked by the operating system
```

Compute Sanitizer is additionally blocked on this host by #127 and would not
have run even with a device.

## Performance checklist

Not on the hot path. Every wrapper is an `inline` function whose body is the
one runtime call the site made before, so no device-side code and no launch
geometry moved. No benchmark number is claimed, and none was measured: the
benchmarks need the device that is blocked above.

## Quality checklist

- [x] Minimal: one new header, one rename, and a name-for-name rewrite of the
      call sites. No wrapper carries logic; the two allocation pairs hide only
      their flag argument, because the pinned flag is the only one this library
      wants and the backends spell it differently.
- [x] Self-documenting: the seam states in its own header what it proves and
      what it does not.
- [x] Conformance tests pass, and the two structural properties this change
      establishes are locked in as new configure-time rules rather than left as
      prose.

## Verification

Run in the WSL Ubuntu-24.04 distribution (CUDA 13.3.73, g++ 13.3, cmake
3.28.3) at `83a6bed`:

```
$ cmake -S . -B ~/b240 -DCUDEC_ENABLE_CUDA=ON ...
-- Configuring done (13.1s)
-- Generating done (0.1s)
-- Build files have been written to: /home/nils/b240

$ cmake --build ~/b240 -j
warnings: 0

$ ctest --test-dir ~/b240 -LE gpu
100% tests passed, 0 tests failed out of 50

$ ctest --test-dir ~/b240 -L gpu
0% tests passed, 9 tests failed out of 9
```

- [x] Builds clean - zero warnings under the strict flags.
- [x] Host-side suite green - **50/50**, the same selection CI runs.
- [ ] **The nine `gpu`-labelled entries did not run.** They fail on the device
      allocation itself, which is the block quoted above rather than anything
      in this change:

  ```
  $ ./tests/smoke
  /mnt/g/Github/cudec/tests/smoke.cu:42: (cudaMalloc(&buffers[i], chunk_bytes)) == cudaSuccess
  ```

  So "the CUDA gate is unchanged" is established here for its host-side half
  and is **not measured** for the device half.

- [x] Prettier (`**/*.{md,yml,yaml}`) - clean.
- [x] Docs synced: `docs/MASTERPLAN.md` section 15.1 now records that the
      ownership boundary moved one step out from where the design panel put
      it. The panel placed the shim on the owners' header; `src/frame.cpp` and
      `src/stream.cpp` reach the runtime directly as well, so a shim owned by
      that header would have left both of them outside it.

## Notes

Out of scope and untouched: the kernel family's width parameterisation
(#241, landed), the runtime wave-width dispatch (#242), the ROCm CI job
(#210), and the `CUDEC_ENABLE_HIP` refusals, which still hold because no HIP
device sources exist.

`tests/`, `bench/` and `examples/` still include `<cuda_runtime.h>` directly
and are deliberately outside the seam's scope: this issue's Surface names the
host layer, and a test that drives the CUDA path is meant to name it.
