### PR TITLE
Freeze cudec_zstd_decompress_batch on the public ABI

### DIFF
--- a/include/cudec.h
+++ b/include/cudec.h
@@ -196,6 +196,54 @@ cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
                                              cudec_chunk_result* d_results,
                                              cudec_stream_t stream);
 
+/* Batch Zstd frame decode. The batch contract above holds argument for
+ * argument: the same device-side arrays of chunk_count entries holding
+ * device pointers, the same 16-byte-aligned d_results, the same per-chunk
+ * result semantics, the same synchronous CUDEC_ERR_INVALID_ARGUMENT reject
+ * classes against the same launch limit, and the same asynchronous launch
+ * on `stream`. Nothing about the batch contract varies by format.
+ *
+ * THE SUPPORTED UNIT IS ONE WHOLE FRAME PER CHUNK, and that is the format's
+ * choice rather than this ABI's. Blocks inside a frame are not independent -
+ * a match reaches back across a block boundary and entropy tables carry from
+ * one block to the next - while frames are, so the frame is the smallest
+ * thing this entry can be handed. A chunk holding several concatenated
+ * frames, or part of one, is a malformed frame and is rejected as such
+ * rather than stepped into. d_src_sizes carries the frame's compressed size
+ * and d_dst_capacities the caller's output capacity; the bound on every
+ * write is that capacity and never a length read out of the frame.
+ *
+ * The accepted envelope is docs/MASTERPLAN.md section 12.2 and is not
+ * restated here, because a copy of that table in this header would drift
+ * against the parser that decides it. What the classes mean does belong
+ * here: CUDEC_ERR_UNSUPPORTED names a frame this decoder declines - a
+ * skippable frame, a dictionary id, an absent content size, a window past
+ * the range this decoder authorises - and CUDEC_ERR_CORRUPT_INPUT names one
+ * that is malformed. The two are different answers because only one of them
+ * can be retried elsewhere.
+ *
+ * Per frame, and isolated to that frame: those two statuses,
+ * CUDEC_ERR_OUTPUT_TOO_SMALL when the decode would pass the supplied
+ * capacity, bytes_written == 0 on any of them, and the destination contents
+ * then unspecified but never presented as a valid decode.
+ *
+ * THIS BUILD CARRIES NO ZSTD KERNEL, AND THAT IS A DEFINED STATUS RATHER
+ * THAN AN ABSENT SYMBOL. A batch that passes the validation above returns
+ * CUDEC_ERR_NOT_IMPLEMENTED, having made no CUDA call at all - so this
+ * entry, like the GDeflate one above, also leaves the thread's pending CUDA
+ * error state untouched on a call it accepts. The symbol, the signature and
+ * every reject class above are frozen now and do not move when the kernel
+ * lands; only the answer to an accepted batch does. A symbol that was absent
+ * instead would make the freeze conditional on a build configuration, which
+ * is two contracts wearing one name. */
+cudec_status cudec_zstd_decompress_batch(const void* const* d_src_ptrs,
+                                         const size_t* d_src_sizes,
+                                         void* const* d_dst_ptrs,
+                                         const size_t* d_dst_capacities,
+                                         size_t chunk_count,
+                                         cudec_chunk_result* d_results,
+                                         cudec_stream_t stream);
+
 /* Decode a single LZ4 frame (the .lz4 container: magic, frame descriptor,
  * data blocks, end mark, optional checksums) from host memory into host
  * memory, using the GPU batch decoder internally. Synchronous.

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -113,11 +113,11 @@ cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
         d_results, stream);
 }
 
-/* The GDeflate entry is the frozen contract without the kernel behind it
- * yet (issue #216). It shares the validator with the two above rather than
- * growing its own, so the reject classes cannot drift apart while they are
- * being frozen, and then stops: no launch, and deliberately no
- * cudec_rt::get_last_error() drain either. Draining is how the entries above
+/* The GDeflate and Zstd entries are the frozen contracts without their
+ * kernels behind them yet (issues #216 and #427). Each shares the validator
+ * with the two above rather than growing its own, so the reject classes
+ * cannot drift apart while they are being frozen, and then stops: no launch,
+ * and deliberately no cudec_rt::get_last_error() drain either. Draining is how the entries above
  * buy a
  * post-launch check that reports their own submission; with nothing
  * submitted there is nothing to report, and consuming a caller's pending
@@ -136,6 +136,26 @@ cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
                                              size_t chunk_count,
                                              cudec_chunk_result* d_results,
                                              cudec_stream_t stream) {
+    (void)stream;
+    const cudec_status valid = cudec_detail::validate_batch_args(
+        d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
+        d_results);
+    if (valid != CUDEC_OK) {
+        return valid;
+    }
+    return CUDEC_ERR_NOT_IMPLEMENTED;
+}
+
+/* The Zstd entry, the same shape and for the same reasons - the comment above
+ * covers both, and the unit each accepts is the only thing that differs
+ * between them. */
+cudec_status cudec_zstd_decompress_batch(const void* const* d_src_ptrs,
+                                         const size_t* d_src_sizes,
+                                         void* const* d_dst_ptrs,
+                                         const size_t* d_dst_capacities,
+                                         size_t chunk_count,
+                                         cudec_chunk_result* d_results,
+                                         cudec_stream_t stream) {
     (void)stream;
     const cudec_status valid = cudec_detail::validate_batch_args(
         d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -141,6 +141,30 @@ int main(void) {
                                             aligned,
                                             0) == CUDEC_ERR_NOT_IMPLEMENTED);
 
+    /* The same nine classes on the Zstd entry (issue #427), written out call
+     * for call for the reason the two blocks above are: a future entry wired
+     * to its own validator, or to none, would pass a test that only counted
+     * on the sharing. */
+    REQUIRE(cudec_zstd_decompress_batch(0, sizes, dsts, caps, 1, aligned,
+                                        0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, 0, dsts, caps, 1, aligned,
+                                        0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, 0, caps, 1, aligned,
+                                        0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, 0, 1, aligned,
+                                        0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, 0,
+                                        0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, misaligned,
+                                        0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 0, aligned,
+                                        0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, SIZE_MAX,
+                                        aligned,
+                                        0) == CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, aligned,
+                                        0) == CUDEC_ERR_NOT_IMPLEMENTED);
+
     /* The frame entry point resolves its own C linkage here. Every call
      * below is a documented argument reject that returns before any CUDA
      * call, so it runs on the GPU-less runner and never dereferences the

--- a/tests/launch_fail.cpp
+++ b/tests/launch_fail.cpp
@@ -68,8 +68,20 @@ int main() {
                                             results, nullptr) ==
             CUDEC_ERR_NOT_IMPLEMENTED);
 
+    /* The Zstd entry, the same opposite assertion and for the same reason
+     * (issue #427). Written out rather than folded into a loop over the two
+     * not-implemented entries: what this file is for is the point where two
+     * entries stop being the same code, and a loop would assume they are. */
+    REQUIRE(cudec_zstd_decompress_batch(nullptr, sizes, dsts, caps, 1, results,
+                                        nullptr) ==
+            CUDEC_ERR_INVALID_ARGUMENT);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, results,
+                                        nullptr) == CUDEC_ERR_NOT_IMPLEMENTED);
+    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, results,
+                                        nullptr) == CUDEC_ERR_NOT_IMPLEMENTED);
+
     std::printf("PASS: with zero visible devices the two kernel-backed batch "
-                "entries report CUDEC_ERR_CUDA and the GDeflate entry "
-                "reports CUDEC_ERR_NOT_IMPLEMENTED\n");
+                "entries report CUDEC_ERR_CUDA and the GDeflate and Zstd "
+                "entries report CUDEC_ERR_NOT_IMPLEMENTED\n");
     return 0;
 }


### PR DESCRIPTION
# What & why

Closes #427.

M5's public batch entry was bundled with its kernel on #203, and it is the one rung of that ladder that needs no device. `cudec_zstd_decompress_batch` is now on the ABI with its signature, its supported unit and all nine of its synchronous answer classes frozen; a batch that passes validation returns `CUDEC_ERR_NOT_IMPLEMENTED` until the kernel lands behind it. This is the rung #216 took for GDeflate, in the same translation unit and through the same validator.

**What it prevents is a kernel moving the reject classes under a test written at the same time as it.** Freezing them first means the day the kernel lands, exactly one line changes meaning - the accepted batch stops being not-implemented - and every other line of the lock is unchanged, so a kernel that widened what the entry accepts reds rather than passing.

The unit is one whole frame per chunk, which is the format's choice rather than this ABI's: `docs/MASTERPLAN.md` section 12.1 records that blocks inside a frame are not independent and frames are. A chunk holding part of a frame, or several concatenated ones, is a malformed frame and is rejected rather than stepped into.

The accepted envelope is deliberately not restated in the header: section 12.2 carries that table, and a copy in `include/cudec.h` would drift against the parser that decides it. What the header does carry is what the two refusal classes mean, because `UNSUPPORTED` and `CORRUPT_INPUT` are different answers and only one of them can be retried elsewhere.

**Means.** C, in `include/cudec.h`, and the same `src/batch.cu` the other three entries live in. The means is forced by what this is - a C ABI entry beside three others sharing one validator - and the alternative worth naming is a second translation unit for the Zstd entry, which would let its reject classes drift from the three it is meant to be identical to.

## Type of change

- [x] API surface

## Engineering checklist

- [x] Fail-closed preserved: the entry validates through the shared `cudec_detail::validate_batch_args` and then stops. All eight argument-reject classes plus the ninth, not-implemented, are asserted call for call in `tests/conformance_c.c`, and the launch-limit class is covered there by `chunk_count` of 0 and of `SIZE_MAX`.
- [x] Oracle coverage: not applicable - this change decodes nothing. No format path is added, and the nine Zstd headers under `src/` are untouched.
- [x] Determinism preserved: the entry returns the same defined status for the same arguments and writes nothing.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI. This entry makes no CUDA call at all - no launch and deliberately no pending-error drain - which is what `tests/launch_fail.cpp` reads: with no visible device an entry that touched the runtime would answer `CUDEC_ERR_CUDA`, so the not-implemented answer is the evidence that an accepted batch reaches the runtime only through a validator that does not touch it.
- [ ] An adversarial review (`/security-review`) was NOT run, and no second person read this. What stands in its place is the two guards deleted below, the full GPU-less suite and CI. That is evidence, not a review, and it is weaker than one.
- [ ] Review record: none, for the reason above.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code. `src/batch.cu` is an `.cu` file, but nothing added to it is `__device__` or `__global__` and no launch is made.

```
```

The block is left empty rather than removed, and the negative disclosure stands: no route to a device the sanitizer can attach to was available. Compute Sanitizer cannot attach on this machine at all (#258, closed with that negative answer), and the paravirtualised device was absent from the WSL instance throughout:

```
$ wsl -d Ubuntu-24.04 -e bash -lc 'ls -l /dev/dxg; nvidia-smi --query-gpu=name --format=csv,noheader'
ls: cannot access '/dev/dxg': No such file or directory
Failed to initialize NVML: GPU access blocked by the operating system
```

So no GPU-labelled test ran, and nothing here asserts anything about the device.

## Performance checklist

Not on the hot path: nothing is launched and nothing is decoded. No number is claimed and none was measured.

## Quality checklist

- [x] Minimal: the definition is the shared validator plus one return. No second validator, no new file.
- [x] Self-documenting: the header says what the unit is and why, what the two refusal classes mean, and that the not-implemented answer is a frozen contract rather than an unfinished one.
- [x] Conformance: the new structural property - a public symbol whose accepted-batch answer is defined while its kernel is absent - is locked in `tests/conformance_c.c` and `tests/launch_fail.cpp`.

## Verification

The canonical container gate could not be used: the Docker engine on this machine is down, and starting a stopped Windows service raises a consent prompt, which is refused here rather than worked around. The route used instead is the WSL CUDA toolkit, CUDA 13.3 rather than the pinned `nvidia/cuda:12.6.2` image, with its GPU half unavailable for the reason above. CI is the gate that decides this pull request.

```
$ cmake --build build-af11n-wsl -j8
$ ctest --test-dir build-af11n-wsl -LE gpu
100% tests passed, 0 tests failed out of 53
```

**Two guards deleted, one at a time, each restored afterwards.** A guard that ships without a failure to its name is a guard nobody has seen bite:

```
MUTANT: the validator dropped from the Zstd entry
  FAIL tests/conformance_c.c:148:
       cudec_zstd_decompress_batch(0, sizes, dsts, caps, 1, aligned, 0) == CUDEC_ERR_INVALID_ARGUMENT

MUTANT: an accepted Zstd batch answered CUDEC_OK
  FAIL tests/launch_fail.cpp:78:
       cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, results, nullptr) == CUDEC_ERR_NOT_IMPLEMENTED
```

With both restored, `ctest -LE gpu` is 53 of 53 again.

- [x] Prettier (`**/*.{md,yml,yaml}`) - no `.md`, `.yml` or `.yaml` file is touched by this change.
- [x] Docs synced: `docs/MASTERPLAN.md` section 12 already describes this entry's unit and envelope, and nothing about either moves here. The masterplan's M5 ladder in 14.5 names the ABI entry inside rung 2 with the kernel; this pull request lands the half of that rung a machine without a device can produce, and the section is not amended for it - #203 is where the rest of rung 2 lives.

## Notes

`tests/batch_limit_parity.cpp` is not touched. Its subject is the batch entry against the streaming one over the shared limit rather than a per-format arm, and #216 left it alone for the same reason; the limit class for this entry is locked in `tests/conformance_c.c` by `chunk_count` of 0 and of `SIZE_MAX`.

The calls in both tests are safe on a machine with no device for the same reason every existing call around them is: the entry dereferences none of the pointers it is handed and reaches no runtime.
