### PR TITLE
Route the validation ladder's device calls through the vendor seam [#243]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,16 @@ function(cudec_add_test name)
   endif()
   add_executable(${name} ${T_SOURCES})
   target_link_libraries(${name} PRIVATE cudec ${T_LIBS})
+  # A device-side test reaches src/: at minimum for the vendor seam it drives
+  # the runtime through (tests/vendor_rt_test.h includes src/vendor_rt.h,
+  # issue #243), and several also launch the shipped kernel or twin a format
+  # header directly. Granted here rather than per target for the reason the
+  # vendor-seam glob states about its own scope - a device test added tomorrow
+  # is covered on the day it lands, not on the day somebody remembers it.
+  if(T_GPU OR T_HUGE)
+    target_include_directories(${name}
+                               PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+  endif()
   set_target_properties(
     ${name} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON
                        CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON
@@ -236,10 +246,6 @@ target_compile_definitions(
 # element trace. Without it the device half of the header is a comment. Not
 # the device gate set (#154) - one thread, no warp cooperation, no kernel.
 cudec_add_test(snappy_block_device SOURCES snappy_block_device.cu GPU)
-if(TARGET snappy_block_device)
-  target_include_directories(snappy_block_device
-                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-endif()
 # The M5 oracle proving itself (issue #181): the pin downloads, the two
 # flavours build, and the compressor and the decode entry points agree on real
 # bytes - plus one refusal per error class the fail-closed matrix will read.
@@ -489,43 +495,24 @@ endif()
 # width, so a wave64 instantiation that stopped compiling, or a block shape
 # that stopped following the parameter, would leave the whole suite green.
 # This test makes the second instantiation a build product and runs the
-# shipped one, and it needs the internal kernel header from src/ to reach
-# either.
+# shipped one.
 cudec_add_test(wave_width_gpu SOURCES wave_width_gpu.cu GPU)
-if(TARGET wave_width_gpu)
-  target_include_directories(wave_width_gpu
-                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-endif()
+# frame_twin verifies the library's own xxhash32.h against liblz4's XXH32,
+# which it reaches through the src/ include every device test is granted.
 cudec_add_test(frame_twin SOURCES frame_twin.cu LIBS lz4_frame_oracle GPU)
-# frame_twin verifies the library's own xxhash32.h against liblz4's XXH32.
-# Guarded: the host-only sanitizer build (issue #42) skips the GPU targets, so
-# this follow-up only runs when the target actually exists.
-if(TARGET frame_twin)
-  target_include_directories(frame_twin
-                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-endif()
 cudec_add_test(stream_twin SOURCES stream_twin.cu LIBS cudec_test_fixtures GPU)
 # The same hostile corpus on the device, behind a host-side watchdog: a warp
 # that never leaves its sequence loop holds the launch, so this one polls an
 # event against a deadline instead of blocking on the stream (issue #72).
+# It also launches the kernel directly, to reach a geometry the shipped entry
+# point never produces: fewer threads than one warp.
 cudec_add_test(termination_gpu SOURCES termination_gpu.cu LIBS
                cudec_test_fixtures GPU)
-# It also launches the kernel directly, to reach a geometry the shipped entry
-# point never produces (fewer threads than one warp), so it needs the internal
-# header from src/.
-if(TARGET termination_gpu)
-  target_include_directories(termination_gpu
-                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-endif()
+
 # Determinism across launch geometry - the axis the existing same-batch-twice
-# compare cannot see. It launches the shipped kernel directly, so it needs the
-# internal header from src/ (like bench/ does).
+# compare cannot see. It launches the shipped kernel directly.
 cudec_add_test(determinism_gpu SOURCES determinism_gpu.cu LIBS
                cudec_test_fixtures GPU)
-if(TARGET determinism_gpu)
-  target_include_directories(determinism_gpu
-                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-endif()
 
 # The one arm of the decode kernel no ordinary fixture reaches: a match past
 # 2^32, which selects the 64-bit gather (issue #331). Deleting the test that
@@ -683,14 +670,15 @@ endforeach()
 # status CUDEC_ERR_CUDA (a caller compiled against that name and this seam may
 # not move it), on the cudec_rt:: spellings the seam introduces, on prose that
 # says CUDA, or on an English word that merely contains "hip".
-function(cudec_scan_vendor_spelling _text _label _out)
+function(cudec_scan_vendor_spelling _text _label _seam _out)
   set(_hits "")
   # A leading space so a match at offset zero still has a left context to
   # test; the class before the prefix is what keeps "chip" and "cudec" out.
   if(" ${_text}" MATCHES "[^A-Za-z0-9_]((cuda|hip)[A-Z_][A-Za-z0-9_]*)")
     string(APPEND _hits "${_label}: names a backend runtime directly "
-           "('${CMAKE_MATCH_1}'); every file under src/ except src/vendor_rt.h "
-           "reaches the runtime through cudec_rt:: (issue #240)\n")
+           "('${CMAKE_MATCH_1}'); every file beside ${_seam} in its own "
+           "tree reaches the runtime through cudec_rt:: "
+           "(issues #240, #243)\n")
   endif()
   set(${_out} "${_hits}" PARENT_SCOPE)
 endfunction()
@@ -702,7 +690,7 @@ endfunction()
 foreach(_violating "    return cudaMalloc(&p, bytes);"
                    "    return hipMemcpyAsync(d, s, n, k, st);"
                    "#include <cuda_runtime.h>")
-  cudec_scan_vendor_spelling("${_violating}" "probe" _probe_hit)
+  cudec_scan_vendor_spelling("${_violating}" "probe" "the seam" _probe_hit)
   if(NOT _probe_hit)
     message(FATAL_ERROR "the vendor-seam rule is dead: the planted violation "
                         "'${_violating}' was not reported (issue #240)")
@@ -710,7 +698,7 @@ foreach(_violating "    return cudaMalloc(&p, bytes);"
 endforeach()
 foreach(_near "return CUDEC_ERR_CUDA;" "return cudec_rt::device_malloc(&p, n);"
               "/* Every CUDA API error is checked, on chip and off. */")
-  cudec_scan_vendor_spelling("${_near}" "probe" _near_hit)
+  cudec_scan_vendor_spelling("${_near}" "probe" "the seam" _near_hit)
   if(_near_hit)
     message(FATAL_ERROR "the vendor-seam rule is over-wide: it reported the "
                         "legitimate spelling '${_near}' (issue #240)")
@@ -748,7 +736,8 @@ list(REMOVE_ITEM _vendor_scan_sources vendor_rt.h)
 set(_vendor_violations "")
 foreach(_source IN LISTS _vendor_scan_sources)
   file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_source} _vsrc)
-  cudec_scan_vendor_spelling("${_vsrc}" "src/${_source}" _found)
+  cudec_scan_vendor_spelling("${_vsrc}" "src/${_source}"
+                             "src/vendor_rt.h" _found)
   string(APPEND _vendor_violations "${_found}")
 endforeach()
 if(_vendor_violations)
@@ -847,6 +836,59 @@ cudec_vendor_arms_agree("${_vendor_rt_src}" _arms_why)
 if(_arms_why)
   message(FATAL_ERROR "src/vendor_rt.h maps the two backends unevenly: "
                       "${_arms_why}(issue #240)")
+endif()
+
+# ---- The harness's half of the same seam (issue #243). The validation ladder
+# drives the device itself - it allocates, poisons, copies back and asks the
+# driver questions the library never asks - so it names runtime operations
+# src/vendor_rt.h has no caller for. tests/vendor_rt_test.h is where those are
+# mapped, and the two rules below are rules one and two above, pointed at
+# tests/ instead of at src/.
+#
+# Why the harness is not simply covered by the scan above. The ladder makes
+# the same claim src/ does - ONE set of sources for both backends - and fails
+# the same way: a cudaMemcpy left in a .cu file compiles clean on the backend
+# this machine can build and reds only under a compiler nobody here has, so no
+# test result reports it first. The functions are shared; only the tree and
+# the exempted file differ.
+set(_vendor_rt_test ${CMAKE_CURRENT_SOURCE_DIR}/vendor_rt_test.h)
+if(NOT EXISTS ${_vendor_rt_test})
+  message(FATAL_ERROR "tests/vendor_rt_test.h is missing: it is the one place "
+                      "under tests/ a backend runtime is named (issue #243)")
+endif()
+file(GLOB_RECURSE _vendor_test_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+     CONFIGURE_DEPENDS
+     ${CMAKE_CURRENT_SOURCE_DIR}/*.c ${CMAKE_CURRENT_SOURCE_DIR}/*.cc
+     ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.cu
+     ${CMAKE_CURRENT_SOURCE_DIR}/*.cuh ${CMAKE_CURRENT_SOURCE_DIR}/*.h
+     ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp ${CMAKE_CURRENT_SOURCE_DIR}/*.inl)
+if(NOT _vendor_test_sources)
+  message(FATAL_ERROR "the harness vendor-seam scan found no sources under "
+                      "tests/ - the glob has stopped matching (issue #243)")
+endif()
+if(NOT vendor_rt_test.h IN_LIST _vendor_test_sources)
+  message(FATAL_ERROR "tests/vendor_rt_test.h is outside the harness "
+                      "vendor-seam glob, so the one file the rule exempts is a "
+                      "file it never saw (issue #243)")
+endif()
+list(REMOVE_ITEM _vendor_test_sources vendor_rt_test.h)
+set(_vendor_test_violations "")
+foreach(_source IN LISTS _vendor_test_sources)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/${_source} _vsrc)
+  cudec_scan_vendor_spelling("${_vsrc}" "tests/${_source}"
+                             "tests/vendor_rt_test.h" _found)
+  string(APPEND _vendor_test_violations "${_found}")
+endforeach()
+if(_vendor_test_violations)
+  message(FATAL_ERROR "the harness vendor seam has leaked:\n"
+                      "${_vendor_test_violations}")
+endif()
+
+file(READ ${_vendor_rt_test} _vendor_rt_test_src)
+cudec_vendor_arms_agree("${_vendor_rt_test_src}" _arms_why)
+if(_arms_why)
+  message(FATAL_ERROR "tests/vendor_rt_test.h maps the two backends unevenly: "
+                      "${_arms_why}(issue #243)")
 endif()
 
 # Single-source lock for the shared decode element (issue #150): the one

--- a/tests/determinism_gpu.cu
+++ b/tests/determinism_gpu.cu
@@ -26,7 +26,7 @@
 #include "snappy_block.h"
 #include "require.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt_test.h"
 
 #include <cstdio>
 #include <string>
@@ -105,10 +105,10 @@ int BuildBatch(const std::vector<Chunk>& chunks, Batch* batch) {
 
     batch->n = n;
     batch->dst_arena_size = dst_total;
-    REQUIRE_CUDA(cudaMalloc(&batch->d_src_blob, src_total));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_dst_arena, dst_total));
-    REQUIRE_CUDA(cudaMemcpy(batch->d_src_blob, src_blob.data(), src_total,
-                            cudaMemcpyHostToDevice));
+    REQUIRE_RT(cudec_rt::device_malloc(&batch->d_src_blob, src_total));
+    REQUIRE_RT(cudec_rt::device_malloc(&batch->d_dst_arena, dst_total));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_src_blob, src_blob.data(), src_total,
+                            cudec_rt::memcpy_h2d));
 
     std::vector<const void*> h_srcs(n);
     std::vector<void*> h_dsts(n);
@@ -117,23 +117,28 @@ int BuildBatch(const std::vector<Chunk>& chunks, Batch* batch) {
         h_srcs[i] = batch->d_src_blob + src_off[i];
         h_dsts[i] = batch->d_dst_arena + dst_off[i];
     }
-    REQUIRE_CUDA(cudaMalloc(&batch->d_srcs, n * sizeof(*batch->d_srcs)));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_dsts, n * sizeof(*batch->d_dsts)));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_sizes, n * sizeof(*batch->d_sizes)));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_caps, n * sizeof(*batch->d_caps)));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_results, n * sizeof(*batch->d_results)));
-    REQUIRE_CUDA(cudaMemcpy(batch->d_srcs, h_srcs.data(),
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&batch->d_srcs, n * sizeof(*batch->d_srcs)));
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&batch->d_dsts, n * sizeof(*batch->d_dsts)));
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&batch->d_sizes, n * sizeof(*batch->d_sizes)));
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&batch->d_caps, n * sizeof(*batch->d_caps)));
+    REQUIRE_RT(cudec_rt::device_malloc(&batch->d_results,
+                                       n * sizeof(*batch->d_results)));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_srcs, h_srcs.data(),
                             n * sizeof(*batch->d_srcs),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(batch->d_dsts, h_dsts.data(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_dsts, h_dsts.data(),
                             n * sizeof(*batch->d_dsts),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(batch->d_sizes, sizes.data(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_sizes, sizes.data(),
                             n * sizeof(*batch->d_sizes),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(batch->d_caps, caps.data(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_caps, caps.data(),
                             n * sizeof(*batch->d_caps),
-                            cudaMemcpyHostToDevice));
+                            cudec_rt::memcpy_h2d));
     return 0;
 }
 
@@ -142,9 +147,10 @@ int BuildBatch(const std::vector<Chunk>& chunks, Batch* batch) {
  * Without this a later run could "match" by inheriting the previous run's
  * bytes. */
 int ResetDeviceState(const Batch& b) {
-    REQUIRE_CUDA(cudaMemset(b.d_dst_arena, kDstPoison, b.dst_arena_size));
-    REQUIRE_CUDA(
-        cudaMemset(b.d_results, 0xFF, b.n * sizeof(*b.d_results)));
+    REQUIRE_RT(
+        cudec_rt::device_memset(b.d_dst_arena, kDstPoison, b.dst_arena_size));
+    REQUIRE_RT(
+        cudec_rt::device_memset(b.d_results, 0xFF, b.n * sizeof(*b.d_results)));
     return 0;
 }
 
@@ -152,11 +158,11 @@ int Download(const Batch& b, std::vector<unsigned char>* dst,
              std::vector<cudec_chunk_result>* results) {
     dst->assign(b.dst_arena_size, 0);
     results->assign(b.n, cudec_chunk_result{});
-    REQUIRE_CUDA(cudaMemcpy(dst->data(), b.d_dst_arena, b.dst_arena_size,
-                            cudaMemcpyDeviceToHost));
-    REQUIRE_CUDA(cudaMemcpy(results->data(), b.d_results,
+    REQUIRE_RT(cudec_rt::memcpy(dst->data(), b.d_dst_arena, b.dst_arena_size,
+                            cudec_rt::memcpy_d2h));
+    REQUIRE_RT(cudec_rt::memcpy(results->data(), b.d_results,
                             b.n * sizeof(*b.d_results),
-                            cudaMemcpyDeviceToHost));
+                            cudec_rt::memcpy_d2h));
     return 0;
 }
 
@@ -191,10 +197,12 @@ std::vector<Geometry> Geometries(size_t chunk_count) {
 using BatchEntry = cudec_status (*)(const void* const*, const size_t*,
                                     void* const*, const size_t*, size_t,
                                     cudec_chunk_result*, cudec_stream_t);
-using DirectLaunch = void (*)(const Batch&, const Geometry&, cudaStream_t);
+using DirectLaunch = void (*)(const Batch&, const Geometry&,
+                              cudec_rt::stream_t);
 
 template <class Parser>
-void LaunchDirect(const Batch& b, const Geometry& g, cudaStream_t stream) {
+void LaunchDirect(const Batch& b, const Geometry& g,
+                  cudec_rt::stream_t stream) {
     cudec_detail::chunk_decode_batch<Parser, false,
                                     cudec_detail::kCudaWaveSize>
         <<<g.blocks, g.threads, 0, stream>>>(b.d_srcs, b.d_sizes, b.d_dsts,
@@ -209,24 +217,24 @@ struct Format {
 
 int RunDirect(const Format& f, const Batch& b, const Geometry& g) {
     REQUIRE(ResetDeviceState(b) == 0);
-    cudaStream_t stream;
-    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    cudec_rt::stream_t stream;
+    REQUIRE_RT(cudec_rt::stream_create(&stream));
     f.launch(b, g, stream);
-    REQUIRE_CUDA(cudaGetLastError());
-    REQUIRE_CUDA(cudaStreamSynchronize(stream));
-    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    REQUIRE_RT(cudec_rt::get_last_error());
+    REQUIRE_RT(cudec_rt::stream_synchronize(stream));
+    REQUIRE_RT(cudec_rt::stream_destroy(stream));
     return 0;
 }
 
 /* The shipped entry point, once over the whole batch. */
 int RunShippedEntry(const Format& f, const Batch& b) {
     REQUIRE(ResetDeviceState(b) == 0);
-    cudaStream_t stream;
-    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    cudec_rt::stream_t stream;
+    REQUIRE_RT(cudec_rt::stream_create(&stream));
     REQUIRE(f.entry(b.d_srcs, b.d_sizes, b.d_dsts, b.d_caps, b.n, b.d_results,
                     stream) == CUDEC_OK);
-    REQUIRE_CUDA(cudaStreamSynchronize(stream));
-    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    REQUIRE_RT(cudec_rt::stream_synchronize(stream));
+    REQUIRE_RT(cudec_rt::stream_destroy(stream));
     return 0;
 }
 
@@ -236,9 +244,9 @@ int RunShippedEntry(const Format& f, const Batch& b) {
  * control. Per-chunk independence means the output must not notice. */
 int RunSplitStreams(const Format& f, const Batch& b, unsigned stream_count) {
     REQUIRE(ResetDeviceState(b) == 0);
-    std::vector<cudaStream_t> streams(stream_count);
+    std::vector<cudec_rt::stream_t> streams(stream_count);
     for (unsigned s = 0; s < stream_count; s++) {
-        REQUIRE_CUDA(cudaStreamCreate(&streams[s]));
+        REQUIRE_RT(cudec_rt::stream_create(&streams[s]));
     }
     const size_t per = (b.n + stream_count - 1) / stream_count;
     for (unsigned s = 0; s < stream_count; s++) {
@@ -254,8 +262,8 @@ int RunSplitStreams(const Format& f, const Batch& b, unsigned stream_count) {
                         b.d_results + begin, streams[s]) == CUDEC_OK);
     }
     for (unsigned s = 0; s < stream_count; s++) {
-        REQUIRE_CUDA(cudaStreamSynchronize(streams[s]));
-        REQUIRE_CUDA(cudaStreamDestroy(streams[s]));
+        REQUIRE_RT(cudec_rt::stream_synchronize(streams[s]));
+        REQUIRE_RT(cudec_rt::stream_destroy(streams[s]));
     }
     return 0;
 }

--- a/tests/gpu_fixture.cu
+++ b/tests/gpu_fixture.cu
@@ -18,7 +18,7 @@
 #include "fixtures.h"
 #include "require.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt_test.h"
 
 #include <cstdio>
 #include <fstream>
@@ -51,20 +51,21 @@ int UploadBatchTables(size_t n, const std::vector<const void*>& h_srcs,
                       const std::vector<size_t>& h_caps,
                       const void*** d_srcs, void*** d_dsts, size_t** d_sizes,
                       size_t** d_caps, cudec_chunk_result** d_results) {
-    REQUIRE_CUDA(cudaMalloc(d_srcs, n * sizeof(**d_srcs)));
-    REQUIRE_CUDA(cudaMalloc(d_dsts, n * sizeof(**d_dsts)));
-    REQUIRE_CUDA(cudaMalloc(d_sizes, n * sizeof(**d_sizes)));
-    REQUIRE_CUDA(cudaMalloc(d_caps, n * sizeof(**d_caps)));
-    REQUIRE_CUDA(cudaMalloc(d_results, n * sizeof(**d_results)));
-    REQUIRE_CUDA(cudaMemcpy(*d_srcs, h_srcs.data(), n * sizeof(**d_srcs),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(*d_dsts, h_dsts.data(), n * sizeof(**d_dsts),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(*d_sizes, h_sizes.data(), n * sizeof(**d_sizes),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(*d_caps, h_caps.data(), n * sizeof(**d_caps),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemset(*d_results, 0xFF, n * sizeof(**d_results)));
+    REQUIRE_RT(cudec_rt::device_malloc(d_srcs, n * sizeof(**d_srcs)));
+    REQUIRE_RT(cudec_rt::device_malloc(d_dsts, n * sizeof(**d_dsts)));
+    REQUIRE_RT(cudec_rt::device_malloc(d_sizes, n * sizeof(**d_sizes)));
+    REQUIRE_RT(cudec_rt::device_malloc(d_caps, n * sizeof(**d_caps)));
+    REQUIRE_RT(cudec_rt::device_malloc(d_results, n * sizeof(**d_results)));
+    REQUIRE_RT(cudec_rt::memcpy(*d_srcs, h_srcs.data(), n * sizeof(**d_srcs),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(*d_dsts, h_dsts.data(), n * sizeof(**d_dsts),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(*d_sizes, h_sizes.data(), n * sizeof(**d_sizes),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(*d_caps, h_caps.data(), n * sizeof(**d_caps),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(
+        cudec_rt::device_memset(*d_results, 0xFF, n * sizeof(**d_results)));
     return 0;
 }
 
@@ -90,13 +91,14 @@ int RunBatch(const std::vector<Chunk>& chunks, BatchEntry entry,
         void* d_src = nullptr;
         void* d_dst = nullptr;
         const size_t src_size = chunks[i].src->size();
-        REQUIRE_CUDA(cudaMalloc(&d_src, src_size ? src_size : 1));
+        REQUIRE_RT(cudec_rt::device_malloc(&d_src, src_size ? src_size : 1));
         if (src_size) {
-            REQUIRE_CUDA(cudaMemcpy(d_src, chunks[i].src->data(), src_size,
-                                    cudaMemcpyHostToDevice));
+            REQUIRE_RT(cudec_rt::memcpy(d_src, chunks[i].src->data(), src_size,
+                                    cudec_rt::memcpy_h2d));
         }
-        REQUIRE_CUDA(cudaMalloc(&d_dst, chunks[i].dst_capacity));
-        REQUIRE_CUDA(cudaMemset(d_dst, kDstPoison, chunks[i].dst_capacity));
+        REQUIRE_RT(cudec_rt::device_malloc(&d_dst, chunks[i].dst_capacity));
+        REQUIRE_RT(
+            cudec_rt::device_memset(d_dst, kDstPoison, chunks[i].dst_capacity));
         h_srcs[i] = d_src;
         h_dsts[i] = d_dst;
         h_sizes[i] = src_size;
@@ -111,21 +113,22 @@ int RunBatch(const std::vector<Chunk>& chunks, BatchEntry entry,
     REQUIRE(UploadBatchTables(n, h_srcs, h_dsts, h_sizes, h_caps, &d_srcs,
                               &d_dsts, &d_sizes, &d_caps, &d_results) == 0);
 
-    cudaStream_t stream;
-    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    cudec_rt::stream_t stream;
+    REQUIRE_RT(cudec_rt::stream_create(&stream));
     REQUIRE(entry(d_srcs, d_sizes, d_dsts, d_caps, n, d_results, stream) ==
             CUDEC_OK);
-    REQUIRE_CUDA(cudaStreamSynchronize(stream));
-    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    REQUIRE_RT(cudec_rt::stream_synchronize(stream));
+    REQUIRE_RT(cudec_rt::stream_destroy(stream));
 
     results->assign(n, cudec_chunk_result{});
-    REQUIRE_CUDA(cudaMemcpy(results->data(), d_results,
-                            n * sizeof(*d_results), cudaMemcpyDeviceToHost));
+    REQUIRE_RT(cudec_rt::memcpy(results->data(), d_results,
+                            n * sizeof(*d_results), cudec_rt::memcpy_d2h));
     dst_bytes->assign(n, {});
     for (size_t i = 0; i < n; i++) {
         (*dst_bytes)[i].assign(h_caps[i], 0);
-        REQUIRE_CUDA(cudaMemcpy((*dst_bytes)[i].data(), h_dsts[i], h_caps[i],
-                                cudaMemcpyDeviceToHost));
+        REQUIRE_RT(cudec_rt::memcpy((*dst_bytes)[i].data(), h_dsts[i],
+                                    h_caps[i],
+                                cudec_rt::memcpy_d2h));
     }
     /* Process teardown reclaims the device allocations; the harness keeps
      * no device state across tests (RUN_SERIAL on the gpu label). */
@@ -266,9 +269,10 @@ int main() {
         const size_t wrap_n = 40000;
         unsigned char* d_src_one;
         unsigned char* d_dst_one;
-        REQUIRE_CUDA(cudaMalloc(&d_src_one, 1));
-        REQUIRE_CUDA(cudaMemset(d_src_one, 0, 1)); /* empty-block token */
-        REQUIRE_CUDA(cudaMalloc(&d_dst_one, 1));
+        REQUIRE_RT(cudec_rt::device_malloc(&d_src_one, 1));
+        /* empty-block token */
+        REQUIRE_RT(cudec_rt::device_memset(d_src_one, 0, 1));
+        REQUIRE_RT(cudec_rt::device_malloc(&d_dst_one, 1));
         std::vector<const void*> h_s(wrap_n, d_src_one);
         std::vector<void*> h_d(wrap_n, d_dst_one);
         std::vector<size_t> h_sz(wrap_n, 1);
@@ -282,10 +286,10 @@ int main() {
                                   &d_sz, &d_cp, &d_r) == 0);
         REQUIRE(cudec_lz4_decompress_batch(d_s, d_sz, d_d, d_cp, wrap_n, d_r,
                                            nullptr) == CUDEC_OK);
-        REQUIRE_CUDA(cudaDeviceSynchronize());
+        REQUIRE_RT(cudec_rt::device_synchronize());
         std::vector<cudec_chunk_result> wrap_res(wrap_n);
-        REQUIRE_CUDA(cudaMemcpy(wrap_res.data(), d_r, wrap_n * sizeof(*d_r),
-                                cudaMemcpyDeviceToHost));
+        REQUIRE_RT(cudec_rt::memcpy(wrap_res.data(), d_r, wrap_n * sizeof(*d_r),
+                                cudec_rt::memcpy_d2h));
         for (size_t i = 0; i < wrap_n; i++) {
             REQUIRE_CTX(wrap_res[i].status == CUDEC_OK, "wrap chunk %zu", i);
             REQUIRE_CTX(wrap_res[i].bytes_written == 0, "wrap chunk %zu", i);

--- a/tests/huge_match_gpu.cu
+++ b/tests/huge_match_gpu.cu
@@ -27,7 +27,7 @@
 #include "fixtures.h"
 #include "require.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt_test.h"
 
 #include <cstdint>
 #include <cstdio>
@@ -117,12 +117,12 @@ int main() {
     const std::vector<unsigned char> block = MakeBlock(match_len);
     const uint64_t dst_capacity = DecodedSize(match_len);
 
-    /* Refused, never skipped. cudaMemGetInfo is asked before anything is
+    /* Refused, never skipped. The free-memory query is asked before anything is
      * allocated so the message names the shortfall instead of an
      * out-of-memory return several calls later. */
     size_t free_bytes = 0;
     size_t total_bytes = 0;
-    REQUIRE_CUDA(cudaMemGetInfo(&free_bytes, &total_bytes));
+    REQUIRE_RT(cudec_rt::mem_get_info(&free_bytes, &total_bytes));
     const uint64_t needed = dst_capacity + block.size();
     REQUIRE_CTX(free_bytes >= needed,
                 "this test needs %llu bytes on the device and %zu are free "
@@ -132,39 +132,40 @@ int main() {
                 total_bytes);
 
     DeviceBatch b;
-    REQUIRE_CUDA(cudaMalloc(&b.src, block.size()));
-    REQUIRE_CUDA(cudaMalloc(&b.dst, static_cast<size_t>(dst_capacity)));
-    REQUIRE_CUDA(cudaMemcpy(b.src, block.data(), block.size(),
-                            cudaMemcpyHostToDevice));
+    REQUIRE_RT(cudec_rt::device_malloc(&b.src, block.size()));
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&b.dst, static_cast<size_t>(dst_capacity)));
+    REQUIRE_RT(cudec_rt::memcpy(b.src, block.data(), block.size(),
+                            cudec_rt::memcpy_h2d));
 
     const void* h_src_ptr = b.src;
     void* h_dst_ptr = b.dst;
     const size_t h_src_size = block.size();
     const size_t h_dst_cap = static_cast<size_t>(dst_capacity);
-    REQUIRE_CUDA(cudaMalloc(&b.src_ptrs, sizeof(h_src_ptr)));
-    REQUIRE_CUDA(cudaMalloc(&b.dst_ptrs, sizeof(h_dst_ptr)));
-    REQUIRE_CUDA(cudaMalloc(&b.src_sizes, sizeof(h_src_size)));
-    REQUIRE_CUDA(cudaMalloc(&b.dst_caps, sizeof(h_dst_cap)));
-    REQUIRE_CUDA(cudaMalloc(&b.results, sizeof(*b.results)));
-    REQUIRE_CUDA(cudaMemcpy(b.src_ptrs, &h_src_ptr, sizeof(h_src_ptr),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(b.dst_ptrs, &h_dst_ptr, sizeof(h_dst_ptr),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(b.src_sizes, &h_src_size, sizeof(h_src_size),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(b.dst_caps, &h_dst_cap, sizeof(h_dst_cap),
-                            cudaMemcpyHostToDevice));
+    REQUIRE_RT(cudec_rt::device_malloc(&b.src_ptrs, sizeof(h_src_ptr)));
+    REQUIRE_RT(cudec_rt::device_malloc(&b.dst_ptrs, sizeof(h_dst_ptr)));
+    REQUIRE_RT(cudec_rt::device_malloc(&b.src_sizes, sizeof(h_src_size)));
+    REQUIRE_RT(cudec_rt::device_malloc(&b.dst_caps, sizeof(h_dst_cap)));
+    REQUIRE_RT(cudec_rt::device_malloc(&b.results, sizeof(*b.results)));
+    REQUIRE_RT(cudec_rt::memcpy(b.src_ptrs, &h_src_ptr, sizeof(h_src_ptr),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(b.dst_ptrs, &h_dst_ptr, sizeof(h_dst_ptr),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(b.src_sizes, &h_src_size, sizeof(h_src_size),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(b.dst_caps, &h_dst_cap, sizeof(h_dst_cap),
+                            cudec_rt::memcpy_h2d));
 
-    cudaStream_t stream;
-    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    cudec_rt::stream_t stream;
+    REQUIRE_RT(cudec_rt::stream_create(&stream));
     REQUIRE(cudec_lz4_decompress_batch(b.src_ptrs, b.src_sizes, b.dst_ptrs,
                                        b.dst_caps, 1, b.results,
                                        stream) == CUDEC_OK);
-    REQUIRE_CUDA(cudaStreamSynchronize(stream));
+    REQUIRE_RT(cudec_rt::stream_synchronize(stream));
 
     cudec_chunk_result result{};
-    REQUIRE_CUDA(cudaMemcpy(&result, b.results, sizeof(result),
-                            cudaMemcpyDeviceToHost));
+    REQUIRE_RT(cudec_rt::memcpy(&result, b.results, sizeof(result),
+                            cudec_rt::memcpy_d2h));
     REQUIRE_CTX(result.status == CUDEC_OK, "chunk status %d", result.status);
     REQUIRE_CTX(result.bytes_written == dst_capacity,
                 "bytes_written %llu, expected %llu",
@@ -176,8 +177,8 @@ int main() {
     const uint64_t window_begin = (uint64_t{1} << 32) - 29;
     const size_t window_bytes = 64;
     unsigned char window[window_bytes];
-    REQUIRE_CUDA(cudaMemcpy(window, b.dst + window_begin, window_bytes,
-                            cudaMemcpyDeviceToHost));
+    REQUIRE_RT(cudec_rt::memcpy(window, b.dst + window_begin, window_bytes,
+                            cudec_rt::memcpy_d2h));
     size_t differing = 0;
     for (size_t i = 0; i < window_bytes; i++) {
         if (window[i] != ExpectedByte(match_len, window_begin + i)) {
@@ -194,10 +195,10 @@ int main() {
      * nothing at all cannot pass. */
     unsigned char head[16];
     unsigned char tail[16];
-    REQUIRE_CUDA(
-        cudaMemcpy(head, b.dst, sizeof(head), cudaMemcpyDeviceToHost));
-    REQUIRE_CUDA(cudaMemcpy(tail, b.dst + dst_capacity - sizeof(tail),
-                            sizeof(tail), cudaMemcpyDeviceToHost));
+    REQUIRE_RT(
+        cudec_rt::memcpy(head, b.dst, sizeof(head), cudec_rt::memcpy_d2h));
+    REQUIRE_RT(cudec_rt::memcpy(tail, b.dst + dst_capacity - sizeof(tail),
+                            sizeof(tail), cudec_rt::memcpy_d2h));
     for (size_t i = 0; i < sizeof(head); i++) {
         REQUIRE_CTX(head[i] == ExpectedByte(match_len, i),
                     "head byte %zu is 0x%02X, expected 0x%02X", i, head[i],
@@ -211,14 +212,14 @@ int main() {
                     ExpectedByte(match_len, at));
     }
 
-    REQUIRE_CUDA(cudaStreamDestroy(stream));
-    REQUIRE_CUDA(cudaFree(b.results));
-    REQUIRE_CUDA(cudaFree(b.dst_caps));
-    REQUIRE_CUDA(cudaFree(b.src_sizes));
-    REQUIRE_CUDA(cudaFree(b.dst_ptrs));
-    REQUIRE_CUDA(cudaFree(b.src_ptrs));
-    REQUIRE_CUDA(cudaFree(b.dst));
-    REQUIRE_CUDA(cudaFree(b.src));
+    REQUIRE_RT(cudec_rt::stream_destroy(stream));
+    REQUIRE_RT(cudec_rt::device_free(b.results));
+    REQUIRE_RT(cudec_rt::device_free(b.dst_caps));
+    REQUIRE_RT(cudec_rt::device_free(b.src_sizes));
+    REQUIRE_RT(cudec_rt::device_free(b.dst_ptrs));
+    REQUIRE_RT(cudec_rt::device_free(b.src_ptrs));
+    REQUIRE_RT(cudec_rt::device_free(b.dst));
+    REQUIRE_RT(cudec_rt::device_free(b.src));
 
     std::printf(
         "PASS: 2^32 + 4096 byte match at offset 3 decodes bit-exact across "

--- a/tests/require.h
+++ b/tests/require.h
@@ -30,7 +30,12 @@
         }                                                                  \
     } while (0)
 
-#define REQUIRE_CUDA(call) REQUIRE((call) == cudaSuccess)
+/* A device-runtime call that must succeed. The comparison goes through
+ * the vendor seam rather than through a backend constant, so a test
+ * asserting on the runtime is one source for both backends (issue #243);
+ * the macro body is only expanded where a test uses it, so the host-only
+ * tests that include this header still pull in no runtime. */
+#define REQUIRE_RT(call) REQUIRE((call) == cudec_rt::success)
 
 /* Byte-diff for the buffer-shaped assertion domain: reports the first
  * mismatch offset plus a small hex window instead of a bare boolean. */

--- a/tests/smoke.cu
+++ b/tests/smoke.cu
@@ -5,7 +5,7 @@
 #include "cudec.h"
 #include "require.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt_test.h"
 
 #include <cstdio>
 
@@ -39,9 +39,10 @@ int main() {
      * batch exercises a real successful decode end to end at the ABI
      * boundary; the fixture test covers content-bearing streams. */
     for (size_t i = 0; i < chunk_count; i++) {
-        REQUIRE_CUDA(cudaMalloc(&buffers[i], chunk_bytes));
-        REQUIRE_CUDA(cudaMemset(buffers[i], 0, 1));
-        REQUIRE_CUDA(cudaMalloc(&buffers[chunk_count + i], chunk_bytes));
+        REQUIRE_RT(cudec_rt::device_malloc(&buffers[i], chunk_bytes));
+        REQUIRE_RT(cudec_rt::device_memset(buffers[i], 0, 1));
+        REQUIRE_RT(
+            cudec_rt::device_malloc(&buffers[chunk_count + i], chunk_bytes));
         h_src_ptrs[i] = buffers[i];
         h_dst_ptrs[i] = buffers[chunk_count + i];
         h_sizes[i] = 1;
@@ -52,24 +53,25 @@ int main() {
     size_t* d_src_sizes;
     size_t* d_dst_caps;
     cudec_chunk_result* d_results;
-    REQUIRE_CUDA(cudaMalloc(&d_src_ptrs, sizeof(h_src_ptrs)));
-    REQUIRE_CUDA(cudaMalloc(&d_dst_ptrs, sizeof(h_dst_ptrs)));
-    REQUIRE_CUDA(cudaMalloc(&d_src_sizes, sizeof(h_sizes)));
-    REQUIRE_CUDA(cudaMalloc(&d_dst_caps, sizeof(h_sizes)));
-    REQUIRE_CUDA(cudaMalloc(&d_results, chunk_count * sizeof(*d_results)));
-    REQUIRE_CUDA(cudaMemcpy(d_src_ptrs, h_src_ptrs, sizeof(h_src_ptrs),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_dst_ptrs, h_dst_ptrs, sizeof(h_dst_ptrs),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_src_sizes, h_sizes, sizeof(h_sizes),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_dst_caps, h_sizes, sizeof(h_sizes),
-                            cudaMemcpyHostToDevice));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_src_ptrs, sizeof(h_src_ptrs)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_dst_ptrs, sizeof(h_dst_ptrs)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_src_sizes, sizeof(h_sizes)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_dst_caps, sizeof(h_sizes)));
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&d_results, chunk_count * sizeof(*d_results)));
+    REQUIRE_RT(cudec_rt::memcpy(d_src_ptrs, h_src_ptrs, sizeof(h_src_ptrs),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_dst_ptrs, h_dst_ptrs, sizeof(h_dst_ptrs),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_src_sizes, h_sizes, sizeof(h_sizes),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_dst_caps, h_sizes, sizeof(h_sizes),
+                            cudec_rt::memcpy_h2d));
 
-    /* cudaStream_t converts to cudec_stream_t with no cast: the public
+    /* cudec_rt::stream_t converts to cudec_stream_t with no cast: the public
      * header's stream type is verified binary-compatible right here. */
-    cudaStream_t stream;
-    REQUIRE_CUDA(cudaStreamCreate(&stream));
+    cudec_rt::stream_t stream;
+    REQUIRE_RT(cudec_rt::stream_create(&stream));
     cudec_stream_t api_stream = stream;
 
     /* Every reject path, one at a time, so dropping any single validation
@@ -103,13 +105,14 @@ int main() {
     /* Poison the result buffer so the per-field checks below prove the
      * kernel wrote every field, not that the allocation happened to be
      * zero-filled. */
-    REQUIRE_CUDA(cudaMemset(d_results, 0xFF, chunk_count * sizeof(*d_results)));
+    REQUIRE_RT(cudec_rt::device_memset(d_results, 0xFF,
+                                       chunk_count * sizeof(*d_results)));
 
     /* A stale caller-side error must not be misreported as this call's
      * failure: plant one, verify it is actually pending, then expect a
      * clean submission. */
-    REQUIRE(cudaSetDevice(12345) != cudaSuccess);
-    REQUIRE(cudaPeekAtLastError() != cudaSuccess);
+    REQUIRE(cudec_rt::set_device(12345) != cudec_rt::success);
+    REQUIRE(cudec_rt::peek_at_last_error() != cudec_rt::success);
 
     /* A rejected call makes no CUDA call, so the planted error must still
      * be pending afterwards - only the passing call below consumes it. */
@@ -117,23 +120,23 @@ int main() {
                                        d_dst_caps, 0, d_results,
                                        api_stream) ==
             CUDEC_ERR_INVALID_ARGUMENT);
-    REQUIRE(cudaPeekAtLastError() != cudaSuccess);
+    REQUIRE(cudec_rt::peek_at_last_error() != cudec_rt::success);
 
     REQUIRE(cudec_lz4_decompress_batch(d_src_ptrs, d_src_sizes, d_dst_ptrs,
                                        d_dst_caps, chunk_count, d_results,
                                        api_stream) == CUDEC_OK);
-    REQUIRE_CUDA(cudaStreamSynchronize(stream));
+    REQUIRE_RT(cudec_rt::stream_synchronize(stream));
 
     cudec_chunk_result h_results[chunk_count];
-    REQUIRE_CUDA(cudaMemcpy(h_results, d_results, sizeof(h_results),
-                            cudaMemcpyDeviceToHost));
+    REQUIRE_RT(cudec_rt::memcpy(h_results, d_results, sizeof(h_results),
+                            cudec_rt::memcpy_d2h));
     for (size_t i = 0; i < chunk_count; i++) {
         REQUIRE(h_results[i].status == CUDEC_OK);
         REQUIRE(h_results[i].reserved == 0);
         REQUIRE(h_results[i].bytes_written == 0);
     }
 
-    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    REQUIRE_RT(cudec_rt::stream_destroy(stream));
     std::printf("PASS: version + fail-closed validation + %zu-chunk "
                 "empty-block decode on device\n",
                 chunk_count);

--- a/tests/snappy_block_device.cu
+++ b/tests/snappy_block_device.cu
@@ -25,7 +25,7 @@
 #include "require.h"
 #include "snappy_block.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt_test.h"
 
 #include <cstdio>
 #include <cstring>
@@ -142,34 +142,37 @@ int main() {
     unsigned long long* d_sizes = nullptr;
     unsigned long long* d_caps = nullptr;
     Trace* d_traces = nullptr;
-    REQUIRE_CUDA(cudaMalloc(&d_streams, flat.size()));
-    REQUIRE_CUDA(cudaMalloc(&d_offsets, offsets.size() * sizeof(*d_offsets)));
-    REQUIRE_CUDA(cudaMalloc(&d_sizes, sizes.size() * sizeof(*d_sizes)));
-    REQUIRE_CUDA(cudaMalloc(&d_caps, caps.size() * sizeof(*d_caps)));
-    REQUIRE_CUDA(cudaMalloc(&d_traces, count * sizeof(*d_traces)));
-    REQUIRE_CUDA(cudaMemcpy(d_streams, flat.data(), flat.size(),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_offsets, offsets.data(),
+    REQUIRE_RT(cudec_rt::device_malloc(&d_streams, flat.size()));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_offsets,
+                                       offsets.size() * sizeof(*d_offsets)));
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&d_sizes, sizes.size() * sizeof(*d_sizes)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_caps, caps.size() * sizeof(*d_caps)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_traces, count * sizeof(*d_traces)));
+    REQUIRE_RT(cudec_rt::memcpy(d_streams, flat.data(), flat.size(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_offsets, offsets.data(),
                             offsets.size() * sizeof(*d_offsets),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_sizes, sizes.data(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_sizes, sizes.data(),
                             sizes.size() * sizeof(*d_sizes),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_caps, caps.data(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_caps, caps.data(),
                             caps.size() * sizeof(*d_caps),
-                            cudaMemcpyHostToDevice));
+                            cudec_rt::memcpy_h2d));
     /* Poisoned, so a trace the kernel never wrote cannot pass as a match. */
-    REQUIRE_CUDA(cudaMemset(d_traces, 0xFF, count * sizeof(*d_traces)));
+    REQUIRE_RT(
+        cudec_rt::device_memset(d_traces, 0xFF, count * sizeof(*d_traces)));
 
     ParseOnDevice<<<(count + kThreadsPerBlock - 1) / kThreadsPerBlock,
                     kThreadsPerBlock>>>(d_streams, d_offsets, d_sizes,
                                         d_caps, count, d_traces);
-    REQUIRE_CUDA(cudaGetLastError());
-    REQUIRE_CUDA(cudaDeviceSynchronize());
+    REQUIRE_RT(cudec_rt::get_last_error());
+    REQUIRE_RT(cudec_rt::device_synchronize());
 
     std::vector<Trace> device_traces(count);
-    REQUIRE_CUDA(cudaMemcpy(device_traces.data(), d_traces,
-                            count * sizeof(Trace), cudaMemcpyDeviceToHost));
+    REQUIRE_RT(cudec_rt::memcpy(device_traces.data(), d_traces,
+                            count * sizeof(Trace), cudec_rt::memcpy_d2h));
 
     size_t accepted = 0;
     for (unsigned i = 0; i < count; i++) {
@@ -203,11 +206,11 @@ int main() {
     REQUIRE(accepted > 0);
     REQUIRE(accepted < count);
 
-    REQUIRE_CUDA(cudaFree(d_streams));
-    REQUIRE_CUDA(cudaFree(d_offsets));
-    REQUIRE_CUDA(cudaFree(d_sizes));
-    REQUIRE_CUDA(cudaFree(d_caps));
-    REQUIRE_CUDA(cudaFree(d_traces));
+    REQUIRE_RT(cudec_rt::device_free(d_streams));
+    REQUIRE_RT(cudec_rt::device_free(d_offsets));
+    REQUIRE_RT(cudec_rt::device_free(d_sizes));
+    REQUIRE_RT(cudec_rt::device_free(d_caps));
+    REQUIRE_RT(cudec_rt::device_free(d_traces));
 
     std::printf("PASS: %u streams parsed identically by the host compiler and "
                 "nvcc from one header (%zu accepted, %zu rejected)\n",

--- a/tests/stream_twin.cu
+++ b/tests/stream_twin.cu
@@ -15,7 +15,7 @@
 #include "fixtures.h"
 #include "require.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt_test.h"
 
 #include <cstdio>
 #include <cstring>
@@ -60,9 +60,10 @@ int RunStreamCtx(cudec_stream_ctx* ctx, const std::vector<SChunk>& chunks,
             h_dst[i] = host_dst[i].data();
         } else {
             void* d = nullptr;
-            REQUIRE_CUDA(cudaMalloc(&d, chunks[i].cap ? chunks[i].cap : 1));
+            REQUIRE_RT(
+                cudec_rt::device_malloc(&d, chunks[i].cap ? chunks[i].cap : 1));
             if (chunks[i].cap) {
-                REQUIRE_CUDA(cudaMemset(d, kPoison, chunks[i].cap));
+                REQUIRE_RT(cudec_rt::device_memset(d, kPoison, chunks[i].cap));
             }
             h_dst[i] = d;
         }
@@ -83,8 +84,8 @@ int RunStreamCtx(cudec_stream_ctx* ctx, const std::vector<SChunk>& chunks,
             std::memcpy((*dst_bytes)[i].data(), host_dst[i].data(),
                         chunks[i].cap);
         } else {
-            REQUIRE_CUDA(cudaMemcpy((*dst_bytes)[i].data(), h_dst[i],
-                                    chunks[i].cap, cudaMemcpyDeviceToHost));
+            REQUIRE_RT(cudec_rt::memcpy((*dst_bytes)[i].data(), h_dst[i],
+                                    chunks[i].cap, cudec_rt::memcpy_d2h));
         }
     }
     return 0;
@@ -391,7 +392,8 @@ int main() {
 
     /* Poison path: a decode forced to a DEFINED CUDA fault poisons the context.
      * An impossibly large device staging (an oversized dst capacity for the
-     * host-output path) fails its cudaMalloc with a defined error BEFORE any
+     * host-output path) fails its device allocation with a defined error
+     * BEFORE any
      * staging copy runs - the grow precedes the wave loop, so the huge capacity
      * is never dereferenced (no undefined behavior). The next decode returns
      * CUDEC_ERR_CUDA; destroy still frees. */
@@ -461,8 +463,8 @@ int main() {
         constexpr unsigned char kStage = 0x5C;
 
         unsigned char* d_stage = nullptr;
-        REQUIRE_CUDA(cudaMalloc(&d_stage, kCap + kSlack));
-        REQUIRE_CUDA(cudaMemset(d_stage, kStage, kCap + kSlack));
+        REQUIRE_RT(cudec_rt::device_malloc(&d_stage, kCap + kSlack));
+        REQUIRE_RT(cudec_rt::device_memset(d_stage, kStage, kCap + kSlack));
 
         std::vector<unsigned char> host(kCap + kSlack, kPoison);
         void* dsts[1] = {host.data()};
@@ -517,7 +519,7 @@ int main() {
         for (size_t j = 16; j < host.size(); j++) {
             REQUIRE_CTX(host[j] == kPoison, "short bw wrote past bw at %zu", j);
         }
-        REQUIRE_CUDA(cudaFree(d_stage));
+        REQUIRE_RT(cudec_rt::device_free(d_stage));
     }
 
     std::printf("PASS: reused-context decode bit-identical to fresh across "

--- a/tests/termination_gpu.cu
+++ b/tests/termination_gpu.cu
@@ -6,7 +6,7 @@
  * does not return a bad status, it holds the launch - and with it every other
  * chunk in the batch and the stream behind it.
  *
- * A plain cudaStreamSynchronize would inherit exactly that hang and stall the
+ * A plain stream synchronise would inherit exactly that hang and stall the
  * suite, so the launch is fenced with an event and polled against a wall-clock
  * deadline: an expiry FAILS the test with a message instead of blocking. The
  * ctest TIMEOUT on this target is the second line of defence; the process exit
@@ -24,7 +24,7 @@
 #include "lz4_block.h"
 #include "require.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt_test.h"
 
 #include <chrono>
 #include <cstdint>
@@ -101,8 +101,8 @@ int BuildBatch(const std::vector<Chunk>& chunks, Batch* batch) {
 
     batch->n = n;
     batch->dst_arena_size = dst_total;
-    REQUIRE_CUDA(cudaMalloc(&batch->d_src_blob, src_total));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_dst_arena, dst_total));
+    REQUIRE_RT(cudec_rt::device_malloc(&batch->d_src_blob, src_total));
+    REQUIRE_RT(cudec_rt::device_malloc(&batch->d_dst_arena, dst_total));
     for (size_t i = 0; i < n; i++) {
         for (size_t k = 0; k < sizes[i]; k++) {
             src_blob[src_off[i] + k] = chunks[i].src[k];
@@ -111,55 +111,62 @@ int BuildBatch(const std::vector<Chunk>& chunks, Batch* batch) {
         h_srcs[i] = batch->d_src_blob + src_off[i];
         h_dsts[i] = batch->d_dst_arena + dst_off[i];
     }
-    REQUIRE_CUDA(cudaMemcpy(batch->d_src_blob, src_blob.data(), src_total,
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemset(batch->d_dst_arena, kDstPoison, dst_total));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_src_blob, src_blob.data(), src_total,
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(
+        cudec_rt::device_memset(batch->d_dst_arena, kDstPoison, dst_total));
 
-    REQUIRE_CUDA(cudaMalloc(&batch->d_srcs, n * sizeof(*batch->d_srcs)));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_dsts, n * sizeof(*batch->d_dsts)));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_sizes, n * sizeof(*batch->d_sizes)));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_caps, n * sizeof(*batch->d_caps)));
-    REQUIRE_CUDA(cudaMalloc(&batch->d_results, n * sizeof(*batch->d_results)));
-    REQUIRE_CUDA(cudaMemcpy(batch->d_srcs, h_srcs.data(),
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&batch->d_srcs, n * sizeof(*batch->d_srcs)));
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&batch->d_dsts, n * sizeof(*batch->d_dsts)));
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&batch->d_sizes, n * sizeof(*batch->d_sizes)));
+    REQUIRE_RT(
+        cudec_rt::device_malloc(&batch->d_caps, n * sizeof(*batch->d_caps)));
+    REQUIRE_RT(cudec_rt::device_malloc(&batch->d_results,
+                                       n * sizeof(*batch->d_results)));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_srcs, h_srcs.data(),
                             n * sizeof(*batch->d_srcs),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(batch->d_dsts, h_dsts.data(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_dsts, h_dsts.data(),
                             n * sizeof(*batch->d_dsts),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(batch->d_sizes, sizes.data(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_sizes, sizes.data(),
                             n * sizeof(*batch->d_sizes),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(batch->d_caps, caps.data(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(batch->d_caps, caps.data(),
                             n * sizeof(*batch->d_caps),
-                            cudaMemcpyHostToDevice));
+                            cudec_rt::memcpy_h2d));
     /* The 0xFF sentinel is out of the status enum's range, so a chunk the
      * kernel never reached cannot be mistaken for a decoded one. */
-    REQUIRE_CUDA(
-        cudaMemset(batch->d_results, 0xFF, n * sizeof(*batch->d_results)));
+    REQUIRE_RT(
+        cudec_rt::device_memset(batch->d_results, 0xFF,
+                                n * sizeof(*batch->d_results)));
     return 0;
 }
 
 /* Submits the batch and waits on an event, not on the stream: a launch that
  * does not finish must be REPORTED, never waited on. */
 int DecodeWithWatchdog(const Batch& b, size_t begin, size_t count) {
-    cudaStream_t stream;
-    cudaEvent_t finished;
-    REQUIRE_CUDA(cudaStreamCreate(&stream));
-    REQUIRE_CUDA(cudaEventCreateWithFlags(&finished, cudaEventDisableTiming));
+    cudec_rt::stream_t stream;
+    cudec_rt::event_t finished;
+    REQUIRE_RT(cudec_rt::stream_create(&stream));
+    REQUIRE_RT(cudec_rt::event_create_untimed(&finished));
     REQUIRE(cudec_lz4_decompress_batch(b.d_srcs + begin, b.d_sizes + begin,
                                        b.d_dsts + begin, b.d_caps + begin,
                                        count, b.d_results + begin,
                                        stream) == CUDEC_OK);
-    REQUIRE_CUDA(cudaEventRecord(finished, stream));
+    REQUIRE_RT(cudec_rt::event_record(finished, stream));
 
     const auto start = std::chrono::steady_clock::now();
     while (true) {
-        const cudaError_t query = cudaEventQuery(finished);
-        if (query == cudaSuccess) {
+        const cudec_rt::error_t query = cudec_rt::event_query(finished);
+        if (query == cudec_rt::success) {
             break;
         }
-        REQUIRE_CTX(query == cudaErrorNotReady, "cudaEventQuery failed: %s",
-                    cudaGetErrorString(query));
+        REQUIRE_CTX(query == cudec_rt::error_not_ready,
+                    "event query failed: %s", cudec_rt::error_string(query));
         const double elapsed =
             std::chrono::duration<double>(std::chrono::steady_clock::now() -
                                           start)
@@ -174,8 +181,8 @@ int DecodeWithWatchdog(const Batch& b, size_t begin, size_t count) {
                     begin, begin + count, kDeadlineSeconds);
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    REQUIRE_CUDA(cudaEventDestroy(finished));
-    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    REQUIRE_RT(cudec_rt::event_destroy(finished));
+    REQUIRE_RT(cudec_rt::stream_destroy(stream));
     return 0;
 }
 
@@ -201,24 +208,24 @@ struct UnsupportedGeometry {
 };
 
 int RequireGeometryRefused(const Batch& b, const UnsupportedGeometry& g) {
-    cudaStream_t stream;
-    cudaEvent_t finished;
-    REQUIRE_CUDA(cudaStreamCreate(&stream));
-    REQUIRE_CUDA(cudaEventCreateWithFlags(&finished, cudaEventDisableTiming));
+    cudec_rt::stream_t stream;
+    cudec_rt::event_t finished;
+    REQUIRE_RT(cudec_rt::stream_create(&stream));
+    REQUIRE_RT(cudec_rt::event_create_untimed(&finished));
     cudec_detail::chunk_decode_batch<cudec_detail::Lz4Parser, false,
                                     cudec_detail::kCudaWaveSize>
         <<<g.blocks, g.threads, 0, stream>>>(b.d_srcs, b.d_sizes, b.d_dsts,
                                              b.d_caps, b.n, b.d_results);
-    REQUIRE_CUDA(cudaGetLastError());
-    REQUIRE_CUDA(cudaEventRecord(finished, stream));
+    REQUIRE_RT(cudec_rt::get_last_error());
+    REQUIRE_RT(cudec_rt::event_record(finished, stream));
     const auto start = std::chrono::steady_clock::now();
     while (true) {
-        const cudaError_t query = cudaEventQuery(finished);
-        if (query == cudaSuccess) {
+        const cudec_rt::error_t query = cudec_rt::event_query(finished);
+        if (query == cudec_rt::success) {
             break;
         }
-        REQUIRE_CTX(query == cudaErrorNotReady, "cudaEventQuery failed: %s",
-                    cudaGetErrorString(query));
+        REQUIRE_CTX(query == cudec_rt::error_not_ready,
+                    "event query failed: %s", cudec_rt::error_string(query));
         const double elapsed =
             std::chrono::duration<double>(std::chrono::steady_clock::now() -
                                           start)
@@ -229,17 +236,17 @@ int RequireGeometryRefused(const Batch& b, const UnsupportedGeometry& g) {
                     g.name, kDeadlineSeconds);
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    REQUIRE_CUDA(cudaEventDestroy(finished));
-    REQUIRE_CUDA(cudaStreamDestroy(stream));
+    REQUIRE_RT(cudec_rt::event_destroy(finished));
+    REQUIRE_RT(cudec_rt::stream_destroy(stream));
 
     /* Refused means refused: every result record still carries the 0xFF
      * sentinel BuildBatch primed, and every destination byte is still poison.
      * Without this the test would pass on a kernel that decoded half of each
      * chunk and returned. */
     std::vector<cudec_chunk_result> results(b.n);
-    REQUIRE_CUDA(cudaMemcpy(results.data(), b.d_results,
+    REQUIRE_RT(cudec_rt::memcpy(results.data(), b.d_results,
                             b.n * sizeof(*b.d_results),
-                            cudaMemcpyDeviceToHost));
+                            cudec_rt::memcpy_d2h));
     for (size_t i = 0; i < b.n; i++) {
         REQUIRE_CTX(results[i].status == -1 && results[i].reserved == 0xFFFFFFFFu &&
                         results[i].bytes_written == UINT64_MAX,
@@ -248,8 +255,8 @@ int RequireGeometryRefused(const Batch& b, const UnsupportedGeometry& g) {
                     g.name, i, b.names[i].c_str());
     }
     std::vector<unsigned char> arena(b.dst_arena_size, 0);
-    REQUIRE_CUDA(cudaMemcpy(arena.data(), b.d_dst_arena, b.dst_arena_size,
-                            cudaMemcpyDeviceToHost));
+    REQUIRE_RT(cudec_rt::memcpy(arena.data(), b.d_dst_arena, b.dst_arena_size,
+                            cudec_rt::memcpy_d2h));
     for (size_t i = 0; i < arena.size(); i++) {
         REQUIRE_CTX(arena[i] == kDstPoison,
                     "%s: destination byte %zu was written by a geometry the "
@@ -261,9 +268,9 @@ int RequireGeometryRefused(const Batch& b, const UnsupportedGeometry& g) {
 
 int CheckResults(const Batch& b) {
     std::vector<cudec_chunk_result> results(b.n);
-    REQUIRE_CUDA(cudaMemcpy(results.data(), b.d_results,
+    REQUIRE_RT(cudec_rt::memcpy(results.data(), b.d_results,
                             b.n * sizeof(*b.d_results),
-                            cudaMemcpyDeviceToHost));
+                            cudec_rt::memcpy_d2h));
     size_t rejected = 0;
     for (size_t i = 0; i < b.n; i++) {
         const cudec_chunk_result& r = results[i];

--- a/tests/vendor_rt_test.h
+++ b/tests/vendor_rt_test.h
@@ -1,0 +1,128 @@
+/* The harness's half of the vendor seam: the ONE file under tests/ that names
+ * a backend runtime, and the counterpart of src/vendor_rt.h (issue #240).
+ *
+ * WHY THE HARNESS NEEDS A SECOND TABLE AND NOT A WIDER FIRST ONE. The
+ * validation ladder drives the device itself - it allocates, poisons, copies
+ * back and asks the driver questions the library never asks - so it reaches
+ * for operations the shipped code has no caller for: a device memset, a
+ * default-flags stream, a planted device error, the free-memory query, an
+ * event created with timing off, and a kernel's own attributes. Putting those
+ * into src/vendor_rt.h would grow the internal library header with surface
+ * nothing in src/ calls, and the src/-only rule that keeps every other file
+ * under src/ off the runtime would then be guarding a table half of which
+ * exists for the tests. So the seam is split by who calls it: this file adds
+ * what only a test needs, includes src/vendor_rt.h rather than restating one
+ * line of it, and is the single exemption of the tests/-side rule that
+ * mirrors #240's (issue #243).
+ *
+ * WHAT THIS FILE DOES NOT CLAIM. No hipcc has compiled the HIP arm below, for
+ * the same reason src/vendor_rt.h states about its own: no ROCm toolchain
+ * exists on the machine this landed from. The two arms are proven CONSISTENT
+ * - the configure-time rule in tests/CMakeLists.txt reds when one arm carries
+ * an entry the other does not - and are NOT proven CORRECT. Issue #210 is the
+ * route to the compiler that would decide it.
+ *
+ * INTERNAL to the test harness; nothing here is part of the public C ABI. */
+#ifndef CUDEC_TESTS_VENDOR_RT_TEST_H
+#define CUDEC_TESTS_VENDOR_RT_TEST_H
+
+#include "vendor_rt.h"
+
+/* The same two-column shape as src/vendor_rt.h, and for the same reason: what
+ * the port owes is the length of the table, a reader compares the columns by
+ * eye, and the configure-time rule reds a column that grew alone. */
+#if defined(__HIP_PLATFORM_AMD__)
+
+#define CUDEC_RT_MEMSET hipMemset
+#define CUDEC_RT_STREAM_CREATE hipStreamCreate
+#define CUDEC_RT_SET_DEVICE hipSetDevice
+#define CUDEC_RT_PEEK_AT_LAST_ERROR hipPeekAtLastError
+#define CUDEC_RT_MEM_GET_INFO hipMemGetInfo
+#define CUDEC_RT_EVENT_CREATE_WITH_FLAGS hipEventCreateWithFlags
+#define CUDEC_RT_EVENT_DISABLE_TIMING hipEventDisableTiming
+#define CUDEC_RT_EVENT_QUERY hipEventQuery
+#define CUDEC_RT_ERROR_NOT_READY hipErrorNotReady
+#define CUDEC_RT_GET_ERROR_STRING hipGetErrorString
+#define CUDEC_RT_FUNC_ATTRIBUTES_T hipFuncAttributes
+#define CUDEC_RT_FUNC_GET_ATTRIBUTES hipFuncGetAttributes
+
+#else
+
+#define CUDEC_RT_MEMSET cudaMemset
+#define CUDEC_RT_STREAM_CREATE cudaStreamCreate
+#define CUDEC_RT_SET_DEVICE cudaSetDevice
+#define CUDEC_RT_PEEK_AT_LAST_ERROR cudaPeekAtLastError
+#define CUDEC_RT_MEM_GET_INFO cudaMemGetInfo
+#define CUDEC_RT_EVENT_CREATE_WITH_FLAGS cudaEventCreateWithFlags
+#define CUDEC_RT_EVENT_DISABLE_TIMING cudaEventDisableTiming
+#define CUDEC_RT_EVENT_QUERY cudaEventQuery
+#define CUDEC_RT_ERROR_NOT_READY cudaErrorNotReady
+#define CUDEC_RT_GET_ERROR_STRING cudaGetErrorString
+#define CUDEC_RT_FUNC_ATTRIBUTES_T cudaFuncAttributes
+#define CUDEC_RT_FUNC_GET_ATTRIBUTES cudaFuncGetAttributes
+
+#endif
+
+namespace cudec_rt {
+
+using func_attributes_t = CUDEC_RT_FUNC_ATTRIBUTES_T;
+
+inline constexpr error_t error_not_ready = CUDEC_RT_ERROR_NOT_READY;
+
+/* One thin inline per operation, as in src/vendor_rt.h, so a call site cannot
+ * pass a flag the port has not mapped. */
+inline error_t device_memset(void* p, int value, size_t bytes) {
+    return CUDEC_RT_MEMSET(p, value, bytes);
+}
+
+/* The typed allocation the harness writes, and the one place a cast for it
+ * lives. The seam's own device_malloc takes void** because the library only
+ * ever allocates into a void*; a test allocates into the pointer type it will
+ * dereference, and CUDA's cudaMalloc is a template that hid the conversion.
+ * Spelling the conversion once here keeps sixty call sites free of a
+ * reinterpret_cast each, and the non-template overload above still wins for a
+ * void** so this adds no second path for the library's own shape. */
+template <class T>
+inline error_t device_malloc(T** p, size_t bytes) {
+    void* raw = 0;
+    const error_t e = device_malloc(&raw, bytes);
+    if (e == success) {
+        *p = static_cast<T*>(raw);
+    }
+    return e;
+}
+
+/* The DEFAULT-flags stream, which is a different object from the seam's
+ * non-blocking one and is deliberately not folded into it: a test that wants
+ * the ordering the default stream imposes must not silently get a stream that
+ * does not impose it. */
+inline error_t stream_create(stream_t* s) { return CUDEC_RT_STREAM_CREATE(s); }
+
+inline error_t set_device(int device) { return CUDEC_RT_SET_DEVICE(device); }
+inline error_t peek_at_last_error() { return CUDEC_RT_PEEK_AT_LAST_ERROR(); }
+inline error_t mem_get_info(size_t* free_bytes, size_t* total_bytes) {
+    return CUDEC_RT_MEM_GET_INFO(free_bytes, total_bytes);
+}
+
+/* Timing off, because the only question asked of these events is whether the
+ * work behind them has retired; a timing event costs a synchronisation the
+ * deadline loop exists to avoid. */
+inline error_t event_create_untimed(event_t* e) {
+    return CUDEC_RT_EVENT_CREATE_WITH_FLAGS(e, CUDEC_RT_EVENT_DISABLE_TIMING);
+}
+inline error_t event_query(event_t e) { return CUDEC_RT_EVENT_QUERY(e); }
+
+inline const char* error_string(error_t e) {
+    return CUDEC_RT_GET_ERROR_STRING(e);
+}
+
+/* The entry is taken as a plain pointer rather than through the CUDA-only
+ * function-template overload, because that overload has no HIP counterpart and
+ * the pointer form is what both runtimes actually declare. */
+inline error_t func_get_attributes(func_attributes_t* attr, const void* entry) {
+    return CUDEC_RT_FUNC_GET_ATTRIBUTES(attr, entry);
+}
+
+}  // namespace cudec_rt
+
+#endif /* CUDEC_TESTS_VENDOR_RT_TEST_H */

--- a/tests/wave_width_gpu.cu
+++ b/tests/wave_width_gpu.cu
@@ -30,7 +30,7 @@
 #include "lz4_block.h"
 #include "require.h"
 
-#include <cuda_runtime.h>
+#include "vendor_rt_test.h"
 
 #include <cstdio>
 #include <cstring>
@@ -77,12 +77,14 @@ int BothInstantiationsAreInTheBinary() {
      * main turns a non-zero answer into the test's own failure. */
     using cudec_detail::chunk_decode_batch;
     using cudec_detail::Lz4Parser;
-    cudaFuncAttributes at_wave32;
-    cudaFuncAttributes at_wave64;
-    REQUIRE_CUDA(cudaFuncGetAttributes(
-        &at_wave32, chunk_decode_batch<Lz4Parser, false, kWave32>));
-    REQUIRE_CUDA(cudaFuncGetAttributes(
-        &at_wave64, chunk_decode_batch<Lz4Parser, false, kWave64>));
+    cudec_rt::func_attributes_t at_wave32;
+    cudec_rt::func_attributes_t at_wave64;
+    REQUIRE_RT(cudec_rt::func_get_attributes(
+        &at_wave32, reinterpret_cast<const void*>(
+                        &chunk_decode_batch<Lz4Parser, false, kWave32>)));
+    REQUIRE_RT(cudec_rt::func_get_attributes(
+        &at_wave64, reinterpret_cast<const void*>(
+                        &chunk_decode_batch<Lz4Parser, false, kWave64>)));
     REQUIRE(at_wave32.maxThreadsPerBlock ==
             static_cast<int>(cudec_detail::kBlockThreadsFor<kWave32>));
     REQUIRE(at_wave64.maxThreadsPerBlock ==
@@ -143,29 +145,30 @@ int main() {
     size_t* d_sizes = nullptr;
     size_t* d_caps = nullptr;
     cudec_chunk_result* d_results = nullptr;
-    REQUIRE_CUDA(cudaMalloc(&d_src, block.size()));
-    REQUIRE_CUDA(cudaMalloc(&d_dst, payload.size()));
-    REQUIRE_CUDA(cudaMalloc(&d_src_ptrs, sizeof(void*)));
-    REQUIRE_CUDA(cudaMalloc(&d_dst_ptrs, sizeof(void*)));
-    REQUIRE_CUDA(cudaMalloc(&d_sizes, sizeof(size_t)));
-    REQUIRE_CUDA(cudaMalloc(&d_caps, sizeof(size_t)));
-    REQUIRE_CUDA(cudaMalloc(&d_results, sizeof(cudec_chunk_result)));
-    REQUIRE_CUDA(cudaMemcpy(d_src, block.data(), block.size(),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemset(d_dst, 0, payload.size()));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_src, block.size()));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_dst, payload.size()));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_src_ptrs, sizeof(void*)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_dst_ptrs, sizeof(void*)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_sizes, sizeof(size_t)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_caps, sizeof(size_t)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_results, sizeof(cudec_chunk_result)));
+    REQUIRE_RT(cudec_rt::memcpy(d_src, block.data(), block.size(),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::device_memset(d_dst, 0, payload.size()));
 
     const void* h_src_ptr = d_src;
     void* h_dst_ptr = d_dst;
     const size_t h_size = block.size();
     const size_t h_cap = payload.size();
-    REQUIRE_CUDA(cudaMemcpy(d_src_ptrs, &h_src_ptr, sizeof(void*),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(cudaMemcpy(d_dst_ptrs, &h_dst_ptr, sizeof(void*),
-                            cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(
-        cudaMemcpy(d_sizes, &h_size, sizeof(size_t), cudaMemcpyHostToDevice));
-    REQUIRE_CUDA(
-        cudaMemcpy(d_caps, &h_cap, sizeof(size_t), cudaMemcpyHostToDevice));
+    REQUIRE_RT(cudec_rt::memcpy(d_src_ptrs, &h_src_ptr, sizeof(void*),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_dst_ptrs, &h_dst_ptr, sizeof(void*),
+                            cudec_rt::memcpy_h2d));
+    REQUIRE_RT(
+        cudec_rt::memcpy(d_sizes, &h_size, sizeof(size_t),
+                         cudec_rt::memcpy_h2d));
+    REQUIRE_RT(
+        cudec_rt::memcpy(d_caps, &h_cap, sizeof(size_t), cudec_rt::memcpy_h2d));
 
     /* The launch geometry is derived from the parameter, exactly as the
      * shipped entry derives it. Hoisted into a named constant because the
@@ -177,18 +180,18 @@ int main() {
                                      cudec_detail::kCudaWaveSize>
         <<<1, kThreads>>>(d_src_ptrs, d_sizes, d_dst_ptrs, d_caps, 1,
                           d_results);
-    REQUIRE_CUDA(cudaGetLastError());
-    REQUIRE_CUDA(cudaDeviceSynchronize());
+    REQUIRE_RT(cudec_rt::get_last_error());
+    REQUIRE_RT(cudec_rt::device_synchronize());
 
     cudec_chunk_result result;
-    REQUIRE_CUDA(cudaMemcpy(&result, d_results, sizeof(result),
-                            cudaMemcpyDeviceToHost));
+    REQUIRE_RT(cudec_rt::memcpy(&result, d_results, sizeof(result),
+                            cudec_rt::memcpy_d2h));
     REQUIRE(result.status == CUDEC_OK);
     REQUIRE(result.bytes_written == payload.size());
 
     std::vector<unsigned char> out(payload.size(), 0);
-    REQUIRE_CUDA(cudaMemcpy(out.data(), d_dst, out.size(),
-                            cudaMemcpyDeviceToHost));
+    REQUIRE_RT(cudec_rt::memcpy(out.data(), d_dst, out.size(),
+                            cudec_rt::memcpy_d2h));
     REQUIRE(std::memcmp(out.data(), payload.data(), payload.size()) == 0);
 
     std::printf("PASS: both wave widths instantiate; the shipped width "


### PR DESCRIPTION
Part of #243. **It does not close it** - the done-when asks for a compile under
`hipcc` and a run in the pinned ROCm container, and neither exists on this
machine. What lands here is the source-level half: the test sources stop naming
a backend runtime, so when #210 supplies the container there is nothing left to
change before the ladder is compiled for the second backend.

## What was wrong

The port's whole claim is that ONE set of sources compiles for either backend.
`src/` has held that since #240. The harness that proves the claim did not: eight
`.cu` files included `<cuda_runtime.h>` and called `cudaMalloc`, `cudaMemcpy`,
`cudaMemset`, `cudaStreamCreate`, `cudaEventQuery` and the rest directly, and
`tests/require.h`'s assertion macro compared against `cudaSuccess`. A ladder that
compiles for one backend cannot certify a library that claims two.

## What changed

`tests/vendor_rt_test.h` is new: the ONE file under `tests/` that names a backend
runtime, in the same two-column table shape as `src/vendor_rt.h`. The eight test
sources reach the runtime through `cudec_rt::` and `require.h`'s macro is
`REQUIRE_RT`, comparing against `cudec_rt::success`.

**Why a second file rather than a wider `src/vendor_rt.h`**, which is the design
call this change takes and the one to argue with. The ladder drives the device
itself - it allocates into typed pointers, poisons arenas, plants a device error
to prove the entry does not misreport it, asks for free memory before refusing a
4 GiB test, creates an untimed event for the watchdog and reads a kernel's own
attributes. Those are operations the shipped library has no caller for. Putting
them into the internal library header would grow a shipped header with surface
nothing in `src/` calls, and the `src/`-only rule would then be guarding a table
half of which exists for the tests. The harness header includes `src/vendor_rt.h`
and restates no line of it, so there is no second definition of anything.

The `src/` include a device test needs is granted once inside `cudec_add_test`
rather than per target, for the reason the vendor-seam glob states about its own
scope: a device test added tomorrow is covered on the day it lands, not on the
day somebody remembers to add it. Four per-target grants that line subsumes are
deleted.

## The two new rules, each watched refusing a planted violation

Neither is trusted against a clean tree only. Both were pointed at a planted
mistake first, and both name the file and the spelling they refuse.

**No file under `tests/` except the seam may name a backend runtime.** Planting
`cudaMalloc` back into `tests/smoke.cu`:

```
CMake Error at CMakeLists.txt:...
  the harness vendor seam has leaked:

  tests/smoke.cu: names a backend runtime directly ('cudaMalloc'); every file
  beside tests/vendor_rt_test.h in its own tree reaches the runtime through
  cudec_rt:: (issues #240, #243)
```

**The two arms of the harness table carry the same operations.** Deleting the HIP
entry for the free-memory query - the mistake somebody actually makes, adding a
line to the arm they can compile:

```
CMake Error at CMakeLists.txt:...
  tests/vendor_rt_test.h maps the two backends unevenly:
  CUDEC_RT_MEM_GET_INFO is mapped for CUDA and not for HIP; (issue #243)
```

Both reuse the functions #240 landed rather than copying them. The scan grew one
argument so it can name whichever seam it is guarding; its own violating and
near-miss probes still run ahead of every tree pass.

## Gate

WSL2, Ubuntu 24.04, `nvcc` 13.3.73, at `5613d9b`, configure and full build and
the host-side subset:

```
$ /usr/local/cuda/bin/nvcc --version | tail -2
Cuda compilation tools, release 13.3, V13.3.73
Build cuda_13.3.r13.3/compiler.38244171_0

$ cmake -B build-af25-wsl -DCUDEC_ENABLE_CUDA=ON ... && cmake --build build-af25-wsl -j
[100%] Built target termination_gpu
[100%] Built target gpu_fixture

$ ctest --test-dir build-af25-wsl -LE gpu --no-tests=error --output-on-failure
100% tests passed, 0 tests failed out of 51
Total Test time (real) =  13.64 sec
```

The nine gpu-labelled entries still register under the same names, which is what
the CI identity greps pin:

```
$ ctest --test-dir build-af25-wsl -N -L gpu
  Test #15: snappy_block_device
  Test #38: smoke
  Test #39: gpu_fixture
  Test #40: wave_width_gpu
  Test #41: frame_twin
  Test #42: stream_twin
  Test #43: termination_gpu
  Test #44: determinism_gpu
  Test #49: bench_frame_selfcheck
Total Tests: 9
```

## What is NOT proven, stated rather than left to be discovered

- **No `hipcc` has read the HIP arm of the new table.** No ROCm toolchain exists
  on this machine, which is the same limit `src/vendor_rt.h` records about its
  own arm. The mapping is proven CONSISTENT - the rule above reds an uneven table
  - and is NOT proven CORRECT. #210 is the route to the compiler that would
  decide it.
- **The gpu-labelled tests were compiled and NOT executed.** No device is
  reachable from this machine tonight: `/dev/dxg` is absent from the WSL
  instance, so `nvidia-smi` reports `GPU access blocked by the operating system`
  and every device test would fail on the runtime rather than on this change.
  What stands behind the eight rewritten files is the compile, the nine entries
  above still registering, and the 51 host-side tests. A device run is owed
  before anybody reads this as a certified rewrite.
- This change had no second reader.
