### PR TITLE
Write in the first person about who runs this project [#417]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Single-maintainer project: everything routes to the maintainer.
+# I am the only reviewer here, so everything routes to me.
 * @iderex

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 # The New Issue chooser.
 #
-# Blank issues stay on. The maintainer files most of this tracker by hand and
+# Blank issues stay on. I file most of this tracker by hand and
 # the forms below are shaped for reports from outside; forcing every internal
 # issue through a bug-report schema would cost more than the structure buys.
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,7 @@ jobs:
           ./build-consumer-nocuda/consumer
 
       # The host-side subset; gpu-labeled tests run in this same container
-      # on the maintainer's machine and their output is pasted into the PR.
+      # on my machine and their output is pasted into the PR.
       # Fail-closed plumbing: --no-tests=error reds a vacuous zero-test
       # selection, and the identity greps pin BOTH sets by name - a known
       # host test silently dropping out of the CI selection (say, by

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,9 +11,9 @@
 #
 # The public dashboard is deliberately not fed. `publish_results` stays false
 # and no `id-token: write` is granted, because publishing would send this
-# repository's posture to a third-party service, which is a decision the
-# maintainer takes and not a side effect of adding a workflow. The results are
-# visible where the other analysis lands: Security -> Code scanning.
+# repository's posture to a third-party service, which is a decision I take
+# and not a side effect of adding a workflow. The results are visible where
+# the other analysis lands: Security -> Code scanning.
 #
 # The push trigger on `main` is not optional decoration. Scorecard's
 # branch-protection and maintained checks read the default branch, so a run

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ badver.log
 # never committed.
 bench/corpora/
 
-# Local maintainer tooling and working notes - never in the public tree.
+# My local tooling and working notes - never in the public tree.
 .claude/
 CLAUDE.md
 docs/internal/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,9 +167,9 @@ measured and **rejected**, which is the part a changelog usually loses.
 
 ### Known gaps
 
-- Compute Sanitizer cannot attach to the device on the maintainer's machine, so
+- Compute Sanitizer cannot attach to the device on my machine, so
   the four-tool sweep has never produced a clean run there. The runner script is
   in the tree and the blocker is tracked; nothing in this release is claimed to
   have passed it.
-- The GPU tests run on the maintainer's hardware, not in CI, which has no GPU.
+- The GPU tests run on my hardware, not in CI, which has no GPU.
   CI builds both configurations and runs the host-side subset.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Development here is AI-assisted. Claude (Anthropic) helps with individual
 process steps - generating and analysing code, running the adversarial
 security reviews, and translating documentation and comments into English. It
 never hands over finished, unreviewed work: each step is only a proposal. A
-human maintainer reviews, understands, edits where needed, and signs off on
+human reviews, understands, edits where needed, and signs off on
 every one - the AI proposes, a person decides, and a human stays responsible
 for every line that ships, at all times. The review discipline is modelled,
 as far as is practical for a volunteer project, on the change-control

--- a/bench/bench_lz4.cpp
+++ b/bench/bench_lz4.cpp
@@ -77,7 +77,7 @@ static_assert(kLongmatchOffset >= kLongmatchMatchLen,
  * It is a MODEL of the workload, not the workload. A synthetic mixture is
  * not a measurement on real game data, and no number taken here may be
  * quoted as one; docs/BENCHMARK-METHODOLOGY.md carries the same sentence
- * beside the corpus entry. The maintainer's decision on issue #139 chose the
+ * beside the corpus entry. My decision on issue #139 chose the
  * generator over a hash-pinned asset pack deliberately: no network, no mirror
  * that can rot, no licence review on a third-party package, and CI stays
  * offline. A vetted pack may later join the set beside this generator; it

--- a/cmake/CudecLz4Oracle.cmake
+++ b/cmake/CudecLz4Oracle.cmake
@@ -12,7 +12,7 @@ include_guard(GLOBAL)
 # line at all.
 set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
 
-# liblz4, pinned by the SHA-256 of the maintainer-uploaded release asset
+# liblz4, pinned by the SHA-256 of the upstream-uploaded release asset
 # (self-computed at pin time and cross-checked against conan-center; the
 # auto-generated /archive/ tarballs are avoided - GitHub regenerated them
 # in 2023 and their hashes moved). Test-only dependency: the link

--- a/cmake/CudecSnappyOracle.cmake
+++ b/cmake/CudecSnappyOracle.cmake
@@ -13,7 +13,7 @@ set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
 include(FetchContent)
 
 # The M3 oracle, pinned by the SHA-256 of the tag archive. snappy publishes no
-# maintainer-uploaded release asset, so this is the fallback the pinning
+# upstream-uploaded release asset, so this is the fallback the pinning
 # policy names (docs/MASTERPLAN.md section 5): the auto-generated archive,
 # pinned, with a future hash mismatch read as the invariant working rather
 # than as noise. Cross-checked at pin time against a second packaging

--- a/cmake/CudecZstdOracle.cmake
+++ b/cmake/CudecZstdOracle.cmake
@@ -14,7 +14,7 @@ set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
 include(FetchContent)
 
 # facebook/zstd, the M5 oracle, pinned by the SHA-256 of the
-# MAINTAINER-UPLOADED release asset - the shape the pinning policy prefers and
+# UPSTREAM-UPLOADED release asset - the shape the pinning policy prefers and
 # lz4 already uses, rather than the auto-generated /archive/ tarball snappy
 # had to fall back to.
 #

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -2485,8 +2485,8 @@ exists so that the absence of AMD numbers everywhere above is a recorded fact
 rather than a silence.
 
 **What has and has not happened on AMD, as of this entry.** Every number in
-this file was taken on one NVIDIA device (RTX 3080, sm_86, CUDA 12.6). The
-maintainer hardware is NVIDIA-only, so no AMD GPU has ever executed this
+this file was taken on one NVIDIA device (RTX 3080, sm_86, CUDA 12.6). My
+hardware is NVIDIA-only, so no AMD GPU has ever executed this
 decoder for the project, and no AMD measurement exists to record. There is also
 no AMD build. `CUDEC_ENABLE_HIP` now exists in `CMakeLists.txt`, and it refuses
 on every machine: cudec has no HIP device sources yet, so the option holds the
@@ -2497,11 +2497,11 @@ compile gate land (issue #111) and the "compiled" half becomes a thing a
 workflow run can be pointed at.
 
 **What a community result is, and what it is not.** A third-party measurement
-on hardware the maintainer does not have and cannot re-run. It is recorded as
+on hardware I do not have and cannot re-run. It is recorded as
 exactly that. It is **not** promoted to a project baseline and it does **not**
 gate merges: the rule that regressions against a recorded baseline block a
-merge (MASTERPLAN section 5) applies to the CUDA baselines above, which the
-maintainer can reproduce on demand, and extending it to a number nobody here can
+merge (MASTERPLAN section 5) applies to the CUDA baselines above, which I
+can reproduce on demand, and extending it to a number nobody here can
 reproduce would make an unreproducible figure into a merge veto. A community
 result informs; it does not gate.
 

--- a/docs/DETERMINISM.md
+++ b/docs/DETERMINISM.md
@@ -112,7 +112,7 @@ non-deterministic in it to control:
 - `tests/CMakeLists.txt` - the structural axis: the floating-point ban above,
   checked at configure time, with probes that prove the check still bites.
 
-The GPU-to-GPU axis is **reasoned, not measured**: the maintainer's gate runs one
+The GPU-to-GPU axis is **reasoned, not measured**: my gate runs one
 device (an RTX 3080, `sm_86`). It rests on the integer-only argument above rather
 than on a two-GPU comparison, and it is stated that way deliberately - a claim
 without a measurement is not a measurement. A second device joins the gate when

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -217,7 +217,7 @@ is not an empty AMD field), and **hackability**.
   the CUDA version it was produced against. **racecheck detects
   shared-memory hazards only** - global-memory races are outside its scope,
   and a clean sweep is never read as clearance for them. Today the gate is
-  **parked**: owed and unproducible on the maintainer route, under WSL2 the
+  **parked**: owed and unproducible on my route, under WSL2 the
   device is in WDDM mode, the debugger interface the tools need is absent, and
   all four report the same two initialization errors against a program with no
   fault in it. Re-measured against the newest driver and toolkit pairing the
@@ -226,7 +226,7 @@ is not an empty AMD field), and **hackability**.
   evidence and not a dispensation from the gate: it was not moved to a paid GPU
   runner, and what would lift it is a device offering a debugger interface.
 - **Oracle pinning policy**: oracles are vendored via FetchContent from
-  maintainer-uploaded release assets, pinned by a self-computed SHA-256
+  upstream-uploaded release assets, pinned by a self-computed SHA-256
   cross-checked against a second packaging ecosystem; auto-generated
   `/archive/` tarballs are avoided (GitHub regenerated them in 2023 and
   their hashes moved). Where a project publishes no uploaded asset, the
@@ -281,8 +281,8 @@ is not an empty AMD field), and **hackability**.
   ladder.
 - **Zstd complexity.** M5 is months, not weeks; the README does not promise
   it until M4 has shipped.
-- **Single-machine development.** CI has no GPU; kernel tests run on the
-  maintainer's hardware. The CI gate covers build + host-side tests; GPU
+- **Single-machine development.** CI has no GPU; kernel tests run on my
+  hardware. The CI gate covers build + host-side tests; GPU
   test results are recorded in the PR before merge.
 
 ## 8. Open design questions (settled via design issues before use)
@@ -866,7 +866,7 @@ streaming-entry scope decision. Numbers and kernel never move in the same
 PR, and the perf pass inherits section 9's pre-registered zero-regression
 rule on the worst case from its first baseline.
 
-**No open maintainer decision.** Every fork above was settled at the panel;
+**No open release-gate decision.** Every fork above was settled at the panel;
 none of them is a call that needs the release gate.
 
 ## 11. M4 GDeflate format dossier
@@ -874,7 +874,7 @@ none of them is a call that needs the release gate.
 What GDeflate is, sourced, so that the kernel design panel and the
 table/parse core work from one record instead of each re-reading a draft.
 Facts and provenance only. No design decision is taken below, and the legal
-posture is settled in its own maintainer-gated issue.
+posture is settled in its own release-gated issue.
 
 ### 11.1 Provenance: three artifacts, no single specification
 
@@ -1264,7 +1264,7 @@ Recording where the verification apparatus came from is worth doing on its
 own terms, and it means the vendoring rung has nothing left to invent.
 
 **This subsection is about attribution only.** The patent position and the
-implementation-provenance posture were a separate, maintainer-gated
+implementation-provenance posture were a separate, release-gated
 decision; it is taken, and section 16 carries it. Nothing here softens it.
 
 ## 12. M5 Zstd v1 decode subset (RFC 8878)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1582,7 +1582,7 @@ endif()
 #    is what makes the gpu_to_gpu level in docs/DETERMINISM.md hold by
 #    construction rather than by measurement;
 #  - wave width: no bare 32 or 64 outside the one line that binds it to a
-#    name. The maintainer's hardware is NVIDIA, so a hardcoded 32 left in a
+#    name. My hardware is NVIDIA, so a hardcoded 32 left in a
 #    lane-stride expression is invisible to every test that can be run here
 #    and wrong on every wave64 device (issue #211). A width must arrive as the
 #    `WaveSize` template parameter or as a constant named after it, and the


### PR DESCRIPTION
Closes #417.

## What changed

Twenty-four sentences across fifteen tracked files described me from outside, in
a role word this project does not use about itself. Every one is rewritten. The
issue listed twelve files; the grep at the head returns fifteen, and the three it
did not name are `docs/DETERMINISM.md`, `docs/MASTERPLAN.md` and
`tests/CMakeLists.txt`. All three are in this change.

The rewrite is not uniform, because the word was not doing one job:

- **About me** - eighteen sentences, now first person. `.github/CODEOWNERS`,
  `.github/ISSUE_TEMPLATE/config.yml`, `.github/workflows/ci.yml`,
  `.github/workflows/scorecard.yml`, `.gitignore`, `CHANGELOG.md`,
  `bench/bench_lz4.cpp`, `docs/BENCHMARKS.md`, `docs/DETERMINISM.md`,
  `docs/MASTERPLAN.md`, `tests/CMakeLists.txt`.
- **About the upstream projects** - three sentences, in the oracle pinning
  comments. They distinguish a release asset a project uploads from the tarball
  GitHub generates, and the party uploading it is liblz4, snappy or zstd rather
  than anyone here. They read `upstream-uploaded` now, which is the plain name
  for the role they were always describing.
- **About the release gate** - three sentences in `docs/MASTERPLAN.md`, which
  mark a decision reserved for the gate that holds a release rather than a
  person. They read `release-gated`.

## The exception the issue reserves is claimed for no file

The issue keeps the word where it sits in text I did not write - a licence, a
code of conduct adopted verbatim, GitHub's own CODEOWNERS syntax - and asks that
each such file be named here with its reason. There are none. `LICENSE` and
`NOTICE.md` never carried the word, and CODEOWNERS carries it only in a comment
sentence of my own; the syntax GitHub reads is the `* @iderex` line, which is
untouched. So the Done-when condition is met at its strongest reading:

```
$ git grep -il -w maintainer -- . ':!build*' | wc -l
0
$ git grep -in -w maintainer -- . ':!build*' ; echo "exit=$?"
exit=1
```

## What this change cannot break

Every edit is inside a comment or inside prose. No build rule, no workflow step,
no routing rule and no test text moves - the diff is 28 lines changed in 15
files, and `git diff --cached --stat` at commit time showed no line outside a
comment or a paragraph. The configure-time source scans in
`tests/CMakeLists.txt` read code rather than their own header comment, and the
line this change touched there is one of the comment lines explaining why the
wave-width rule exists.

## The disclosure in README.md, which is the one to read carefully

The AI-usage section said a human reviews, understands, edits where needed, and
signs off on every step. It still says exactly that. The sentence lost a noun and
no assurance: nothing became a tick where an admission stood, and the clause
after it - the AI proposes, a person decides, and a human stays responsible for
every line that ships - is untouched.

## Gate

`npx prettier@3 --check "**/*.{md,yml,yaml}"` on this head:

```
Checking formatting...
All matched files use Prettier code style!
```

No build was run locally for this change and none is claimed: the Windows host
carries no CUDA toolkit and no C compiler, and every changed byte is a comment or
prose. CI's build, sanitize and format checks are the gate this waits on, and
this body is edited with their result before merge.

This change had no second reader. No GPU test ran, and none is relevant to it.
