### PR TITLE
Select the decode kernel by the width the device reports [#242]

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -2431,6 +2431,25 @@ that is normally the most invasive part of a HIP port does not arise here
 at all. What is left is arithmetic that assumes a width, and the parameter
 is what removes the assumption.
 
+**Landed** in two halves: the kernel family in #241, the host dispatch in
+#242. The dispatch asks `src/vendor_rt.h` for the width a launch is built
+for and selects the instantiation from the answer; a width this build emits
+no kernel for is refused with `CUDEC_ERR_UNSUPPORTED` rather than
+approximated by the 32-lane kernel, because a block that is not a whole
+number of waves leaves output bytes written by nobody.
+
+Where the width comes from is a backend difference and is written in the
+seam rather than at the dispatch. On CUDA it is a constant - every CUDA
+device reports 32 - so a submission there gains no call that can fail. On
+HIP it is read from the device, and a query that fails is
+`CUDEC_ERR_CUDA` rather than a default.
+
+**The wave64 branch has never executed.** No machine in this project has a
+wave64 device and no hosted runner carries an AMD GPU, so what is proven is
+that both instantiations are emitted into the shipped translation unit and
+that the selection returns the wave64 arm for a width of 64. The first run
+on wave64 silicon is #415.
+
 ### 15.3 ROCm 7.0 is the floor, because `__syncwarp` is load-bearing
 
 Section 9's discipline is warp-synchronous and every `__syncwarp` in the

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -106,7 +106,18 @@ typedef char cudec_chunk_result_layout_check
  * everywhere. A rejected call makes no CUDA call and leaves the thread's
  * pending CUDA error state untouched; a call that passes validation
  * consumes that pending state (cudaGetLastError semantics), so the
- * returned status reflects this submission alone. */
+ * returned status reflects this submission alone.
+ *
+ * A call that passes validation then asks the runtime for the current
+ * device's wave width and launches the kernel built for it. Two synchronous
+ * failures come from that step and neither one launches: the query itself
+ * failing returns CUDEC_ERR_CUDA, and a device reporting a wave width this
+ * build has no kernel for returns CUDEC_ERR_UNSUPPORTED. The second one is
+ * refused rather than approximated on purpose - launching a kernel built for
+ * a different width would map chunks onto lanes that are not there, so the
+ * refusal is the fail-closed answer and not a missing feature that will be
+ * papered over later. Neither status is reachable on any CUDA device, all of
+ * which report 32. */
 cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
                                         const size_t* d_src_sizes,
                                         void* const* d_dst_ptrs,

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -1,11 +1,28 @@
 #include "cudec.h"
 #include "chunk_decode.cuh"
+#include "batch_limits.h"
 #include "lz4_block.h"
 #include "snappy_block.h"
 
 #include "vendor_rt.h"
 
 namespace {
+
+/* The launch, written once for both widths. The grid is a whole number of
+ * blocks and each block is kBlockWarps waves at whichever width was selected,
+ * so the geometry the kernel refuses - a block that is not a wave multiple -
+ * cannot be produced by either arm. */
+template <class Parser, int WaveSize>
+void launch_decode(const void* const* d_src_ptrs, const size_t* d_src_sizes,
+                   void* const* d_dst_ptrs, const size_t* d_dst_capacities,
+                   size_t chunk_count, cudec_chunk_result* d_results,
+                   cudec_stream_t stream) {
+    cudec_detail::chunk_decode_batch<Parser, false, WaveSize>
+        <<<cudec_detail::decode_grid_blocks(chunk_count),
+           cudec_detail::kBlockThreadsFor<WaveSize>, 0, stream>>>(
+            d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
+            d_results);
+}
 
 /* The two entries differ in one template argument and in nothing else, so
  * the body they share is written once. Templated rather than handed a
@@ -27,14 +44,45 @@ cudec_status submit_batch(const void* const* d_src_ptrs,
 
     /* Drain any error already pending on this thread so the post-launch
      * check reports this submission alone; the header documents that the
-     * call consumes the pending error state. */
+     * call consumes the pending error state. Before the width query rather
+     * than after it, so a fault this call inherits cannot be reported as the
+     * query's own. */
     (void)cudec_rt::get_last_error();
 
-    cudec_detail::chunk_decode_batch<Parser, false, cudec_detail::kCudaWaveSize>
-        <<<cudec_detail::decode_grid_blocks(chunk_count),
-           cudec_detail::kBlockThreads, 0, stream>>>(
-            d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
-            d_results);
+    /* The width is resolved per submission rather than once, and the reason is
+     * correctness rather than caution: a process may change device between two
+     * submissions, and a width cached for the first one is a launch geometry
+     * chosen for the wrong GPU. On a backend that fixes the width this costs a
+     * constant; on one that does not it is an attribute read against a kernel
+     * launch, and that ratio is NOT MEASURED - no device was reachable when
+     * this landed, and no backend that would pay it has a compiler here. */
+    int reported_width = 0;
+    if (cudec_rt::wave_width_for_launch(&reported_width) != cudec_rt::success) {
+        return CUDEC_ERR_CUDA;
+    }
+
+    /* Both instantiations are emitted on both backends, and on CUDA the
+     * wave64 arm is unreachable by construction - no CUDA device reports 64.
+     * It is emitted anyway because a compiler is the only thing that can say
+     * the second half of the width family still builds, and the CUDA
+     * toolchain is the one this project's gate actually runs. Stripping it
+     * where it cannot be launched would mean the wave64 kernel is first
+     * compiled by whoever first has ROCm, which is the opposite of a lock.
+     * #212 holds the same property for the HIP binary. */
+    switch (cudec_detail::select_wave_instantiation(reported_width)) {
+        case cudec_detail::WaveInstantiation::kWave32:
+            launch_decode<Parser, cudec_detail::kWaveWidth32>(
+                d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities,
+                chunk_count, d_results, stream);
+            break;
+        case cudec_detail::WaveInstantiation::kWave64:
+            launch_decode<Parser, cudec_detail::kWaveWidth64>(
+                d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities,
+                chunk_count, d_results, stream);
+            break;
+        case cudec_detail::WaveInstantiation::kUnsupported:
+            return CUDEC_ERR_UNSUPPORTED;
+    }
     return cudec_rt::get_last_error() == cudec_rt::success ? CUDEC_OK
                                                            : CUDEC_ERR_CUDA;
 }

--- a/src/batch_limits.h
+++ b/src/batch_limits.h
@@ -57,6 +57,44 @@ constexpr size_t kMaxBatchChunks =
 static_assert(kMaxBatchChunks < SIZE_MAX,
               "the SIZE_MAX over-limit contract test relies on this");
 
+/* WHICH KERNEL THE DISPATCH LAUNCHES FOR A WIDTH THE DEVICE REPORTED, and the
+ * one place that decision is written (issue #242). Host logic with nothing
+ * device-specific in it, which is why it lives in this header rather than in
+ * src/chunk_decode.cuh: the wave64 answer can then be exercised on a machine
+ * with no wave64 device, and on a machine with no device at all.
+ *
+ * THE DEFAULT ARM REFUSES AND MUST NOT FALL BACK TO 32. A width this build
+ * emits no kernel for is not a hardware detail to paper over: the kernel maps
+ * chunks onto lanes by the width it was instantiated at, so launching the
+ * 32-lane kernel on a device whose wave is some other size gives a block that
+ * is not a whole number of waves - and that is the case src/chunk_decode.cuh
+ * documents as leaving every output byte whose index modulo the width lands in
+ * the missing part written by nobody. A silent wrong answer, on the fail-closed
+ * side of a decoder. The caller gets CUDEC_ERR_UNSUPPORTED instead.
+ *
+ * The enumerators carry the widths as their values so a reader cannot pair the
+ * wrong one with a launch, and the type still refuses to convert to a width
+ * implicitly. */
+constexpr int kWaveWidth32 = 32;
+constexpr int kWaveWidth64 = 64;
+
+enum class WaveInstantiation {
+    kUnsupported = 0,
+    kWave32 = kWaveWidth32,
+    kWave64 = kWaveWidth64
+};
+
+inline WaveInstantiation select_wave_instantiation(int reported_width) {
+    switch (reported_width) {
+        case kWaveWidth32:
+            return WaveInstantiation::kWave32;
+        case kWaveWidth64:
+            return WaveInstantiation::kWave64;
+        default:
+            return WaveInstantiation::kUnsupported;
+    }
+}
+
 }  // namespace cudec_detail
 
 #endif /* CUDEC_BATCH_LIMITS_H */

--- a/src/chunk_decode.cuh
+++ b/src/chunk_decode.cuh
@@ -71,11 +71,12 @@ template <int WaveSize>
 inline constexpr unsigned kBlockThreadsFor =
     static_cast<unsigned>(WaveSize) * kBlockWarps;
 
-/* The one width this CUDA build instantiates. It is named here rather than
- * written as digits at each launch, for the reason issue #211 gives, and it
- * is a compile-time constant on purpose: the runtime-width dispatch is a
- * sibling issue, and until it lands the CUDA translation units emit exactly
- * one kernel per format. */
+/* The width every CUDA device reports, named rather than written as digits
+ * for the reason issue #211 gives. IT IS NO LONGER WHAT THE SHIPPED ENTRY
+ * LAUNCHES AT: since #242 the entry reads the width from the runtime and
+ * selects the instantiation, so this constant is what the fixed-width callers
+ * that never leave CUDA - the bench and the determinism harness - are written
+ * against, and what tests/wave_width_gpu.cu pins the CUDA answer to. */
 constexpr int kCudaWaveSize = static_cast<int>(kWarpSize);
 
 constexpr unsigned kBlockThreads = kBlockThreadsFor<kCudaWaveSize>;
@@ -117,8 +118,9 @@ __global__ void __launch_bounds__(kBlockThreadsFor<WaveSize>)
      *    full-mask __syncwarp() is executed by a fraction of a wave. Both
      *    halves of that argument scale with the width rather than with the
      *    digits they used to be written in.
-     * The shipped entry always launches kBlockThreads, but the kernel must
-     * not depend on its caller for either property. Both tests are
+     * The shipped entry launches a whole number of waves at whichever width
+     * it selected, but the kernel must not depend on its caller for either
+     * property. Both tests are
      * grid-uniform (gridDim/blockDim only), so neither can strand lanes at a
      * __syncwarp().
      *

--- a/src/vendor_rt.h
+++ b/src/vendor_rt.h
@@ -60,6 +60,10 @@
 #define CUDEC_RT_EVENT_SYNCHRONIZE hipEventSynchronize
 #define CUDEC_RT_DEVICE_SYNCHRONIZE hipDeviceSynchronize
 #define CUDEC_RT_GET_LAST_ERROR hipGetLastError
+#define CUDEC_RT_GET_DEVICE hipGetDevice
+#define CUDEC_RT_DEVICE_GET_ATTRIBUTE hipDeviceGetAttribute
+#define CUDEC_RT_ATTR_WAVE_WIDTH hipDeviceAttributeWarpSize
+#define CUDEC_RT_FIXED_WAVE_WIDTH 0
 
 #else
 #include <cuda_runtime.h>
@@ -88,6 +92,10 @@
 #define CUDEC_RT_EVENT_SYNCHRONIZE cudaEventSynchronize
 #define CUDEC_RT_DEVICE_SYNCHRONIZE cudaDeviceSynchronize
 #define CUDEC_RT_GET_LAST_ERROR cudaGetLastError
+#define CUDEC_RT_GET_DEVICE cudaGetDevice
+#define CUDEC_RT_DEVICE_GET_ATTRIBUTE cudaDeviceGetAttribute
+#define CUDEC_RT_ATTR_WAVE_WIDTH cudaDevAttrWarpSize
+#define CUDEC_RT_FIXED_WAVE_WIDTH 32
 
 #endif
 
@@ -141,6 +149,46 @@ inline error_t event_synchronize(event_t e) {
 }
 inline error_t device_synchronize() { return CUDEC_RT_DEVICE_SYNCHRONIZE(); }
 inline error_t get_last_error() { return CUDEC_RT_GET_LAST_ERROR(); }
+
+/* WHETHER THE BACKEND FIXES THE WAVE WIDTH, and zero where it does not. This
+ * is the one difference between the two backends that reaches past the mapping
+ * table, so it is written here as a table entry rather than as a preprocessor
+ * branch at the dispatch. Every CUDA device that exists reports 32; on HIP the
+ * width is 32 on RDNA and 64 on CDNA and only the device knows which. */
+inline constexpr int fixed_wave_width = CUDEC_RT_FIXED_WAVE_WIDTH;
+
+/* The one composite in this file, and the exception the paragraph above is
+ * written against. The device's wave width is ONE question that both runtimes
+ * answer in two calls, so splitting it across the seam would put the same
+ * two-step at every call site and give each of them its own chance to skip the
+ * error check on the first. The attribute is read rather than the whole
+ * property struct: it names the same field of the same runtime, it costs no
+ * kilobyte-sized copy, and it is per-device, so a caller that changed device
+ * between two submissions gets its own device's width instead of a cached
+ * process-wide one. On failure *out is left alone - the caller has a status to
+ * act on and must not read a width nobody wrote (issue #242). */
+inline error_t device_wave_width(int* out) {
+    int device = 0;
+    const error_t e = CUDEC_RT_GET_DEVICE(&device);
+    if (e != success) {
+        return e;
+    }
+    return CUDEC_RT_DEVICE_GET_ATTRIBUTE(out, CUDEC_RT_ATTR_WAVE_WIDTH, device);
+}
+
+/* The width a launch is built for, which is what the dispatch asks. On a
+ * backend that fixes the width this is a constant and the runtime is never
+ * touched - so a submission on such a backend gains no call that can fail, and
+ * the GPU-less launch-failure test keeps reaching the launch it is about. On a
+ * backend that does not, the query is the answer and its failure is the
+ * caller's, never a default. */
+inline error_t wave_width_for_launch(int* out) {
+    if (fixed_wave_width != 0) {
+        *out = fixed_wave_width;
+        return success;
+    }
+    return device_wave_width(out);
+}
 
 }  // namespace cudec_rt
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -437,6 +437,15 @@ cudec_add_test(batch_limit_width_lock SOURCES batch_limit_width_lock.cpp)
 target_include_directories(batch_limit_width_lock
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
+# The width-to-instantiation choice the batch entries dispatch on (issue
+# #242). Host-side because that is the only place the wave64 answer can be
+# executed at all: no machine here has a wave64 device, so the width is handed
+# to the selector rather than read from one. The refusal arm is what the entry
+# turns into CUDEC_ERR_UNSUPPORTED.
+cudec_add_test(wave_dispatch SOURCES wave_dispatch.cpp)
+target_include_directories(wave_dispatch
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+
 cudec_add_test(frame_host_negative SOURCES frame_host_negative.cpp)
 target_include_directories(frame_host_negative
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)

--- a/tests/wave_dispatch.cpp
+++ b/tests/wave_dispatch.cpp
@@ -1,0 +1,65 @@
+/* The width-to-instantiation selection the batch entries dispatch on (issue
+ * #242). Host-side and GPU-less: nothing here launches and nothing here calls
+ * into a device runtime.
+ *
+ * WHY A MOCKED WIDTH IS THE ONLY WAY THIS LEG EXISTS AT ALL. The answer that
+ * matters is the wave64 one, and no machine in this project has ever had a
+ * wave64 device - no hosted runner carries an AMD GPU either. Handing the
+ * selector the number the runtime would have reported is the whole of what
+ * can be executed here, and it is worth executing: the failure it catches is
+ * a dispatch that reads 64 and launches the 32-lane kernel anyway, which is a
+ * silent wrong answer rather than a crash.
+ *
+ * WHAT IT DOES NOT PROVE, stated here because the file's name invites the
+ * larger reading. It does not prove that a wave64 DEVICE launches the wave64
+ * kernel, that the kernel decodes correctly at that width, or that the
+ * runtime reports 64 where this project expects it to. Those need the
+ * hardware, and the pull request that landed this says so in the same words.
+ * What is executed here is the choice, and only the choice.
+ *
+ * THE UNSUPPORTED ARM IS THE ONE WITH TEETH. A selector that fell back to the
+ * 32-lane kernel for an unknown width would pass every assertion about 32 and
+ * 64 above it, so the widths below are not decoration: they are the whole
+ * difference between a fail-closed refusal and a launch at a geometry the
+ * kernel's own comment describes as leaving output bytes written by nobody. */
+#include "batch_limits.h"
+#include "require.h"
+
+#include <cstdio>
+
+using cudec_detail::select_wave_instantiation;
+using cudec_detail::WaveInstantiation;
+
+int main() {
+    /* The two widths this build emits a kernel for. 32 is every CUDA device
+     * and RDNA; 64 is CDNA. */
+    REQUIRE(select_wave_instantiation(32) == WaveInstantiation::kWave32);
+    REQUIRE(select_wave_instantiation(64) == WaveInstantiation::kWave64);
+
+    /* Everything else refuses. The list is chosen rather than swept: each one
+     * is a value a runtime could plausibly hand back, and the two nearest
+     * neighbours of each supported width are the mistakes an off-by-one in a
+     * range test would let through.
+     *
+     * 0 is what a query that wrote nothing leaves in an initialised variable,
+     * so it is the value a caller sees if the dispatch ever ignores a failed
+     * status - and it must not select a kernel. */
+    const int kRefused[] = {0,  1,  16, 31, 33, 48,
+                            63, 65, 96, 128, 256, -1};
+    for (int width : kRefused) {
+        REQUIRE(select_wave_instantiation(width) ==
+                WaveInstantiation::kUnsupported);
+    }
+
+    /* The enumerators carry their widths, which is what lets a reader check a
+     * launch against the arm that selected it. A renumbering that broke this
+     * would leave every assertion above green. */
+    REQUIRE(static_cast<int>(WaveInstantiation::kWave32) == 32);
+    REQUIRE(static_cast<int>(WaveInstantiation::kWave64) == 64);
+    REQUIRE(static_cast<int>(WaveInstantiation::kUnsupported) == 0);
+
+    std::printf("PASS: the dispatch selects 32 and 64 by the reported width "
+                "and refuses %zu other widths\n",
+                sizeof(kRefused) / sizeof(kRefused[0]));
+    return 0;
+}


### PR DESCRIPTION
# What & why

The batch entries stop launching a width they assumed. They resolve the wave
width for the launch through `src/vendor_rt.h`, select the 32- or 64-lane
instantiation from the answer in one place
(`cudec_detail::select_wave_instantiation`), and refuse a width this build
emits no kernel for with `CUDEC_ERR_UNSUPPORTED`.

This leaves #242 open. It pays the Done-when clause the 2026-08-28 ruling on
that issue released - "land the selection with everything this machine can
prove" - and the clause that ruling could not release is the first wave64 run,
which is now #415 rather than a footnote.

**#414 is merged** (`50690a5`) and this base is now `main`.

**Its checks needed one push to start, and that is the trigger rather than a
failure.** `.github/workflows/ci.yml` declares `pull_request: branches: [main]`,
so while this pull request was stacked on a feature branch no run started at
all:

```
$ gh pr checks 416
no checks reported on the 'feature/242-runtime-wave-width' branch
```

Retargeting is a base change and not a `synchronize`, so `origin/main` was
merged into this branch and the push started the run. All seven checks are
green on `aa6f8b3`.

## What this refuses, and why refusing is the point

A width this build has no kernel for must not fall back to the 32-lane one.
`src/chunk_decode.cuh` already documents what that costs: a block that is not a
whole number of waves means `lane` only ever takes the low part of its range
while the copy loops stride by the wave width, so every output byte whose index
modulo the width lands in the missing part is written by nobody. That is a
silent wrong answer out of a decoder whose contract is bit-identical output,
which is worse than an error, so the entry answers `CUDEC_ERR_UNSUPPORTED`.

## Where the width comes from is a backend difference, and it lives in the seam

The issue body says both "width comes from the device property at dispatch" and
"CUDA dispatches 32 unconditionally, so the CUDA path takes no new branch
cost". Those are only both true if the difference is a backend fact, so it is
written as one more entry in the seam's mapping table
(`CUDEC_RT_FIXED_WAVE_WIDTH`, `32` on CUDA and `0` on HIP) rather than as a
preprocessor branch at the dispatch:

- On CUDA the width is a constant. Every CUDA device reports 32, so a
  submission gains no call that can fail.
- On HIP it is read from the device, and a query that fails is
  `CUDEC_ERR_CUDA` and never a default.

**That choice is load-bearing for an existing test and I would have lost it
the other way.** Written with an unconditional runtime query, a validation-
passing call on a GPU-less runner fails at the query and never reaches the
launch - which takes `tests/launch_fail.cpp` apart from the inside. That file's
third leg exists to catch an entry that dropped its post-launch error check and
returns `CUDEC_OK` while submitting nothing, and it can only catch it by
reaching the launch. Measured rather than assumed, because the two failures are
indistinguishable from the test's own verdict:

```
$ CUDA_VISIBLE_DEVICES= ./probe
cudaGetDevice -> 35 (cudaErrorInsufficientDriver), dev=-1
cudaDeviceGetAttribute(warpSize,0) -> 35 (cudaErrorInsufficientDriver), w=-1
```

Both calls fail with no visible device, so the entry would have refused before
submitting and `launch_fail.cpp` would still have gone green while proving
something smaller. With the width fixed on CUDA it reaches the launch exactly
as before.

## The wave64 branch has never executed on a device

No machine in this project has a wave64 device and no hosted runner carries an
AMD GPU. What is proven here is narrower than the Done-when's first clause and
is stated as such.

**Both instantiations are emitted into the shipped translation unit**, for both
parsers:

```
$ cuobjdump -elf CMakeFiles/cudec.dir/src/batch.cu.o \
    | grep -o '_Z[A-Za-z0-9_]*chunk_decode_batch[A-Za-z0-9_]*' | sort -u | c++filt
void cudec_detail::chunk_decode_batch<cudec_detail::SnappyParser, false, 32>(...)
void cudec_detail::chunk_decode_batch<cudec_detail::SnappyParser, false, 64>(...)
void cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, false, 32>(...)
void cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, false, 64>(...)
```

**The selection is executed at both widths.** `tests/wave_dispatch.cpp` is
host-side and GPU-less: it asserts 32 and 64 select their arms, that twelve
other widths (including 0, 63, 65 and -1) are refused, and that the
enumerators still carry their widths.

What is **not** proven: that a wave64 device reports 64 through the seam, that
the dispatch then launches the 64-lane kernel, or that the kernel decodes
correctly at that width. #415 closes on exactly that run and on nothing else.

## Type of change

- [x] Decode kernel / device code (the launch, not the kernel body)
- [x] API surface (two synchronous statuses documented)
- [x] Refactor / code quality

## Engineering checklist

- [x] Fail-closed preserved and extended: the new arm refuses rather than
      approximating, and the query's failure is a status rather than a default.
      `tests/wave_dispatch.cpp` is the negative test for the refusal.
- [x] Oracle coverage unchanged: no parser, no bound and no decode branch moved.
- [x] Determinism preserved: on CUDA the selected width is the same constant
      the entry launched at before, so the shipped launch is byte-for-byte the
      same submission.
- [x] Every runtime call's error is checked; no exceptions cross the C ABI.
- [ ] **An adversarial review was NOT run and there was no second reader.** The
      mutant below and the two measurements above are what stand in its place.

## The mutant

The one that matters is the fallback the design refuses, because it is the
change a reader would call a robustness improvement:

| mutant                                                          | verdict |
| --------------------------------------------------------------- | ------- |
| `select_wave_instantiation` default arm returns `kWave32` instead of `kUnsupported` | red     |

```
1/1 Test #33: wave_dispatch ....................***Failed    0.00 sec
FAIL tests/wave_dispatch.cpp:50: select_wave_instantiation(width) == WaveInstantiation::kUnsupported
```

Reverted before the commit. Two rules that already existed also bit during this
work and are worth naming, because both caught a real mistake rather than a
planted one: the wave-width literal rule (#211) refused `32` and `64` written
as digits at the launch and in the selector, which is why the widths are
`kWaveWidth32` / `kWaveWidth64`; and the vendor-seam rule landing in #414
refused the query until it was routed through the seam.

## GPU sanitizer gate

- [ ] Not applicable: this change touches device-side code (`src/batch.cu`),
      so the gate applies and could not be run.

```
commit:    0d24a95
gpu:       none reachable
cuda:      Build cuda_13.3.r13.3/compiler.38244171_0
sanitizer: not attempted - no device to attach to
```

```
$ nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
Failed to initialize NVML: GPU access blocked by the operating system
```

Compute Sanitizer is additionally blocked on this host by #127.

## Performance checklist

No number is claimed and none was measured - the benchmarks need the device
that is blocked above. On CUDA the resolution folds to a constant and the
launch is the same submission; on HIP it is one attribute read per submission
against one kernel launch, and that ratio is unmeasured because no backend
that would pay it has a compiler here.

The width is resolved per submission rather than cached, and that is a
correctness choice rather than an oversight: a process may change device
between two submissions, and a width cached for the first is a launch geometry
chosen for the wrong GPU.

## Quality checklist

- [x] Minimal: the two launch arms are one function template, not two copies.
      The selector is a `switch` in the header that already owns the batch
      geometry.
- [x] Self-documenting: the refusal's reason is written where the refusal is,
      and `include/cudec.h` states both statuses where a caller reads them.
- [x] Conformance tests pass, and the new structural property - which width
      selects which instantiation - is locked in as `wave_dispatch`.

## Verification

WSL Ubuntu-24.04, CUDA 13.3.73, g++ 13.3, cmake 3.28.3, at `0d24a95`:

```
$ cmake --build ~/b240 -j
warnings: 0

$ ctest --test-dir ~/b240 -LE gpu
100% tests passed, 0 tests failed out of 51
```

- [x] Builds clean - zero warnings under the strict flags.
- [x] Host-side suite green - **51/51**, one more than before this change and
      the new one is `wave_dispatch`.
- [ ] **The nine `gpu`-labelled entries did not run**, for the device reason
      quoted above and not for anything in this change.
- [x] Prettier clean.
- [x] Docs synced: `docs/MASTERPLAN.md` 15.2 records the landed half, where the
      width comes from on each backend, and that the wave64 branch has never
      executed.

## Notes

Out of scope: #212, the lock that both instantiations survive into the **HIP**
binary - this pull request shows only that they survive into the CUDA one, and
that issue's own Done-when names the other. The kernel body is untouched;
#241 landed its width parameter.

`src/chunk_decode.cuh`'s `kCudaWaveSize` is no longer what the shipped entry
launches at, and its comment now says so rather than continuing to name the
runtime dispatch as a change that has not happened.
