### PR TITLE
Derive the GDeflate reject ladder from the code [#183]

### DIFF
--- a/src/gdeflate_block.h
+++ b/src/gdeflate_block.h
@@ -115,7 +115,9 @@ CUDEC_HOST_DEVICE inline uint32_t GDeflateDistExtra(uint32_t sym) {
  * lengths). Built through the same construction every other table goes
  * through, so a static block and a dynamic block share one decoder. */
 CUDEC_HOST_DEVICE inline bool GDeflateStaticTables(GDeflateLitLenTable& litlen,
-                                                   GDeflateDistTable& dist) {
+                                                   GDeflateDistTable& dist,
+                                                   GDeflateReject* why =
+                                                       nullptr) {
     unsigned char lens[kGDeflateNumLitLenSyms];
     for (uint32_t i = 0; i < kGDeflateNumLitLenSyms; i++) {
         if (i < 144) {
@@ -128,14 +130,14 @@ CUDEC_HOST_DEVICE inline bool GDeflateStaticTables(GDeflateLitLenTable& litlen,
             lens[i] = 8;
         }
     }
-    if (!GDeflateBuildTable(lens, kGDeflateNumLitLenSyms, litlen)) {
+    if (!GDeflateBuildTable(lens, kGDeflateNumLitLenSyms, litlen, why)) {
         return false;
     }
     unsigned char dist_lens[kGDeflateNumDistSyms];
     for (uint32_t i = 0; i < kGDeflateNumDistSyms; i++) {
         dist_lens[i] = 5;
     }
-    return GDeflateBuildTable(dist_lens, kGDeflateNumDistSyms, dist);
+    return GDeflateBuildTable(dist_lens, kGDeflateNumDistSyms, dist, why);
 }
 
 /* One lane's outstanding match: the length it reserved and where in the output
@@ -196,8 +198,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateDoCopy(GDeflatePageState& st,
      * cannot be the place a narrowing hides: `offset` is at most 65536 and
      * `c.out_pos` is where the reservation started. */
     if (static_cast<uint64_t>(offset) > c.out_pos) {
-        s.failed = true;
-        return false;
+        return GDeflateRefuse(s, kGDeflateRejectMatchBeforeOutput);
     }
     const uint64_t src = c.out_pos - offset;
     /* Byte by byte, forwards, which is what an overlapping match MEANS: a
@@ -261,8 +262,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
         GDeflateEnsure(s, page);
 
         if (block_type == kGDeflateBlockReserved) {
-            s.failed = true;
-            return false;
+            return GDeflateRefuse(s, kGDeflateRejectBlockTypeReserved);
         }
 
         if (block_type == kGDeflateBlockStored) {
@@ -285,9 +285,16 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
             if (s.failed) {
                 return false;
             }
-            if (len > out_cap - out_pos || len > reachable) {
-                s.failed = true;
-                return false;
+            /* Two rungs rather than one condition, for the reason the pop
+             * width and the lane occupancy are two in the schedule: a length
+             * past what the caller can hold and a length past what the page
+             * can still supply are different defects, and a single rung would
+             * let a negative for either stand in for the other. */
+            if (len > out_cap - out_pos) {
+                return GDeflateRefuse(s, kGDeflateRejectStoredPastCap);
+            }
+            if (len > reachable) {
+                return GDeflateRefuse(s, kGDeflateRejectStoredPastPage);
             }
             for (uint32_t n = 0; n < len; n++) {
                 out[out_pos] = static_cast<unsigned char>(GDeflatePop(s, 8));
@@ -299,9 +306,9 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
             }
         } else {
             if (block_type == kGDeflateBlockStatic) {
-                if (!GDeflateStaticTables(st.litlen, st.dist)) {
-                    s.failed = true;
-                    return false;
+                GDeflateReject static_why = kGDeflateRejectNone;
+                if (!GDeflateStaticTables(st.litlen, st.dist, &static_why)) {
+                    return GDeflateRefuseAs(s, static_why);
                 }
             } else if (!GDeflateReadDynamicTables(s, page, st.lens, st.litlen,
                                                   st.dist)) {
@@ -334,8 +341,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
                 }
                 if (sym < kGDeflateEndOfBlock) {
                     if (out_pos == out_cap) {
-                        s.failed = true;
-                        return false;
+                        return GDeflateRefuse(s, kGDeflateRejectLiteralPastCap);
                     }
                     out[out_pos] = static_cast<unsigned char>(sym);
                     out_pos++;
@@ -359,8 +365,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
                     return false;
                 }
                 if (length > out_cap - out_pos) {
-                    s.failed = true;
-                    return false;
+                    return GDeflateRefuse(s, kGDeflateRejectMatchPastCap);
                 }
                 /* The reservation, not the copy. The distance symbol this
                  * match needs arrives on this same lane one round of its own
@@ -379,8 +384,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
                 /* The round cap was reached with no end-of-block. A page that
                  * ran that far has produced more rounds than its own capacity
                  * admits, so it is refused rather than reported as a decode. */
-                s.failed = true;
-                return false;
+                return GDeflateRefuse(s, kGDeflateRejectRoundFuelExhausted);
             }
 
             /* The drain: one round per lane, retiring whatever is still
@@ -407,8 +411,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
         type_bytes[block_type] += out_pos - block_out_start;
     }
     if (!final_block) {
-        s.failed = true;
-        return false;
+        return GDeflateRefuse(s, kGDeflateRejectNoFinalBlock);
     }
     st.blocks = blocks_read;
     for (uint32_t n = 0; n < kGDeflateBlockTypeCount; n++) {

--- a/src/gdeflate_schedule.h
+++ b/src/gdeflate_schedule.h
@@ -101,6 +101,76 @@ static_assert(sizeof(uint64_t) * 8 == kGDeflateLaneBufferBits,
  * than bad input. */
 constexpr uint32_t kGDeflateMaxPopBits = kGDeflateLowWatermarkBits;
 
+/* THE REJECT LADDER (issue #183). Every refusal in these three headers names
+ * one branch of this enumeration, and each branch is named by exactly one
+ * site, so the ladder's branch set is DERIVED from the code rather than
+ * restated beside it. tests/CMakeLists.txt refuses a build where that stops
+ * being true, and the twins hold the run-time half: a negative has to reach
+ * every branch that any page can reach, and a branch declared unreachable has
+ * to stay unreached. Adding a rung therefore costs a branch here and a
+ * negative there, and a rung that reuses a neighbour's branch to avoid both is
+ * what the exactly-one count refuses.
+ *
+ * ONE ENUMERATION FOR THREE HEADERS, because one sticky field carries it: a
+ * page decode fails once, in whichever of the three the defect was found, and
+ * a caller reading the verdict should not have to ask which layer to ask.
+ * The sections below are the layers, and the sentinels between them are what
+ * lets each twin assert coverage over its own header rather than over all
+ * three. A sentinel carries an explicit value; a branch never does, which is
+ * how the configure-time lock tells them apart without a list to maintain. */
+enum GDeflateReject {
+    kGDeflateRejectNone = 0,
+
+    /* src/gdeflate_schedule.h - the bit cursor. */
+    kGDeflateRejectPagePartialWord,
+    kGDeflateRejectPageBelowPrimingRound,
+    kGDeflateRejectRefillPastEnd,
+    kGDeflateRejectRemovePastLane,
+    kGDeflateRejectPopWidthPastFormat,
+    kGDeflateRejectPopPastLane,
+    kGDeflateRejectScheduleFirst = kGDeflateRejectPagePartialWord,
+    kGDeflateRejectScheduleLast = kGDeflateRejectPopPastLane,
+
+    /* src/gdeflate_tables.h - table construction and symbol decode. */
+    kGDeflateRejectTablePastCapacity,
+    kGDeflateRejectTableLengthPastMax,
+    kGDeflateRejectTableOverSubscribed,
+    kGDeflateRejectTableIncomplete,
+    kGDeflateRejectEmptyTableUsed,
+    kGDeflateRejectCodewordNotInCode,
+    kGDeflateRejectRepeatNothingBefore,
+    kGDeflateRejectRepeatRunPastAlphabet,
+    kGDeflateRejectTablesFirst = kGDeflateRejectTablePastCapacity,
+    kGDeflateRejectTablesLast = kGDeflateRejectRepeatRunPastAlphabet,
+
+    /* src/gdeflate_block.h - the block loop. */
+    kGDeflateRejectBlockTypeReserved,
+    kGDeflateRejectStoredPastCap,
+    kGDeflateRejectStoredPastPage,
+    kGDeflateRejectLiteralPastCap,
+    kGDeflateRejectMatchPastCap,
+    kGDeflateRejectMatchBeforeOutput,
+    kGDeflateRejectRoundFuelExhausted,
+    kGDeflateRejectNoFinalBlock,
+    kGDeflateRejectBlockFirst = kGDeflateRejectBlockTypeReserved,
+    kGDeflateRejectBlockLast = kGDeflateRejectNoFinalBlock,
+
+    kGDeflateRejectCount
+};
+
+/* The sections have to stay contiguous and in this order, because each twin
+ * walks its own First..Last range. A branch inserted into the wrong section
+ * would be asserted by the wrong twin, which is a coverage hole that reads as
+ * coverage. */
+static_assert(kGDeflateRejectScheduleFirst == kGDeflateRejectNone + 1,
+              "the schedule section must start immediately after None");
+static_assert(kGDeflateRejectTablesFirst == kGDeflateRejectScheduleLast + 1,
+              "the table section must follow the schedule section");
+static_assert(kGDeflateRejectBlockFirst == kGDeflateRejectTablesLast + 1,
+              "the block section must follow the table section");
+static_assert(kGDeflateRejectCount == kGDeflateRejectBlockLast + 1,
+              "the block section must be the last one");
+
 /* The 32 lane bit buffers, the current lane, and the one shared word cursor.
  * The failure flag is sticky: once set, every operation is a no-op, so a
  * caller that checks it once at the end reads the same verdict as one that
@@ -112,7 +182,62 @@ struct GDeflateSchedule {
     uint64_t cursor;
     uint64_t word_count;
     bool failed;
+    /* Which rung refused, and it is the reason the flag alone is not enough:
+     * a caller that only knows the page failed cannot tell a page that ran off
+     * its own end from one whose code lengths are not a code, and neither can
+     * a test asserting that its negative reached the branch it was written
+     * for. Set only through the choke point below. */
+    GDeflateReject reject;
 };
+
+/* THE ONE PLACE A REFUSAL IS RECORDED, for the reason SnappyRefuse is one in
+ * src/snappy_block.h: a refusal that never passes through here names no rung,
+ * so it is invisible to the configure-time count and to the twins' coverage
+ * alike, and adding one would be the one change that could grow the ladder
+ * with both halves of the lock still green. It answers false so that a bool
+ * caller can `return GDeflateRefuse(...)` and a void one can call it and
+ * return.
+ *
+ * FIRST REFUSAL WINS. The flag is sticky and every operation is a no-op once
+ * it is set, so a later call could only overwrite the branch with a
+ * consequence of the first one. */
+CUDEC_HOST_DEVICE inline bool GDeflateRefuse(GDeflateSchedule& s,
+                                             GDeflateReject branch) {
+    if (!s.failed) {
+        s.failed = true;
+        s.reject = branch;
+    }
+    return false;
+}
+
+/* Re-raise a refusal a nested ladder already named. Table construction runs
+ * without a schedule - it is called on a length vector and nothing else - so
+ * it names its rung into a caller-supplied slot, and the caller that owns the
+ * schedule raises it here. Kept as its own verb rather than as a GDeflateRefuse
+ * call with a variable argument, because the configure-time lock reads the
+ * branch off the call site: a site passing a variable would have to be
+ * exempted from that read, and an exemption spelled the same way as the rule
+ * is how the rule stops being read. */
+CUDEC_HOST_DEVICE inline bool GDeflateRefuseAs(GDeflateSchedule& s,
+                                               GDeflateReject already_named) {
+    if (!s.failed) {
+        s.failed = true;
+        s.reject = already_named;
+    }
+    return false;
+}
+
+/* The same choke point for a ladder with no schedule to record into. `slot`
+ * is the caller's, and a null one is a caller that does not want the reason -
+ * the refusal still happens, which is what makes this safe to call from a
+ * table build that a test drives directly. */
+CUDEC_HOST_DEVICE inline bool GDeflateTableRefuse(GDeflateReject* slot,
+                                                  GDeflateReject branch) {
+    if (slot != nullptr) {
+        *slot = branch;
+    }
+    return false;
+}
 
 /* Little-endian, byte by byte, for the reason every other parser in this tree
  * reads its integers this way: the page is a byte buffer with no alignment
@@ -141,7 +266,7 @@ CUDEC_HOST_DEVICE inline void GDeflateEnsure(GDeflateSchedule& s,
          * cannot reach here, so this is a refusal and not a tail case: a
          * decoder that carried on with a short buffer would be reading the
          * lane's stale bits as if the stream had supplied them. */
-        s.failed = true;
+        GDeflateRefuse(s, kGDeflateRejectRefillPastEnd);
         return;
     }
     s.bitbuf[s.idx] |= static_cast<uint64_t>(GDeflateWordAt(page, s.cursor))
@@ -188,20 +313,19 @@ CUDEC_HOST_DEVICE inline bool GDeflateInit(GDeflateSchedule& s,
     s.idx = 0;
     s.cursor = 0;
     s.failed = false;
+    s.reject = kGDeflateRejectNone;
     s.word_count = page_bytes / 4u;
     /* Whole words only. A trailing partial word is not a word this schedule
      * could hand a lane, and rounding down would leave those bytes reachable
      * by nothing while the page still claimed them. */
     if (page_bytes % 4u != 0u) {
-        s.failed = true;
-        return false;
+        return GDeflateRefuse(s, kGDeflateRejectPagePartialWord);
     }
     if (s.word_count < kGDeflateNumStreams) {
         /* Draft section 5.3: the first round always loads 32 consecutive
          * words, so a stream below 128 bytes cannot be valid. Refused here
          * rather than discovered part-way through the priming round. */
-        s.failed = true;
-        return false;
+        return GDeflateRefuse(s, kGDeflateRejectPageBelowPrimingRound);
     }
     for (uint32_t n = 0; n < kGDeflateNumStreams; ++n) {
         GDeflateAdvance(s, page);
@@ -232,7 +356,7 @@ CUDEC_HOST_DEVICE inline void GDeflateRemove(GDeflateSchedule& s, uint32_t n) {
         return;
     }
     if (n > s.bitsleft[s.idx]) {
-        s.failed = true;
+        GDeflateRefuse(s, kGDeflateRejectRemovePastLane);
         return;
     }
     s.bitbuf[s.idx] >>= n;
@@ -246,8 +370,18 @@ CUDEC_HOST_DEVICE inline uint32_t GDeflatePop(GDeflateSchedule& s, uint32_t n) {
     if (s.failed) {
         return 0;
     }
-    if (n > kGDeflateMaxPopBits || n > s.bitsleft[s.idx]) {
-        s.failed = true;
+    /* Two refusals rather than one condition, because they are different
+     * failures and the ladder is what says so: a width past the format's
+     * widest field is a caller asking for something no page encodes, while a
+     * lane that cannot serve a legal width is a page that ran out of bits
+     * where the schedule says it should not have. A single rung would let a
+     * negative for either satisfy the other. */
+    if (n > kGDeflateMaxPopBits) {
+        GDeflateRefuse(s, kGDeflateRejectPopWidthPastFormat);
+        return 0;
+    }
+    if (n > s.bitsleft[s.idx]) {
+        GDeflateRefuse(s, kGDeflateRejectPopPastLane);
         return 0;
     }
     const uint32_t value = GDeflatePeek(s, n);

--- a/src/gdeflate_tables.h
+++ b/src/gdeflate_tables.h
@@ -143,16 +143,24 @@ CUDEC_HOST_DEVICE inline uint32_t GDeflateReverseBits(uint32_t code,
  * the table unusable for every vector the reference refuses, and for the two
  * it refuses that the format cannot produce (a length past `kMaxLen`, an
  * alphabet past the capacity) - both are caller errors rather than bad input,
- * and refusing is the answer that cannot be mistaken for a decode. */
+ * and refusing is the answer that cannot be mistaken for a decode.
+ *
+ * `why` is where the rung is named. This runs on a length vector with no
+ * schedule in reach - a test builds a table out of bytes it wrote itself, and
+ * so does the static block - so the ladder branch goes into the caller's slot
+ * and the caller holding a schedule raises it with GDeflateRefuseAs. A null
+ * slot is a caller that does not want the reason, never a caller that gets a
+ * table it should not have. */
 template <uint32_t kCapSyms, uint32_t kRootBits, uint32_t kMaxLen>
 CUDEC_HOST_DEVICE inline bool GDeflateBuildTable(
     const unsigned char* lens, uint32_t num_syms,
-    GDeflateHuffTable<kCapSyms, kRootBits, kMaxLen>& t) {
+    GDeflateHuffTable<kCapSyms, kRootBits, kMaxLen>& t,
+    GDeflateReject* why = nullptr) {
     static_assert(kRootBits <= kMaxLen,
                   "a root wider than the longest codeword would index slots "
                   "no code can reach");
     if (num_syms > kCapSyms) {
-        return false;
+        return GDeflateTableRefuse(why, kGDeflateRejectTablePastCapacity);
     }
     for (uint32_t len = 0; len <= kMaxLen; len++) {
         t.count[len] = 0;
@@ -168,7 +176,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateBuildTable(
              * bits - so it is a caller error, and it is refused rather than
              * truncated because a truncated length silently describes a
              * different code. */
-            return false;
+            return GDeflateTableRefuse(why, kGDeflateRejectTableLengthPastMax);
         }
         t.count[len] = static_cast<uint16_t>(t.count[len] + 1u);
     }
@@ -192,7 +200,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateBuildTable(
         /* Over-subscribed: the lengths claim more of the codespace than
          * exists, so at least two symbols share a prefix and no assignment
          * exists. */
-        return false;
+        return GDeflateTableRefuse(why, kGDeflateRejectTableOverSubscribed);
     }
 
     /* Canonical order, and the first index of each length. Both are needed by
@@ -236,7 +244,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateBuildTable(
             return true;
         }
         if (codespace != (full >> 1) || t.count[1] != 1) {
-            return false;
+            return GDeflateTableRefuse(why, kGDeflateRejectTableIncomplete);
         }
         /* One symbol at length 1. The reference gives it both codewords, 0 and
          * 1, so a single bit resolves it whichever way that bit falls; the
@@ -302,7 +310,7 @@ CUDEC_HOST_DEVICE inline uint32_t GDeflateDecodeSymbol(
         /* Stricter than the reference, deliberately: it hands back a symbol
          * the stream never encoded, and a distance built from that symbol is
          * indistinguishable from one the page asked for. */
-        s.failed = true;
+        GDeflateRefuse(s, kGDeflateRejectEmptyTableUsed);
         return kGDeflateNoSymbol;
     }
     if (t.kind == kGDeflateTableSingle) {
@@ -334,7 +342,7 @@ CUDEC_HOST_DEVICE inline uint32_t GDeflateDecodeSymbol(
             return t.sorted[t.first_index[len] + (code - t.first_code[len])];
         }
     }
-    s.failed = true;
+    GDeflateRefuse(s, kGDeflateRejectCodewordNotInCode);
     return kGDeflateNoSymbol;
 }
 
@@ -458,15 +466,16 @@ CUDEC_HOST_DEVICE inline bool GDeflateReadCodeLengths(
     }
 
     GDeflatePrecodeTable precode;
-    if (!GDeflateBuildTable(precode_lens, kGDeflateNumPrecodeSyms, precode)) {
+    GDeflateReject precode_why = kGDeflateRejectNone;
+    if (!GDeflateBuildTable(precode_lens, kGDeflateNumPrecodeSyms, precode,
+                            &precode_why)) {
         /* The flag, not just the return. A precode that is not a code is bad
          * input like any other refusal here, and this header's own contract
          * says a caller that checks the sticky flag once at the end reads the
          * same verdict as one that checks after every call - so a refusal that
          * left the flag clear would break that contract silently. Found by
          * fuzz/fuzz_gdeflate_tables.cpp on its first seed replay. */
-        s.failed = true;
-        return false;
+        return GDeflateRefuseAs(s, precode_why);
     }
 
     /* The expansion starts at a reset exactly as the header did, so the first
@@ -495,8 +504,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateReadCodeLengths(
             if (i == 0) {
                 /* Nothing to repeat. The reference refuses this as well, and
                  * it is the one repeat-code refusal the two decoders share. */
-                s.failed = true;
-                return false;
+                return GDeflateRefuse(s, kGDeflateRejectRepeatNothingBefore);
             }
             rep_val = out.lens[i - 1];
             rep_count = 3u + GDeflatePop(s, 2);
@@ -513,8 +521,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateReadCodeLengths(
              * slack this alphabet does not carry. Written as a subtraction on
              * the side that cannot overflow - `i` is below `total` here, so
              * `total - i` is what is left rather than a sum that could wrap. */
-            s.failed = true;
-            return false;
+            return GDeflateRefuse(s, kGDeflateRejectRepeatRunPastAlphabet);
         }
         for (uint32_t n = 0; n < rep_count; n++) {
             out.lens[i++] = rep_val;
@@ -539,16 +546,20 @@ CUDEC_HOST_DEVICE inline bool GDeflateReadDynamicTables(
     if (!GDeflateReadCodeLengths(s, page, lens)) {
         return false;
     }
-    if (!GDeflateBuildTable(lens.lens, lens.num_litlen, litlen)) {
+    GDeflateReject why = kGDeflateRejectNone;
+    if (!GDeflateBuildTable(lens.lens, lens.num_litlen, litlen, &why)) {
         /* A vector that is not a code is bad input, so the schedule carries
          * the same verdict a bad round would leave: a caller that checks only
-         * the flag must not read this as a page still worth decoding. */
-        s.failed = true;
-        return false;
+         * the flag must not read this as a page still worth decoding. The rung
+         * is the one the construction named, not a second one saying which of
+         * the two vectors carried it: what refused is the property of the
+         * lengths, and a rung per call site would be two rungs one negative
+         * could not tell apart. */
+        return GDeflateRefuseAs(s, why);
     }
-    if (!GDeflateBuildTable(lens.lens + lens.num_litlen, lens.num_dist, dist)) {
-        s.failed = true;
-        return false;
+    if (!GDeflateBuildTable(lens.lens + lens.num_litlen, lens.num_dist, dist,
+                            &why)) {
+        return GDeflateRefuseAs(s, why);
     }
     return true;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -200,6 +200,16 @@ cudec_add_test(gdeflate_block_twin SOURCES gdeflate_block_twin.cpp LIBS
                gdeflate_oracle)
 target_include_directories(gdeflate_block_twin
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The run-time half of the reject-ladder lock (issue #183), whose static half
+# is the configure-time scan further down this file. One negative per declared
+# rung of enum GDeflateReject, each asserting the rung it lands on, and a sweep
+# requiring every rung to be reached or declared unreachable with its argument.
+# It asks no oracle - which rung this decoder takes is a question about this
+# tree - so it links nothing and stays GPU-less, reaching src/ for the three
+# headers under test.
+cudec_add_test(gdeflate_ladder_lock SOURCES gdeflate_ladder_lock.cpp)
+target_include_directories(gdeflate_ladder_lock
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 # The reference's own decode behaviours, executed rather than read (issue
 # #155). Host-side and GPU-less on purpose: it is the oracle answering, and
 # the answers are what the M3 fail-closed matrix is allowed to lock against.
@@ -1588,6 +1598,332 @@ if(_snappy_violations)
   message(FATAL_ERROR "the Snappy parser core is not single-sourced, or its "
                       "reject ladder and its refusal sites have drifted "
                       "apart (issue #173):\n${_snappy_violations}")
+endif()
+
+# ---- The GDeflate reject ladder is derived from the code (issue #183).
+#
+# Same honest scope as every check above: a drift detector under the KNOWN
+# SPELLINGS, not tamper-proofing. A refusal spelled through a helper this scan
+# does not know, or a ladder re-copied under fresh names, is out of reach of a
+# text scan and is what review is for.
+#
+# The rule. Every refusal in the three GDeflate headers goes through one of the
+# three choke points in src/gdeflate_schedule.h and names a branch that
+# `enum GDeflateReject` declares, and each declared branch is named by EXACTLY
+# ONE site. That makes the ladder's branch set DERIVED from the code rather
+# than restated beside it, and it is the static half of a pair: the three twins
+# hold the run-time half, requiring a negative to reach every branch a page can
+# reach. Adding a rung therefore costs an enumerator here and a negative there,
+# and a rung that quietly reuses a neighbour's enumerator to avoid both is what
+# the exactly-one count refuses.
+#
+# Why the sticky field is guarded too. The flag and the branch are one verdict:
+# a site that sets `failed` by hand names no rung and is invisible to both
+# halves of the pair, and a site that writes `reject` by hand can name a rung
+# it did not take. Both are refused outside the choke points, which is the one
+# place either may be written.
+function(cudec_check_gdeflate_locks src_dir out_violations)
+  set(_violations "")
+  set(_headers gdeflate_schedule.h gdeflate_tables.h gdeflate_block.h)
+  foreach(_name IN LISTS _headers)
+    if(NOT EXISTS ${src_dir}/${_name})
+      string(APPEND _violations
+             "  ${src_dir}/${_name} is missing: the GDeflate ladder is "
+             "single-sourced across the three headers (issue #183)\n")
+    endif()
+  endforeach()
+  if(_violations)
+    set(${out_violations} "${_violations}" PARENT_SCOPE)
+    return()
+  endif()
+
+  # The declared branches, read out of the enumeration between its None and
+  # Count sentinels. An enumerator carrying an explicit value is a SECTION
+  # SENTINEL rather than a rung - that is what lets each twin walk its own
+  # header's range - and the distinction is the presence of an initialiser
+  # rather than a list of sentinel names somebody has to keep in step here.
+  cudec_code_lines(${src_dir}/gdeflate_schedule.h _schedule_lines)
+  set(_declared "")
+  set(_in_enum FALSE)
+  foreach(_line IN LISTS _schedule_lines)
+    if(_line MATCHES "enum GDeflateReject[ \t]*{")
+      set(_in_enum TRUE)
+      continue()
+    endif()
+    if(_in_enum)
+      if(_line MATCHES "kGDeflateRejectCount")
+        set(_in_enum FALSE)
+        continue()
+      endif()
+      if(_line MATCHES "^[ \t]*(kGDeflateReject[A-Za-z0-9_]*)[ \t]*,")
+        list(APPEND _declared ${CMAKE_MATCH_1})
+      endif()
+    endif()
+  endforeach()
+  if(NOT _declared)
+    string(APPEND _violations
+           "  gdeflate_schedule.h declares no reject ladder: "
+           "'enum GDeflateReject' must enumerate one branch per reject reason "
+           "(issue #183)\n")
+  endif()
+
+  # The refusal sites, over all three headers. The choke points are defined in
+  # the first of them, so their own definition lines and their own writes to
+  # the sticky state are what the scan steps over - tracked as a state rather
+  # than matched by name, because a rule that skipped every line mentioning the
+  # choke point would skip a violation that mentions it too.
+  set(_named "")
+  foreach(_name IN LISTS _headers)
+    cudec_code_lines(${src_dir}/${_name} _lines)
+    set(_lineno 0)
+    set(_in_choke FALSE)
+    foreach(_line IN LISTS _lines)
+      math(EXPR _lineno "${_lineno} + 1")
+      if(_line MATCHES "inline bool GDeflate(Refuse|RefuseAs|TableRefuse)\\(")
+        set(_in_choke TRUE)
+      elseif(_line MATCHES "^}")
+        set(_in_choke FALSE)
+      endif()
+      if(NOT _in_choke)
+        # The choke point, refused first: a refusal that sets the flag by hand
+        # reaches no branch, so it is invisible to the count below and to the
+        # twins alike, and it is the one shape that could add a rung with both
+        # halves of the pair still green.
+        if(_line MATCHES "\\.failed[ \t]*=[ \t]*true")
+          string(APPEND _violations
+                 "  ${_name}:${_lineno}: sets the failure flag without going "
+                 "through GDeflateRefuse - every refusal names its ladder "
+                 "branch (issue #183)\n")
+        endif()
+        # The same for the branch itself. Clearing it is how a decode starts,
+        # so only a write of an actual rung is refused here.
+        if(_line MATCHES "\\.reject[ \t]*=" AND
+           NOT _line MATCHES "\\.reject[ \t]*=[ \t]*kGDeflateRejectNone")
+          string(APPEND _violations
+                 "  ${_name}:${_lineno}: names a ladder branch outside "
+                 "GDeflateRefuse (issue #183)\n")
+        endif()
+      endif()
+      if(_line MATCHES "GDeflate(Table)?Refuse\\(" AND
+         NOT _line MATCHES "inline bool GDeflate")
+        # The branch has to be on the line the call opens on. A wrapped first
+        # argument would hide the name from this scan exactly as a wrapped
+        # mask hides from the collective rule.
+        if(_line MATCHES "GDeflate(Table)?Refuse\\([^,]+,[ \t]*(kGDeflateReject[A-Za-z0-9_]*)")
+          list(APPEND _named ${CMAKE_MATCH_2})
+        else()
+          string(APPEND _violations
+                 "  ${_name}:${_lineno}: a GDeflateRefuse call with no ladder "
+                 "branch on its own line (issue #183)\n")
+        endif()
+      endif()
+    endforeach()
+  endforeach()
+
+  foreach(_branch IN LISTS _declared)
+    set(_count 0)
+    foreach(_site IN LISTS _named)
+      if(_site STREQUAL _branch)
+        math(EXPR _count "${_count} + 1")
+      endif()
+    endforeach()
+    if(_count EQUAL 0)
+      string(APPEND _violations
+             "  ladder branch '${_branch}' is declared and no refusal site "
+             "names it (issue #183)\n")
+    elseif(NOT _count EQUAL 1)
+      string(APPEND _violations
+             "  ladder branch '${_branch}' is named by ${_count} refusal "
+             "sites: a new rung takes a new branch, so that the twin's "
+             "negative for it cannot be satisfied by its neighbour "
+             "(issue #183)\n")
+    endif()
+  endforeach()
+  foreach(_site IN LISTS _named)
+    if(NOT _site IN_LIST _declared)
+      string(APPEND _violations
+             "  a refusal site names '${_site}', which 'enum GDeflateReject' "
+             "does not declare (issue #183)\n")
+    endif()
+  endforeach()
+
+  set(${out_violations} "${_violations}" PARENT_SCOPE)
+endfunction()
+
+# The rules above are run against planted source trees before they are trusted
+# against the real one, and every violating probe is matched against the TEXT
+# its own rule emits rather than against a non-empty result - so one rule
+# cannot cover for another that has quietly stopped matching. The probe headers
+# are read, never compiled, which is why they are this terse.
+set(_gdeflate_probe_root ${CMAKE_CURRENT_BINARY_DIR}/gdeflate-lock-probes)
+file(REMOVE_RECURSE ${_gdeflate_probe_root})
+
+# A compliant ladder header: two rungs, one section sentinel, the choke points,
+# two sites. Each block is ONE string rather than a list of lines, because the
+# variants below are cut from it with string(REPLACE) and a list would come
+# back joined on semicolons - a stray separator written into a C header.
+#
+# The head is 27 lines, so an injected rung starts at line 28, which is the
+# number the line-scoped rules are asserted on below.
+set(_gd_head "#ifndef PROBE_GDEFLATE_SCHEDULE_H
+#define PROBE_GDEFLATE_SCHEDULE_H
+namespace cudec_detail {
+enum GDeflateReject {
+    kGDeflateRejectNone = 0,
+    kGDeflateRejectAlpha,
+    kGDeflateRejectBeta,
+    kGDeflateRejectScheduleFirst = kGDeflateRejectAlpha,
+    kGDeflateRejectCount
+};
+struct GDeflateSchedule {
+    bool failed;
+    GDeflateReject reject;
+};
+inline bool GDeflateRefuse(GDeflateSchedule& s, GDeflateReject branch) {
+    if (!s.failed) {
+        s.failed = true;
+        s.reject = branch;
+    }
+    return false;
+}
+inline bool GDeflateTableRefuse(GDeflateReject* slot, GDeflateReject branch) {
+    *slot = branch;
+    return false;
+}
+inline bool Walk(GDeflateSchedule& s, bool first) {
+    if (first) {
+")
+set(_gd_tail "    }
+    return GDeflateRefuse(s, kGDeflateRejectBeta);
+}
+}  // namespace cudec_detail
+#endif
+")
+set(_gd_site "        return GDeflateRefuse(s, kGDeflateRejectAlpha);
+")
+# The two headers a probe does not vary. They have to exist, because an absent
+# one is its own rule and would answer for every probe below.
+set(_gd_other "/* not the header the ladder lives in */
+")
+
+function(cudec_write_gdeflate_probe dir head site tail other)
+  file(WRITE ${dir}/gdeflate_schedule.h "${head}" "${site}" "${tail}")
+  file(WRITE ${dir}/gdeflate_tables.h "${other}")
+  file(WRITE ${dir}/gdeflate_block.h "${other}")
+endfunction()
+
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/clean "${_gd_head}"
+                           "${_gd_site}" "${_gd_tail}" "${_gd_other}")
+# The tree with no ladder header at all.
+file(WRITE ${_gdeflate_probe_root}/missing_header/other.cu "void probe() {}
+")
+# A rung that sets the sticky flag by hand.
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/bare_flag "${_gd_head}"
+                           "        s.failed = true;
+        return false;
+" "${_gd_tail}" "${_gd_other}")
+# A rung that names a branch by writing the sticky field directly.
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/bare_branch "${_gd_head}"
+                           "        s.reject = kGDeflateRejectAlpha;
+        return GDeflateRefuse(s, kGDeflateRejectAlpha);
+" "${_gd_tail}" "${_gd_other}")
+# Clearing the branch is how a decode starts and must stay silent, or the rule
+# above would refuse the initialisation every page needs.
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/clears_branch "${_gd_head}"
+                           "        s.reject = kGDeflateRejectNone;
+        return GDeflateRefuse(s, kGDeflateRejectAlpha);
+" "${_gd_tail}" "${_gd_other}")
+# A rung whose branch is wrapped onto the next line, out of a line-scoped
+# scan's sight.
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/wrapped_refuse "${_gd_head}"
+                           "        return GDeflateRefuse(
+            s, kGDeflateRejectAlpha);
+" "${_gd_tail}" "${_gd_other}")
+# A branch nothing refuses through: the shape a deleted rung leaves behind.
+string(REPLACE "    kGDeflateRejectBeta,
+" "    kGDeflateRejectBeta,
+    kGDeflateRejectGamma,
+" _gd_extra_branch "${_gd_head}")
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/branch_unused
+                           "${_gd_extra_branch}" "${_gd_site}" "${_gd_tail}"
+                           "${_gd_other}")
+# A site naming a branch the enumeration does not carry: the shape a rung added
+# without an enumerator leaves behind.
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/site_undeclared "${_gd_head}"
+                           "        return GDeflateRefuse(s, kGDeflateRejectGamma);
+" "${_gd_tail}" "${_gd_other}")
+# Two rungs behind one branch - a new rung borrowing its neighbour's
+# enumerator, which would let the twin's negative for the old rung stand in for
+# the new one.
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/branch_shared "${_gd_head}"
+                           "        if (!first) {
+            return GDeflateRefuse(s, kGDeflateRejectAlpha);
+        }
+${_gd_site}" "${_gd_tail}" "${_gd_other}")
+# No enumeration at all.
+string(REGEX REPLACE "enum GDeflateReject" "enum SomethingElse" _gd_no_enum
+                     "${_gd_head}")
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/no_enum "${_gd_no_enum}"
+                           "${_gd_site}" "${_gd_tail}" "${_gd_other}")
+# Prose is not code. This header is compliant and its comments spell out both a
+# bare flag write and a wrapped refusal; a scan that read comments would refuse
+# the file that documents itself best.
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/prose "${_gd_head}"
+                           "        /* Not: s.failed = true; and not a wrapped
+         * GDeflateRefuse( either. */
+${_gd_site}" "${_gd_tail}" "${_gd_other}")
+# A violation below an unbalanced bracket - the shape that reads only the top
+# of a file (issue #294). The rule must still report, and at the line it is on.
+cudec_write_gdeflate_probe(${_gdeflate_probe_root}/bracket_above "${_gd_head}"
+                           "        /* Reading page[from .. as the real header does. */
+        s.failed = true;
+" "${_gd_tail}" "${_gd_other}")
+
+# The compliant probes come first and carry no expected text: a lock that
+# refuses honest work is a worse defect than one rule gone quiet, and the
+# clean, clears_branch and prose entries are what keep the rules from being
+# written as blanket refusals.
+set(_gdeflate_lock_probes
+    "clean|"
+    "clears_branch|"
+    "prose|"
+    "missing_header|gdeflate_schedule.h is missing"
+    "bare_flag|gdeflate_schedule.h:28: sets the failure flag without going"
+    "bare_branch|gdeflate_schedule.h:28: names a ladder branch outside"
+    "wrapped_refuse|gdeflate_schedule.h:28: a GDeflateRefuse call with no ladder"
+    "branch_unused|ladder branch 'kGDeflateRejectGamma' is declared and no refusal"
+    "site_undeclared|a refusal site names 'kGDeflateRejectGamma', which"
+    "branch_shared|ladder branch 'kGDeflateRejectAlpha' is named by 2 refusal"
+    "no_enum|declares no reject ladder"
+    "bracket_above|gdeflate_schedule.h:29: sets the failure flag without going")
+foreach(_entry IN LISTS _gdeflate_lock_probes)
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\1" _probe "${_entry}")
+  string(REGEX REPLACE "^([^|]+)\\|(.*)$" "\\2" _expected "${_entry}")
+  cudec_check_gdeflate_locks(${_gdeflate_probe_root}/${_probe} _probe_result)
+  if(_expected STREQUAL "")
+    # Checked here rather than through string(FIND): an empty needle is found
+    # at position 0 in every string, so the branch below would assert nothing.
+    if(_probe_result)
+      message(FATAL_ERROR "the GDeflate lock refuses a compliant probe: "
+                          "${_probe} must come back silent (issue #183). It "
+                          "reported:\n${_probe_result}")
+    endif()
+  else()
+    string(FIND "${_probe_result}" "${_expected}" _found_at)
+    if(_found_at EQUAL -1)
+      message(FATAL_ERROR "the GDeflate lock is dead for one rule: probe "
+                          "${_probe} did not report \"${_expected}\" "
+                          "(issue #183). It reported:\n${_probe_result}")
+    endif()
+  endif()
+endforeach()
+
+# And now against the tree the rules are for.
+cudec_check_gdeflate_locks(${CMAKE_CURRENT_SOURCE_DIR}/../src
+                           _gdeflate_violations)
+if(_gdeflate_violations)
+  message(FATAL_ERROR "the GDeflate reject ladder and its refusal sites have "
+                      "drifted apart (issue #183):\n${_gdeflate_violations}")
 endif()
 
 # ---- Termination, warp-collective integrity, and determinism as structural

--- a/tests/gdeflate_ladder_lock.cpp
+++ b/tests/gdeflate_ladder_lock.cpp
@@ -1,0 +1,614 @@
+/* The run-time half of the GDeflate reject-ladder lock (issue #183).
+ *
+ * The configure-time half in tests/CMakeLists.txt reads the three headers and
+ * requires every declared branch of `enum GDeflateReject` to be named by
+ * exactly one refusal site. That says nothing about whether any input reaches
+ * the site. This file is the other half: one negative per declared branch,
+ * each asserting the branch it lands on, and a final sweep requiring every
+ * branch in the enumeration either to have been reached here or to be declared
+ * unreachable with its argument written beside it.
+ *
+ * WHAT THE PAIR BUYS, AND IT IS THE STANDING GATE THE ISSUE ASKS FOR. Adding a
+ * rung costs an enumerator, a refusal site and a negative: the enumerator with
+ * no site reds the configure, the site with no enumerator reds it too, and the
+ * pair of them with no negative reds this test. A rung that borrows a
+ * neighbouring enumerator to avoid all three is what the exactly-one count
+ * refuses next door.
+ *
+ * WHY IT IS ONE BINARY RATHER THAN A SECTION IN EACH TWIN. The ladder is one
+ * enumeration across three headers because one sticky field carries it, and
+ * the negatives that reach it are spread over four twins today - the
+ * code-length rungs live in gdeflate_header_twin.cpp, the construction rungs
+ * in gdeflate_tables_twin.cpp, the block rungs in gdeflate_block_twin.cpp. A
+ * coverage claim assembled from four processes is a claim about whichever of
+ * them ran, so the sweep needs one process that can reach the whole
+ * enumeration. That is this file, and the cost is that its fixtures are its
+ * own rather than the ones the twins carry - it proves the ladder is
+ * reachable, and the twins remain where a rung is held against the reference.
+ *
+ * NO ORACLE HERE, DELIBERATELY. Every assertion below is about which rung the
+ * decoder in this tree takes, which is a question about this tree and not
+ * about the reference. Reject parity with the reference is what the twins
+ * establish and it is not restated here. */
+#include "gdeflate_block.h"
+#include "gdeflate_page_writer.h"
+#include "require.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+using cudec_detail::GDeflateAdvance;
+using cudec_detail::GDeflateBuildTable;
+using cudec_detail::GDeflateDecodePage;
+using cudec_detail::GDeflateDecodeSymbol;
+using cudec_detail::GDeflateInit;
+using cudec_detail::GDeflateLitLenTable;
+using cudec_detail::GDeflatePageState;
+using cudec_detail::GDeflatePop;
+using cudec_detail::GDeflateReject;
+using cudec_detail::GDeflateRemove;
+using cudec_detail::GDeflateSchedule;
+using cudec_detail::kGDeflateNoSymbol;
+using cudec_detail::kGDeflateNumStreams;
+using cudec_detail::kGDeflateRejectCount;
+using cudec_detail::kGDeflateRejectNone;
+using cudec_test::CompleteLengths;
+using cudec_test::EmitPage;
+using cudec_test::GDeflatePageWriter;
+using cudec_test::LenToken;
+using cudec_test::PlanPrecode;
+
+bool g_covered[kGDeflateRejectCount] = {false};
+
+/* Mark and assert in one act. A negative that lands on a NEIGHBOURING rung
+ * would otherwise fill the sweep below while testing something else, which is
+ * the failure mode a coverage array has: it counts arrivals, and only the
+ * expected branch makes an arrival evidence of anything. */
+bool Landed(const GDeflateSchedule& s, GDeflateReject expected) {
+    if (!s.failed || s.reject != expected) {
+        std::fprintf(stderr,
+                     "FAIL ladder: failed=%d reject=%d, wanted reject=%d\n",
+                     static_cast<int>(s.failed), static_cast<int>(s.reject),
+                     static_cast<int>(expected));
+        return false;
+    }
+    g_covered[expected] = true;
+    return true;
+}
+
+/* A construction rung has no schedule to record into, so it names itself into
+ * the slot its caller supplied. */
+bool NamedInSlot(bool built, GDeflateReject slot, GDeflateReject expected) {
+    if (built || slot != expected) {
+        std::fprintf(stderr, "FAIL ladder: built=%d slot=%d, wanted slot=%d\n",
+                     static_cast<int>(built), static_cast<int>(slot),
+                     static_cast<int>(expected));
+        return false;
+    }
+    g_covered[expected] = true;
+    return true;
+}
+
+std::vector<unsigned char> IndexedWords(uint32_t count) {
+    std::vector<unsigned char> page(static_cast<size_t>(count) * 4u);
+    for (uint32_t n = 0; n < count; n++) {
+        page[n * 4u + 0] = static_cast<unsigned char>(n);
+        page[n * 4u + 1] = 0;
+        page[n * 4u + 2] = 0;
+        page[n * 4u + 3] = 0xA5;
+    }
+    return page;
+}
+
+/* ---- src/gdeflate_schedule.h ---- */
+
+int ScheduleRungs() {
+    const std::vector<unsigned char> page = IndexedWords(64);
+
+    /* A trailing partial word is not a word any lane could be handed. */
+    GDeflateSchedule partial;
+    REQUIRE(!GDeflateInit(partial, page.data(), page.size() - 1));
+    REQUIRE(Landed(partial, cudec_detail::kGDeflateRejectPagePartialWord));
+
+    /* Draft section 5.3: the priming round needs 32 words. */
+    const std::vector<unsigned char> short_page = IndexedWords(31);
+    GDeflateSchedule below;
+    REQUIRE(!GDeflateInit(below, short_page.data(), short_page.size()));
+    REQUIRE(Landed(below, cudec_detail::kGDeflateRejectPageBelowPrimingRound));
+
+    /* The page ends under a lane that still wants a word. Drained lane by lane
+     * rather than jumped to, so the rung is reached the way a page reaches
+     * it. */
+    const uint32_t words = 40;
+    const std::vector<unsigned char> ending = IndexedWords(words);
+    GDeflateSchedule out_of_words;
+    REQUIRE(GDeflateInit(out_of_words, ending.data(), ending.size()));
+    for (uint64_t guard = 0; !out_of_words.failed && guard < 100000u; guard++) {
+        (void)GDeflatePop(out_of_words, 8);
+        GDeflateAdvance(out_of_words, ending.data());
+    }
+    REQUIRE(Landed(out_of_words, cudec_detail::kGDeflateRejectRefillPastEnd));
+
+    /* A remove wider than the lane holds, reached directly: a codeword width
+     * comes out of a decode table, so this guard stands between a table entry
+     * and an occupancy that would wrap. */
+    GDeflateSchedule removes;
+    REQUIRE(GDeflateInit(removes, page.data(), page.size()));
+    GDeflateRemove(removes, removes.bitsleft[0] + 1u);
+    REQUIRE(Landed(removes, cudec_detail::kGDeflateRejectRemovePastLane));
+
+    /* A read wider than the widest field the format has, on a lane that could
+     * have served a legal one. */
+    GDeflateSchedule too_wide;
+    REQUIRE(GDeflateInit(too_wide, page.data(), page.size()));
+    REQUIRE(GDeflatePop(too_wide, cudec_detail::kGDeflateMaxPopBits + 1u) == 0);
+    REQUIRE(Landed(too_wide, cudec_detail::kGDeflateRejectPopWidthPastFormat));
+
+    /* And a legal width the lane cannot serve, which is the other half of the
+     * condition that used to be one. The lane is emptied first, or the width
+     * bound above would answer instead and this rung would never be seen. */
+    GDeflateSchedule empty_lane;
+    REQUIRE(GDeflateInit(empty_lane, page.data(), page.size()));
+    (void)GDeflatePop(empty_lane, cudec_detail::kGDeflateMaxPopBits);
+    REQUIRE(!empty_lane.failed);
+    REQUIRE(empty_lane.bitsleft[0] == 0);
+    REQUIRE(GDeflatePop(empty_lane, 1) == 0);
+    REQUIRE(Landed(empty_lane, cudec_detail::kGDeflateRejectPopPastLane));
+    return 0;
+}
+
+/* ---- src/gdeflate_tables.h, the construction ---- */
+
+int ConstructionRungs() {
+    GDeflateLitLenTable t;
+    std::vector<unsigned char> lens;
+
+    /* An alphabet past the capacity of the table. */
+    lens.assign(cudec_detail::kGDeflateNumLitLenSyms + 1u, 0);
+    GDeflateReject slot = kGDeflateRejectNone;
+    bool built = GDeflateBuildTable(
+        lens.data(), cudec_detail::kGDeflateNumLitLenSyms + 1u, t, &slot);
+    REQUIRE(NamedInSlot(built, slot,
+                        cudec_detail::kGDeflateRejectTablePastCapacity));
+
+    /* A length past the longest codeword the alphabet admits. */
+    lens.assign(4, 0);
+    lens[0] = static_cast<unsigned char>(cudec_detail::kGDeflateMaxCodeLen + 1u);
+    slot = kGDeflateRejectNone;
+    built = GDeflateBuildTable(lens.data(), 4, t, &slot);
+    REQUIRE(NamedInSlot(built, slot,
+                        cudec_detail::kGDeflateRejectTableLengthPastMax));
+
+    /* Over-subscribed: three symbols at length 1 claim more codespace than
+     * exists, so no assignment is possible. */
+    lens.assign(4, 0);
+    lens[0] = 1;
+    lens[1] = 1;
+    lens[2] = 1;
+    slot = kGDeflateRejectNone;
+    built = GDeflateBuildTable(lens.data(), 4, t, &slot);
+    REQUIRE(NamedInSlot(built, slot,
+                        cudec_detail::kGDeflateRejectTableOverSubscribed));
+
+    /* Incomplete, and not one of the two shapes the reference admits: two
+     * symbols at length 2 leave half the codespace unclaimed. */
+    lens.assign(4, 0);
+    lens[0] = 2;
+    lens[1] = 2;
+    slot = kGDeflateRejectNone;
+    built = GDeflateBuildTable(lens.data(), 4, t, &slot);
+    REQUIRE(NamedInSlot(built, slot,
+                        cudec_detail::kGDeflateRejectTableIncomplete));
+    return 0;
+}
+
+/* ---- src/gdeflate_tables.h, the decode ---- */
+
+int EmptyTableRung() {
+    /* An all-zero vector is the empty code, which the construction ADMITS and
+     * this header refuses on use - stricter than the reference, which resolves
+     * such a codeword to a symbol the stream never encoded. */
+    GDeflateLitLenTable t;
+    const std::vector<unsigned char> lens(cudec_detail::kGDeflateNumLitLenSyms,
+                                          0);
+    GDeflateReject slot = kGDeflateRejectNone;
+    REQUIRE(GDeflateBuildTable(lens.data(),
+                               cudec_detail::kGDeflateNumLitLenSyms, t, &slot));
+    REQUIRE(t.kind == cudec_detail::kGDeflateTableEmpty);
+
+    const std::vector<unsigned char> page = IndexedWords(64);
+    GDeflateSchedule s;
+    REQUIRE(GDeflateInit(s, page.data(), page.size()));
+    REQUIRE(GDeflateDecodeSymbol(s, t) == kGDeflateNoSymbol);
+    REQUIRE(Landed(s, cudec_detail::kGDeflateRejectEmptyTableUsed));
+    return 0;
+}
+
+/* ---- src/gdeflate_tables.h, the code-length rounds ---- */
+
+/* A page whose code-length stream is exactly `toks`. The literal/length and
+ * distance vectors are the smallest the header fields can state, because what
+ * is under test is the expansion of the token stream and not the code those
+ * lengths would describe. */
+bool PageWithTokens(const std::vector<LenToken>& toks,
+                    std::vector<unsigned char>* page) {
+    unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms];
+    uint32_t num_explicit = 0;
+    if (!PlanPrecode(toks, 0, precode_lens, &num_explicit)) {
+        return false;
+    }
+    const std::vector<unsigned char> litlen_lens = CompleteLengths(257);
+    const std::vector<unsigned char> dist_lens(1, 1);
+    const std::vector<uint32_t> no_symbols;
+    return EmitPage(litlen_lens, dist_lens, toks, precode_lens, num_explicit,
+                    no_symbols, page);
+}
+
+/* Every fixture below is handed to the page decode rather than to the function
+ * that owns the rung. The rungs are reached through the block header the
+ * decoder reads first, which is what a page reaches them through - calling the
+ * code-length round straight after the priming round would read the block
+ * header bits as HLIT and test a misalignment this file invented. */
+int DecodeRefuses(const std::vector<unsigned char>& page, uint64_t out_cap,
+                  GDeflateReject expected) {
+    GDeflatePageState st;
+    uint64_t out_len = 0;
+    std::vector<unsigned char> out(static_cast<size_t>(out_cap), 0);
+    REQUIRE(!GDeflateDecodePage(st, page.data(), page.size(), out.data(),
+                                out.size(), &out_len));
+    REQUIRE(Landed(st.s, expected));
+    return 0;
+}
+
+int CodeLengthRungs() {
+    /* A repeat-previous code with nothing before it. */
+    std::vector<LenToken> toks;
+    LenToken repeat_prev = {16, 2, 0};
+    toks.push_back(repeat_prev);
+    std::vector<unsigned char> page;
+    REQUIRE(PageWithTokens(toks, &page));
+    REQUIRE(DecodeRefuses(
+                page, 64,
+                cudec_detail::kGDeflateRejectRepeatNothingBefore) == 0);
+
+    /* A zero run reaching past the end of the two vectors the header declared.
+     * The smallest legal HLIT and HDIST make 258 lengths, and one explicit
+     * length followed by two maximal zero runs is 277. */
+    toks.clear();
+    LenToken explicit_one = {1, 0, 0};
+    LenToken zero_run = {18, 7, 127};
+    toks.push_back(explicit_one);
+    toks.push_back(zero_run);
+    toks.push_back(zero_run);
+    std::vector<unsigned char> overrun;
+    REQUIRE(PageWithTokens(toks, &overrun));
+    REQUIRE(DecodeRefuses(
+                overrun, 64,
+                cudec_detail::kGDeflateRejectRepeatRunPastAlphabet) == 0);
+    return 0;
+}
+
+/* ---- src/gdeflate_block.h ---- */
+
+/* A page opening with BFINAL set and the given block type, and nothing after
+ * the three header bits. Every rung that refuses inside the block header needs
+ * no more of a page than this. */
+std::vector<unsigned char> PageWithBlockType(uint32_t block_type) {
+    GDeflatePageWriter w;
+    w.Reset();
+    w.Push(1, 1);
+    w.Push(2, block_type);
+    return w.Finish();
+}
+
+int ReservedBlockTypeRung() {
+    const std::vector<unsigned char> page = PageWithBlockType(3);
+    GDeflatePageState st;
+    uint64_t out_len = 0;
+    std::vector<unsigned char> out(64, 0);
+    REQUIRE(!GDeflateDecodePage(st, page.data(), page.size(), out.data(),
+                                out.size(), &out_len));
+    REQUIRE(Landed(st.s, cudec_detail::kGDeflateRejectBlockTypeReserved));
+    return 0;
+}
+
+/* A stored block declaring `len` bytes and carrying none of them. `trim` drops
+ * the zero tail the writer appends for the reference, which is what makes the
+ * page small enough for a declared length to outrun the bytes it can still
+ * supply. */
+std::vector<unsigned char> StoredPage(uint32_t len, bool trim) {
+    GDeflatePageWriter w;
+    w.Reset();
+    w.Push(1, 1);
+    w.Push(2, 0);
+    w.Ensure();
+    w.Push(16, len);
+    std::vector<unsigned char> page = w.Finish();
+    if (trim) {
+        page.resize(page.size() -
+                    static_cast<size_t>(cudec_test::kGDeflateWriterTailWords) *
+                        4u);
+    }
+    return page;
+}
+
+int StoredRungs() {
+    /* Past the capacity of the caller, which is the only output bound a stored
+     * block has: the format states no uncompressed size inside a page. */
+    const std::vector<unsigned char> page = StoredPage(8, false);
+    GDeflatePageState st;
+    uint64_t out_len = 0;
+    std::vector<unsigned char> small(4, 0);
+    REQUIRE(!GDeflateDecodePage(st, page.data(), page.size(), small.data(),
+                                small.size(), &out_len));
+    REQUIRE(Landed(st.s, cudec_detail::kGDeflateRejectStoredPastCap));
+
+    /* Past what the page can still supply, with a capacity wide enough that
+     * the rung above cannot answer first. */
+    const std::vector<unsigned char> tight = StoredPage(4000, true);
+    GDeflatePageState st2;
+    std::vector<unsigned char> wide(65536, 0);
+    REQUIRE(!GDeflateDecodePage(st2, tight.data(), tight.size(), wide.data(),
+                                wide.size(), &out_len));
+    REQUIRE(Landed(st2.s, cudec_detail::kGDeflateRejectStoredPastPage));
+    return 0;
+}
+
+/* A dynamic block whose body is `symbols`, over a literal/length code that can
+ * spell every symbol they use. */
+bool PageWithSymbols(const std::vector<unsigned char>& litlen_lens,
+                     const std::vector<unsigned char>& dist_lens,
+                     const std::vector<uint32_t>& symbols,
+                     std::vector<unsigned char>* page) {
+    std::vector<unsigned char> all(litlen_lens);
+    all.insert(all.end(), dist_lens.begin(), dist_lens.end());
+    const std::vector<LenToken> toks = cudec_test::BuildTokens(all);
+    unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms];
+    uint32_t num_explicit = 0;
+    if (!PlanPrecode(toks, 0, precode_lens, &num_explicit)) {
+        return false;
+    }
+    return EmitPage(litlen_lens, dist_lens, toks, precode_lens, num_explicit,
+                    symbols, page);
+}
+
+int LiteralPastCapRung() {
+    /* Three literals into a two-byte destination. The refusal is on the third,
+     * before anything is written. */
+    std::vector<unsigned char> litlen_lens(257, 0);
+    litlen_lens[65] = 1;
+    litlen_lens[cudec_test::kEndOfBlock] = 1;
+    const std::vector<unsigned char> dist_lens(1, 1);
+    std::vector<uint32_t> symbols;
+    symbols.push_back(65);
+    symbols.push_back(65);
+    symbols.push_back(65);
+    symbols.push_back(cudec_test::kEndOfBlock);
+    std::vector<unsigned char> page;
+    REQUIRE(PageWithSymbols(litlen_lens, dist_lens, symbols, &page));
+
+    GDeflatePageState st;
+    uint64_t out_len = 0;
+    std::vector<unsigned char> out(2, 0);
+    REQUIRE(!GDeflateDecodePage(st, page.data(), page.size(), out.data(),
+                                out.size(), &out_len));
+    REQUIRE(Landed(st.s, cudec_detail::kGDeflateRejectLiteralPastCap));
+    return 0;
+}
+
+/* A page whose first round reserves a match of the minimum length and whose
+ * second round ends the block, so the deferred copy is retired in the drain -
+ * which is where the distance symbol is decoded. Written straight against the
+ * writer because EmitPage stops at literals and end-of-block. */
+bool MatchPage(std::vector<unsigned char>* page) {
+    std::vector<unsigned char> litlen_lens(258, 0);
+    litlen_lens[65] = 2;
+    litlen_lens[cudec_test::kEndOfBlock] = 2;
+    litlen_lens[257] = 1; /* length 3, and no extra bits behind it */
+    const std::vector<unsigned char> dist_lens(1, 1);
+
+    std::vector<unsigned char> all(litlen_lens);
+    all.insert(all.end(), dist_lens.begin(), dist_lens.end());
+    const std::vector<LenToken> toks = cudec_test::BuildTokens(all);
+    unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms];
+    uint32_t num_explicit = 0;
+    if (!PlanPrecode(toks, 0, precode_lens, &num_explicit)) {
+        return false;
+    }
+    cudec_detail::GDeflatePrecodeTable precode;
+    if (!GDeflateBuildTable(precode_lens, cudec_detail::kGDeflateNumPrecodeSyms,
+                            precode)) {
+        return false;
+    }
+    GDeflateLitLenTable litlen;
+    if (!GDeflateBuildTable(litlen_lens.data(),
+                            static_cast<uint32_t>(litlen_lens.size()),
+                            litlen)) {
+        return false;
+    }
+    cudec_detail::GDeflateDistTable dist;
+    if (!GDeflateBuildTable(dist_lens.data(),
+                            static_cast<uint32_t>(dist_lens.size()), dist)) {
+        return false;
+    }
+
+    GDeflatePageWriter w;
+    w.Reset();
+    w.Push(1, 1);
+    w.Push(2, cudec_test::kBlockTypeDynamic);
+    w.Ensure();
+    w.Push(5, static_cast<uint32_t>(litlen_lens.size()) - 257u);
+    w.Push(5, static_cast<uint32_t>(dist_lens.size()) - 1u);
+    w.Push(4, num_explicit - 4u);
+    w.Ensure();
+    for (uint32_t i = 0; i < num_explicit; i++) {
+        w.Push(3, precode_lens[cudec_detail::GDeflatePrecodeOrder(i)]);
+        w.Advance();
+    }
+    w.Reset();
+    for (size_t i = 0; i < toks.size(); i++) {
+        uint32_t code = 0;
+        uint32_t len = 0;
+        if (!cudec_test::CodewordOf(precode, precode_lens, toks[i].presym,
+                                    &code, &len)) {
+            return false;
+        }
+        w.PushCode(code, len);
+        if (toks[i].extra_bits != 0) {
+            w.Push(toks[i].extra_bits, toks[i].extra_value);
+        }
+        w.Advance();
+    }
+
+    w.Reset();
+    uint32_t code = 0;
+    uint32_t len = 0;
+    /* Lane 0: the length symbol, then - in the same stream of bits, because a
+     * lane is one sequence - the distance symbol the drain asks this lane for
+     * thirty-two rounds later. */
+    if (!cudec_test::CodewordOf(litlen, litlen_lens.data(), 257, &code, &len)) {
+        return false;
+    }
+    w.PushCode(code, len);
+    uint32_t dcode = 0;
+    uint32_t dlen = 0;
+    if (!cudec_test::CodewordOf(dist, dist_lens.data(), 0, &dcode, &dlen)) {
+        return false;
+    }
+    w.PushCode(dcode, dlen);
+    w.Advance();
+    /* Lane 1: end of block, which the decoder leaves without advancing. */
+    if (!cudec_test::CodewordOf(litlen, litlen_lens.data(),
+                                cudec_test::kEndOfBlock, &code, &len)) {
+        return false;
+    }
+    w.PushCode(code, len);
+    for (uint32_t i = 0; i < kGDeflateNumStreams; i++) {
+        w.Advance();
+    }
+    if (!w.ok()) {
+        return false;
+    }
+    *page = w.Finish();
+    return true;
+}
+
+int MatchRungs() {
+    std::vector<unsigned char> page;
+    REQUIRE(MatchPage(&page));
+
+    /* The reservation is refused against the capacity before the hole is
+     * claimed: three bytes do not fit in two. */
+    GDeflatePageState st;
+    uint64_t out_len = 0;
+    std::vector<unsigned char> tight(2, 0);
+    REQUIRE(!GDeflateDecodePage(st, page.data(), page.size(), tight.data(),
+                                tight.size(), &out_len));
+    REQUIRE(Landed(st.s, cudec_detail::kGDeflateRejectMatchPastCap));
+
+    /* With room for the match, the same page reaches the copy - and its
+     * distance points before the first byte this page produced. */
+    GDeflatePageState st2;
+    std::vector<unsigned char> roomy(64, 0);
+    REQUIRE(!GDeflateDecodePage(st2, page.data(), page.size(), roomy.data(),
+                                roomy.size(), &out_len));
+    REQUIRE(Landed(st2.s, cudec_detail::kGDeflateRejectMatchBeforeOutput));
+    return 0;
+}
+
+/* ---- The sweep ---- */
+
+/* The three rungs no input reaches, each with the argument that says why. They
+ * are guards the decoder already carried rather than guards this ladder added,
+ * and the assertion below is that they stay unreached: the day one of them
+ * becomes reachable, this test fails and a negative is owed for it.
+ *
+ * kGDeflateRejectCodewordNotInCode - the walk past the longest codeword. A
+ * table that decodes is complete, empty or the single-symbol degenerate, and
+ * the last two are answered above the walk; on a COMPLETE canonical code every
+ * bit sequence resolves at or before the longest length, so the walk cannot
+ * fall out of its loop.
+ *
+ * kGDeflateRejectRoundFuelExhausted - the round cap with no end-of-block.
+ * Every round writes a byte, reserves a match of at least the minimum length,
+ * or retires a reservation, and the cap is two per output byte plus one per
+ * lane, so the capacity refusals answer first on every page that would run
+ * that far.
+ *
+ * kGDeflateRejectNoFinalBlock - the block cap with no final block. A block
+ * costs lane 0 at least its own three header bits and a refill, so a page
+ * carries at most about as many blocks as it has words, while the cap is
+ * twenty-one times that; a page of non-final blocks runs out of words, and
+ * kGDeflateRejectRefillPastEnd is what it lands on. */
+bool DeclaredUnreachable(int branch) {
+    return branch == cudec_detail::kGDeflateRejectCodewordNotInCode ||
+           branch == cudec_detail::kGDeflateRejectRoundFuelExhausted ||
+           branch == cudec_detail::kGDeflateRejectNoFinalBlock;
+}
+
+/* A sentinel is not a rung: it carries an explicit value, so it shares a
+ * number with the branch it bounds and is covered when that branch is. The
+ * sweep walks NUMBERS, so it sees each number once whatever it is called. */
+int Sweep() {
+    int reached = 0;
+    int unreachable = 0;
+    for (int branch = kGDeflateRejectNone + 1; branch < kGDeflateRejectCount;
+         branch++) {
+        const bool covered = g_covered[branch];
+        if (DeclaredUnreachable(branch)) {
+            REQUIRE_CTX(!covered,
+                        "ladder branch %d is declared unreachable and a "
+                        "negative reached it: it owes a negative and the "
+                        "declaration above owes a correction",
+                        branch);
+            unreachable++;
+            continue;
+        }
+        REQUIRE_CTX(covered,
+                    "ladder branch %d is declared by enum GDeflateReject and "
+                    "no negative in this file reaches it (issue #183)",
+                    branch);
+        reached++;
+    }
+    std::printf(
+        "gdeflate_ladder_lock: %d rungs reached by a negative, %d declared "
+        "unreachable, %d declared in total\n",
+        reached, unreachable, static_cast<int>(kGDeflateRejectCount) - 1);
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    if (ScheduleRungs() != 0) {
+        return 1;
+    }
+    if (ConstructionRungs() != 0) {
+        return 1;
+    }
+    if (EmptyTableRung() != 0) {
+        return 1;
+    }
+    if (CodeLengthRungs() != 0) {
+        return 1;
+    }
+    if (ReservedBlockTypeRung() != 0) {
+        return 1;
+    }
+    if (StoredRungs() != 0) {
+        return 1;
+    }
+    if (LiteralPastCapRung() != 0) {
+        return 1;
+    }
+    if (MatchRungs() != 0) {
+        return 1;
+    }
+    if (Sweep() != 0) {
+        return 1;
+    }
+    std::printf("gdeflate_ladder_lock: ok\n");
+    return 0;
+}

--- a/tests/gdeflate_ladder_lock.cpp
+++ b/tests/gdeflate_ladder_lock.cpp
@@ -356,6 +356,35 @@ int StoredRungs() {
     return 0;
 }
 
+/* A page of non-final stored blocks, each declaring zero bytes, which is the
+ * cheapest block the format has. It is the measurement behind the
+ * kGDeflateRejectNoFinalBlock declaration at the bottom of this file: the
+ * argument there is that a page runs out of words long before the block cap,
+ * and an argument about a fuel cap is exactly the kind that is wrong quietly.
+ * The page is asserted to land on the refill rung instead. */
+int NoFinalBlockStopsAtTheRefill() {
+    GDeflatePageWriter w;
+    for (uint32_t block = 0; block < 4096u; block++) {
+        w.Reset();
+        w.Push(1, 0);
+        w.Push(2, 0);
+        w.Ensure();
+        w.Push(16, 0);
+    }
+    REQUIRE(w.ok());
+    std::vector<unsigned char> page = w.Finish();
+    page.resize(page.size() -
+                static_cast<size_t>(cudec_test::kGDeflateWriterTailWords) * 4u);
+
+    GDeflatePageState st;
+    uint64_t out_len = 0;
+    std::vector<unsigned char> out(64, 0);
+    REQUIRE(!GDeflateDecodePage(st, page.data(), page.size(), out.data(),
+                                out.size(), &out_len));
+    REQUIRE(Landed(st.s, cudec_detail::kGDeflateRejectRefillPastEnd));
+    return 0;
+}
+
 /* A dynamic block whose body is `symbols`, over a literal/length code that can
  * spell every symbol they use. */
 bool PageWithSymbols(const std::vector<unsigned char>& litlen_lens,
@@ -537,11 +566,13 @@ int MatchRungs() {
  * lane, so the capacity refusals answer first on every page that would run
  * that far.
  *
- * kGDeflateRejectNoFinalBlock - the block cap with no final block. A block
- * costs lane 0 at least its own three header bits and a refill, so a page
- * carries at most about as many blocks as it has words, while the cap is
- * twenty-one times that; a page of non-final blocks runs out of words, and
- * kGDeflateRejectRefillPastEnd is what it lands on. */
+ * kGDeflateRejectNoFinalBlock - the block cap with no final block. The
+ * cheapest non-final block is a stored one declaring zero bytes, which costs
+ * lane 0 nineteen bits - three of header and sixteen of length - and lane 0 is
+ * refilled from one word each time those reads drop it under the watermark, so
+ * a page yields fewer than two blocks per word it carries. The cap is
+ * twenty-one per word, so a page of non-final blocks runs out of words first
+ * and kGDeflateRejectRefillPastEnd is what it lands on. */
 bool DeclaredUnreachable(int branch) {
     return branch == cudec_detail::kGDeflateRejectCodewordNotInCode ||
            branch == cudec_detail::kGDeflateRejectRoundFuelExhausted ||
@@ -598,6 +629,9 @@ int main() {
         return 1;
     }
     if (StoredRungs() != 0) {
+        return 1;
+    }
+    if (NoFinalBlockStopsAtTheRefill() != 0) {
         return 1;
     }
     if (LiteralPastCapRung() != 0) {


### PR DESCRIPTION
## What this changes

The three GDeflate headers refused with a bare sticky flag. The set of reasons a
page can be refused therefore existed only in the prose above each site: nothing
could ask which rung a page took, and nothing could tell a rung added without a
negative from one that has carried a negative since it landed.

Every refusal now names a branch of one `enum GDeflateReject` and reaches the
sticky state through a choke point. Two halves hold the enumeration to the code,
which is the standing mechanical gate #183 asks for in its second bullet.

**The configure-time half**, `cudec_check_gdeflate_locks` in
`tests/CMakeLists.txt`, modelled on `cudec_check_snappy_locks` next to it as
that issue's note suggested. Each declared branch must be named by exactly one
refusal site; a site naming a branch the enumeration does not carry is refused;
a line writing `.failed = true` or `.reject = <a rung>` outside the choke points
is refused, because such a site names no rung and is invisible to both halves.

**The run-time half**, `tests/gdeflate_ladder_lock.cpp`, a new GPU-less ctest
entry. One negative per rung, each asserting the rung it lands on rather than
only that the page was refused:

```
gdeflate_ladder_lock: 19 rungs reached by a negative, 3 declared unreachable, 22 declared in total
```

**Two condition pairs became two rungs** rather than staying one, because a
single rung lets a negative for either stand in for the other: a pop wider than
the widest field the format has against a lane that cannot serve a legal width,
and a stored length past the capacity of the caller against one past the bytes
the page can still supply.

## The three rungs declared unreachable, and what that costs

`kGDeflateRejectCodewordNotInCode`, `kGDeflateRejectRoundFuelExhausted` and
`kGDeflateRejectNoFinalBlock` are reached by no input, and the argument for each
is written at the declaration in the test rather than summarised here. They are
guards the decoder already carried; this change names them, it does not add
them. The sweep asserts they stay UNREACHED, so the day one becomes reachable
the test fails and a negative is owed for it.

## Proof that both halves bite

Twelve planted probe trees drive the configure-time rules before the real tree
is judged, each matched against the text its own rule emits rather than against
a non-empty result - three of them compliant, so a rule written as a blanket
refusal fails the probe rather than passing the tree.

Against the real tree, a second site naming an existing rung - the shape a new
rung borrowing its neighbour takes:

```
$ cmake -B build-af39-probe -DCUDEC_ENABLE_CUDA=ON ...
CMake Error at tests/CMakeLists.txt:1917 (message):
  the GDeflate reject ladder and its refusal sites have drifted apart (issue
  #183):

    ladder branch 'kGDeflateRejectPopPastLane' is named by 2 refusal sites: a new rung takes a new branch, so that the twin's negative for it cannot be satisfied by its neighbour (issue #183)
```

And a rung with its own enumerator and its own site, which the static half
correctly admits, reaching the half that is about negatives:

```
configure exit=0  (the static half admits it: the rung has exactly one site)
FAIL tests/gdeflate_ladder_lock.cpp:569: covered | ladder branch 23 is declared by enum GDeflateReject and no negative in this file reaches it (issue #183)
ladder_lock exit=1
```

Both plants were reverted; the branch carries neither.

## The gate that was run, and the half of it that was not

```
$ wsl -d Ubuntu-24.04 -- bash -lc 'cd /mnt/g/Github/cudec && cmake -B build-af39-wsl -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc && cmake --build build-af39-wsl -j8 && ctest --test-dir build-af39-wsl -LE gpu'
100% tests passed, 0 tests failed out of 52
```

51 of those are the host-side entries `main` already carried; the 52nd is the
new one. **The nine gpu-labelled entries did not run**, and the reason is the
session rather than the change - the paravirtualisation device is absent from
the WSL instance tonight:

```
$ wsl -d Ubuntu-24.04 -- bash -lc 'ls /dev/dxg; nvidia-smi --query-gpu=name --format=csv,noheader'
ls: cannot access '/dev/dxg': No such file or directory
Failed to initialize NVML: GPU access blocked by the operating system
```

Nothing in this change reaches device code: the three headers are single-sourced
for host and device, and no translation unit compiles them `__device__` yet.
That is a reason to expect the gpu entries to be unaffected, not a measurement
that they are.

Two further limits on the run above, both of which hold for every run made
through this route. It is CUDA 13.3 rather than the `nvidia/cuda:12.6.2`
container `CONTRIBUTING.md` names as the canonical gate, and the Docker engine
on this machine is stopped. And the Compute Sanitizer sweep that
`CONTRIBUTING.md` asks of a device-code change **was not produced**: the gate is
parked for the reason that file records, and no device code is touched here in
any case.

## What this does not do

This does not satisfy #183. Its remaining bullet is two-directional reject
parity over the oracle-derived mutation corpus, which collides with the
reasoning recorded on #192 and is a scope call rather than something derivable
from this tree. The rung names this change adds are what that work needed first,
so it is now buildable if the call is taken.

No second reader was available on this board tonight, and the evidence above
stands in place of one.

## Why this is not merged

Six of the seven checks are green - `build`, `sanitize`, `fuzz`, `analyze`,
`CodeQL`, `dependency-review`. `format` is red, and not for anything in this
change: Prettier passed in that same job, and the step that failed is
`scripts/check-dependabot-config.sh`, whose SHA-256 pin on the upstream
Dependabot schema stopped matching between 09:16Z and 17:14Z today. #422 holds
that, with the recomputed hash and the window it moved in.

The ruleset on `main` requires `build` and `format` and carries no bypass
actors, read rather than assumed:

```
$ gh api repos/iderex/cudec/rulesets/19067516 --jq '{enforcement, bypass: .bypass_actors, required: [.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context]}'
{"bypass":[],"enforcement":"active","required":["build","format"]}
```

So this waits on #422 and on nothing in its own diff. Moving that pin is a
deliberate act - the script says so in the message it fails with - and it is
not made from here.

## Corrected on the branch: one of the three unreachability arguments was wrong, and it is now executed

The declaration for `kGDeflateRejectNoFinalBlock` said a block costs lane 0 its
header bits and a refill, so a page carries about as many blocks as it has
words. The refill half does not hold - a lane holds up to sixty-one bits after
one, so several blocks pass between two refills of lane 0 - and the sentence was
an argument about a fuel cap that nobody had run. The cheapest non-final block
is a stored one declaring zero bytes, nineteen bits on lane 0, so a page yields
fewer than two blocks per word against a cap of twenty-one per word.

A page of four thousand such blocks now stands beside the declaration and is
required to land on `kGDeflateRejectRefillPastEnd`, so that claim is executed
rather than asserted. `67ac117` carries it, and the suite is unchanged at 52 of
52 host-side.

## What the red format job leaves unmeasured, said rather than implied

The Dependabot step is the third of that job, so the steps after it never ran:
the tense-present document path check, the Action SHA-pin audit, and whatever
follows them. A red job is not a statement that its later steps would pass, and
this change is not claiming they did.

Two of them were run here instead, which is a local run and not the job:

```
$ GH_TOKEN=... bash scripts/check-doc-paths.sh
PASS: every path a tense-present document names resolves, and every declared forward reference names an open issue
$ bash scripts/check-fuzz-corpus.sh
PASS: fuzz/corpus - 106 seed(s) across 10 target(s), all hash-pinned
```
