### PR TITLE
Give the three sequence-execution units a tiled form

### DIFF
--- a/src/zstd_exec.h
+++ b/src/zstd_exec.h
@@ -141,30 +141,53 @@ struct ZstdExecPlan {
     uint64_t literals_used;
 };
 
-/* The prefix sum over (Literal_Length + Match_Length), block-relative.
+/* Where a prefix sum taken a tile at a time has got to.
  *
- * `out_destinations` receives `sequence_count + 1` entries: entry `i` is where
- * sequence `i` writes its literals, and the last entry is where the leftover
- * literals begin. The one-past-the-end entry is not a convenience - it is what
- * the execution compares each sequence's own arithmetic against, and it is
- * what tells the tail where it starts without a second sum.
+ * WHY THE SUM IS RESUMABLE AT ALL. `docs/MASTERPLAN.md` section 14.9 costs the
+ * whole-block intermediates against the shared memory a fused kernel has - at
+ * 43690 sequences a block may declare, the destinations alone are over 300 KiB
+ * - and produces them 128 at a time instead. Carrying the two running
+ * quantities is what lets the sum stop and continue; the whole-block form
+ * below is written on top of this one rather than beside it.
+ *
+ * THE CEILING IS COMPARED AGAINST THE RUNNING TOTAL AND NEVER AGAINST A
+ * TILE'S OWN. Both fields are the block's, not the tile's, so a block that
+ * exceeds its maximum across a tile boundary is refused at the sequence that
+ * passes it. That is the same comparison the whole-block form makes, moved,
+ * and not a weaker one. */
+struct ZstdExecCarry {
+    /* Block-relative destination of the next sequence: the sum of every
+     * (Literal_Length + Match_Length) before it. */
+    uint64_t at;
+    /* Literal bytes the sequences so far consume. */
+    uint64_t literals_used;
+};
+
+/* One tile of the prefix sum over (Literal_Length + Match_Length),
+ * block-relative.
+ *
+ * `out_destinations` receives one entry per sequence of this tile - entry `i`
+ * is where sequence `i` writes its literals - and never the one-past-the-end
+ * entry, which is `ZstdExecPrefixSumFinish`'s and exists once per block.
+ *
+ * `out_literal_cursors`, when given, receives each sequence's own literal
+ * cursor. A whole-block execution carries that in a loop variable and does not
+ * need it; a fan-out across lanes has no loop to carry it in, and section
+ * 14.9's tile record is where it lives. Optional rather than always written,
+ * because the caller that has a loop should not pay an array for it.
  *
  * `block_maximum` is Block_Maximum_Size for this frame (RFC 8878 section
  * 3.1.1.2.4), the ceiling a compressed block's regenerated size may not pass.
  * It is bounded here, before any copy, rather than discovered by a destination
  * that overflows: the copies are independent of each other and one of them
  * running past the end is not something the others would notice. */
-CUDEC_HOST_DEVICE inline cudec_status ZstdExecPrefixSum(
+CUDEC_HOST_DEVICE inline cudec_status ZstdExecPrefixSumTile(
     const ZstdSequence* sequences, uint32_t sequence_count,
-    uint64_t literals_size, uint64_t block_maximum,
-    uint64_t* out_destinations, uint32_t destinations_capacity,
-    ZstdExecPlan* out_plan, ZstdExecReject* reject) {
+    uint64_t literals_size, uint64_t block_maximum, ZstdExecCarry* carry,
+    uint64_t* out_destinations, uint64_t* out_literal_cursors,
+    uint32_t destinations_capacity, ZstdExecReject* reject) {
     if (reject != 0) {
         *reject = kZstdExecRejectNone;
-    }
-    if (out_plan != 0) {
-        out_plan->block_size = 0;
-        out_plan->literals_used = 0;
     }
     /* THE CEILING IS BOUNDED BEFORE IT IS USED, AND THAT IS WHAT MAKES EVERY
      * SUM BELOW SAFE RATHER THAN LUCKY. Both of these are the caller's own
@@ -176,21 +199,28 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdExecPrefixSum(
      * file can wrap and no reject rung is needed for one. A rung for an
      * overflow that 32-bit length fields cannot reach would be a guard no
      * negative could ever red, which is worse than no guard: it reads as
-     * coverage. */
-    if (out_destinations == 0 || out_plan == 0 ||
-        (sequences == 0 && sequence_count != 0) ||
-        destinations_capacity < 1 ||
-        destinations_capacity - 1 < sequence_count ||
+     * coverage.
+     *
+     * The carry is bounded on the way in for the same reason. It arrives from
+     * whatever ran the previous tile, so believing it would put every bound
+     * below behind a number this call did not compute. */
+    if (carry == 0 || (sequences == 0 && sequence_count != 0) ||
+        (out_destinations == 0 && sequence_count != 0) ||
+        destinations_capacity < sequence_count ||
         block_maximum > kZstdBlockSizeCeiling ||
-        literals_size > kZstdBlockSizeCeiling) {
+        literals_size > kZstdBlockSizeCeiling || carry->at > block_maximum ||
+        carry->literals_used > literals_size) {
         return ZstdExecRefuse(kZstdExecRejectBadRequest,
                               CUDEC_ERR_INVALID_ARGUMENT, reject);
     }
 
-    uint64_t at = 0;
-    uint64_t literals_used = 0;
+    uint64_t at = carry->at;
+    uint64_t literals_used = carry->literals_used;
     for (uint32_t index = 0; index < sequence_count; index++) {
         out_destinations[index] = at;
+        if (out_literal_cursors != 0) {
+            out_literal_cursors[index] = literals_used;
+        }
         const uint64_t literals_length = sequences[index].literals_length;
         const uint64_t match_length = sequences[index].match_length;
         /* Checked as a subtraction against what is left of the ceiling, which
@@ -209,16 +239,163 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdExecPrefixSum(
         }
         literals_used += literals_length;
     }
-    out_destinations[sequence_count] = at;
+    /* Advanced only on success: a carry left half-way through a refused tile
+     * is a running total nobody may continue from. */
+    carry->at = at;
+    carry->literals_used = literals_used;
+    return CUDEC_OK;
+}
 
-    const uint64_t tail = literals_size - literals_used;
+/* Closes a block's prefix sum: the one-past-the-end destination, the leftover
+ * literals, and the plan the execution is held to.
+ *
+ * `out_last_destination` is where the tail begins. It is what the execution
+ * compares each sequence's own arithmetic against, and it is what tells the
+ * tail where it starts without a second sum. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdExecPrefixSumFinish(
+    const ZstdExecCarry* carry, uint64_t literals_size, uint64_t block_maximum,
+    uint64_t* out_last_destination, ZstdExecPlan* out_plan,
+    ZstdExecReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdExecRejectNone;
+    }
+    if (out_plan != 0) {
+        out_plan->block_size = 0;
+        out_plan->literals_used = 0;
+    }
+    if (carry == 0 || out_plan == 0 || out_last_destination == 0 ||
+        block_maximum > kZstdBlockSizeCeiling ||
+        literals_size > kZstdBlockSizeCeiling || carry->at > block_maximum ||
+        carry->literals_used > literals_size) {
+        return ZstdExecRefuse(kZstdExecRejectBadRequest,
+                              CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+
+    const uint64_t at = carry->at;
+    *out_last_destination = at;
+    const uint64_t tail = literals_size - carry->literals_used;
     if (tail > block_maximum - at) {
         return ZstdExecRefuse(kZstdExecRejectBlockTooLarge,
                               CUDEC_ERR_CORRUPT_INPUT, reject);
     }
-    const uint64_t block_size = at + tail;
-    out_plan->block_size = block_size;
-    out_plan->literals_used = literals_used;
+    out_plan->block_size = at + tail;
+    out_plan->literals_used = carry->literals_used;
+    return CUDEC_OK;
+}
+
+/* The whole block's prefix sum in one call: one tile the size of the block,
+ * then the close.
+ *
+ * `out_destinations` receives `sequence_count + 1` entries: entry `i` is where
+ * sequence `i` writes its literals, and the last entry is where the leftover
+ * literals begin. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdExecPrefixSum(
+    const ZstdSequence* sequences, uint32_t sequence_count,
+    uint64_t literals_size, uint64_t block_maximum,
+    uint64_t* out_destinations, uint32_t destinations_capacity,
+    ZstdExecPlan* out_plan, ZstdExecReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdExecRejectNone;
+    }
+    if (out_plan != 0) {
+        out_plan->block_size = 0;
+        out_plan->literals_used = 0;
+    }
+    /* The one-past-the-end entry is this form's own, so the room for it is
+     * bounded here; the tile below is told about its own entries only. */
+    if (out_destinations == 0 || out_plan == 0 || destinations_capacity < 1 ||
+        destinations_capacity - 1 < sequence_count) {
+        return ZstdExecRefuse(kZstdExecRejectBadRequest,
+                              CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    ZstdExecCarry carry;
+    carry.at = 0;
+    carry.literals_used = 0;
+    const cudec_status summed = ZstdExecPrefixSumTile(
+        sequences, sequence_count, literals_size, block_maximum, &carry,
+        out_destinations, 0, destinations_capacity - 1, reject);
+    if (summed != CUDEC_OK) {
+        return summed;
+    }
+    return ZstdExecPrefixSumFinish(&carry, literals_size, block_maximum,
+                                   &out_destinations[sequence_count], out_plan,
+                                   reject);
+}
+
+/* Executes one sequence: its literals, then its match, into the frame's
+ * output.
+ *
+ * WHY THE BODY IS ITS OWN FUNCTION. On the device the sequences of a tile run
+ * one per lane, and a loop body reached only from a whole-block loop would
+ * have to be spelled a second time to get there. The two offset bounds and the
+ * plan-consistency check are the last things in this format that should
+ * acquire a second spelling, so the body moves and both callers reach it.
+ *
+ * Everything a lane needs arrives by value: its destination, its successor's,
+ * its own literal cursor - which the tiled prefix sum supplies where there is
+ * no loop to carry one - and the block size the plan fixed. `base` is where
+ * this block starts in the frame's output, so the offset bounds below are the
+ * frame's and never the block's. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdExecuteSequence(
+    const ZstdSequence* sequence, uint64_t destination,
+    uint64_t next_destination, uint64_t offset, const unsigned char* literals,
+    uint64_t literals_size, uint64_t literal_at, uint64_t block_size,
+    uint64_t window_size, unsigned char* dst, uint64_t base,
+    ZstdExecReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdExecRejectNone;
+    }
+    if (sequence == 0 || dst == 0 || (literals == 0 && literals_size != 0) ||
+        literal_at > literals_size) {
+        return ZstdExecRefuse(kZstdExecRejectBadRequest,
+                              CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+
+    const uint64_t literals_length = sequence->literals_length;
+    const uint64_t match_length = sequence->match_length;
+    const uint64_t at = destination;
+    /* The array is re-derived rather than believed: this sequence's own
+     * lengths have to carry the destination to the next one's, and the
+     * last one's to where the tail begins. A scan that dropped a sequence,
+     * doubled one, or ran in the wrong order fails here rather than
+     * writing over a neighbour's bytes. */
+    if (at > block_size || literals_length + match_length > block_size - at ||
+        at + literals_length + match_length != next_destination) {
+        return ZstdExecRefuse(kZstdExecRejectPlanInconsistent,
+                              CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    if (literals_length > literals_size - literal_at) {
+        return ZstdExecRefuse(kZstdExecRejectLiteralsExhausted,
+                              CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+
+    uint64_t to = base + at;
+    for (uint64_t i = 0; i < literals_length; i++) {
+        dst[to + i] = literals[literal_at + i];
+    }
+    to += literals_length;
+
+    if (offset == 0) {
+        return ZstdExecRefuse(kZstdExecRejectOffsetZero,
+                              CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    if (offset > window_size) {
+        return ZstdExecRefuse(kZstdExecRejectOffsetPastWindow,
+                              CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    /* `to` is where this match starts, so the bytes produced before it are
+     * everything the frame holds up to that point - the earlier blocks,
+     * this block's earlier sequences, and this sequence's own literals.
+     * Comparing against the block's own start instead would refuse the
+     * cross-block match the format allows. */
+    if (offset > to) {
+        return ZstdExecRefuse(kZstdExecRejectOffsetBeforeOutput,
+                              CUDEC_ERR_CORRUPT_INPUT, reject);
+    }
+    const uint64_t from = to - offset;
+    for (uint64_t i = 0; i < match_length; i++) {
+        dst[to + i] = dst[from + i];
+    }
     return CUDEC_OK;
 }
 
@@ -262,54 +439,14 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdExecuteBlock(
 
     uint64_t literal_at = 0;
     for (uint32_t index = 0; index < sequence_count; index++) {
-        const uint64_t literals_length = sequences[index].literals_length;
-        const uint64_t match_length = sequences[index].match_length;
-        const uint64_t at = destinations[index];
-        /* The array is re-derived rather than believed: this sequence's own
-         * lengths have to carry the destination to the next one's, and the
-         * last one's to where the tail begins. A scan that dropped a sequence,
-         * doubled one, or ran in the wrong order fails here rather than
-         * writing over a neighbour's bytes. */
-        if (at > plan->block_size ||
-            literals_length + match_length > plan->block_size - at ||
-            at + literals_length + match_length != destinations[index + 1]) {
-            return ZstdExecRefuse(kZstdExecRejectPlanInconsistent,
-                                  CUDEC_ERR_CORRUPT_INPUT, reject);
+        const cudec_status status = ZstdExecuteSequence(
+            &sequences[index], destinations[index], destinations[index + 1],
+            offsets[index], literals, literals_size, literal_at,
+            plan->block_size, window_size, dst, base, reject);
+        if (status != CUDEC_OK) {
+            return status;
         }
-        if (literals_length > literals_size - literal_at) {
-            return ZstdExecRefuse(kZstdExecRejectLiteralsExhausted,
-                                  CUDEC_ERR_CORRUPT_INPUT, reject);
-        }
-
-        uint64_t to = base + at;
-        for (uint64_t i = 0; i < literals_length; i++) {
-            dst[to + i] = literals[literal_at + i];
-        }
-        literal_at += literals_length;
-        to += literals_length;
-
-        const uint64_t offset = offsets[index];
-        if (offset == 0) {
-            return ZstdExecRefuse(kZstdExecRejectOffsetZero,
-                                  CUDEC_ERR_CORRUPT_INPUT, reject);
-        }
-        if (offset > window_size) {
-            return ZstdExecRefuse(kZstdExecRejectOffsetPastWindow,
-                                  CUDEC_ERR_CORRUPT_INPUT, reject);
-        }
-        /* `to` is where this match starts, so the bytes produced before it are
-         * everything the frame holds up to that point - the earlier blocks,
-         * this block's earlier sequences, and this sequence's own literals.
-         * Comparing against the block's own start instead would refuse the
-         * cross-block match the format allows. */
-        if (offset > to) {
-            return ZstdExecRefuse(kZstdExecRejectOffsetBeforeOutput,
-                                  CUDEC_ERR_CORRUPT_INPUT, reject);
-        }
-        const uint64_t from = to - offset;
-        for (uint64_t i = 0; i < match_length; i++) {
-            dst[to + i] = dst[from + i];
-        }
+        literal_at += sequences[index].literals_length;
     }
 
     /* Where the tail begins, and the last thing the plan is held to.

--- a/src/zstd_seq.h
+++ b/src/zstd_seq.h
@@ -551,30 +551,56 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdSeqUpdateState(
     return CUDEC_OK;
 }
 
-/* The three-state interleaved loop over one backward bitstream.
+/* A sequence decode in progress: everything the three-state loop has to carry
+ * from one tile of sequences to the next.
  *
- * Three orders, all the format's and no two of them the same: the states are
- * initialised literals-length, offset, match-length; the extra bits are read
- * offset, match-length, literals-length; and the states are updated
- * literals-length, match-length, offset. An implementation that gets any one
- * of them wrong still decodes the first field of the first sequence
- * correctly, which is why the corpus sweep asserts exact consumption rather
- * than only the count.
+ * WHY THE LOOP IS RESUMABLE AT ALL. A block may declare Block_Maximum_Size / 3
+ * sequences, which is 43690 for a 128 KiB block, and the whole-set form below
+ * fills an array of that many. `docs/MASTERPLAN.md` section 14.9 costs that
+ * against the shared memory a fused kernel has and produces sequences 128 at a
+ * time instead, so the loop needs a form whose reader and three states survive
+ * the call. The whole-set form is written on top of this one rather than
+ * beside it: a second copy of the three orders below is the one duplication
+ * this file cannot afford.
+ *
+ * THE TABLES ARE HELD RATHER THAN RE-PASSED, AND THAT IS NOT A TRUST
+ * DECISION. Their capacities are bounded once, when the decode starts, which
+ * is exactly when the whole-set form bounds them; every cell read afterwards
+ * is bounded by `table_size` at the read, which is where it always was. */
+struct ZstdSeqCursor {
+    ZstdBitReader reader;
+    const ZstdSeqTable* litlen;
+    const ZstdSeqTable* offset;
+    const ZstdSeqTable* matchlen;
+    ZstdFseState litlen_state;
+    ZstdFseState offset_state;
+    ZstdFseState matchlen_state;
+    /* The block's declared count, and how many of them have been emitted. */
+    uint32_t total;
+    uint32_t emitted;
+    /* Set by the tile that emits the last sequence, once the bitstream has
+     * been held to ending exactly there. A cursor is only spent when this is
+     * true; a decode that stopped early stopped on a refusal. */
+    bool finished;
+};
+
+/* Starts a sequence decode: validates what the whole block's decode rests on,
+ * reads the start marker, and initialises the three states.
  *
  * `src`/`size` are the bitstream alone: the section header and the table
  * descriptions have already been stepped over by the caller. */
-CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeSequences(
+CUDEC_HOST_DEVICE inline cudec_status ZstdSeqBegin(
     const unsigned char* src, uint64_t size, uint32_t sequence_count,
     const ZstdSeqTable* litlen, const ZstdSeqTable* offset,
-    const ZstdSeqTable* matchlen, ZstdSequence* out, uint32_t out_capacity,
+    const ZstdSeqTable* matchlen, ZstdSeqCursor* cursor,
     ZstdSeqReject* reject) {
     if (reject != 0) {
         *reject = kZstdSeqRejectNone;
     }
-    if (src == 0 || litlen == 0 || offset == 0 || matchlen == 0 || out == 0 ||
-        sequence_count == 0 || out_capacity < sequence_count ||
-        litlen->cells == 0 || offset->cells == 0 || matchlen->cells == 0 ||
-        !litlen->present || !offset->present || !matchlen->present) {
+    if (src == 0 || litlen == 0 || offset == 0 || matchlen == 0 ||
+        cursor == 0 || sequence_count == 0 || litlen->cells == 0 ||
+        offset->cells == 0 || matchlen->cells == 0 || !litlen->present ||
+        !offset->present || !matchlen->present) {
         return ZstdSeqRefuse(kZstdSeqRejectBadRequest,
                              CUDEC_ERR_INVALID_ARGUMENT, reject);
     }
@@ -593,42 +619,83 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeSequences(
         return ZstdSeqRefuse(kZstdSeqRejectBitstreamMissing,
                              CUDEC_ERR_CORRUPT_INPUT, reject);
     }
-    ZstdBitReader reader{src, size};
-    if (reader.Start() != CUDEC_OK) {
+
+    cursor->reader = ZstdBitReader{src, size};
+    cursor->litlen = litlen;
+    cursor->offset = offset;
+    cursor->matchlen = matchlen;
+    cursor->total = sequence_count;
+    cursor->emitted = 0;
+    cursor->finished = false;
+    if (cursor->reader.Start() != CUDEC_OK) {
         return ZstdSeqRefuse(kZstdSeqRejectBitstreamMissing,
                              CUDEC_ERR_CORRUPT_INPUT, reject);
     }
 
-    ZstdFseState litlen_state;
-    ZstdFseState offset_state;
-    ZstdFseState matchlen_state;
     ZstdFseReject fse_reject = kZstdFseRejectNone;
-    if (ZstdFseInitState(&reader, litlen->accuracy_log, &litlen_state,
-                         &fse_reject) != CUDEC_OK ||
-        ZstdFseInitState(&reader, offset->accuracy_log, &offset_state,
-                         &fse_reject) != CUDEC_OK ||
-        ZstdFseInitState(&reader, matchlen->accuracy_log, &matchlen_state,
-                         &fse_reject) != CUDEC_OK) {
+    if (ZstdFseInitState(&cursor->reader, litlen->accuracy_log,
+                         &cursor->litlen_state, &fse_reject) != CUDEC_OK ||
+        ZstdFseInitState(&cursor->reader, offset->accuracy_log,
+                         &cursor->offset_state, &fse_reject) != CUDEC_OK ||
+        ZstdFseInitState(&cursor->reader, matchlen->accuracy_log,
+                         &cursor->matchlen_state, &fse_reject) != CUDEC_OK) {
         return ZstdSeqRefuse(kZstdSeqRejectStateInitTruncated,
                              CUDEC_ERR_CORRUPT_INPUT, reject);
     }
+    return CUDEC_OK;
+}
 
-    for (uint32_t index = 0; index < sequence_count; index++) {
+/* Decodes the next `want` sequences of a started decode, or however many are
+ * left if that is fewer.
+ *
+ * Three orders, all the format's and no two of them the same: the states are
+ * initialised literals-length, offset, match-length; the extra bits are read
+ * offset, match-length, literals-length; and the states are updated
+ * literals-length, match-length, offset. An implementation that gets any one
+ * of them wrong still decodes the first field of the first sequence
+ * correctly, which is why the corpus sweep asserts exact consumption rather
+ * than only the count.
+ *
+ * THE END CHECK BELONGS TO THE TILE THAT EMITS THE LAST SEQUENCE and not to
+ * whoever calls last. The stream must end exactly where the final sequence
+ * leaves it, so the check runs the moment `emitted` reaches `total` - a caller
+ * that stops there and never calls again has still had the stream held to its
+ * count. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdSeqDecodeTile(
+    ZstdSeqCursor* cursor, ZstdSequence* out, uint32_t out_capacity,
+    uint32_t want, uint32_t* out_count, ZstdSeqReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdSeqRejectNone;
+    }
+    if (out_count != 0) {
+        *out_count = 0;
+    }
+    if (cursor == 0 || out == 0 || out_count == 0 || want == 0 ||
+        out_capacity < want || cursor->litlen == 0 || cursor->offset == 0 ||
+        cursor->matchlen == 0 || cursor->finished ||
+        cursor->emitted >= cursor->total) {
+        return ZstdSeqRefuse(kZstdSeqRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+
+    const uint32_t remaining = cursor->total - cursor->emitted;
+    const uint32_t count = want < remaining ? want : remaining;
+    for (uint32_t index = 0; index < count; index++) {
         unsigned litlen_code = 0;
         unsigned offset_code = 0;
         unsigned matchlen_code = 0;
-        cudec_status status =
-            ZstdSeqPeekSymbol(litlen, &litlen_state, &litlen_code, reject);
+        cudec_status status = ZstdSeqPeekSymbol(
+            cursor->litlen, &cursor->litlen_state, &litlen_code, reject);
         if (status != CUDEC_OK) {
             return status;
         }
-        status = ZstdSeqPeekSymbol(offset, &offset_state, &offset_code,
-                                   reject);
+        status = ZstdSeqPeekSymbol(cursor->offset, &cursor->offset_state,
+                                   &offset_code, reject);
         if (status != CUDEC_OK) {
             return status;
         }
-        status = ZstdSeqPeekSymbol(matchlen, &matchlen_state, &matchlen_code,
-                                   reject);
+        status = ZstdSeqPeekSymbol(cursor->matchlen, &cursor->matchlen_state,
+                                   &matchlen_code, reject);
         if (status != CUDEC_OK) {
             return status;
         }
@@ -646,11 +713,11 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeSequences(
         uint64_t offset_extra = 0;
         uint64_t matchlen_extra = 0;
         uint64_t litlen_extra = 0;
-        if (reader.ReadBits(offset_code, &offset_extra) != CUDEC_OK ||
-            reader.ReadBits(ZstdSeqMatchLenExtraBits(matchlen_code),
-                            &matchlen_extra) != CUDEC_OK ||
-            reader.ReadBits(ZstdSeqLitLenExtraBits(litlen_code),
-                            &litlen_extra) != CUDEC_OK) {
+        if (cursor->reader.ReadBits(offset_code, &offset_extra) != CUDEC_OK ||
+            cursor->reader.ReadBits(ZstdSeqMatchLenExtraBits(matchlen_code),
+                                    &matchlen_extra) != CUDEC_OK ||
+            cursor->reader.ReadBits(ZstdSeqLitLenExtraBits(litlen_code),
+                                    &litlen_extra) != CUDEC_OK) {
             return ZstdSeqRefuse(kZstdSeqRejectSequenceTruncated,
                                  CUDEC_ERR_CORRUPT_INPUT, reject);
         }
@@ -660,32 +727,68 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeSequences(
                                   static_cast<uint32_t>(matchlen_extra);
         out[index].literals_length = ZstdSeqLitLenBaseline(litlen_code) +
                                      static_cast<uint32_t>(litlen_extra);
+        cursor->emitted++;
 
         /* The last sequence consumes its states without updating them, which
          * is what makes the stream end exactly here. */
-        if (index + 1 == sequence_count) {
+        if (cursor->emitted == cursor->total) {
             continue;
         }
-        status = ZstdSeqUpdateState(&reader, litlen, &litlen_state, reject);
+        status = ZstdSeqUpdateState(&cursor->reader, cursor->litlen,
+                                    &cursor->litlen_state, reject);
         if (status != CUDEC_OK) {
             return status;
         }
-        status = ZstdSeqUpdateState(&reader, matchlen, &matchlen_state,
-                                    reject);
+        status = ZstdSeqUpdateState(&cursor->reader, cursor->matchlen,
+                                    &cursor->matchlen_state, reject);
         if (status != CUDEC_OK) {
             return status;
         }
-        status = ZstdSeqUpdateState(&reader, offset, &offset_state, reject);
+        status = ZstdSeqUpdateState(&cursor->reader, cursor->offset,
+                                    &cursor->offset_state, reject);
         if (status != CUDEC_OK) {
             return status;
         }
     }
 
-    if (!reader.AtEnd()) {
-        return ZstdSeqRefuse(kZstdSeqRejectBitstreamNotConsumed,
-                             CUDEC_ERR_CORRUPT_INPUT, reject);
+    if (cursor->emitted == cursor->total) {
+        if (!cursor->reader.AtEnd()) {
+            return ZstdSeqRefuse(kZstdSeqRejectBitstreamNotConsumed,
+                                 CUDEC_ERR_CORRUPT_INPUT, reject);
+        }
+        cursor->finished = true;
     }
+    *out_count = count;
     return CUDEC_OK;
+}
+
+/* The whole block's sequences in one call: the shape the host twins and the
+ * frame decoder use, and one tile the size of the block. */
+CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeSequences(
+    const unsigned char* src, uint64_t size, uint32_t sequence_count,
+    const ZstdSeqTable* litlen, const ZstdSeqTable* offset,
+    const ZstdSeqTable* matchlen, ZstdSequence* out, uint32_t out_capacity,
+    ZstdSeqReject* reject) {
+    if (reject != 0) {
+        *reject = kZstdSeqRejectNone;
+    }
+    /* Bounded here as well as in the tile, because the tile is handed `want`
+     * rather than the block's count: a capacity short of the whole block is a
+     * caller bug this form has always refused, and refusing it before the
+     * bitstream is touched keeps that answer independent of the stream. */
+    if (out == 0 || sequence_count == 0 || out_capacity < sequence_count) {
+        return ZstdSeqRefuse(kZstdSeqRejectBadRequest,
+                             CUDEC_ERR_INVALID_ARGUMENT, reject);
+    }
+    ZstdSeqCursor cursor;
+    const cudec_status started = ZstdSeqBegin(
+        src, size, sequence_count, litlen, offset, matchlen, &cursor, reject);
+    if (started != CUDEC_OK) {
+        return started;
+    }
+    uint32_t decoded = 0;
+    return ZstdSeqDecodeTile(&cursor, out, out_capacity, sequence_count,
+                             &decoded, reject);
 }
 
 }  // namespace cudec_detail

--- a/tests/zstd_exec_twin.cpp
+++ b/tests/zstd_exec_twin.cpp
@@ -86,6 +86,9 @@ struct Outcome {
     uint64_t literals_used = 0;
     uint64_t produced = 0;
     std::vector<uint64_t> destinations;
+    /* Empty when the tiled halves agreed with this row at every tile size;
+     * what diverged otherwise. Filled on every row, positive and negative. */
+    std::string tiled_mismatch;
 };
 
 /* The window a row means when it does not care about the window bound. Larger
@@ -93,10 +96,11 @@ struct Outcome {
  * rung. */
 constexpr uint64_t kWideWindow = 1ull << 20;
 
-Outcome Execute(const std::vector<ZstdSequence>& sequences,
-                const std::vector<uint64_t>& offsets, const Bytes& literals,
-                uint64_t block_maximum, uint64_t window_size, Bytes* dst,
-                uint64_t produced) {
+/* The whole-block halves, in the shape every caller in the tree uses. */
+Outcome ExecuteWhole(const std::vector<ZstdSequence>& sequences,
+                     const std::vector<uint64_t>& offsets,
+                     const Bytes& literals, uint64_t block_maximum,
+                     uint64_t window_size, Bytes* dst, uint64_t produced) {
     Outcome out;
     out.produced = produced;
     out.destinations.assign(sequences.size() + 1, 0);
@@ -120,6 +124,201 @@ Outcome Execute(const std::vector<ZstdSequence>& sequences,
         offsets.empty() ? 0 : offsets.data(),
         literals.empty() ? 0 : literals.data(), literals.size(), &plan,
         window_size, dst->data(), dst->size(), &out.produced, &out.rung);
+    return out;
+}
+
+/* ------------------------------------------------------- the tiled form */
+
+/* The tile sizes the resumable form is driven at. One is the pathological
+ * shape - every call carrying a single sequence, so every boundary in the
+ * block is a call boundary - 128 is what `docs/MASTERPLAN.md` section 14.10
+ * budgets shared memory for, and the sizes between are the ones where a tile
+ * ends part-way through a block rather than on it. */
+const uint32_t kTileSizes[] = {1, 2, 3, 7, 128};
+
+/* One block put through the tiled halves, in the shape a fused kernel runs
+ * them: the sum a tile at a time carrying its two running quantities, then one
+ * call per sequence taking the literal cursor that sum produced.
+ *
+ * THE TWO BLOCK-LEVEL STEPS ARE SPELLED HERE RATHER THAN CALLED, and that is
+ * what makes this a model instead of a second caller. `ZstdExecuteBlock`'s
+ * destination bound and its tail equation belong to the whole-block form; a
+ * kernel has its own place to put them, and writing them out here is what lets
+ * a divergence between the two spellings show up as a failure rather than as
+ * two functions agreeing because they are one function. */
+struct TiledOutcome {
+    cudec_status status = CUDEC_OK;
+    ZstdExecReject rung = kZstdExecRejectNone;
+    uint64_t produced = 0;
+    ZstdExecPlan plan = {0, 0};
+    std::vector<uint64_t> destinations;
+};
+
+TiledOutcome ExecuteTiled(const std::vector<ZstdSequence>& sequences,
+                          const std::vector<uint64_t>& offsets,
+                          const Bytes& literals, uint64_t block_maximum,
+                          uint64_t window_size, Bytes* dst, uint64_t produced,
+                          uint32_t tile) {
+    TiledOutcome out;
+    out.produced = produced;
+    const uint32_t count = static_cast<uint32_t>(sequences.size());
+    out.destinations.assign(count + 1, 0);
+    std::vector<uint64_t> cursors(static_cast<size_t>(count) + 1, 0);
+
+    cudec_detail::ZstdExecCarry carry;
+    carry.at = 0;
+    carry.literals_used = 0;
+    uint32_t at = 0;
+    while (at < count) {
+        const uint32_t want = tile < count - at ? tile : count - at;
+        out.status = cudec_detail::ZstdExecPrefixSumTile(
+            sequences.data() + at, want, literals.size(), block_maximum,
+            &carry, out.destinations.data() + at, cursors.data() + at, want,
+            &out.rung);
+        if (out.status != CUDEC_OK) {
+            return out;
+        }
+        at += want;
+    }
+    out.status = cudec_detail::ZstdExecPrefixSumFinish(
+        &carry, literals.size(), block_maximum, &out.destinations[count],
+        &out.plan, &out.rung);
+    if (out.status != CUDEC_OK) {
+        return out;
+    }
+
+    const uint64_t base = produced;
+    if (base > dst->size() || out.plan.block_size > dst->size() - base) {
+        out.status = CUDEC_ERR_OUTPUT_TOO_SMALL;
+        out.rung = kZstdExecRejectDestinationTooSmall;
+        return out;
+    }
+    for (uint32_t index = 0; index < count; index++) {
+        out.status = cudec_detail::ZstdExecuteSequence(
+            &sequences[index], out.destinations[index],
+            out.destinations[index + 1], offsets[index],
+            literals.empty() ? 0 : literals.data(), literals.size(),
+            cursors[index], out.plan.block_size, window_size, dst->data(),
+            base, &out.rung);
+        if (out.status != CUDEC_OK) {
+            return out;
+        }
+    }
+
+    const uint64_t tail_at = out.destinations[count];
+    if (tail_at > out.plan.block_size ||
+        literals.size() - out.plan.literals_used !=
+            out.plan.block_size - tail_at) {
+        out.status = CUDEC_ERR_CORRUPT_INPUT;
+        out.rung = kZstdExecRejectPlanInconsistent;
+        return out;
+    }
+    for (uint64_t i = out.plan.literals_used; i < literals.size(); i++) {
+        (*dst)[static_cast<size_t>(base + tail_at + i -
+                                   out.plan.literals_used)] = literals[i];
+    }
+    out.produced = base + out.plan.block_size;
+    return out;
+}
+
+/* The tiled halves held to the whole-block ones, at every tile size, on the
+ * same bytes. Returns an empty string when they agree; what it returns
+ * otherwise is what the row prints. */
+std::string TiledDivergence(const std::vector<ZstdSequence>& sequences,
+                            const std::vector<uint64_t>& offsets,
+                            const Bytes& literals, uint64_t block_maximum,
+                            uint64_t window_size, const Bytes& dst_before,
+                            const Bytes& dst_after, uint64_t produced,
+                            const Outcome& whole) {
+    char detail[256];
+    for (size_t t = 0; t < sizeof(kTileSizes) / sizeof(kTileSizes[0]); t++) {
+        const uint32_t tile = kTileSizes[t];
+        Bytes dst = dst_before;
+        const TiledOutcome tiled =
+            ExecuteTiled(sequences, offsets, literals, block_maximum,
+                         window_size, &dst, produced, tile);
+        if (tiled.status != whole.status || tiled.rung != whole.rung) {
+            std::snprintf(detail, sizeof(detail),
+                          "tile %u: status %d rung %d, whole-block %d/%d",
+                          tile, static_cast<int>(tiled.status),
+                          static_cast<int>(tiled.rung),
+                          static_cast<int>(whole.status),
+                          static_cast<int>(whole.rung));
+            return detail;
+        }
+        if (tiled.produced != whole.produced) {
+            std::snprintf(detail, sizeof(detail),
+                          "tile %u: produced %llu, whole-block %llu", tile,
+                          static_cast<unsigned long long>(tiled.produced),
+                          static_cast<unsigned long long>(whole.produced));
+            return detail;
+        }
+        /* The destinations are compared on every row, refused ones included:
+         * a tile that wrote an entry the whole-block sum did not, or stopped
+         * one short of it, is a boundary bug that the bytes of a legal block
+         * can still survive. */
+        for (size_t s = 0; s < whole.destinations.size(); s++) {
+            if (tiled.destinations[s] == whole.destinations[s]) {
+                continue;
+            }
+            std::snprintf(detail, sizeof(detail),
+                          "tile %u: destination %zu is %llu, whole-block %llu",
+                          tile, s,
+                          static_cast<unsigned long long>(tiled.destinations[s]),
+                          static_cast<unsigned long long>(
+                              whole.destinations[s]));
+            return detail;
+        }
+        if (whole.status == CUDEC_OK &&
+            (tiled.plan.block_size != whole.block_size ||
+             tiled.plan.literals_used != whole.literals_used)) {
+            std::snprintf(detail, sizeof(detail),
+                          "tile %u: plan %llu/%llu, whole-block %llu/%llu",
+                          tile,
+                          static_cast<unsigned long long>(
+                              tiled.plan.block_size),
+                          static_cast<unsigned long long>(
+                              tiled.plan.literals_used),
+                          static_cast<unsigned long long>(whole.block_size),
+                          static_cast<unsigned long long>(
+                              whole.literals_used));
+            return detail;
+        }
+        /* Byte for byte, on the refused rows too. A refusal partway through a
+         * block leaves whatever the sequences before it wrote, and the two
+         * forms have to leave the same bytes as well as the same status. */
+        if (dst.size() != dst_after.size()) {
+            std::snprintf(detail, sizeof(detail), "tile %u: buffer resized",
+                          tile);
+            return detail;
+        }
+        for (size_t i = 0; i < dst.size(); i++) {
+            if (dst[i] == dst_after[i]) {
+                continue;
+            }
+            std::snprintf(detail, sizeof(detail),
+                          "tile %u: byte %zu is %02x, whole-block %02x", tile,
+                          i, dst[i], dst_after[i]);
+            return detail;
+        }
+    }
+    return std::string();
+}
+
+/* Every row goes through both, on the same bytes, and carries what the two
+ * disagreed about. A row that only ever ran the whole-block form would let the
+ * tiled halves rot behind it, which is the one way this extraction can go
+ * quiet with the suite still green. */
+Outcome Execute(const std::vector<ZstdSequence>& sequences,
+                const std::vector<uint64_t>& offsets, const Bytes& literals,
+                uint64_t block_maximum, uint64_t window_size, Bytes* dst,
+                uint64_t produced) {
+    const Bytes before = *dst;
+    Outcome out = ExecuteWhole(sequences, offsets, literals, block_maximum,
+                               window_size, dst, produced);
+    out.tiled_mismatch =
+        TiledDivergence(sequences, offsets, literals, block_maximum,
+                        window_size, before, *dst, produced, out);
     return out;
 }
 
@@ -214,6 +413,8 @@ int Accepts(const char* name, const std::vector<ZstdSequence>& sequences,
      * before it on every block after. */
     REQUIRE_CTX(equal_bytes(dst.data(), prefix.data(), prefix.size()),
                 "%s: the earlier output moved", name);
+    REQUIRE_CTX(out.tiled_mismatch.empty(), "%s: %s", name,
+                out.tiled_mismatch.c_str());
     g_rows++;
     g_sequences += sequences.size();
     g_bytes += expected.size();
@@ -238,6 +439,8 @@ int Refuses(const char* name, const std::vector<ZstdSequence>& sequences,
      * present bytes it has no reason to believe. */
     REQUIRE_CTX(out.produced == produced, "%s: produced moved to %llu", name,
                 static_cast<unsigned long long>(out.produced));
+    REQUIRE_CTX(out.tiled_mismatch.empty(), "%s: %s", name,
+                out.tiled_mismatch.c_str());
     CoverRung(out.rung);
     g_rows++;
     return 0;
@@ -565,6 +768,77 @@ int Negatives() {
         CoverRung(rung);
         g_rows++;
     }
+
+    /* The tiled halves' own refusals. Every one is a caller bug rather than a
+     * stream, and none is reachable through the whole-block forms, which start
+     * their carry at zero and make one call: what they refuse is a kernel that
+     * continued from a running total it did not compute. */
+    {
+        const std::vector<ZstdSequence> sequences = {Seq(1, 1)};
+        const Bytes literals = Ascii("ab");
+        uint64_t destinations[2] = {0, 0};
+        cudec_detail::ZstdExecCarry carry;
+        ZstdExecReject rung = kZstdExecRejectNone;
+
+        /* A carry past the ceiling the sum is bounded by. Believing it would
+         * put every comparison below behind a number this call did not
+         * compute. */
+        carry.at = cudec_detail::kZstdBlockSizeCeiling + 1;
+        carry.literals_used = 0;
+        REQUIRE(cudec_detail::ZstdExecPrefixSumTile(
+                    sequences.data(), 1, literals.size(),
+                    cudec_detail::kZstdBlockSizeCeiling, &carry, destinations,
+                    0, 1, &rung) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == kZstdExecRejectBadRequest);
+        CoverRung(rung);
+
+        /* A carry claiming more literal bytes than the section produced. The
+         * subtraction the tile makes against what is left would wrap. */
+        carry.at = 0;
+        carry.literals_used = literals.size() + 1;
+        REQUIRE(cudec_detail::ZstdExecPrefixSumTile(
+                    sequences.data(), 1, literals.size(),
+                    cudec_detail::kZstdBlockSizeCeiling, &carry, destinations,
+                    0, 1, &rung) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == kZstdExecRejectBadRequest);
+        CoverRung(rung);
+
+        /* Room for fewer destinations than the tile carries sequences. */
+        carry.at = 0;
+        carry.literals_used = 0;
+        REQUIRE(cudec_detail::ZstdExecPrefixSumTile(
+                    sequences.data(), 1, literals.size(),
+                    cudec_detail::kZstdBlockSizeCeiling, &carry, destinations,
+                    0, 0, &rung) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == kZstdExecRejectBadRequest);
+        CoverRung(rung);
+
+        /* The same bound on the close, which reads the carry a second time
+         * and is reached by whoever ran the last tile rather than the
+         * first. */
+        ZstdExecPlan plan;
+        uint64_t last = 0;
+        carry.at = 0;
+        carry.literals_used = literals.size() + 1;
+        REQUIRE(cudec_detail::ZstdExecPrefixSumFinish(
+                    &carry, literals.size(),
+                    cudec_detail::kZstdBlockSizeCeiling, &last, &plan,
+                    &rung) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == kZstdExecRejectBadRequest);
+        CoverRung(rung);
+
+        /* A literal cursor past the literals it indexes. A lane gets its own
+         * from the tile record rather than from a loop, so this is the
+         * mistake a fan-out makes and a serial walk cannot. */
+        Bytes dst(64, 0);
+        REQUIRE(cudec_detail::ZstdExecuteSequence(
+                    &sequences[0], 0, 2, 1, literals.data(), literals.size(),
+                    literals.size() + 1, 2, kWideWindow, dst.data(), 0,
+                    &rung) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(rung == kZstdExecRejectBadRequest);
+        CoverRung(rung);
+        g_rows++;
+    }
     return 0;
 }
 
@@ -653,6 +927,8 @@ int Sweep() {
                     expected.size());
         REQUIRE_CTX(equal_bytes(dst.data(), expected.data(), expected.size()),
                     "run %d: bytes", run);
+        REQUIRE_CTX(out.tiled_mismatch.empty(), "run %d: %s", run,
+                    out.tiled_mismatch.c_str());
 
         /* The destinations the unit produced, checked against the model's own
          * cursor. A scan that is wrong in a way the bytes happen to survive -

--- a/tests/zstd_seq_twin.cpp
+++ b/tests/zstd_seq_twin.cpp
@@ -121,7 +121,120 @@ struct SectionResult {
     cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
     cudec_detail::ZstdSeqSectionHeader header;
     std::vector<cudec_detail::ZstdSequence> sequences;
+    /* Empty when the tiled loop agreed with the whole-block one at every tile
+     * size on this section; what diverged otherwise. */
+    std::string tiled_mismatch;
 };
+
+/* ------------------------------------------------------- the tiled form */
+
+/* The tile sizes the resumable loop is driven at. One is the pathological
+ * shape - every sequence its own call, so every boundary in the block is a
+ * call boundary - 128 is what `docs/MASTERPLAN.md` section 14.10 budgets
+ * shared memory for, and the sizes between are the ones where a tile ends
+ * part-way through a block rather than on it. */
+const uint32_t kSeqTileSizes[] = {1, 2, 3, 7, 128};
+
+/* What one tiled decode ended as. */
+struct TiledSequences {
+    cudec_status status = CUDEC_OK;
+    cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+    bool finished = false;
+    std::vector<cudec_detail::ZstdSequence> sequences;
+};
+
+/* Drives ZstdSeqBegin and ZstdSeqDecodeTile to the end of a block's
+ * sequences, in the shape a fused kernel runs them. */
+TiledSequences DecodeSequencesTiled(
+    const unsigned char* src, uint64_t size, uint32_t sequence_count,
+    const cudec_detail::ZstdSeqTable* litlen,
+    const cudec_detail::ZstdSeqTable* offset,
+    const cudec_detail::ZstdSeqTable* matchlen, uint32_t tile) {
+    TiledSequences out;
+    out.sequences.assign(sequence_count, cudec_detail::ZstdSequence{0, 0, 0});
+    cudec_detail::ZstdSeqCursor cursor;
+    out.status = cudec_detail::ZstdSeqBegin(src, size, sequence_count, litlen,
+                                            offset, matchlen, &cursor,
+                                            &out.rung);
+    if (out.status != CUDEC_OK) {
+        return out;
+    }
+    /* Bounded by the count rather than by the cursor's own answer: a tile that
+     * reported no progress would otherwise spin here, and a test that hangs
+     * says less than one that fails. */
+    uint32_t at = 0;
+    for (uint32_t call = 0; call <= sequence_count && at < sequence_count;
+         call++) {
+        const uint32_t want =
+            tile < sequence_count - at ? tile : sequence_count - at;
+        uint32_t got = 0;
+        out.status = cudec_detail::ZstdSeqDecodeTile(
+            &cursor, out.sequences.data() + at, want, want, &got, &out.rung);
+        if (out.status != CUDEC_OK) {
+            return out;
+        }
+        at += got;
+    }
+    out.finished = cursor.finished;
+    return out;
+}
+
+/* The tiled loop held to the whole-block one, at every tile size, on the same
+ * bytes. Returns an empty string when they agree; what it returns otherwise is
+ * what the row prints. */
+std::string TiledSequenceDivergence(
+    const unsigned char* src, uint64_t size, uint32_t sequence_count,
+    const cudec_detail::ZstdSeqTable* litlen,
+    const cudec_detail::ZstdSeqTable* offset,
+    const cudec_detail::ZstdSeqTable* matchlen, cudec_status whole_status,
+    cudec_detail::ZstdSeqReject whole_rung,
+    const std::vector<cudec_detail::ZstdSequence>& whole) {
+    char detail[256];
+    for (size_t t = 0; t < sizeof(kSeqTileSizes) / sizeof(kSeqTileSizes[0]);
+         t++) {
+        const uint32_t tile = kSeqTileSizes[t];
+        const TiledSequences tiled = DecodeSequencesTiled(
+            src, size, sequence_count, litlen, offset, matchlen, tile);
+        if (tiled.status != whole_status || tiled.rung != whole_rung) {
+            std::snprintf(detail, sizeof(detail),
+                          "tile %u: status %d rung %d, whole-block %d/%d",
+                          tile, static_cast<int>(tiled.status),
+                          static_cast<int>(tiled.rung),
+                          static_cast<int>(whole_status),
+                          static_cast<int>(whole_rung));
+            return detail;
+        }
+        if (whole_status != CUDEC_OK) {
+            continue;
+        }
+        /* A decode that produced every sequence and never held the stream to
+         * ending there has skipped the one check the tiled form moved. */
+        if (!tiled.finished) {
+            std::snprintf(detail, sizeof(detail),
+                          "tile %u: accepted without finishing", tile);
+            return detail;
+        }
+        for (size_t s = 0; s < whole.size(); s++) {
+            if (tiled.sequences[s].literals_length ==
+                    whole[s].literals_length &&
+                tiled.sequences[s].match_length == whole[s].match_length &&
+                tiled.sequences[s].offset_value == whole[s].offset_value) {
+                continue;
+            }
+            std::snprintf(
+                detail, sizeof(detail),
+                "tile %u: sequence %zu is %u/%u/%llu, whole-block %u/%u/%llu",
+                tile, s, tiled.sequences[s].literals_length,
+                tiled.sequences[s].match_length,
+                static_cast<unsigned long long>(
+                    tiled.sequences[s].offset_value),
+                whole[s].literals_length, whole[s].match_length,
+                static_cast<unsigned long long>(whole[s].offset_value));
+            return detail;
+        }
+    }
+    return std::string();
+}
 
 /* Header, three table descriptions, bitstream - the whole section, in the
  * order the format writes them. This is the caller the block loop will be, and
@@ -173,6 +286,14 @@ SectionResult DecodeSection(const unsigned char* section, size_t size,
         &tables->litlen, &tables->offset, &tables->matchlen,
         result.sequences.data(),
         static_cast<uint32_t>(result.sequences.size()), &result.rung);
+    /* Every section this caller decodes goes through both forms. A row that
+     * only ever ran the whole-block one would let the resumable loop rot
+     * behind it, which is the one way this extraction can go quiet with the
+     * suite still green. */
+    result.tiled_mismatch = TiledSequenceDivergence(
+        section + position, size - position, result.header.sequence_count,
+        &tables->litlen, &tables->offset, &tables->matchlen, result.status,
+        result.rung, result.sequences);
     return result;
 }
 
@@ -332,6 +453,8 @@ int main() {
         const SectionResult result = DecodeSection(
             section.data(), section.size(), kAcceptedContentSize, &tables);
         REQUIRE(result.status == CUDEC_OK);
+        REQUIRE_CTX(result.tiled_mismatch.empty(), "%s",
+                    result.tiled_mismatch.c_str());
         REQUIRE(result.header.sequence_count == 1);
         REQUIRE(result.header.litlen_mode == cudec_detail::kZstdSeqModeRle);
         REQUIRE(result.header.offset_mode == cudec_detail::kZstdSeqModeRle);
@@ -527,6 +650,18 @@ int main() {
         REQUIRE(decoded[1].literals_length == 4);
         REQUIRE(decoded[1].match_length == 36);
         REQUIRE(decoded[1].offset_value == 13);
+
+        /* The same bit string through the resumable loop. This is the row
+         * where a tile boundary lands between the two sequences, so a reader
+         * or a state that did not survive the call moves the second tuple and
+         * nothing else. */
+        const std::vector<cudec_detail::ZstdSequence> whole(decoded,
+                                                            decoded + 2);
+        const std::string mismatch = TiledSequenceDivergence(
+            stream.data(), stream.size(), 2, &tables.litlen, &tables.offset,
+            &tables.matchlen, CUDEC_OK, cudec_detail::kZstdSeqRejectNone,
+            whole);
+        REQUIRE_CTX(mismatch.empty(), "%s", mismatch.c_str());
     }
 
     /* ---- Step 5: the corpus sweep. Every compressed block of every fixture
@@ -653,6 +788,18 @@ int main() {
                                 "%s: sequence %zu", where, s);
                     REQUIRE_CTX(sequences[s].offset_value >= 1, "%s", where);
                 }
+
+                /* The same bitstream through the resumable loop, at every
+                 * tile size. These are real compressor output, so they are
+                 * where a tile boundary meets a state update the hand-built
+                 * sections above cannot reach. */
+                const std::string mismatch = TiledSequenceDivergence(
+                    fixture.compressed.data() + position,
+                    block.block_end - position, block.sequence_count,
+                    &tables.litlen, &tables.offset, &tables.matchlen,
+                    CUDEC_OK, cudec_detail::kZstdSeqRejectNone, sequences);
+                REQUIRE_CTX(mismatch.empty(), "%s: %s", where,
+                            mismatch.c_str());
             }
         }
         /* A sweep that found nothing passes every assertion above, which is
@@ -736,6 +883,8 @@ int main() {
                         "%s: refused through rung %d, want %d", negative.name,
                         static_cast<int>(result.rung),
                         static_cast<int>(negative.rung));
+            REQUIRE_CTX(result.tiled_mismatch.empty(), "%s: %s",
+                        negative.name, result.tiled_mismatch.c_str());
             CoverRung(result.rung);
             if (!negative.frame_is_real) {
                 continue;
@@ -903,6 +1052,90 @@ int main() {
             REQUIRE(rung == cudec_detail::kZstdSeqRejectStateOutOfTable);
             CoverRung(rung);
         }
+    }
+
+    /* ---- Step 7: the resumable loop's own refusals. Every one of these is a
+     * caller bug rather than a stream, and every one of them is what a kernel
+     * driving the loop by hand can get wrong: the whole-block form cannot
+     * reach any of them, because it makes exactly one call with the block's
+     * own count. */
+    {
+        SeqTables tables;
+        for (unsigned cell = 0; cell < 4; cell++) {
+            tables.litlen_cells[cell] = {0, 0, 0};
+            tables.offset_cells[cell] = {0, 0, 0};
+            tables.matchlen_cells[cell] = {0, 0, 0};
+        }
+        tables.litlen_cells[0] = {1, 0, 1};
+        tables.litlen_cells[2] = {0, 4, 0};
+        tables.offset_cells[1] = {0, 2, 2};
+        tables.offset_cells[2] = {0, 3, 0};
+        tables.matchlen_cells[2] = {0, 0, 3};
+        tables.matchlen_cells[3] = {0, 32, 0};
+        tables.litlen.table_size = 4;
+        tables.litlen.accuracy_log = 2;
+        tables.litlen.present = true;
+        tables.offset.table_size = 4;
+        tables.offset.accuracy_log = 2;
+        tables.offset.present = true;
+        tables.matchlen.table_size = 4;
+        tables.matchlen.accuracy_log = 2;
+        tables.matchlen.present = true;
+        const Bytes stream{0xEB, 0x6E, 0x04};
+
+        /* A count of zero has no first sequence to start on, so there is no
+         * cursor to hand back rather than one that yields nothing. */
+        {
+            cudec_detail::ZstdSeqCursor cursor;
+            cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+            REQUIRE(cudec_detail::ZstdSeqBegin(
+                        stream.data(), stream.size(), 0, &tables.litlen,
+                        &tables.offset, &tables.matchlen, &cursor,
+                        &rung) != CUDEC_OK);
+            REQUIRE(rung == cudec_detail::kZstdSeqRejectBadRequest);
+            CoverRung(rung);
+        }
+
+        cudec_detail::ZstdSeqCursor cursor;
+        cudec_detail::ZstdSeqReject rung = cudec_detail::kZstdSeqRejectNone;
+        REQUIRE(cudec_detail::ZstdSeqBegin(stream.data(), stream.size(), 2,
+                                           &tables.litlen, &tables.offset,
+                                           &tables.matchlen, &cursor,
+                                           &rung) == CUDEC_OK);
+        cudec_detail::ZstdSequence decoded[2];
+        uint32_t got = 0;
+
+        /* A tile of nothing. Refused rather than answered with zero: a caller
+         * looping until the cursor finishes would never leave the loop. */
+        REQUIRE(cudec_detail::ZstdSeqDecodeTile(&cursor, decoded, 2, 0, &got,
+                                                &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdSeqRejectBadRequest);
+        CoverRung(rung);
+
+        /* Room for one sequence and a tile of two. The write would land one
+         * past the caller's array, which is the mistake a tile size that does
+         * not divide the block invites. */
+        REQUIRE(cudec_detail::ZstdSeqDecodeTile(&cursor, decoded, 1, 2, &got,
+                                                &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdSeqRejectBadRequest);
+        CoverRung(rung);
+
+        /* Neither refusal moved the cursor: the two sequences are still
+         * there to decode, so a refused tile costs the block nothing. */
+        REQUIRE(cudec_detail::ZstdSeqDecodeTile(&cursor, decoded, 2, 2, &got,
+                                                &rung) == CUDEC_OK);
+        REQUIRE(got == 2);
+        REQUIRE(cursor.finished);
+        REQUIRE(decoded[0].literals_length == 0);
+        REQUIRE(decoded[1].literals_length == 4);
+
+        /* One more call on a spent cursor. The stream has already been held
+         * to ending where it does, and reading past that is what the end
+         * check exists to refuse. */
+        REQUIRE(cudec_detail::ZstdSeqDecodeTile(&cursor, decoded, 2, 1, &got,
+                                                &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdSeqRejectBadRequest);
+        CoverRung(rung);
     }
 
     for (int declared = cudec_detail::kZstdSeqRejectNone + 1;


### PR DESCRIPTION
# What & why

Closes #425.

`docs/MASTERPLAN.md` section 14.9 names three units the fused M5 kernel re-shapes, because a block may declare 43690 sequences and their whole intermediate set is over a megabyte against the 12292-byte shared-memory budget section 14.10 fixes. The kernel therefore produces and consumes sequences 128 at a time, and the three units took the whole block at once, so there was nothing for it to call.

Each now has a resumable form, and each whole-block form is written on top of it rather than beside it:

- `ZstdSeqBegin` and `ZstdSeqDecodeTile` carry the reader and the three FSE states across calls. The end-of-bitstream check moves to the tile that emits the final sequence, so a caller that stops there and never calls again has still had the stream held to its count.
- `ZstdExecPrefixSumTile` and `ZstdExecPrefixSumFinish` carry the running destination and the literals cursor. The block maximum is compared against the running total rather than against a tile's own, which is the same comparison moved and not a weaker one; the carry is bounded on the way in, because it arrives from whatever ran the previous tile.
- `ZstdExecuteSequence` is `ZstdExecuteBlock`'s loop body, taking the literal cursor the tiled sum supplies where there is no loop to carry one.

**What this prevents is the failure a second spelling produces.** A kernel that hand-fanned these loops instead would leave the host twins covering code the device no longer runs, and the two offset bounds and the plan-consistency check would drift apart with every test still green. None of the three new entries is device-only: each has a host caller in the tree, which is what keeps the oracle diff running the code the device will run.

Nothing on the device is in this change: no `.cu`, no kernel, no ABI entry. Those stay on #203, which this was split out of.

**Means.** C++ headers under `src/`, single-sourced for host and device behind `CUDEC_HOST_DEVICE`, which is what every format unit in this tree already is and is what makes the host twin the thing that tests the code the device will run. A device-only form would be the one shape that cannot be gated on a machine with no device, and that is the machine this landed on.

## Type of change

- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] Refactor / code quality

## Engineering checklist

- [x] Fail-closed preserved: every rung of both ladders keeps one spelling and is now reached through the tiled entries as well. The new entries' own refusals get a negative each - an empty tile, a spent cursor, a tile with room for fewer sequences than it was asked for, a carry outside the bounds the sum rests on, and a literal cursor past the section it indexes.
- [x] Oracle coverage: the corpus sweep in `tests/zstd_seq_twin.cpp` decodes 332 compressed blocks positioned by the frame walker, and every one of them is now decoded through the tiled loop as well and required to agree sequence for sequence. `tests/zstd_exec_twin.cpp` links no oracle for the reason its own header gives; its frame-level parity is `tests/zstd_entropy_twin.cpp`, which is green.
- [x] Determinism preserved: the tiled forms are required to produce byte-identical output to the whole-block forms at every tile size, on positive and refused rows alike.
- [x] No CUDA API call is added and no exception crosses the C ABI: this change adds no `.cu` and touches no ABI surface.
- [ ] An adversarial review (`/security-review`) was NOT run, and no second person read this. What stands in its place is below under Verification: four guards deleted one at a time with the failure each produced, the full GPU-less suite, and the ASan+UBSan run over both twins. That is evidence, not a review, and it is weaker than one.
- [ ] Review record: none, for the reason above.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

```
```

The block is left empty rather than removed, and the negative disclosure stands on its own: no route to a device the sanitizer can attach to was available here. Compute Sanitizer cannot attach on this machine at all (#258, closed with that negative answer), and the paravirtualised device was absent from the WSL instance for the whole of this work:

```
$ wsl -d Ubuntu-24.04 -e bash -lc 'ls -l /dev/dxg; nvidia-smi --query-gpu=name --format=csv,noheader'
ls: cannot access '/dev/dxg': No such file or directory
Failed to initialize NVML: GPU access blocked by the operating system
```

So no GPU-labelled test ran, and nothing here asserts anything about the device.

## Performance checklist

Not on the hot path in this change: no kernel exists yet to be on it. The whole-block forms make one tile call apiece, so the host path gains a call and no work. No number is claimed and none was measured.

## Quality checklist

- [x] Minimal: no logic is duplicated - each whole-block form is its tiled form plus the bounds that are the whole block's own.
- [x] Self-documenting: each new entry's header says what it carries and why the check that moved is the same check.
- [x] Conformance: both twins' per-rung coverage assertions still require a declared negative for every rung, and they pass.

## Verification

The canonical container gate could not be used: the Docker engine on this machine is down, and starting a stopped Windows service raises a consent prompt, which is refused here rather than worked around. The route used instead is the WSL CUDA toolkit, which is CUDA 13.3 rather than the pinned `nvidia/cuda:12.6.2` image, and its GPU half did not run for the reason disclosed above. CI is the gate that decides this pull request.

Local build and the GPU-less suite, at the commit this pull request carries:

```
$ cmake --build build-af11n-wsl -j8
$ ctest --test-dir build-af11n-wsl -LE gpu
100% tests passed, 0 tests failed out of 53
```

The two twins under ASan+UBSan, which is what the `sanitize` job runs over the host attack surface and `zstd_exec_twin` is inside its named set:

```
$ cmake -B build-af11n-san -DCUDEC_ENABLE_CUDA=ON -DCUDEC_SANITIZE=address,undefined
$ ldd build-af11n-san/tests/zstd_exec_twin | grep -c 'libasan\|libubsan'
2
$ ./build-af11n-san/tests/zstd_exec_twin
PASS: 539 rows, 1133 sequences executed, 35436 bytes regenerated, 8 reject rungs covered
$ ./build-af11n-san/tests/zstd_seq_twin
PASS: 125067 sequences decoded across 332 corpus blocks, 332 section headers reproduced against the frame walker, 17 of 17 reject rungs covered by a declared negative
```

**Four guards deleted one at a time, each restored afterwards.** A guard that ships without a failure to its name is a guard nobody has seen bite:

```
MUTANT: the carry-in dropped in ZstdExecPrefixSumTile
  FAIL tests/zstd_exec_twin.cpp:416: out.tiled_mismatch.empty()
       | multi-sequence: tile 1: status 2 rung 4, whole-block 0/0

MUTANT: the end-of-bitstream check deleted from ZstdSeqDecodeTile
  FAIL tests/zstd_seq_twin.cpp:880: result.status != CUDEC_OK
       | bitstream-not-consumed was accepted

MUTANT: the empty-tile refusal deleted from ZstdSeqDecodeTile
  FAIL tests/zstd_seq_twin.cpp:1110: ZstdSeqDecodeTile(&cursor, decoded, 2, 0, &got, &rung) != CUDEC_OK

MUTANT: the literal-cursor bound deleted from ZstdExecuteSequence
  FAIL tests/zstd_exec_twin.cpp:834: ZstdExecuteSequence(..., literals.size() + 1, ...) == CUDEC_ERR_INVALID_ARGUMENT
```

With all four restored, `ctest -LE gpu` is 53 of 53 again.

- [x] Prettier (`**/*.{md,yml,yaml}`) - `All matched files use Prettier code style!`
- [x] Docs synced: nothing in `docs/` moves. Section 14.9 asked for exactly these three re-shapes and describes them still; no behaviour, API or performance claim changed.

## Notes

The whole-block forms keep their signatures and their rungs, so every existing caller is untouched. The one place a reader should look twice is `ZstdExecPrefixSum`: its own bad-request checks stay in the whole-block form ahead of the tile, so an out-of-range ceiling and a short destinations array still refuse at the same rung and before the sum runs, rather than behind a `CORRUPT_INPUT` the tile would reach first.
