### PR TITLE
Move the Dependabot schema pin, having read what moved [#422]

### DIFF
--- a/scripts/check-dependabot-config.sh
+++ b/scripts/check-dependabot-config.sh
@@ -31,11 +31,19 @@ set -eu
 
 cfg="${1:-.github/dependabot.yml}"
 
-# Pinned 2026-08-06 against https://www.schemastore.org/dependabot-2.0.json
+# Pinned 2026-08-31 against https://www.schemastore.org/dependabot-2.0.json
 # (json.schemastore.org 301-redirects there). Recompute with:
 #   curl -fsSL "$schema_url" | sha256sum
+#
+# Moved from 46255f69 on 2026-08-31 after reading what changed upstream (#422).
+# One commit touched the file in the window, SchemaStore 07a2d101 "make
+# multi-ecosystem patterns optional", and its whole diff is the removal of one
+# conditional: a config naming multi-ecosystem-group no longer has to name
+# patterns. That is a loosening, so it cannot invalidate a document that
+# validated before it, and this repository uses neither key - so the rule that
+# went away could never have applied here.
 schema_url="https://www.schemastore.org/dependabot-2.0.json"
-schema_sha256="46255f692a8d661325e9d044b50f4b687aff68633b716420b64e460fb212b471"
+schema_sha256="c6c2432adc55b40f828b0f987f8024bb9b8926a978301e9cdf4fe3410ee7cf31"
 
 # Exact versions, so the gate's own dependencies cannot move underneath it.
 yaml_pkg="js-yaml@4.1.0"


### PR DESCRIPTION
Closes #422.

The pinned Dependabot schema moved upstream today, so `scripts/check-dependabot-config.sh` refused it and reddened `format` on every pull request. `format` is a required context, so this held the whole board rather than one change.

## What moved

One commit, SchemaStore `07a2d101` at 2026-08-31T15:42:29Z, `fix: make multi-ecosystem patterns optional`, inside the window the issue narrows to. Its entire diff to the file is a removal:

```
-        },
-        {
-          "$comment": "If multi-ecosystem-group is specified, patterns is required",
-          "if": {
-            "required": ["multi-ecosystem-group"]
-          },
-          "then": {
-            "properties": {
-              "patterns": {
-                "$ref": "#/definitions/update/properties/patterns"
-              }
-            },
-            "required": ["patterns"]
-          }
         }
```

A configuration naming `multi-ecosystem-group` no longer has to name `patterns`. Nothing was added, nothing renamed, no other rule moved.

## Why the pin follows rather than holding

A removed requirement is a loosening, so it cannot invalidate a document that validated against the older schema. Accepting a loosening normally means the gate checks less than it did, and that would be worth weighing. Here it checks exactly as much:

```
$ grep -nE "multi-ecosystem-group|patterns" .github/dependabot.yml
(no matches)
```

This repository uses neither key, so the rule that went away could never have applied to its configuration.

## Verified

The bytes had settled before the pin was moved to them - the value below was read at 17:20Z on the issue and again four hours later:

```
$ curl -fsSL "https://www.schemastore.org/dependabot-2.0.json" | sha256sum
c6c2432adc55b40f828b0f987f8024bb9b8926a978301e9cdf4fe3410ee7cf31  -
```

And the check passes on this branch with its own self-test still refusing, so it is green because it passes rather than because it was weakened:

```
$ bash scripts/check-dependabot-config.sh
PASS: self-test - the validator refuses a known-bad config
PASS: .github/dependabot.yml validates against https://www.schemastore.org/dependabot-2.0.json
```

The reasoning sits above the pin in the file as well as here, because whoever meets the next refusal will be reading that file rather than this pull request.
