### PR TITLE
Build the GDeflate throughput worst case and lock its refill density

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -146,12 +146,14 @@ target_link_libraries(bench_gdeflate PRIVATE gdeflate_oracle)
 #
 # ../tests for tests/gdeflate_page_writer.h, which the --worstrounds corpus
 # emits its pages with (issue #226). That header holds the mirror of the
-# decoder's round order, and its own comment says why there may be exactly one
-# copy of it: a page that got a refill wrong is a page the reference reads off
-# the end of. A generator in this directory with its own copy would be the
-# second one. It is a header this directory READS - the consumer-only rule
-# above is about not modifying project targets, and nothing here builds or
-# links a test target.
+# decoder's round order - which lane takes which word in which round, and where
+# a deferred copy's distance is read - and it was lifted out of one fixture file
+# under issue #193 precisely so a second consumer would share it instead of
+# copying it. A generator in this directory with its own copy would be that
+# second copy. It is a header this directory READS: the consumer-only rule above
+# is about not modifying project targets, and nothing here builds or links a
+# test target. bench_zstd already crosses the same boundary one step further,
+# by compiling ../tests/zstd_corpus.cpp.
 target_include_directories(
   bench_gdeflate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
                          ${CMAKE_CURRENT_SOURCE_DIR}/../tests)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -143,8 +143,18 @@ add_executable(bench_gdeflate bench_gdeflate.cpp)
 target_link_libraries(bench_gdeflate PRIVATE gdeflate_oracle)
 # ../src for the corpus digest, which reads src/xxhash64.h - the hash already
 # in the tree rather than a new dependency for a bench.
-target_include_directories(bench_gdeflate PRIVATE
-                           ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+#
+# ../tests for tests/gdeflate_page_writer.h, which the --worstrounds corpus
+# emits its pages with (issue #226). That header holds the mirror of the
+# decoder's round order, and its own comment says why there may be exactly one
+# copy of it: a page that got a refill wrong is a page the reference reads off
+# the end of. A generator in this directory with its own copy would be the
+# second one. It is a header this directory READS - the consumer-only rule
+# above is about not modifying project targets, and nothing here builds or
+# links a test target.
+target_include_directories(
+  bench_gdeflate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+                         ${CMAKE_CURRENT_SOURCE_DIR}/../tests)
 # The report names the oracle pin, and it is passed in from the one place that
 # holds it (cmake/CudecGDeflateOracle.cmake) rather than typed into the source:
 # a commit written twice is a commit that can disagree with itself, and the
@@ -210,6 +220,22 @@ add_test(NAME bench_gdeflate_blocktypes_selfcheck COMMAND bench_gdeflate
 # device to run on the host side.
 add_test(NAME bench_gdeflate_blockmix_selfcheck COMMAND bench_gdeflate
                                                  --blockmix --selfcheck)
+
+# The GDeflate throughput worst case (issue #226). Separate from every entry
+# above because it rots on a different property again: those rot on corpus
+# shape and on block-type coverage, this one rots on ADVERSARIALITY. Its pages
+# are emitted by this harness rather than by the compressor - a compressor
+# picks the code that costs the fewest bits, which is the opposite of what
+# this row is for - so validity is not a given and the reference is the gate
+# on it. Round-tripping is still not the check: a valid-but-easy page set
+# round-trips and leaves this entry green while the report says worst case, so
+# the entry also holds a floor on refills per decoded byte, counted by cudec's
+# own schedule on a decode required to reproduce the source.
+#
+# CPU-only, like the entries above: the emitter, the reference decode and the
+# refill count are all host code.
+add_test(NAME bench_gdeflate_worst_selfcheck COMMAND bench_gdeflate
+                                              --worstrounds --selfcheck)
 
 # The Zstd worst-case corpus (issue #229). No CUDA in it at all: the frames
 # are constructed on the host, emitted through the reference's own
@@ -290,5 +316,6 @@ set_tests_properties(
   bench_snappy_worst_selfcheck bench_snappy_worstlit_selfcheck
   bench_gdeflate_selfcheck bench_gdeflate_assetlike_selfcheck
   bench_gdeflate_blocktypes_selfcheck bench_gdeflate_blockmix_selfcheck
+  bench_gdeflate_worst_selfcheck
   PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 cudec_assert_test_timeouts()

--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -588,9 +588,12 @@ std::vector<unsigned char> MakeAssetlikeSource(size_t pages) {
  *    this page emits - literal, length and distance alike - sits at DEFLATE's
  *    maximum codeword length. The spine symbols that make the code complete
  *    are never emitted.
- *  - EVERY LANE CONSUMING NEAR ITS WATERMARK ON EVERY ROUND. A lane spending
- *    a maximum codeword plus a maximum extra-bit field per round refills on
- *    most rounds; the measured rate is printed with the row.
+ *  - EVERY LANE CONSUMING NEAR ITS WATERMARK ON EVERY ROUND. A length round
+ *    spends a maximum codeword and sixteen extra bits, a distance round a
+ *    maximum codeword and the widest extra-bit field the output so far
+ *    reaches back over, and a literal round the codeword alone - so the
+ *    average is the density the row prints and not a claim about every round
+ *    separately.
  *  - COPIES SPLIT ACROSS TWO ROUNDS ON THE SAME LANE. The body is minimum
  *    matches: the length round reserves and the distance round on the same
  *    lane retires, so `GDeflateDoCopy` runs once per three decoded bytes and
@@ -616,8 +619,9 @@ std::vector<unsigned char> MakeAssetlikeSource(size_t pages) {
  * WHAT REFILLS ARE AND ARE NOT, because the issue's scope line offers the
  * compressed/original ratio as a substitute and the honest answer is not a
  * clean refusal. For a page whose every emitted word is consumed - which this
- * one is, exactly, and the check below proves it page by page - the two are
- * affine: density equals the emitted stream's ratio divided by 32/8. What
+ * one is, exactly, and MeasureRefillDensity refuses a page that is not - the
+ * two are affine: density equals the emitted stream's ratio divided by 32/8.
+ * What
  * refills buy is that they are defined by decoder work rather than by page
  * size, so they do not move with bytes no decoder reads, and they are read out
  * of a decode that had to reproduce the source. The ratio proxy's real defect
@@ -646,17 +650,30 @@ constexpr uint32_t kWorstDeepLiterals = kWorstLitLenDeep - 2u;
 constexpr uint32_t kWorstFirstDeepLiteral =
     cudec_test::kEndOfBlock - kWorstDeepLiterals;
 
-/* The Kraft identity that makes the code complete, as the compiler's
- * arithmetic rather than as a comment: the spine spends 1 - 2^-spine and the
- * deep symbols spend deep * 2^-15, and the two are equal only when the deep
- * count is exactly 2^(15 - spine). */
-static_assert(kWorstLitLenDeep == (1u << (kWorstCodeBits - kWorstLitLenSpine)),
-              "the deep literal/length count is what makes the code complete");
+/* WHAT THESE ASSERTIONS DO AND DO NOT DO. The Kraft identity itself is NOT
+ * among them: `kWorstLitLenDeep` is DEFINED as 2^(15 - spine), so an assertion
+ * comparing the two is a tautology that passes whatever the constants say.
+ * What the code being complete actually depends on is that the vector the
+ * generator builds assigns exactly that many symbols the maximum length, and
+ * that is read off the built vector by WorstCodeIsComplete below rather than
+ * argued here.
+ *
+ * These are the bounds instead, and they are written so that no subtraction
+ * they depend on can wrap before they are evaluated: an unsigned underflow
+ * turns a spine that outgrew its alphabet into a huge first index, which the
+ * writes in WorstLitLenLengths would take past the end of the vector. */
 static_assert(kWorstLitLenSpine < kWorstCodeBits,
               "a spine at or past the maximum length spends the codespace "
               "before the deep symbols get any");
-static_assert(kWorstFirstDeepLiteral > kWorstLitLenSpine,
-              "the spine and the deep literals must not claim one symbol");
+static_assert(kWorstLitLenDeep + kWorstLitLenSpine < cudec_test::kEndOfBlock,
+              "the spine and the deep literals must fit below end-of-block "
+              "without the first-deep-literal subtraction wrapping");
+static_assert(kWorstDeepLiterals < cudec_test::kEndOfBlock &&
+                  kWorstFirstDeepLiteral > kWorstLitLenSpine &&
+                  kWorstFirstDeepLiteral + kWorstDeepLiterals <=
+                      cudec_test::kEndOfBlock,
+              "every deep literal index must land inside the vector and clear "
+              "the spine");
 static_assert(kWorstLitLenSyms > cudec_test::kEndOfBlock &&
                   kWorstLitLenSyms > kWorstLengthSym,
               "every symbol this generator writes must be inside the vector it "
@@ -672,9 +689,17 @@ constexpr uint32_t kWorstDistSyms = cudec_detail::kGDeflateNumDistSyms;
 constexpr uint32_t kWorstDistSpine = 11;
 constexpr uint32_t kWorstDistDeep = 1u << (kWorstCodeBits - kWorstDistSpine);
 constexpr uint32_t kWorstFirstDeepDist = kWorstDistSyms - kWorstDistDeep;
-static_assert(kWorstFirstDeepDist > kWorstDistSpine,
-              "the distance spine and the deep distance symbols must not claim "
-              "one symbol");
+static_assert(kWorstDistSpine < kWorstCodeBits,
+              "a distance spine at or past the maximum length spends the "
+              "codespace before the deep symbols get any");
+static_assert(kWorstDistDeep + kWorstDistSpine < kWorstDistSyms,
+              "the distance spine and the deep distance symbols must fit in "
+              "the alphabet without the first-deep-distance subtraction "
+              "wrapping");
+static_assert(kWorstFirstDeepDist > kWorstDistSpine &&
+                  kWorstFirstDeepDist + kWorstDistDeep <= kWorstDistSyms,
+              "every deep distance index must land inside the vector and clear "
+              "the spine");
 
 /* The match this page is made of: the minimum length the format admits, asked
  * for in the most expensive way it can be asked for. */
@@ -722,12 +747,70 @@ constexpr size_t kWorstRoundsPages = 512;
  * sits at b/32; a stored block spends 8 and lands at 0.250. This corpus
  * spends a maximum-length length symbol, sixteen extra bits, a maximum-length
  * distance symbol and up to fourteen more extra bits for every three decoded
- * bytes, and measures 0.6152. The same generator with both codes balanced
- * instead of maximal - the same matches, the same whole page, no long
- * codeword anywhere - measures 0.4483 and is watched being refused. The floor
- * sits between those two readings rather than between a reading and an
- * estimate. */
-constexpr double kWorstRefillFloor = 0.55;
+ * bytes, and measures 0.6152. Weakened by hand and watched being refused: the
+ * same generator with both codes balanced instead of maximal measures 0.4483,
+ * and with every codeword capped at twelve bits instead of fifteen it
+ * measures 0.5523. The floor sits above the second of those, so it refuses a
+ * page set that kept the matches and dropped the codeword depth - which the
+ * 0.55 it was first set to did not.
+ *
+ * A FLOOR ALONE CANNOT CARRY THE DEPTH CLAIM AND IS NOT ASKED TO. Most of a
+ * match's cost is its extra-bit fields, which are the same width whatever the
+ * codewords are, so the density separates the two shapes by a tenth rather
+ * than by a mile. What refuses a shallow code outright is
+ * WorstCodeIsMaximal, which reads the depth of every symbol the page emits
+ * off the vector it emitted it from. */
+constexpr double kWorstRefillFloor = 0.60;
+
+/* A canonical code is decodable only if its lengths spend the codespace
+ * exactly. Read off the vector the generator built rather than argued from the
+ * constants it was built from: the two are the same thing only while nobody
+ * has edited one of them. Integer arithmetic, so "exactly" is exact. */
+bool WorstCodeIsComplete(const std::vector<unsigned char>& lens) {
+    uint64_t spent = 0;
+    for (size_t i = 0; i < lens.size(); i++) {
+        if (lens[i] == 0) {
+            continue;
+        }
+        if (lens[i] > kWorstCodeBits) {
+            return false;
+        }
+        spent += static_cast<uint64_t>(1) << (kWorstCodeBits - lens[i]);
+    }
+    return spent == (static_cast<uint64_t>(1) << kWorstCodeBits);
+}
+
+/* THE DEPTH CLAIM, AS A REFUSAL. The provenance line this corpus prints says
+ * every symbol in it sits at the maximum codeword length, and the density
+ * floor cannot carry that sentence: extra-bit fields are most of a match's
+ * cost and they do not move with the codewords, so a twelve-bit code loses
+ * only a tenth of the density. This reads the length of every symbol the body
+ * actually emits out of the vector it will be encoded from, so a generator
+ * that shallowed its codes is refused rather than printing a claim about
+ * bytes it did not produce. */
+bool WorstCodeIsMaximal(const std::vector<cudec_test::BodyToken>& body,
+                        const std::vector<unsigned char>& litlen_lens,
+                        const std::vector<unsigned char>& dist_lens) {
+    for (size_t i = 0; i < body.size(); i++) {
+        const std::vector<unsigned char>& lens =
+            body[i].from_dist ? dist_lens : litlen_lens;
+        if (body[i].sym >= lens.size() || lens[body[i].sym] != kWorstCodeBits) {
+            std::fprintf(stderr,
+                         "the worst-rounds body emits %s symbol %u at %u bits "
+                         "and this corpus reports every symbol at the maximum "
+                         "%u; the page would be valid and the report would be "
+                         "false%s",
+                         body[i].from_dist ? "distance" : "literal/length",
+                         body[i].sym,
+                         body[i].sym >= lens.size()
+                             ? 0u
+                             : static_cast<uint32_t>(lens[body[i].sym]),
+                         kWorstCodeBits, "\n");
+            return false;
+        }
+    }
+    return true;
+}
 
 /* The literal/length code lengths described above. */
 std::vector<unsigned char> WorstLitLenLengths() {
@@ -865,6 +948,18 @@ bool BuildWorstRoundsPage(size_t page_index,
                      static_cast<unsigned long long>(out_pos), kPageBytes);
         return false;
     }
+    if (!WorstCodeIsComplete(litlen_lens) ||
+        !WorstCodeIsComplete(dist_lens)) {
+        std::fprintf(stderr,
+                     "the worst-rounds code lengths do not spend the codespace "
+                     "exactly, so the page would carry a code no decoder can "
+                     "rebuild%s",
+                     "\n");
+        return false;
+    }
+    if (!WorstCodeIsMaximal(body, litlen_lens, dist_lens)) {
+        return false;
+    }
     if (!cudec_test::EmitPageTokens(litlen_lens, dist_lens, toks, precode_lens,
                                     num_explicit, body, page)) {
         std::fprintf(stderr, "the page writer refused page %zu\n", page_index);
@@ -983,11 +1078,39 @@ bool MeasureRefillDensity(const std::vector<unsigned char>& source,
         if (i == 0 || page_density < density->worst_page) {
             density->worst_page = page_density;
         }
+        /* EVERY EMITTED WORD IS CONSUMED, and this is where that stops
+         * being a sentence. The page carries the writer's declared zero tail
+         * past the words it handed out; the cursor says how far a mirror of
+         * the reference walked, so a cursor short of the emitted words means
+         * the page is carrying stream nothing reads, and a cursor past them
+         * means the emission has drifted from the schedule and the tail is
+         * load-bearing rather than padding. Neither is this corpus. */
+        const uint64_t page_words = corpus.compressed[i].size() / 4u;
+        const uint64_t tail_words = cudec_test::kGDeflateWriterTailWords;
+        const uint64_t emitted_words =
+            page_words < tail_words ? 0 : page_words - tail_words;
+        if (st.s.cursor != emitted_words) {
+            std::fprintf(stderr,
+                         "page %zu of %s consumed %llu of its %llu emitted "
+                         "words; the density this corpus locks is only the "
+                         "stream's expansion when every emitted word is "
+                         "read%s",
+                         i, corpus.name.c_str(),
+                         static_cast<unsigned long long>(st.s.cursor),
+                         static_cast<unsigned long long>(emitted_words),
+                         "\n");
+            return false;
+        }
         density->refills += st.s.cursor;
         density->out_bytes += produced;
-        /* Every match is one copy, and every three bytes past the opening run
-         * is one match, so this is the deferred-copy path's own count rather
-         * than an inference from the shape. */
+        /* ARITHMETIC OVER THE SHAPE, NOT A COUNT THE DECODE REPORTS.
+         * GDeflatePageState carries the live copy slots and the per-type
+         * census and no retired-copy counter, so nothing here observes a
+         * retirement. Every three bytes past the opening run is one
+         * minimum-length match by construction, and this is that construction
+         * divided out - printed because it says how much of the page is the
+         * deferred-copy path, and labelled so nobody reads it as a
+         * measurement. */
         density->copies += (produced - WorstLeadBytes()) / kWorstMatchLen;
         offset += want;
     }
@@ -997,8 +1120,10 @@ bool MeasureRefillDensity(const std::vector<unsigned char>& source,
 /* The lock. Validity alone is not enough: a valid-but-easy page set
  * round-trips and leaves CI green while the report still says worst case,
  * which is what this floor exists to refuse. It is taken on the WORST page and
- * not on the mean, because a mean clears the floor while nine per cent of the
- * corpus is the easiest page the format admits. */
+ * not on the mean, because a mean clears the floor while part of the corpus is
+ * the easiest page this generator can build: with one page of the 512 built
+ * all-literal, the run prints a mean of 0.6149 - above the floor - beside a
+ * worst page of 0.4697. */
 bool CheckRefillFloor(const RefillDensity& density) {
     if (density.worst_page >= kWorstRefillFloor) {
         return true;
@@ -1093,10 +1218,12 @@ void PrintReport(const Corpus& corpus, int level,
                     static_cast<unsigned long long>(density->refills),
                     static_cast<unsigned long long>(density->out_bytes),
                     density->worst_page, kWorstRefillFloor);
-        std::printf("- deferred copies: %llu retired, one per %u decoded "
-                    "bytes past the opening literal run; the length "
-                    "round reserves and the distance round on the same "
-                    "lane retires\n",
+        std::printf("- deferred copies: %llu, one per %u decoded bytes past "
+                    "the opening literal run - the length round reserves and "
+                    "the distance round on the same lane retires. ARITHMETIC "
+                    "over the corpus's construction and not a count read out "
+                    "of the decode: no decoder in this tree reports a "
+                    "retirement\n",
                     static_cast<unsigned long long>(density->copies),
                     kWorstMatchLen);
     }
@@ -1287,7 +1414,7 @@ bool CheckDigest(uint64_t actual, const std::string& name, int level,
         std::snprintf(where, sizeof(where), " (no compression level)");
     }
     std::fprintf(stderr,
-                 "the selfcheck corpus digest moved on %s%s: "
+                 "the corpus digest moved on %s%s: "
                  "expected %016llx, built %016llx - the corpus this harness "
                  "constructs is not the one its numbers were recorded on\n",
                  name.c_str(), where,
@@ -1581,20 +1708,24 @@ int RunBlockmix(const std::vector<unsigned char>& source,
 constexpr uint64_t kWorstRoundsSelfcheckDigest = 0x925326a21c48a952ull;
 constexpr uint64_t kWorstRoundsFullDigest = 0x6e2f2850f76891bbull;
 
-/* The worst-rounds path. Four gates before anything is timed:
+/* The worst-rounds path. Four gates, all of them before anything is timed and
+ * before anything is printed:
  *
- *  - cudec's own decode reproduces the source, fills a whole page, and yields
- *    the refill count. It runs FIRST because it is the bounds-checked reader:
- *    the reference refills without a bound check, so anything structurally
- *    wrong with a page should be refused by the decoder that refuses rather
- *    than found by the one that reads;
+ *  - the reference accepts every page and it round-trips to the source. It is
+ *    the sole authority on validity and it runs first, which is what #226
+ *    asks for. It is safe to hand it a hand-emitted page only because the
+ *    page carries the writer's declared zero tail: the reference refills
+ *    without a bound check, and that tail is what turns an emission that
+ *    drifted into a read of zeros;
+ *  - cudec's own decode reproduces the source, fills a whole page, consumes
+ *    exactly the emitted words, and yields the refill count;
  *  - the refill density clears its floor, on the worst page and not the mean;
- *  - the reference accepts every page and it round-trips to the source, which
- *    is the sole authority on validity here;
  *  - the digest matches the pin for the corpus size that was built.
  *
  * A corpus that drifted is therefore named by what it stopped being before it
- * is named by a number that moved. */
+ * is named by a number that moved, and a corpus that failed any of the four
+ * prints no report at all - a throughput row beside a refused gate is the one
+ * thing this path may not emit. */
 int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
     const size_t pages = selfcheck ? kSelfcheckPages : kWorstRoundsPages;
     Corpus corpus;
@@ -1607,11 +1738,15 @@ int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
         "sixteen-extra-bit length symbol, so the deferred-copy path runs once "
         "per three decoded bytes; ADVERSARIAL, the M4 security-posture row "
         "and never a headline throughput figure, and NOT scale-comparable "
-        "with the level-sweep rows above, which are six times this corpus";
+        "with this harness's other corpora, which are recorded on their own "
+        "invocations and are several times this one in pages";
     corpus.composition = kCompositionNotAsserted;
 
     std::vector<unsigned char> source;
     if (!BuildWorstRoundsCorpus(pages, &source, &corpus)) {
+        return 1;
+    }
+    if (!CorpusRoundTrips(source, corpus)) {
         return 1;
     }
     RefillDensity density;
@@ -1621,9 +1756,6 @@ int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
     if (!CheckRefillFloor(density)) {
         return 1;
     }
-    if (!CorpusRoundTrips(source, corpus)) {
-        return 1;
-    }
     /* Every page opens with the dynamic block this generator emits, and it is
      * the whole page: the writer puts BFINAL on the one block it writes. That
      * is asserted rather than narrated, so a generator that started emitting
@@ -1631,18 +1763,17 @@ int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
     if (!AssertComposition(&corpus, kBlockDynamic)) {
         return 1;
     }
-    bool ok = true;
     if (!CheckDigest(CorpusDigest(corpus), corpus.name, /*level=*/-1,
                      selfcheck ? kWorstRoundsSelfcheckDigest
                                : kWorstRoundsFullDigest)) {
-        ok = false;
+        return 1;
     }
     std::vector<double> times;
     if (!TimeCorpus(corpus, warmup, runs, &times)) {
         return 1;
     }
     PrintReport(corpus, /*level=*/-1, times, warmup, runs, &density);
-    return ok ? 0 : 1;
+    return 0;
 }
 
 }  // namespace

--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -58,6 +58,7 @@
 #include <libdeflate.h>
 
 #include "gdeflate_block.h"
+#include "gdeflate_page_writer.h"
 #include "gdeflate_schedule.h"
 #include "xxhash64.h"
 
@@ -562,9 +563,293 @@ std::vector<unsigned char> MakeAssetlikeSource(size_t pages) {
     return out;
 }
 
+/* THE WORST-ROUNDS CORPUS (issue #226), and what it locks.
+ *
+ * WHY IT IS NOT COMPRESSED BY THE REFERENCE. Every other corpus in this file
+ * is what the pinned compressor chose to emit; a compressor picks the code
+ * that costs the FEWEST bits, which is the opposite of what this row is for.
+ * The security-posture question is what a page an attacker fully controls can
+ * force out of a decoder, so the page is emitted here and the reference is
+ * kept as the authority on whether it is valid at all.
+ *
+ * THE QUANTITY IS REFILLS PER DECODED BYTE, AND IT IS NOT THE ONE THE PLAN
+ * FIRST NAMED. MASTERPLAN section 13.5 fixed rounds per decoded byte; a round
+ * is 32 lanes consuming one symbol each, so an all-literal dynamic block and a
+ * stored block both sit at 1/32 and a floor on that quantity cannot fail. A
+ * refill is one 32-bit word handed to one lane, so it counts BITS consumed
+ * rather than symbols, and it is the thing this shape moves. 13.5 was amended
+ * with that reason in the same change as this generator.
+ *
+ * THE RATIO PROXY IS REFUSED HERE RATHER THAN UNUSED, because the issue's own
+ * scope line offers it. The M4 denominator table on #224 measured level 0 -
+ * the highest ratio the format can produce - as the FASTEST family on both
+ * corpora, so a ratio floor selects for the easiest pages and would leave CI
+ * green over a corpus the report still called the worst case. The floor below
+ * is read out of a decode instead.
+ *
+ * WHAT THE SHAPE IS. Every literal is coded at DEFLATE's maximum codeword
+ * length, so each decoded byte costs 15 bits where a stored block costs 8.
+ * That is 13.5's "code lengths long enough
+ * that the root accelerator misses and the canonical walk runs" and its
+ * "every lane consumes near its watermark on every round" in one construction:
+ * a lane holding 32 bits and spending 15 of them per round falls below the
+ * watermark on alternate rounds, which is the highest sustained refill rate a
+ * literal stream can reach.
+ *
+ * WHAT IT DOES NOT CARRY, said here rather than left to be inferred. 13.5 also
+ * names frequent block headers as part of the shape. The page writer this
+ * corpus rides on emits one final block per page, and reaching the multi-block
+ * form means mirroring the reference's inter-block drain rounds, which no
+ * reading of this tree settles - so this corpus is the long-codeword half of
+ * 13.5's shape and claims nothing about the header-round half. */
+
+/* DEFLATE's maximum code length (RFC 1951, and the bound
+ * src/gdeflate_tables.h builds against). Nothing about this generator is
+ * adversarial except that every emitted symbol sits at this length. */
+constexpr uint32_t kWorstCodeBits = 15;
+
+/* The literal/length vector runs 0..256, so HLIT is 0 and the end-of-block
+ * symbol is the last entry. */
+constexpr size_t kWorstLitLenSyms = 257;
+
+/* The unary spine: symbols 0..kWorstSpineSyms-1 at lengths 1..kWorstSpineSyms.
+ * They are never emitted; they exist so the four deep symbols below can sit at
+ * the maximum length in a code that spends its codespace exactly. Kraft:
+ * (1 - 2^-13) + 4 * 2^-15 = 1, which is why the spine is two shorter than the
+ * maximum length rather than one. */
+constexpr uint32_t kWorstSpineSyms = kWorstCodeBits - 2;
+
+/* The three literals that carry the output, all at kWorstCodeBits. A single
+ * literal would do for the density, but a page of one repeated byte is a
+ * corpus whose round trip a wrong decoder can pass by accident. */
+constexpr uint32_t kWorstDeepLiterals[] = {253, 254, 255};
+constexpr size_t kWorstDeepLiteralCount =
+    sizeof(kWorstDeepLiterals) / sizeof(kWorstDeepLiterals[0]);
+
+/* Slack past the words this page actually hands out, for the reason
+ * tests/gdeflate_page_writer.h states: the reference's ENSURE_BITS reads a
+ * word with no bound check, so a writer off by a refill would be reported as
+ * an out-of-bounds read in the oracle rather than as a bug here. It is a
+ * padding convention and not a check - cudec's own schedule refuses the same
+ * read by an explicit bound. Small, because these bytes are counted in the
+ * ratio this row prints. */
+constexpr uint32_t kWorstTailWords = 32;
+
+/* Big enough that the timed run is not measuring the harness, far smaller than
+ * the level sweep's corpora because every page here costs 15 bits per decoded
+ * byte to emit as well as to decode. */
+constexpr size_t kWorstRoundsPages = 512;
+
+/* The floor the corpus is required to clear, in refills per decoded byte.
+ *
+ * WHERE THE NUMBER COMES FROM. A page whose every literal costs kWorstCodeBits
+ * consumes kWorstCodeBits bits per output byte, and a refill hands a lane
+ * kGDeflateBitsPerPacket of them, so the construction sits just above
+ * 15/32 = 0.469, and it measures 0.4695. The floor is set below that and well
+ * above what any weaker page reaches: a stored block spends 8 bits per decoded
+ * byte and therefore 0.250, and the same generator with a balanced literal
+ * code instead of the long one measures 0.2612 - watched refusing, so the
+ * distance between the two is a reading rather than an estimate. */
+constexpr double kWorstRefillFloor = 0.45;
+
+/* The lengths of the literal/length code described above. */
+std::vector<unsigned char> WorstLitLenLengths() {
+    std::vector<unsigned char> lens(kWorstLitLenSyms, 0);
+    for (uint32_t i = 0; i < kWorstSpineSyms; i++) {
+        lens[i] = static_cast<unsigned char>(i + 1u);
+    }
+    for (size_t i = 0; i < kWorstDeepLiteralCount; i++) {
+        lens[kWorstDeepLiterals[i]] = static_cast<unsigned char>(kWorstCodeBits);
+    }
+    lens[cudec_test::kEndOfBlock] = static_cast<unsigned char>(kWorstCodeBits);
+    return lens;
+}
+
+/* One page: a single final dynamic block whose body is kPageBytes literals,
+ * every one of them coded at the maximum length, followed by end-of-block.
+ * `page_index` rotates which of the three deep literals opens the page, so no
+ * two pages in the corpus are the same bytes. */
+bool BuildWorstRoundsPage(size_t page_index,
+                          std::vector<unsigned char>* original,
+                          std::vector<unsigned char>* page) {
+    const std::vector<unsigned char> litlen_lens = WorstLitLenLengths();
+    /* One distance symbol at length 1: the degenerate code the reference
+     * admits. No match is emitted, so the distance code is never read - it
+     * exists because HDIST has no encoding for an absent code. */
+    const std::vector<unsigned char> dist_lens = cudec_test::CompleteLengths(1);
+
+    std::vector<unsigned char> all(litlen_lens);
+    all.insert(all.end(), dist_lens.begin(), dist_lens.end());
+    const std::vector<cudec_test::LenToken> toks = cudec_test::BuildTokens(all);
+    unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms];
+    uint32_t num_explicit = 0;
+    if (!cudec_test::PlanPrecode(toks, /*forced_explicit=*/0, precode_lens,
+                                 &num_explicit)) {
+        std::fprintf(stderr,
+                     "no precode covers the worst-rounds length vector\n");
+        return false;
+    }
+
+    std::vector<uint32_t> symbols;
+    symbols.reserve(kPageBytes + 1);
+    original->clear();
+    original->reserve(kPageBytes);
+    for (size_t n = 0; n < kPageBytes; n++) {
+        const uint32_t sym =
+            kWorstDeepLiterals[(n + page_index) % kWorstDeepLiteralCount];
+        symbols.push_back(sym);
+        original->push_back(static_cast<unsigned char>(sym));
+    }
+    symbols.push_back(cudec_test::kEndOfBlock);
+
+    if (!cudec_test::EmitPage(litlen_lens, dist_lens, toks, precode_lens,
+                              num_explicit, symbols, page)) {
+        std::fprintf(stderr, "the page writer refused page %zu\n", page_index);
+        return false;
+    }
+    /* The writer appends a fixed tail sized for a decoding fixture, and this
+     * corpus prints a ratio, so it is cut back to this corpus's own slack -
+     * derived from the writer's declared constant rather than found by
+     * scanning back over zeros, which would eat an emitted word that happened
+     * to be zero (the reading fuzz/gdeflate_structure.h takes). */
+    const size_t writer_tail = cudec_test::kGDeflateWriterTailWords * 4u;
+    if (page->size() < writer_tail) {
+        std::fprintf(stderr, "the emitted page is shorter than the tail\n");
+        return false;
+    }
+    page->resize(page->size() - writer_tail + kWorstTailWords * 4u, 0);
+    return true;
+}
+
+/* The whole corpus, plus the source it is required to decode back to. The
+ * source is assembled here rather than handed in, because these pages are not
+ * a cut of anything - the bytes exist because the page says them. */
+bool BuildWorstRoundsCorpus(size_t pages, std::vector<unsigned char>* source,
+                            Corpus* corpus) {
+    for (size_t i = 0; i < pages; i++) {
+        std::vector<unsigned char> original;
+        std::vector<unsigned char> page;
+        if (!BuildWorstRoundsPage(i, &original, &page)) {
+            return false;
+        }
+        source->insert(source->end(), original.begin(), original.end());
+        corpus->originals.push_back(std::move(original));
+        corpus->compressed.push_back(std::move(page));
+    }
+    corpus->original_bytes = 0;
+    corpus->compressed_bytes = 0;
+    for (size_t i = 0; i < corpus->originals.size(); i++) {
+        corpus->original_bytes += corpus->originals[i].size();
+        corpus->compressed_bytes += corpus->compressed[i].size();
+    }
+    return true;
+}
+
+/* What the density lock reads. Both members are counted by a decode rather
+ * than derived from sizes: a refill is a schedule event and a page's size
+ * says nothing about how many of them it forces. */
+struct RefillDensity {
+    uint64_t refills = 0;
+    uint64_t out_bytes = 0;
+};
+
+double PerDecodedByte(const RefillDensity& d) {
+    return d.out_bytes == 0 ? 0.0
+                            : static_cast<double>(d.refills) /
+                                  static_cast<double>(d.out_bytes);
+}
+
+/* Walk every page with cudec's own schedule and count the words it hands to
+ * lanes. `GDeflateSchedule::cursor` IS that count: it advances by exactly one
+ * per refill, in GDeflateEnsure, and by nothing else.
+ *
+ * The decode is required to produce the source bytes, for the reason
+ * CensusCorpus gives about its own walk: a count read off a decode that did
+ * not follow this page is a number about something else. */
+bool MeasureRefillDensity(const std::vector<unsigned char>& source,
+                          const Corpus& corpus, RefillDensity* density) {
+    size_t offset = 0;
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        const size_t want = corpus.originals[i].size();
+        std::vector<unsigned char> out(want == 0 ? 1 : want);
+        cudec_detail::GDeflatePageState st;
+        uint64_t produced = 0;
+        if (!cudec_detail::GDeflateDecodePage(st, corpus.compressed[i].data(),
+                                              corpus.compressed[i].size(),
+                                              out.data(), want, &produced)) {
+            std::fprintf(stderr,
+                         "page %zu of %s was refused by the page decoder, so "
+                         "no refill count can be read out of it\n",
+                         i, corpus.name.c_str());
+            return false;
+        }
+        if (produced != want ||
+            std::memcmp(out.data(), source.data() + offset, want) != 0) {
+            std::fprintf(stderr,
+                         "page %zu of %s decoded to bytes that are not its "
+                         "source, so the walk behind the refill count did not "
+                         "follow this page\n",
+                         i, corpus.name.c_str());
+            return false;
+        }
+        /* THE TAIL IS SLACK AND THIS IS WHERE THAT STOPS BEING AN ASSUMPTION.
+         * The page carries kWorstTailWords of zeros past the words the writer
+         * handed out, because the reference refills without a bound check and
+         * a writer off by one refill would show up as an out-of-bounds read
+         * inside the oracle rather than as a defect here. cudec's schedule
+         * refuses that read instead of padding for it, so its cursor says how
+         * far a mirror of the reference actually walked: a cursor inside the
+         * emitted words means the reference never reached the tail either, and
+         * a cursor past them means the tail is load-bearing and the emission
+         * has drifted from the schedule. */
+        const uint64_t page_words = corpus.compressed[i].size() / 4u;
+        const uint64_t emitted_words =
+            page_words < kWorstTailWords ? 0 : page_words - kWorstTailWords;
+        if (st.s.cursor > emitted_words) {
+            std::fprintf(stderr,
+                         "page %zu of %s consumed %llu of its %llu emitted "
+                         "words and reached into the %u-word tail, which is "
+                         "padding for the reference's unchecked refill and "
+                         "not stream this page emitted\n",
+                         i, corpus.name.c_str(),
+                         static_cast<unsigned long long>(st.s.cursor),
+                         static_cast<unsigned long long>(emitted_words),
+                         kWorstTailWords);
+            return false;
+        }
+        density->refills += st.s.cursor;
+        density->out_bytes += produced;
+        offset += want;
+    }
+    return true;
+}
+
+/* The lock. Validity alone is not enough: a valid-but-easy page round-trips
+ * and leaves CI green while the report still says worst case, which is what
+ * this floor exists to refuse. */
+bool CheckRefillFloor(const RefillDensity& density) {
+    const double got = PerDecodedByte(density);
+    if (got >= kWorstRefillFloor) {
+        return true;
+    }
+    std::fprintf(stderr,
+                 "the worst-rounds corpus forces %.4f refills per decoded "
+                 "byte, under the %.4f floor this corpus exists to hold: it "
+                 "is still a valid page set and it is no longer the "
+                 "adversarial one the report names\n",
+                 got, kWorstRefillFloor);
+    return false;
+}
+
+/* `level` is negative for a corpus no compressor produced, and `density` is
+ * null for every corpus that locks something other than refills. Neither is a
+ * default a caller may forget: printing a compression level beside a
+ * hand-emitted page would attest a compressor that never ran, and printing a
+ * density line for a corpus that measured none would attest a lock that does
+ * not exist. */
 void PrintReport(const Corpus& corpus, int level,
-                 const std::vector<double>& sorted, size_t warmup,
-                 size_t runs) {
+                 const std::vector<double>& sorted, size_t warmup, size_t runs,
+                 const RefillDensity* density) {
     std::vector<size_t> sizes;
     sizes.reserve(corpus.originals.size());
     for (const auto& original : corpus.originals) {
@@ -588,8 +873,14 @@ void PrintReport(const Corpus& corpus, int level,
                 static_cast<double>(corpus.compressed_bytes) /
                     static_cast<double>(corpus.original_bytes),
                 corpus.provenance.c_str());
-    std::printf("- granularity: %zu KiB pages, compression level %d\n",
-                kPageBytes / 1024, level);
+    if (level >= 0) {
+        std::printf("- granularity: %zu KiB pages, compression level %d\n",
+                    kPageBytes / 1024, level);
+    } else {
+        std::printf("- granularity: %zu KiB pages, emitted by this harness - "
+                    "no compressor and therefore no compression level\n",
+                    kPageBytes / 1024);
+    }
     std::printf("- corpus digest: %016llx (XXH64 over per-page length and "
                 "XXH64, little-endian, in corpus order)\n",
                 static_cast<unsigned long long>(CorpusDigest(corpus)));
@@ -604,6 +895,17 @@ void PrintReport(const Corpus& corpus, int level,
                 warmup, runs);
     std::printf("- block-type composition: %s\n",
                 corpus.composition.c_str());
+    if (density != nullptr) {
+        std::printf("- refill density: %.4f refills per decoded byte over "
+                    "%llu refills and %llu decoded bytes, floor %.4f, counted "
+                    "by cudec's own schedule (src/gdeflate_schedule.h) on a "
+                    "decode required to reproduce the source; this is the "
+                    "quantity the corpus is locked on and not a timing\n",
+                    PerDecodedByte(*density),
+                    static_cast<unsigned long long>(density->refills),
+                    static_cast<unsigned long long>(density->out_bytes),
+                    kWorstRefillFloor);
+    }
     const double p50 = Percentile(sorted, 50);
     const double p90 = Percentile(sorted, 90);
     const double p99 = Percentile(sorted, 99);
@@ -613,6 +915,43 @@ void PrintReport(const Corpus& corpus, int level,
                 "%.3f GB/s\n",
                 GbpsFromMs(gb, p50 * 1e3), GbpsFromMs(gb, p90 * 1e3),
                 GbpsFromMs(gb, p99 * 1e3));
+}
+
+/* The warmup and measured passes, sorted. One decompressor for the whole
+ * sequence and one set of destinations, both allocated outside the timed
+ * region. A failed decode anywhere ends the sequence rather than shortening
+ * it: a corpus that stopped decoding must not be reported as a fast one. */
+bool TimeCorpus(const Corpus& corpus, size_t warmup, size_t runs,
+                std::vector<double>* times) {
+    libdeflate_gdeflate_decompressor* d =
+        libdeflate_alloc_gdeflate_decompressor();
+    if (d == nullptr) {
+        std::fprintf(stderr, "cannot allocate a decompressor\n");
+        return false;
+    }
+    std::vector<std::vector<unsigned char>> buffers = MakeBuffers(corpus);
+    bool ok = true;
+    for (size_t i = 0; i < warmup && ok; i++) {
+        if (DecodeAllSeconds(d, corpus, &buffers) < 0) {
+            std::fprintf(stderr, "a warmup decode failed\n");
+            ok = false;
+        }
+    }
+    for (size_t i = 0; i < runs && ok; i++) {
+        const double seconds = DecodeAllSeconds(d, corpus, &buffers);
+        if (seconds < 0) {
+            std::fprintf(stderr, "a measured decode failed\n");
+            ok = false;
+            break;
+        }
+        times->push_back(seconds);
+    }
+    libdeflate_free_gdeflate_decompressor(d);
+    if (!ok || times->empty()) {
+        return false;
+    }
+    std::sort(times->begin(), times->end());
+    return true;
 }
 
 /* Reports the digest of the corpus it built through `digest_out` rather than
@@ -642,36 +981,11 @@ bool RunLevel(const std::vector<unsigned char>& source, const std::string& name,
     }
     *digest_out = CorpusDigest(corpus);
 
-    libdeflate_gdeflate_decompressor* d =
-        libdeflate_alloc_gdeflate_decompressor();
-    if (d == nullptr) {
-        std::fprintf(stderr, "cannot allocate a decompressor\n");
-        return false;
-    }
-    std::vector<std::vector<unsigned char>> buffers = MakeBuffers(corpus);
-    bool ok = true;
-    for (size_t i = 0; i < warmup && ok; i++) {
-        if (DecodeAllSeconds(d, corpus, &buffers) < 0) {
-            std::fprintf(stderr, "a warmup decode failed\n");
-            ok = false;
-        }
-    }
     std::vector<double> times;
-    for (size_t i = 0; i < runs && ok; i++) {
-        const double seconds = DecodeAllSeconds(d, corpus, &buffers);
-        if (seconds < 0) {
-            std::fprintf(stderr, "a measured decode failed\n");
-            ok = false;
-            break;
-        }
-        times.push_back(seconds);
-    }
-    libdeflate_free_gdeflate_decompressor(d);
-    if (!ok || times.empty()) {
+    if (!TimeCorpus(corpus, warmup, runs, &times)) {
         return false;
     }
-    std::sort(times.begin(), times.end());
-    PrintReport(corpus, level, times, warmup, runs);
+    PrintReport(corpus, level, times, warmup, runs, /*density=*/nullptr);
     return true;
 }
 
@@ -765,16 +1079,24 @@ static_assert(kForcedFamilyCount >= 3,
               "the forced set must keep both stored forcings and the static "
               "one; a smaller table covers less than #225 asks for");
 
+/* `level` is negative on a corpus no compressor produced, and the message says
+ * so rather than printing a level that never existed. */
 bool CheckDigest(uint64_t actual, const std::string& name, int level,
                  uint64_t expected) {
     if (actual == expected) {
         return true;
     }
+    char where[64];
+    if (level >= 0) {
+        std::snprintf(where, sizeof(where), " at level %d", level);
+    } else {
+        std::snprintf(where, sizeof(where), " (no compression level)");
+    }
     std::fprintf(stderr,
-                 "the selfcheck corpus digest moved on %s at level %d: "
+                 "the selfcheck corpus digest moved on %s%s: "
                  "expected %016llx, built %016llx - the corpus this harness "
                  "constructs is not the one its numbers were recorded on\n",
-                 name.c_str(), level,
+                 name.c_str(), where,
                  static_cast<unsigned long long>(expected),
                  static_cast<unsigned long long>(actual));
     return false;
@@ -793,7 +1115,7 @@ bool ParseCount(const char* text, size_t lo, size_t hi, size_t* out) {
 void Usage(const char* argv0) {
     std::fprintf(stderr,
                  "usage: %s [--warmup N] [--runs N] [--assetlike] "
-                 "[--blocktypes] [--blockmix] [--selfcheck] "
+                 "[--blocktypes] [--blockmix] [--worstrounds] [--selfcheck] "
                  "[corpus files...]\n",
                  argv0);
 }
@@ -1051,6 +1373,72 @@ int RunBlockmix(const std::vector<unsigned char>& source,
     return ok ? 0 : 1;
 }
 
+/* The digest of the kSelfcheckPages-page worst-rounds corpus. It is a
+ * constant for the same reason the level sweep's digests are: this page set is
+ * emitted from fixed constants by code in this tree, so a change to the
+ * generator, to the length vector or to the page writer's round order moves
+ * it, and none of those would stop the pages round-tripping. */
+constexpr uint64_t kWorstRoundsSelfcheckDigest = 0x44a114301d086752ull;
+
+/* The worst-rounds path. Three gates before anything is timed, in the order
+ * that puts the cheapest disqualification first:
+ *
+ *  - the reference accepts every page and it round-trips to the source, which
+ *    is the sole authority on validity here;
+ *  - cudec's own decode reproduces the same bytes and yields the refill count;
+ *  - the refill density clears its floor.
+ *
+ * The digest is checked after all three under --selfcheck, so a corpus that
+ * drifted is named by what it stopped being before it is named by a number
+ * that moved. */
+int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
+    const size_t pages = selfcheck ? kSelfcheckPages : kWorstRoundsPages;
+    Corpus corpus;
+    corpus.name = "worst-rounds";
+    corpus.provenance =
+        "HAND-CONSTRUCTED by this harness and validated by the pinned "
+        "gdeflate fork, not produced by any compressor: one final dynamic "
+        "block per page whose every literal is coded at DEFLATE's maximum "
+        "codeword length, so each decoded byte costs 15 bits where a stored "
+        "block costs 8; ADVERSARIAL, the M4 security-posture row and never a "
+        "headline throughput figure";
+    corpus.composition = kCompositionNotAsserted;
+
+    std::vector<unsigned char> source;
+    if (!BuildWorstRoundsCorpus(pages, &source, &corpus)) {
+        return 1;
+    }
+    if (!CorpusRoundTrips(source, corpus)) {
+        return 1;
+    }
+    RefillDensity density;
+    if (!MeasureRefillDensity(source, corpus, &density)) {
+        return 1;
+    }
+    if (!CheckRefillFloor(density)) {
+        return 1;
+    }
+    /* Every page opens with the dynamic block this generator emits, and it is
+     * the whole page: the writer puts BFINAL on the one block it writes. That
+     * is asserted rather than narrated, so a generator that started emitting
+     * something else is caught here and not in the prose. */
+    if (!AssertComposition(&corpus, kBlockDynamic)) {
+        return 1;
+    }
+    bool ok = true;
+    if (selfcheck &&
+        !CheckDigest(CorpusDigest(corpus), corpus.name, /*level=*/-1,
+                     kWorstRoundsSelfcheckDigest)) {
+        ok = false;
+    }
+    std::vector<double> times;
+    if (!TimeCorpus(corpus, warmup, runs, &times)) {
+        return 1;
+    }
+    PrintReport(corpus, /*level=*/-1, times, warmup, runs, &density);
+    return ok ? 0 : 1;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -1060,6 +1448,7 @@ int main(int argc, char** argv) {
     bool assetlike = false;
     bool blocktypes = false;
     bool blockmix = false;
+    bool worstrounds = false;
     std::vector<std::string> files;
 
     for (int i = 1; i < argc; i++) {
@@ -1070,6 +1459,8 @@ int main(int argc, char** argv) {
             blocktypes = true;
         } else if (arg == "--blockmix") {
             blockmix = true;
+        } else if (arg == "--worstrounds") {
+            worstrounds = true;
         } else if (arg == "--selfcheck") {
             selfcheck = true;
         } else if (arg == "--runs" && i + 1 < argc) {
@@ -1104,6 +1495,14 @@ int main(int argc, char** argv) {
         return 2;
     }
 
+    if (worstrounds && (assetlike || blocktypes || blockmix || !files.empty())) {
+        std::fprintf(stderr,
+                     "--worstrounds emits its own corpus and no compressor "
+                     "runs on that path; do not pass corpus files or any of "
+                     "the compressor-driven modes with it\n");
+        return 2;
+    }
+
     if (blockmix && blocktypes) {
         std::fprintf(stderr,
                      "--blockmix censuses the level sweep's corpora and "
@@ -1122,6 +1521,10 @@ int main(int argc, char** argv) {
 
     if (blocktypes) {
         return RunBlocktypes(warmup, runs, selfcheck);
+    }
+
+    if (worstrounds) {
+        return RunWorstRounds(warmup, runs, selfcheck);
     }
 
     std::vector<unsigned char> source;

--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -39,10 +39,13 @@
  * WHAT THE COMPOSITION LOCK CANNOT SEE, said before anyone reads it as more.
  * It reads the FIRST block of each page and stops. A GDeflate block boundary
  * is not findable by scanning - dossier 11.3 D5, and the schedule header says
- * the same - so reaching a page's second block means decoding to it, and
- * there is no decoder in the tree yet (#176, #182). So a family asserting
- * `static` proves every page OPENS with a static block, and says nothing
- * about what follows in that page.
+ * the same - so reaching a page's second block means decoding to it, and this
+ * walk decodes nothing. So a family asserting `static` proves every page OPENS
+ * with a static block, and says nothing about what follows in that page. THAT
+ * SENTENCE USED TO GIVE THE ABSENCE OF A DECODER AS THE REASON, naming #176
+ * and #182; both landed, `--blockmix` censuses whole pages through
+ * src/gdeflate_block.h, and the bound above is a property of THIS walk rather
+ * than of the tree.
  *
  * Ratio is printed beside throughput on every row. For a DEFLATE-class format
  * the ratio is half the pitch, and a throughput-only table would misreport
@@ -114,6 +117,12 @@ struct Corpus {
     std::vector<std::vector<unsigned char>> compressed;
     size_t original_bytes = 0;
     size_t compressed_bytes = 0;
+    /* Bytes inside `compressed` that no decoder reads: the zero tail a
+     * hand-emitted page carries for the reference's unchecked refill. Held
+     * apart from compressed_bytes because a ratio that silently counted
+     * padding would attest a stream that is not there. Zero for every corpus
+     * the compressor produced. */
+    size_t padding_bytes = 0;
     /* Printed verbatim in the methodology block, so it must stay true for
      * whichever corpus ran. */
     std::string provenance;
@@ -572,111 +581,216 @@ std::vector<unsigned char> MakeAssetlikeSource(size_t pages) {
  * force out of a decoder, so the page is emitted here and the reference is
  * kept as the authority on whether it is valid at all.
  *
+ * WHAT THE SHAPE IS, against the four ingredients MASTERPLAN section 13.5
+ * names. Three of them are here and the fourth is not:
+ *
+ *  - CODE LENGTHS LONG ENOUGH THAT THE ROOT ACCELERATOR MISSES. Every symbol
+ *    this page emits - literal, length and distance alike - sits at DEFLATE's
+ *    maximum codeword length. The spine symbols that make the code complete
+ *    are never emitted.
+ *  - EVERY LANE CONSUMING NEAR ITS WATERMARK ON EVERY ROUND. A lane spending
+ *    a maximum codeword plus a maximum extra-bit field per round refills on
+ *    most rounds; the measured rate is printed with the row.
+ *  - COPIES SPLIT ACROSS TWO ROUNDS ON THE SAME LANE. The body is minimum
+ *    matches: the length round reserves and the distance round on the same
+ *    lane retires, so `GDeflateDoCopy` runs once per three decoded bytes and
+ *    the deferred-copy machinery is exercised rather than skipped. Length
+ *    symbol 285 is DEFLATE64's base 3 with SIXTEEN extra bits, which is the
+ *    most expensive way the format has of asking for three bytes.
+ *  - FREQUENT BLOCK HEADERS is the one that is NOT here. The page writer this
+ *    generator rides on emits one final block per page; extending it to
+ *    several is unbuilt, and this corpus claims nothing about that ingredient.
+ *    Issue #430 holds it.
+ *
  * THE QUANTITY IS REFILLS PER DECODED BYTE, AND IT IS NOT THE ONE THE PLAN
- * FIRST NAMED. MASTERPLAN section 13.5 fixed rounds per decoded byte; a round
- * is 32 lanes consuming one symbol each, so an all-literal dynamic block and a
- * stored block both sit at 1/32 and a floor on that quantity cannot fail. A
- * refill is one 32-bit word handed to one lane, so it counts BITS consumed
- * rather than symbols, and it is the thing this shape moves. 13.5 was amended
- * with that reason in the same change as this generator.
+ * FIRST NAMED. Section 13.5 fixed rounds per decoded byte. That quantity does
+ * not separate an easy page from this one in the direction a floor can use: an
+ * all-literal dynamic block and a stored block both sit at exactly 1/32, so a
+ * floor between them is impossible, and a match-carrying page sits BELOW 1/32
+ * (two rounds per three bytes at the minimum length), so 1/32 is the maximum
+ * of that quantity rather than a value nothing falls under. A refill is one
+ * 32-bit word handed to one lane, so it counts the bits a page spends, and it
+ * ranks all three cases the way the cost does. 13.5 carries the same reasoning
+ * and was amended in the change that built this.
  *
- * THE RATIO PROXY IS REFUSED HERE RATHER THAN UNUSED, because the issue's own
- * scope line offers it. The M4 denominator table on #224 measured level 0 -
- * the highest ratio the format can produce - as the FASTEST family on both
- * corpora, so a ratio floor selects for the easiest pages and would leave CI
- * green over a corpus the report still called the worst case. The floor below
- * is read out of a decode instead.
- *
- * WHAT THE SHAPE IS. Every literal is coded at DEFLATE's maximum codeword
- * length, so each decoded byte costs 15 bits where a stored block costs 8.
- * That is 13.5's "code lengths long enough
- * that the root accelerator misses and the canonical walk runs" and its
- * "every lane consumes near its watermark on every round" in one construction:
- * a lane holding 32 bits and spending 15 of them per round falls below the
- * watermark on alternate rounds, which is the highest sustained refill rate a
- * literal stream can reach.
- *
- * WHAT IT DOES NOT CARRY, said here rather than left to be inferred. 13.5 also
- * names frequent block headers as part of the shape. The page writer this
- * corpus rides on emits one final block per page, and reaching the multi-block
- * form means mirroring the reference's inter-block drain rounds, which no
- * reading of this tree settles - so this corpus is the long-codeword half of
- * 13.5's shape and claims nothing about the header-round half. */
+ * WHAT REFILLS ARE AND ARE NOT, because the issue's scope line offers the
+ * compressed/original ratio as a substitute and the honest answer is not a
+ * clean refusal. For a page whose every emitted word is consumed - which this
+ * one is, exactly, and the check below proves it page by page - the two are
+ * affine: density equals the emitted stream's ratio divided by 32/8. What
+ * refills buy is that they are defined by decoder work rather than by page
+ * size, so they do not move with bytes no decoder reads, and they are read out
+ * of a decode that had to reproduce the source. The ratio proxy's real defect
+ * is over COMPRESSOR output, where it points the wrong way: the M4 denominator
+ * table on #224 measures level 0 - the highest ratio the format can produce -
+ * as the FASTEST family on both corpora. */
 
-/* DEFLATE's maximum code length (RFC 1951, and the bound
- * src/gdeflate_tables.h builds against). Nothing about this generator is
- * adversarial except that every emitted symbol sits at this length. */
-constexpr uint32_t kWorstCodeBits = 15;
+/* DEFLATE's maximum code length, from the header that builds against it rather
+ * than as a second copy of 15. Nothing about this generator is adversarial
+ * except that every emitted symbol sits at this length. */
+constexpr uint32_t kWorstCodeBits = cudec_detail::kGDeflateMaxCodeLen;
 
-/* The literal/length vector runs 0..256, so HLIT is 0 and the end-of-block
- * symbol is the last entry. */
-constexpr size_t kWorstLitLenSyms = 257;
+/* The literal/length vector runs 0..285, so the length symbol below is inside
+ * it and HLIT is 29. */
+constexpr uint32_t kWorstLengthSym = 285;
+constexpr size_t kWorstLitLenSyms = kWorstLengthSym + 1;
 
-/* The unary spine: symbols 0..kWorstSpineSyms-1 at lengths 1..kWorstSpineSyms.
- * They are never emitted; they exist so the four deep symbols below can sit at
- * the maximum length in a code that spends its codespace exactly. Kraft:
- * (1 - 2^-13) + 4 * 2^-15 = 1, which is why the spine is two shorter than the
- * maximum length rather than one. */
-constexpr uint32_t kWorstSpineSyms = kWorstCodeBits - 2;
+/* The unary spine: symbols 0..kWorstSpineSyms-1 at lengths 1..kWorstSpineSyms,
+ * never emitted, present so the deep symbols can sit at the maximum length in
+ * a code that spends its codespace exactly. */
+constexpr uint32_t kWorstLitLenSpine = 10;
+constexpr uint32_t kWorstLitLenDeep = 1u << (kWorstCodeBits - kWorstLitLenSpine);
+/* Two of the deep slots are the end-of-block symbol and the length symbol; the
+ * rest are literals, and they are the last ones before end-of-block. */
+constexpr uint32_t kWorstDeepLiterals = kWorstLitLenDeep - 2u;
+constexpr uint32_t kWorstFirstDeepLiteral =
+    cudec_test::kEndOfBlock - kWorstDeepLiterals;
 
-/* The three literals that carry the output, all at kWorstCodeBits. A single
- * literal would do for the density, but a page of one repeated byte is a
- * corpus whose round trip a wrong decoder can pass by accident. */
-constexpr uint32_t kWorstDeepLiterals[] = {253, 254, 255};
-constexpr size_t kWorstDeepLiteralCount =
-    sizeof(kWorstDeepLiterals) / sizeof(kWorstDeepLiterals[0]);
+/* The Kraft identity that makes the code complete, as the compiler's
+ * arithmetic rather than as a comment: the spine spends 1 - 2^-spine and the
+ * deep symbols spend deep * 2^-15, and the two are equal only when the deep
+ * count is exactly 2^(15 - spine). */
+static_assert(kWorstLitLenDeep == (1u << (kWorstCodeBits - kWorstLitLenSpine)),
+              "the deep literal/length count is what makes the code complete");
+static_assert(kWorstLitLenSpine < kWorstCodeBits,
+              "a spine at or past the maximum length spends the codespace "
+              "before the deep symbols get any");
+static_assert(kWorstFirstDeepLiteral > kWorstLitLenSpine,
+              "the spine and the deep literals must not claim one symbol");
+static_assert(kWorstLitLenSyms > cudec_test::kEndOfBlock &&
+                  kWorstLitLenSyms > kWorstLengthSym,
+              "every symbol this generator writes must be inside the vector it "
+              "writes into");
+static_assert(kWorstLitLenSyms >= 257 && kWorstLitLenSyms <= 288,
+              "HLIT is five bits over a 257-symbol floor");
 
-/* Slack past the words this page actually hands out, for the reason
- * tests/gdeflate_page_writer.h states: the reference's ENSURE_BITS reads a
- * word with no bound check, so a writer off by a refill would be reported as
- * an out-of-bounds read in the oracle rather than as a bug here. It is a
- * padding convention and not a check - cudec's own schedule refuses the same
- * read by an explicit bound. Small, because these bytes are counted in the
- * ratio this row prints. */
-constexpr uint32_t kWorstTailWords = 32;
+/* The distance vector is the whole alphabet, with its own spine and its own
+ * deep set. The deep set is the TOP of the alphabet because extra-bit count
+ * grows with the distance base, and an extra-bit field is bits the lane spends
+ * for no symbol: symbol 31 carries fourteen of them. */
+constexpr uint32_t kWorstDistSyms = cudec_detail::kGDeflateNumDistSyms;
+constexpr uint32_t kWorstDistSpine = 11;
+constexpr uint32_t kWorstDistDeep = 1u << (kWorstCodeBits - kWorstDistSpine);
+constexpr uint32_t kWorstFirstDeepDist = kWorstDistSyms - kWorstDistDeep;
+static_assert(kWorstFirstDeepDist > kWorstDistSpine,
+              "the distance spine and the deep distance symbols must not claim "
+              "one symbol");
+
+/* The match this page is made of: the minimum length the format admits, asked
+ * for in the most expensive way it can be asked for. */
+constexpr uint32_t kWorstMatchLen = cudec_detail::kGDeflateMinMatchLen;
+constexpr uint32_t kWorstLengthIndex =
+    kWorstLengthSym - 257u; /* into GDeflateLengthBase/Extra */
+
+/* One group is one round of reservations across all 32 lanes, followed by the
+ * round of retirements that pays for them. */
+constexpr uint32_t kWorstGroupMatches = cudec_detail::kGDeflateNumStreams;
+constexpr uint32_t kWorstGroupBytes = kWorstGroupMatches * kWorstMatchLen;
+
+/* The literal run the page opens with, and the group count that follows it.
+ * The run exists because a match may not reach before the page's own output,
+ * so the cheapest deep distance symbol's base is the floor on how much output
+ * must exist before the first match; the run is the smallest whole number of
+ * groups plus the page's own remainder that clears that base. Derived from the
+ * table rather than written down, so a base that moved moves the run with it.
+ */
+uint32_t WorstLeadBytes() {
+    uint32_t lead = kPageBytes % kWorstGroupBytes;
+    const uint32_t need = cudec_detail::GDeflateDistBase(kWorstFirstDeepDist);
+    while (lead < need) {
+        lead += kWorstGroupBytes;
+    }
+    return lead;
+}
+
+uint32_t WorstGroups() {
+    return static_cast<uint32_t>((kPageBytes - WorstLeadBytes()) /
+                                 kWorstGroupBytes);
+}
 
 /* Big enough that the timed run is not measuring the harness, far smaller than
- * the level sweep's corpora because every page here costs 15 bits per decoded
- * byte to emit as well as to decode. */
+ * the level sweep's corpora because every page here is emitted a bit at a time
+ * as well as decoded. The row therefore is NOT scale-comparable with the
+ * level-sweep rows, and the provenance string says so where the number is
+ * printed. */
 constexpr size_t kWorstRoundsPages = 512;
 
-/* The floor the corpus is required to clear, in refills per decoded byte.
+/* The floor the corpus is required to clear, in refills per decoded byte, and
+ * what sits under it.
  *
- * WHERE THE NUMBER COMES FROM. A page whose every literal costs kWorstCodeBits
- * consumes kWorstCodeBits bits per output byte, and a refill hands a lane
- * kGDeflateBitsPerPacket of them, so the construction sits just above
- * 15/32 = 0.469, and it measures 0.4695. The floor is set below that and well
- * above what any weaker page reaches: a stored block spends 8 bits per decoded
- * byte and therefore 0.250, and the same generator with a balanced literal
- * code instead of the long one measures 0.2612 - watched refusing, so the
- * distance between the two is a reading rather than an estimate. */
-constexpr double kWorstRefillFloor = 0.45;
+ * A refill hands a lane 32 bits, so a page spending b bits per decoded byte
+ * sits at b/32; a stored block spends 8 and lands at 0.250. This corpus
+ * spends a maximum-length length symbol, sixteen extra bits, a maximum-length
+ * distance symbol and up to fourteen more extra bits for every three decoded
+ * bytes, and measures 0.6152. The same generator with both codes balanced
+ * instead of maximal - the same matches, the same whole page, no long
+ * codeword anywhere - measures 0.4483 and is watched being refused. The floor
+ * sits between those two readings rather than between a reading and an
+ * estimate. */
+constexpr double kWorstRefillFloor = 0.55;
 
-/* The lengths of the literal/length code described above. */
+/* The literal/length code lengths described above. */
 std::vector<unsigned char> WorstLitLenLengths() {
     std::vector<unsigned char> lens(kWorstLitLenSyms, 0);
-    for (uint32_t i = 0; i < kWorstSpineSyms; i++) {
+    for (uint32_t i = 0; i < kWorstLitLenSpine; i++) {
         lens[i] = static_cast<unsigned char>(i + 1u);
     }
-    for (size_t i = 0; i < kWorstDeepLiteralCount; i++) {
-        lens[kWorstDeepLiterals[i]] = static_cast<unsigned char>(kWorstCodeBits);
+    for (uint32_t i = 0; i < kWorstDeepLiterals; i++) {
+        lens[kWorstFirstDeepLiteral + i] =
+            static_cast<unsigned char>(kWorstCodeBits);
     }
     lens[cudec_test::kEndOfBlock] = static_cast<unsigned char>(kWorstCodeBits);
+    lens[kWorstLengthSym] = static_cast<unsigned char>(kWorstCodeBits);
     return lens;
 }
 
-/* One page: a single final dynamic block whose body is kPageBytes literals,
- * every one of them coded at the maximum length, followed by end-of-block.
- * `page_index` rotates which of the three deep literals opens the page, so no
- * two pages in the corpus are the same bytes. */
+/* The distance code lengths described above. */
+std::vector<unsigned char> WorstDistLengths() {
+    std::vector<unsigned char> lens(kWorstDistSyms, 0);
+    for (uint32_t i = 0; i < kWorstDistSpine; i++) {
+        lens[i] = static_cast<unsigned char>(i + 1u);
+    }
+    for (uint32_t i = 0; i < kWorstDistDeep; i++) {
+        lens[kWorstFirstDeepDist + i] =
+            static_cast<unsigned char>(kWorstCodeBits);
+    }
+    return lens;
+}
+
+/* The most expensive distance symbol whose match can legally be taken at this
+ * output position. Every deep symbol costs a maximum codeword, so what
+ * separates them is the extra-bit field, which grows with the base - and the
+ * base is exactly what the output has to be long enough to reach back over
+ * (src/gdeflate_block.h refuses a match that begins before the page's own
+ * output). Walking down from the top is therefore walking down from the most
+ * expensive. */
+bool WorstDistSymFor(uint64_t out_pos, uint32_t* sym) {
+    for (uint32_t s = kWorstDistSyms; s-- > kWorstFirstDeepDist;) {
+        if (cudec_detail::GDeflateDistBase(s) <= out_pos) {
+            *sym = s;
+            return true;
+        }
+    }
+    return false;
+}
+
+/* One page: an opening literal run, then `kWorstGroups` groups of 32 minimum
+ * matches, then end-of-block.
+ *
+ * THE GROUP SHAPE IS THE DECODER'S AND NOT A CHOICE. A body token at position
+ * p rides lane p mod 32, and the distance a reserved match needs is read on
+ * that lane's NEXT round - position p + 32. So 32 reservations followed by 32
+ * retirements is the only shape in which every lane holds a match for exactly
+ * one round, which is what "copies split across two rounds on the same lane"
+ * means when every lane does it at once.
+ *
+ * `page_index` seeds the literal run, so the pages of a corpus differ from one
+ * another in their bytes as well as in their index. */
 bool BuildWorstRoundsPage(size_t page_index,
                           std::vector<unsigned char>* original,
                           std::vector<unsigned char>* page) {
     const std::vector<unsigned char> litlen_lens = WorstLitLenLengths();
-    /* One distance symbol at length 1: the degenerate code the reference
-     * admits. No match is emitted, so the distance code is never read - it
-     * exists because HDIST has no encoding for an absent code. */
-    const std::vector<unsigned char> dist_lens = cudec_test::CompleteLengths(1);
+    const std::vector<unsigned char> dist_lens = WorstDistLengths();
 
     std::vector<unsigned char> all(litlen_lens);
     all.insert(all.end(), dist_lens.begin(), dist_lens.end());
@@ -690,34 +804,79 @@ bool BuildWorstRoundsPage(size_t page_index,
         return false;
     }
 
-    std::vector<uint32_t> symbols;
-    symbols.reserve(kPageBytes + 1);
-    original->clear();
-    original->reserve(kPageBytes);
-    for (size_t n = 0; n < kPageBytes; n++) {
-        const uint32_t sym =
-            kWorstDeepLiterals[(n + page_index) % kWorstDeepLiteralCount];
-        symbols.push_back(sym);
-        original->push_back(static_cast<unsigned char>(sym));
-    }
-    symbols.push_back(cudec_test::kEndOfBlock);
+    const uint32_t lead = WorstLeadBytes();
+    const uint32_t groups = WorstGroups();
+    std::vector<cudec_test::BodyToken> body;
+    body.reserve(lead + 2u * groups * kWorstGroupMatches + 1u);
+    original->assign(kPageBytes, 0);
 
-    if (!cudec_test::EmitPage(litlen_lens, dist_lens, toks, precode_lens,
-                              num_explicit, symbols, page)) {
+    /* The opening run. A fixed LCG seeded by the page index, so every page of
+     * a corpus is different bytes and every corpus is reproducible. */
+    uint64_t state = 0x9E3779B97F4A7C15ull + page_index;
+    uint64_t out_pos = 0;
+    for (uint32_t n = 0; n < lead; n++) {
+        state = state * 6364136223846793005ull + 1442695040888963407ull;
+        const uint32_t sym =
+            kWorstFirstDeepLiteral +
+            static_cast<uint32_t>((state >> 33) % kWorstDeepLiterals);
+        body.push_back(cudec_test::BodyToken{sym, false, 0, 0});
+        (*original)[out_pos] = static_cast<unsigned char>(sym);
+        out_pos++;
+    }
+
+    for (uint32_t g = 0; g < groups; g++) {
+        uint64_t reserved[kWorstGroupMatches];
+        uint32_t dist_sym[kWorstGroupMatches];
+        for (uint32_t m = 0; m < kWorstGroupMatches; m++) {
+            if (!WorstDistSymFor(out_pos, &dist_sym[m])) {
+                std::fprintf(stderr,
+                             "no deep distance symbol reaches back over %llu "
+                             "bytes of output\n",
+                             static_cast<unsigned long long>(out_pos));
+                return false;
+            }
+            reserved[m] = out_pos;
+            out_pos += kWorstMatchLen;
+            body.push_back(cudec_test::BodyToken{
+                kWorstLengthSym, false,
+                cudec_detail::GDeflateLengthExtra(kWorstLengthIndex), 0});
+        }
+        for (uint32_t m = 0; m < kWorstGroupMatches; m++) {
+            const uint32_t s = dist_sym[m];
+            const uint64_t offset = cudec_detail::GDeflateDistBase(s);
+            /* Mirrors GDeflateDoCopy exactly, in the same order the decoder
+             * retires the group, so the expected bytes are what a decode
+             * produces rather than what this generator meant. */
+            for (uint32_t i = 0; i < kWorstMatchLen; i++) {
+                (*original)[reserved[m] + i] =
+                    (*original)[reserved[m] - offset + i];
+            }
+            body.push_back(cudec_test::BodyToken{
+                s, true, cudec_detail::GDeflateDistExtra(s), 0});
+        }
+    }
+    body.push_back(
+        cudec_test::BodyToken{cudec_test::kEndOfBlock, false, 0, 0});
+
+    if (out_pos != kPageBytes) {
+        std::fprintf(stderr,
+                     "the worst-rounds page produces %llu bytes and the page "
+                     "is %zu\n",
+                     static_cast<unsigned long long>(out_pos), kPageBytes);
+        return false;
+    }
+    if (!cudec_test::EmitPageTokens(litlen_lens, dist_lens, toks, precode_lens,
+                                    num_explicit, body, page)) {
         std::fprintf(stderr, "the page writer refused page %zu\n", page_index);
         return false;
     }
-    /* The writer appends a fixed tail sized for a decoding fixture, and this
-     * corpus prints a ratio, so it is cut back to this corpus's own slack -
-     * derived from the writer's declared constant rather than found by
-     * scanning back over zeros, which would eat an emitted word that happened
-     * to be zero (the reading fuzz/gdeflate_structure.h takes). */
-    const size_t writer_tail = cudec_test::kGDeflateWriterTailWords * 4u;
-    if (page->size() < writer_tail) {
-        std::fprintf(stderr, "the emitted page is shorter than the tail\n");
-        return false;
-    }
-    page->resize(page->size() - writer_tail + kWorstTailWords * 4u, 0);
+    /* The writer's zero tail is kept at the size the writer declares. It is
+     * not slack this corpus may trade for a tidier ratio: the reference
+     * refills without a bound check, so the tail is what turns an emission
+     * that drifted from the schedule into a read of zeros instead of a read
+     * past the end of this vector - and no sanitizer build covers bench/, so
+     * nothing else would see it. What the ratio owes instead is disclosure,
+     * which is `Corpus::padding_bytes` below. */
     return true;
 }
 
@@ -742,15 +901,19 @@ bool BuildWorstRoundsCorpus(size_t pages, std::vector<unsigned char>* source,
         corpus->original_bytes += corpus->originals[i].size();
         corpus->compressed_bytes += corpus->compressed[i].size();
     }
+    corpus->padding_bytes =
+        corpus->originals.size() * cudec_test::kGDeflateWriterTailWords * 4u;
     return true;
 }
 
-/* What the density lock reads. Both members are counted by a decode rather
- * than derived from sizes: a refill is a schedule event and a page's size
- * says nothing about how many of them it forces. */
+/* What the density lock reads. */
 struct RefillDensity {
     uint64_t refills = 0;
     uint64_t out_bytes = 0;
+    /* The worst single page, which is what the lock is taken on: an aggregate
+     * that clears a floor can hold a page set where most pages are trivial. */
+    double worst_page = 0.0;
+    uint64_t copies = 0;
 };
 
 double PerDecodedByte(const RefillDensity& d) {
@@ -765,13 +928,36 @@ double PerDecodedByte(const RefillDensity& d) {
  *
  * The decode is required to produce the source bytes, for the reason
  * CensusCorpus gives about its own walk: a count read off a decode that did
- * not follow this page is a number about something else. */
+ * not follow this page is a number about something else. It is also required
+ * to produce a WHOLE PAGE, which is the constraint the density is maximal
+ * under - the fixed per-page cost of the priming round, the header and the
+ * drain divides by the output, so a page emitting fewer bytes clears any floor
+ * without carrying a single long codeword.
+ *
+ * The source bound is asserted here rather than inherited from whichever gate
+ * ran first, so the gate order stays a matter of cost and not of safety. */
 bool MeasureRefillDensity(const std::vector<unsigned char>& source,
                           const Corpus& corpus, RefillDensity* density) {
     size_t offset = 0;
     for (size_t i = 0; i < corpus.compressed.size(); i++) {
         const size_t want = corpus.originals[i].size();
-        std::vector<unsigned char> out(want == 0 ? 1 : want);
+        if (want != kPageBytes) {
+            std::fprintf(stderr,
+                         "page %zu of %s decodes to %zu bytes and this corpus "
+                         "is locked per decoded byte, so a page short of the "
+                         "%zu-byte page would clear any floor on the fixed "
+                         "per-page cost alone\n",
+                         i, corpus.name.c_str(), want, kPageBytes);
+            return false;
+        }
+        if (offset + want > source.size()) {
+            std::fprintf(stderr,
+                         "page %zu of %s runs past the source it is compared "
+                         "against\n",
+                         i, corpus.name.c_str());
+            return false;
+        }
+        std::vector<unsigned char> out(want);
         cudec_detail::GDeflatePageState st;
         uint64_t produced = 0;
         if (!cudec_detail::GDeflateDecodePage(st, corpus.compressed[i].data(),
@@ -792,52 +978,39 @@ bool MeasureRefillDensity(const std::vector<unsigned char>& source,
                          i, corpus.name.c_str());
             return false;
         }
-        /* THE TAIL IS SLACK AND THIS IS WHERE THAT STOPS BEING AN ASSUMPTION.
-         * The page carries kWorstTailWords of zeros past the words the writer
-         * handed out, because the reference refills without a bound check and
-         * a writer off by one refill would show up as an out-of-bounds read
-         * inside the oracle rather than as a defect here. cudec's schedule
-         * refuses that read instead of padding for it, so its cursor says how
-         * far a mirror of the reference actually walked: a cursor inside the
-         * emitted words means the reference never reached the tail either, and
-         * a cursor past them means the tail is load-bearing and the emission
-         * has drifted from the schedule. */
-        const uint64_t page_words = corpus.compressed[i].size() / 4u;
-        const uint64_t emitted_words =
-            page_words < kWorstTailWords ? 0 : page_words - kWorstTailWords;
-        if (st.s.cursor > emitted_words) {
-            std::fprintf(stderr,
-                         "page %zu of %s consumed %llu of its %llu emitted "
-                         "words and reached into the %u-word tail, which is "
-                         "padding for the reference's unchecked refill and "
-                         "not stream this page emitted\n",
-                         i, corpus.name.c_str(),
-                         static_cast<unsigned long long>(st.s.cursor),
-                         static_cast<unsigned long long>(emitted_words),
-                         kWorstTailWords);
-            return false;
+        const double page_density = static_cast<double>(st.s.cursor) /
+                                    static_cast<double>(produced);
+        if (i == 0 || page_density < density->worst_page) {
+            density->worst_page = page_density;
         }
         density->refills += st.s.cursor;
         density->out_bytes += produced;
+        /* Every match is one copy, and every three bytes past the opening run
+         * is one match, so this is the deferred-copy path's own count rather
+         * than an inference from the shape. */
+        density->copies += (produced - WorstLeadBytes()) / kWorstMatchLen;
         offset += want;
     }
     return true;
 }
 
-/* The lock. Validity alone is not enough: a valid-but-easy page round-trips
- * and leaves CI green while the report still says worst case, which is what
- * this floor exists to refuse. */
+/* The lock. Validity alone is not enough: a valid-but-easy page set
+ * round-trips and leaves CI green while the report still says worst case,
+ * which is what this floor exists to refuse. It is taken on the WORST page and
+ * not on the mean, because a mean clears the floor while nine per cent of the
+ * corpus is the easiest page the format admits. */
 bool CheckRefillFloor(const RefillDensity& density) {
-    const double got = PerDecodedByte(density);
-    if (got >= kWorstRefillFloor) {
+    if (density.worst_page >= kWorstRefillFloor) {
         return true;
     }
     std::fprintf(stderr,
-                 "the worst-rounds corpus forces %.4f refills per decoded "
-                 "byte, under the %.4f floor this corpus exists to hold: it "
-                 "is still a valid page set and it is no longer the "
-                 "adversarial one the report names\n",
-                 got, kWorstRefillFloor);
+                 "the worst page of the worst-rounds corpus forces %.4f "
+                 "refills per decoded byte, under the %.4f floor this corpus "
+                 "exists to hold (the corpus mean is %.4f): it is still a "
+                 "valid page set and it is no longer the adversarial one the "
+                 "report names\n",
+                 density.worst_page, kWorstRefillFloor,
+                 PerDecodedByte(density));
     return false;
 }
 
@@ -865,14 +1038,26 @@ void PrintReport(const Corpus& corpus, int level,
                 "the denominator and carries no cudec number\n",
                 CUDEC_GDEFLATE_COMMIT);
     std::printf("- host CPU: %s\n", cudec_bench::HostCpuName().c_str());
+    /* The ratio is taken over the STREAM and never over the buffer: a
+     * hand-emitted page carries a zero tail no decoder reads, and counting it
+     * would attest bytes that are not stream. It is disclosed on its own line
+     * rather than dropped. */
+    const size_t stream_bytes = corpus.compressed_bytes - corpus.padding_bytes;
     std::printf("- corpus: %s, %zu pages, %.2f MB original, %.2f MB "
                 "compressed (ratio %.4f), %s\n",
                 corpus.name.c_str(), corpus.originals.size(),
                 static_cast<double>(corpus.original_bytes) / 1e6,
-                static_cast<double>(corpus.compressed_bytes) / 1e6,
-                static_cast<double>(corpus.compressed_bytes) /
+                static_cast<double>(stream_bytes) / 1e6,
+                static_cast<double>(stream_bytes) /
                     static_cast<double>(corpus.original_bytes),
                 corpus.provenance.c_str());
+    if (corpus.padding_bytes != 0) {
+        std::printf("- padding: %.2f MB on top of the compressed figure "
+                    "above, a zero tail per page for the reference's "
+                    "unchecked refill; no decoder reads it and the ratio "
+                    "does not count it\n",
+                    static_cast<double>(corpus.padding_bytes) / 1e6);
+    }
     if (level >= 0) {
         std::printf("- granularity: %zu KiB pages, compression level %d\n",
                     kPageBytes / 1024, level);
@@ -897,14 +1082,23 @@ void PrintReport(const Corpus& corpus, int level,
                 corpus.composition.c_str());
     if (density != nullptr) {
         std::printf("- refill density: %.4f refills per decoded byte over "
-                    "%llu refills and %llu decoded bytes, floor %.4f, counted "
-                    "by cudec's own schedule (src/gdeflate_schedule.h) on a "
-                    "decode required to reproduce the source; this is the "
-                    "quantity the corpus is locked on and not a timing\n",
+                    "%llu refills and %llu decoded bytes, worst page "
+                    "%.4f, floor %.4f taken on the worst page rather "
+                    "than on the mean, counted by cudec's own schedule "
+                    "(src/gdeflate_schedule.h) on a decode required to "
+                    "reproduce the source and to fill a whole page; this "
+                    "is the quantity the corpus is locked on and not a "
+                    "timing\n",
                     PerDecodedByte(*density),
                     static_cast<unsigned long long>(density->refills),
                     static_cast<unsigned long long>(density->out_bytes),
-                    kWorstRefillFloor);
+                    density->worst_page, kWorstRefillFloor);
+        std::printf("- deferred copies: %llu retired, one per %u decoded "
+                    "bytes past the opening literal run; the length "
+                    "round reserves and the distance round on the same "
+                    "lane retires\n",
+                    static_cast<unsigned long long>(density->copies),
+                    kWorstMatchLen);
     }
     const double p50 = Percentile(sorted, 50);
     const double p90 = Percentile(sorted, 90);
@@ -1373,24 +1567,34 @@ int RunBlockmix(const std::vector<unsigned char>& source,
     return ok ? 0 : 1;
 }
 
-/* The digest of the kSelfcheckPages-page worst-rounds corpus. It is a
- * constant for the same reason the level sweep's digests are: this page set is
+/* The digests of the two worst-rounds corpora, the four-page one the ctest
+ * entry builds and the full one the reported row is taken on. They are
+ * constants for the reason the level sweep's digests are: this page set is
  * emitted from fixed constants by code in this tree, so a change to the
- * generator, to the length vector or to the page writer's round order moves
- * it, and none of those would stop the pages round-tripping. */
-constexpr uint64_t kWorstRoundsSelfcheckDigest = 0x44a114301d086752ull;
-
-/* The worst-rounds path. Three gates before anything is timed, in the order
- * that puts the cheapest disqualification first:
+ * generator, to either length vector or to the page writer's round order moves
+ * one of them, and none of those would stop the pages round-tripping.
  *
+ * BOTH ARE CHECKED ON EVERY RUN, and that is a departure from the sibling
+ * paths, which check a digest only under --selfcheck. It is deliberate: the
+ * full corpus is the one a reported number is taken on, and a reporting path
+ * whose corpus nothing pins is a number attesting a page set nobody fixed. */
+constexpr uint64_t kWorstRoundsSelfcheckDigest = 0x925326a21c48a952ull;
+constexpr uint64_t kWorstRoundsFullDigest = 0x6e2f2850f76891bbull;
+
+/* The worst-rounds path. Four gates before anything is timed:
+ *
+ *  - cudec's own decode reproduces the source, fills a whole page, and yields
+ *    the refill count. It runs FIRST because it is the bounds-checked reader:
+ *    the reference refills without a bound check, so anything structurally
+ *    wrong with a page should be refused by the decoder that refuses rather
+ *    than found by the one that reads;
+ *  - the refill density clears its floor, on the worst page and not the mean;
  *  - the reference accepts every page and it round-trips to the source, which
  *    is the sole authority on validity here;
- *  - cudec's own decode reproduces the same bytes and yields the refill count;
- *  - the refill density clears its floor.
+ *  - the digest matches the pin for the corpus size that was built.
  *
- * The digest is checked after all three under --selfcheck, so a corpus that
- * drifted is named by what it stopped being before it is named by a number
- * that moved. */
+ * A corpus that drifted is therefore named by what it stopped being before it
+ * is named by a number that moved. */
 int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
     const size_t pages = selfcheck ? kSelfcheckPages : kWorstRoundsPages;
     Corpus corpus;
@@ -1398,17 +1602,16 @@ int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
     corpus.provenance =
         "HAND-CONSTRUCTED by this harness and validated by the pinned "
         "gdeflate fork, not produced by any compressor: one final dynamic "
-        "block per page whose every literal is coded at DEFLATE's maximum "
-        "codeword length, so each decoded byte costs 15 bits where a stored "
-        "block costs 8; ADVERSARIAL, the M4 security-posture row and never a "
-        "headline throughput figure";
+        "block per page, every symbol in it at DEFLATE's maximum codeword "
+        "length, and a body of minimum-length matches asked for through the "
+        "sixteen-extra-bit length symbol, so the deferred-copy path runs once "
+        "per three decoded bytes; ADVERSARIAL, the M4 security-posture row "
+        "and never a headline throughput figure, and NOT scale-comparable "
+        "with the level-sweep rows above, which are six times this corpus";
     corpus.composition = kCompositionNotAsserted;
 
     std::vector<unsigned char> source;
     if (!BuildWorstRoundsCorpus(pages, &source, &corpus)) {
-        return 1;
-    }
-    if (!CorpusRoundTrips(source, corpus)) {
         return 1;
     }
     RefillDensity density;
@@ -1416,6 +1619,9 @@ int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
         return 1;
     }
     if (!CheckRefillFloor(density)) {
+        return 1;
+    }
+    if (!CorpusRoundTrips(source, corpus)) {
         return 1;
     }
     /* Every page opens with the dynamic block this generator emits, and it is
@@ -1426,9 +1632,9 @@ int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
         return 1;
     }
     bool ok = true;
-    if (selfcheck &&
-        !CheckDigest(CorpusDigest(corpus), corpus.name, /*level=*/-1,
-                     kWorstRoundsSelfcheckDigest)) {
+    if (!CheckDigest(CorpusDigest(corpus), corpus.name, /*level=*/-1,
+                     selfcheck ? kWorstRoundsSelfcheckDigest
+                               : kWorstRoundsFullDigest)) {
         ok = false;
     }
     std::vector<double> times;

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1873,41 +1873,75 @@ runs.
 
 **The quantity that corpus locks is REFILLS per decoded byte, and this
 section fixed ROUNDS until #226 built it.** The change is not a
-convenience. A round is one symbol per lane, so an all-literal dynamic block
-and a stored block both sit at exactly 1/32 rounds per decoded byte, and a
-floor on that quantity is one no page can fall under - a density lock exists
-to catch a generator that stopped being adversarial, and one that a
-pathological input cannot move proves nothing. A refill is one 32-bit word
-handed to one lane, so it counts the bits a page spends rather than the
-symbols it emits, and it separates the two cases the round count cannot.
-Measured on the corpus the flag builds:
+convenience, and the reason it was made is narrower than the reason first
+written here. A round is one symbol per lane, so an all-literal dynamic
+block and a stored block sit at exactly the same 1/32 rounds per decoded
+byte: no floor separates the adversarial page from the easiest one the
+format admits, which is the whole job a density lock has. What stood here
+went further and said no page could fall under 1/32. That is false, and it
+is corrected rather than trimmed because a later reader would have checked
+it: a match costs two rounds on one lane - the length round reserves, the
+distance round retires - and yields at least three bytes, so a
+match-carrying page sits at 2/(32L) and 1/32 is the MAXIMUM of that quantity
+rather than a bound below it.
+
+A refill is one 32-bit word handed to one lane, so it counts the bits a page
+spends rather than the symbols it emits, and it ranks all three cases the
+way the cost does. Measured on the corpus the flag builds, one line of the
+report, wrapped here and not otherwise altered:
 
     bench_gdeflate --worstrounds --selfcheck
-    - refill density: 0.4695 refills per decoded byte over 123088 refills and
-      262144 decoded bytes, floor 0.4500
+    - refill density: 0.6152 refills per decoded byte over 161272 refills and
+      262144 decoded bytes, worst page 0.6152, floor 0.5500 taken on the worst
+      page rather than on the mean, counted by cudec's own schedule
+      (src/gdeflate_schedule.h) on a decode required to reproduce the source
+      and to fill a whole page; this is the quantity the corpus is locked on
+      and not a timing
 
-Against that, arithmetic rather than a second measurement, and marked as
-such: a refill hands a lane 32 bits, so a page spending b bits per decoded
-byte sits at b/32. A stored block spends 8 and lands at 0.250; a page whose
-literals carry a balanced code over the 257 literal/length symbols spends
-about 9 and lands near 0.28, which is what the weakened generator measures
-at 0.2612 when the floor above is watched refusing it.
+Beside it, arithmetic rather than a second measurement and marked as such: a
+refill hands a lane 32 bits, so a page spending b bits per decoded byte sits
+at b/32, and a stored block spends 8 and lands at 0.250. And beside that, a
+second reading rather than an estimate: the same generator with both codes
+balanced instead of maximal - the same matches, the same whole page, no long
+codeword anywhere - measures 0.4483 and is watched being refused by the
+floor. The floor therefore sits between two readings.
 
-The ratio proxy is refused for the same reason and it is the one that reads
-as success. The M4 CPU denominator recorded on #224 measures level 0 - the
-highest ratio this format can produce, since it emits uncompressed blocks by
-construction - as the FASTEST family on both corpora. A ratio floor
-therefore selects for the easiest pages while the report still says worst
-case.
+**Refills are not independent of the compressed size, and saying so was the
+other overreach.** For a page whose every emitted word is consumed - which
+the corpus is, exactly, and its own per-page check proves it - refills per
+decoded byte is the emitted stream's expansion ratio divided by four. What
+the refill count buys is that it is defined by decoder WORK: it does not
+move with bytes no decoder reads, it is read out of a decode that had to
+reproduce the source, and it is unavailable to a page that stopped decoding
+half way. The ratio's real defect is over COMPRESSOR output, and it is
+measured rather than argued: the M4 CPU denominator recorded on #224 has
+level 0 - the highest ratio this format can produce, since it emits
+uncompressed blocks by construction - as the FASTEST family on both corpora,
+so a ratio floor taken over compressor output selects for the easiest pages
+while the report still says worst case.
 
-That corpus is #226, `bench_gdeflate --worstrounds`, and the floor is its
-proof: every literal coded at DEFLATE's maximum codeword length, validated
-by the pinned reference, counted by cudec's own schedule on a decode
-required to reproduce the source. It is the long-codeword half of the shape
-above; the frequent-block-header half is not in it, because the page writer
-it rides on emits one final block per page and reaching the multi-block form
-means mirroring the reference's inter-block drain rounds, which nothing in
-this tree settles.
+**The floor's denominator is pinned as well as its numerator.** The fixed
+per-page cost - the 32-word priming round, the block header, the drain -
+divides by whatever the page produced, so a page emitting a hundred bytes
+clears any floor with no long codeword in it at all. The corpus therefore
+requires every page to decode to a whole 64 KiB tile. The floor is also
+taken on the WORST page rather than on the corpus mean, and the difference
+is measured rather than supposed: with one page of four built the easy way,
+the mean is 0.5735 and clears the 0.5500 floor while the worst page is
+0.4483 and does not.
+
+That corpus is #226, `bench_gdeflate --worstrounds`. Of the four ingredients
+this section opens with it carries three. Every symbol it emits sits at the
+maximum codeword length, literals, lengths and distances alike. Its lanes
+spend a maximum codeword plus a maximum extra-bit field per round. And its
+body is minimum-length matches, so a copy is split across two rounds on one
+lane once per three decoded bytes and `GDeflateDoCopy` runs 21728 times per
+page rather than never.
+
+The frequent-block-header ingredient is NOT in it: the page writer it rides
+on emits one final block per page, and emitting a second means writing the
+inter-block round order, which no fixture in this tree has ever emitted.
+#430 holds that, and this paragraph is removed when it lands.
 
 What would falsify this design, recorded before it is built:
 

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1903,13 +1903,24 @@ refill hands a lane 32 bits, so a page spending b bits per decoded byte sits
 at b/32, and a stored block spends 8 and lands at 0.250. And beside that, a
 second reading rather than an estimate: the same generator with both codes
 balanced instead of maximal - the same matches, the same whole page, no long
-codeword anywhere - measures 0.4483 and is watched being refused by the
-floor. The floor therefore sits between two readings.
+codeword anywhere - measures 0.4483, and the same generator with every
+codeword capped at twelve bits instead of fifteen measures 0.5523. Both are
+weakenings run by hand and watched being refused; the pull request carries the
+transcripts. The floor sits above the second of them.
+
+**A density floor cannot carry the codeword-depth claim on its own, and it is
+not asked to.** Most of a minimum-length match's cost is its extra-bit fields,
+which are the same width whatever the codewords are, so a twelve-bit code
+loses about a tenth of the density rather than most of it. What refuses a
+shallow code outright is a check that reads the length of every symbol the page
+emits out of the vector it is encoded from, so the sentence the report prints
+about codeword depth is a refusal rather than an assertion.
 
 **Refills are not independent of the compressed size, and saying so was the
 other overreach.** For a page whose every emitted word is consumed - which
-the corpus is, exactly, and its own per-page check proves it - refills per
-decoded byte is the emitted stream's expansion ratio divided by four. What
+the corpus is, exactly, and its own per-page check refuses a page that is
+not - refills per decoded byte is the emitted stream's expansion ratio divided
+by four. What
 the refill count buys is that it is defined by decoder WORK: it does not
 move with bytes no decoder reads, it is read out of a decode that had to
 reproduce the source, and it is unavailable to a page that stopped decoding
@@ -1926,17 +1937,22 @@ divides by whatever the page produced, so a page emitting a hundred bytes
 clears any floor with no long codeword in it at all. The corpus therefore
 requires every page to decode to a whole 64 KiB tile. The floor is also
 taken on the WORST page rather than on the corpus mean, and the difference
-is measured rather than supposed: with one page of four built the easy way,
-the mean is 0.5735 and clears the 0.5500 floor while the worst page is
-0.4483 and does not.
+is read off a run rather than supposed. With one page of the 512 built the
+easy way - all literals, still every codeword at the maximum length, still a
+whole page - the run prints a corpus mean of 0.6149, which clears the 0.6000
+floor, beside a worst page of 0.4697, which does not.
 
 That corpus is #226, `bench_gdeflate --worstrounds`. Of the four ingredients
 this section opens with it carries three. Every symbol it emits sits at the
-maximum codeword length, literals, lengths and distances alike. Its lanes
-spend a maximum codeword plus a maximum extra-bit field per round. And its
-body is minimum-length matches, so a copy is split across two rounds on one
-lane once per three decoded bytes and `GDeflateDoCopy` runs 21728 times per
-page rather than never.
+maximum codeword length, literals, lengths and distances alike, and a check
+that reads the depth off the vector each symbol is encoded from refuses a
+generator that shallowed them. A length round spends that codeword and sixteen
+extra bits, a distance round that codeword and the widest extra-bit field the
+output so far reaches back over, and a literal round the codeword alone. And
+its body is minimum-length matches, so a copy is split across two rounds on one
+lane once per three decoded bytes: 21728 of them per page by the corpus's own
+construction, which is arithmetic rather than a count any decoder here
+reports.
 
 The frequent-block-header ingredient is NOT in it: the page writer it rides
 on emits one final block per page, and emitting a second means writing the

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1869,10 +1869,45 @@ lane consumes near its watermark on every round, copies split across two
 rounds on the same lane (section 11), block headers frequent enough that
 the one-active-lane header rounds are a real share of the total, and code
 lengths long enough that the root accelerator misses and the canonical walk
-runs. The quantity that corpus locks is rounds per decoded byte, and its
-generator asserts a floor on it, so a generator that stops being
-adversarial reds CI rather than quietly reporting a better number. That
-corpus is #226 and the density floor is its proof.
+runs.
+
+**The quantity that corpus locks is REFILLS per decoded byte, and this
+section fixed ROUNDS until #226 built it.** The change is not a
+convenience. A round is one symbol per lane, so an all-literal dynamic block
+and a stored block both sit at exactly 1/32 rounds per decoded byte, and a
+floor on that quantity is one no page can fall under - a density lock exists
+to catch a generator that stopped being adversarial, and one that a
+pathological input cannot move proves nothing. A refill is one 32-bit word
+handed to one lane, so it counts the bits a page spends rather than the
+symbols it emits, and it separates the two cases the round count cannot.
+Measured on the corpus the flag builds:
+
+    bench_gdeflate --worstrounds --selfcheck
+    - refill density: 0.4695 refills per decoded byte over 123088 refills and
+      262144 decoded bytes, floor 0.4500
+
+Against that, arithmetic rather than a second measurement, and marked as
+such: a refill hands a lane 32 bits, so a page spending b bits per decoded
+byte sits at b/32. A stored block spends 8 and lands at 0.250; a page whose
+literals carry a balanced code over the 257 literal/length symbols spends
+about 9 and lands near 0.28, which is what the weakened generator measures
+at 0.2612 when the floor above is watched refusing it.
+
+The ratio proxy is refused for the same reason and it is the one that reads
+as success. The M4 CPU denominator recorded on #224 measures level 0 - the
+highest ratio this format can produce, since it emits uncompressed blocks by
+construction - as the FASTEST family on both corpora. A ratio floor
+therefore selects for the easiest pages while the report still says worst
+case.
+
+That corpus is #226, `bench_gdeflate --worstrounds`, and the floor is its
+proof: every literal coded at DEFLATE's maximum codeword length, validated
+by the pinned reference, counted by cudec's own schedule on a decode
+required to reproduce the source. It is the long-codeword half of the shape
+above; the frequent-block-header half is not in it, because the page writer
+it rides on emits one final block per page and reaching the multi-block form
+means mirroring the reference's inter-block drain rounds, which nothing in
+this tree settles.
 
 What would falsify this design, recorded before it is built:
 

--- a/tests/gdeflate_page_writer.h
+++ b/tests/gdeflate_page_writer.h
@@ -1,4 +1,5 @@
-/* A GDeflate page writer, for tests only (issue #175). It exists because the
+/* A GDeflate page writer, for the tests and the bench (issues #175, #226).
+ * It exists because the
  * reference's answer to "is this a code?" is not callable: the pinned fork
  * compiles `gdeflate_decompress.c` with `HIDE_INTERFACE` defined, so
  * `build_decode_table` is static inside that translation unit and the plain
@@ -6,6 +7,12 @@
  * reference's table construction is a whole GDeflate page, so a test that
  * wants the reference's verdict on a chosen code-length vector has to emit
  * one.
+ *
+ * WHO READS IT. tests/ drives it for the fixtures below; fuzz/ drives it
+ * through fuzz/gdeflate_structure.h; and bench/bench_gdeflate.cpp drives it for
+ * the adversarial corpus (#226), which is why the header is not test-only any
+ * more. The bench consumer is also the one that broke the size assumption
+ * stated at LaneBits below.
  *
  * WHAT MAKES THIS SAFE TO TRUST. A writer that is wrong produces pages the
  * reference rejects, and a reject is exactly what a negative test is looking
@@ -46,9 +53,15 @@
 
 namespace cudec_test {
 
-/* One byte per bit while the page is being built. A page here is a few hundred
- * symbols, so the shape that is easiest to reason about wins over the shape
- * that is compact. */
+/* One byte per bit while the page is being built: the shape that is easiest to
+ * reason about wins over the shape that is compact.
+ *
+ * WHAT THAT COSTS, MEASURED RATHER THAN ASSUMED. It said a page here is a few
+ * hundred symbols. The adversarial corpus (#226) drives a whole 64 KiB page
+ * through it, which is 65537 symbols and about 0.94 MB of lane storage for one
+ * page. That is paid one page at a time and the whole corpus run measures
+ * 6.52 s wall and 173 MB peak, so the shape stands - but a caller sizing a
+ * fixture off the old sentence would be sizing off a number that moved. */
 using LaneBits = std::vector<unsigned char>;
 
 /* Slack for the reference's unchecked refill, not a property of the format.
@@ -342,17 +355,39 @@ inline bool PlanPrecode(const std::vector<LenToken>& toks, uint32_t forced_expli
     return true;
 }
 
+/* One element of the BODY stream. A literal or a length symbol reads out of
+ * the literal/length code; the distance symbol a reserved match needs reads
+ * out of the distance code, on the same lane one round of its own later
+ * (src/gdeflate_block.h: a round whose lane holds a pending copy reads the
+ * distance and nothing else). Both kinds can carry the extra-bit field that
+ * follows them in the SAME round, which is what lets a body carry matches at
+ * all rather than literals only. */
+struct BodyToken {
+    uint32_t sym;
+    bool from_dist;
+    uint32_t extra_bits;
+    uint32_t extra_value;
+};
+
 /* Emit one whole page: a single final dynamic block whose header carries
- * `toks` and whose body encodes `symbols`. Every round here mirrors
+ * `toks` and whose body encodes `body`. Every round here mirrors
  * gdeflate_decompress_template.h in the pinned fork - the header fields ride
  * lane 0 with no round between them, each precode length is its own round,
- * and a repeat code's extra bits are pushed before the round ends. */
-inline bool EmitPage(const std::vector<unsigned char>& litlen_lens,
-              const std::vector<unsigned char>& dist_lens,
-              const std::vector<LenToken>& toks,
-              const unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms],
-              uint32_t num_explicit, const std::vector<uint32_t>& symbols,
-              std::vector<unsigned char>* page) {
+ * and a repeat code's extra bits are pushed before the round ends.
+ *
+ * THE BODY IS A TOKEN STREAM AND NOT A SYMBOL LIST, because a match is two
+ * rounds on one lane rather than one symbol: the token at position p rides
+ * lane p mod 32, so a length token at p has its distance token at p+32 by
+ * construction. A caller that gets that spacing wrong emits a page the
+ * reference reads differently from this writer, which is the failure the
+ * single-copy rule for this file exists to keep to one place. */
+inline bool EmitPageTokens(
+    const std::vector<unsigned char>& litlen_lens,
+    const std::vector<unsigned char>& dist_lens,
+    const std::vector<LenToken>& toks,
+    const unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms],
+    uint32_t num_explicit, const std::vector<BodyToken>& body,
+    std::vector<unsigned char>* page) {
     cudec_detail::GDeflatePrecodeTable precode;
     if (!cudec_detail::GDeflateBuildTable(precode_lens, cudec_detail::kGDeflateNumPrecodeSyms, precode)) {
         return false;
@@ -361,6 +396,10 @@ inline bool EmitPage(const std::vector<unsigned char>& litlen_lens,
     const bool litlen_ok =
         cudec_detail::GDeflateBuildTable(litlen_lens.data(),
                            static_cast<uint32_t>(litlen_lens.size()), litlen);
+    cudec_detail::GDeflateDistTable dist;
+    const bool dist_ok =
+        cudec_detail::GDeflateBuildTable(dist_lens.data(),
+                           static_cast<uint32_t>(dist_lens.size()), dist);
 
     GDeflatePageWriter w;
     w.Reset();
@@ -389,20 +428,31 @@ inline bool EmitPage(const std::vector<unsigned char>& litlen_lens,
         w.Advance();
     }
 
-    if (!symbols.empty()) {
+    if (!body.empty()) {
         if (!litlen_ok) {
             return false;
         }
         w.Reset();
-        for (size_t i = 0; i < symbols.size(); i++) {
+        for (size_t i = 0; i < body.size(); i++) {
+            const BodyToken& t = body[i];
+            if (t.from_dist && !dist_ok) {
+                return false;
+            }
             uint32_t code = 0;
             uint32_t len = 0;
-            if (!CodewordOf(litlen, litlen_lens.data(), symbols[i], &code,
-                            &len)) {
+            const bool found =
+                t.from_dist
+                    ? CodewordOf(dist, dist_lens.data(), t.sym, &code, &len)
+                    : CodewordOf(litlen, litlen_lens.data(), t.sym, &code,
+                                 &len);
+            if (!found) {
                 return false;
             }
             w.PushCode(code, len);
-            if (symbols[i] == kEndOfBlock) {
+            if (t.extra_bits != 0) {
+                w.Push(t.extra_bits, t.extra_value);
+            }
+            if (!t.from_dist && t.sym == kEndOfBlock) {
                 /* The reference leaves the decode loop on end-of-block without
                  * advancing, then runs 32 rounds to drain deferred copies.
                  * Those rounds refill, so the writer owes their words. */
@@ -420,6 +470,25 @@ inline bool EmitPage(const std::vector<unsigned char>& litlen_lens,
     }
     *page = w.Finish();
     return true;
+}
+
+/* The literals-only body, which is what every fixture written before matches
+ * were expressible needs. One token per symbol, no extra bits, no distance
+ * code read - so this is the same page it always emitted, and the round order
+ * is still the one above rather than a second copy of it. */
+inline bool EmitPage(const std::vector<unsigned char>& litlen_lens,
+              const std::vector<unsigned char>& dist_lens,
+              const std::vector<LenToken>& toks,
+              const unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms],
+              uint32_t num_explicit, const std::vector<uint32_t>& symbols,
+              std::vector<unsigned char>* page) {
+    std::vector<BodyToken> body;
+    body.reserve(symbols.size());
+    for (size_t i = 0; i < symbols.size(); i++) {
+        body.push_back(BodyToken{symbols[i], false, 0, 0});
+    }
+    return EmitPageTokens(litlen_lens, dist_lens, toks, precode_lens,
+                          num_explicit, body, page);
 }
 
 }  // namespace cudec_test

--- a/tests/gdeflate_page_writer.h
+++ b/tests/gdeflate_page_writer.h
@@ -56,12 +56,14 @@ namespace cudec_test {
 /* One byte per bit while the page is being built: the shape that is easiest to
  * reason about wins over the shape that is compact.
  *
- * WHAT THAT COSTS, MEASURED RATHER THAN ASSUMED. It said a page here is a few
- * hundred symbols. The adversarial corpus (#226) drives a whole 64 KiB page
- * through it, which is 65537 symbols and about 0.94 MB of lane storage for one
- * page. That is paid one page at a time and the whole corpus run measures
- * 6.52 s wall and 173 MB peak, so the shape stands - but a caller sizing a
- * fixture off the old sentence would be sizing off a number that moved. */
+ * THE SENTENCE THAT USED TO BOUND IT IS GONE. It said a page here is a few
+ * hundred symbols, and the adversarial corpus (#226) drives whole 64 KiB pages
+ * through this writer instead - tens of thousands of tokens, and one byte of
+ * lane storage for every bit the page spends, so of the order of a megabyte
+ * for one page. The shape still stands, because a page is built and released
+ * one at a time. No figure is quoted here: a cost that moves with the caller
+ * is not a property of this header, and the caller that pays it prints its own
+ * numbers with its own methodology. */
 using LaneBits = std::vector<unsigned char>;
 
 /* Slack for the reference's unchecked refill, not a property of the format.


### PR DESCRIPTION
# What & why

Closes #226.

The M4 adversarial corpus exists now, as `bench_gdeflate --worstrounds`, with a
CPU-only ctest entry beside it. Its pages are emitted by this harness rather
than compressed by the reference, because a compressor picks the code that
costs the fewest bits and this row exists to find the code that costs the most.
The pinned `gdeflate` fork stays the sole authority on whether a page is valid.

Against the four ingredients `docs/MASTERPLAN.md` 13.5 names, the corpus carries
three. Every symbol it emits sits at DEFLATE's maximum codeword length -
literals, lengths and distances alike - and a check reads that depth off the
vector each symbol is encoded from rather than asserting it. A length round
spends that codeword and sixteen extra bits, a distance round that codeword and
the widest extra-bit field the output so far reaches back over, and a literal
round the codeword alone. And its body is minimum-length matches, so a copy is
split across two rounds on one lane once per three decoded bytes: 21728 of them
per page by the corpus's own construction. The frequent-block-header ingredient
is **not** in it, and #430 holds it.

**The locked quantity is refills per decoded byte, and 13.5 moves with it.** 13.5
fixed rounds per decoded byte. A round is one symbol per lane, so an all-literal
dynamic block and a stored block sit at exactly the same 1/32: no floor
separates the adversarial page from the easiest one the format admits, which is
the whole job a density lock has. A refill is one 32-bit word handed to one
lane, so it counts the bits a page spends, and it ranks all three cases the way
the cost does. The plan section says why the quantity changed, so the next
reader sees that the first one could not fail rather than that it was
inconvenient.

## Type of change

- [x] Build / CI / supply chain
- [x] Docs

Bench harness, one shared test header generalised, one plan section. No kernel,
no device code, no API surface, no format parsing in the shipped library.

## Engineering checklist

- [x] Fail-closed preserved: no shipped decode path is touched. Every gate below
      refuses rather than reporting a number.
- [x] Oracle coverage: every page round-trips through the pinned `gdeflate` fork
      against its source before anything is timed, and through cudec's own page
      decoder before the density is read.
- [x] Determinism preserved: the corpus is built from fixed constants and a
      seeded LCG; both its digests are pinned and checked on every run.
- [x] Every CUDA API call's error is checked; no exceptions cross the C ABI.
      `bench_gdeflate` links no CUDA at all and makes no device call.
- [x] An adversarial review was run - twice. Record below.
- [x] Review record below.

## GPU sanitizer gate

- [x] Not applicable: this change touches no device code.

There is also no route to a device on this machine at all, which is #418 rather
than a property of this change:

```
nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
Failed to initialize NVML: GPU access blocked by the operating system
```

One thing that leaves uncovered, stated rather than left to be found: the
sanitizer CI job does not build `bench/` (`CMakeLists.txt`, the
`if(NOT CUDEC_SANITIZE)` guard, with the nvcc-link reason recorded there), so no
ASan run reaches this code. That is why the page writer's zero tail is kept at
the size the writer declares rather than trimmed - see the review record.

## Performance checklist

- [x] The claim is measured, not reasoned.
- [x] No recorded baseline moves. **No number from this corpus is written into
      `docs/BENCHMARKS.md`** - recording GDeflate rows is #228 and it is blocked
      on the M4 kernel.

The full-scale run, for the record and not as a recorded baseline:

```
./bench_gdeflate --worstrounds --runs 30 --warmup 3
- corpus: worst-rounds, 512 pages, 33.55 MB original, 82.57 MB compressed
  (ratio 2.4608), HAND-CONSTRUCTED by this harness and validated by the pinned
  gdeflate fork ...
- padding: 8.39 MB on top of the compressed figure above, a zero tail per page
  for the reference's unchecked refill; no decoder reads it and the ratio does
  not count it
- corpus digest: 6e2f2850f76891bb
- refill density: 0.6152 refills per decoded byte over 20642816 refills and
  33554432 decoded bytes, worst page 0.6152, floor 0.6000 ...
- deferred copies: 11124736, one per 3 decoded bytes past the opening literal
  run ... ARITHMETIC over the corpus's construction and not a count read out of
  the decode
- wall per run: p50 103.739 ms / p90 110.284 ms / p99 115.978 ms
- decode throughput: p50 0.323 GB/s / p90 0.304 GB/s / p99 0.289 GB/s
```

Host CPU AMD Ryzen 9 5950X, single thread, oracle commit
`8ba9502fb30d2bf728592d121f0d402e40c8cb05`. The row is deliberately not
scale-comparable with this harness's other corpora, which are several times this
one in pages, and the provenance string says so where the number is printed.

## Quality checklist

- [x] Minimal: the generator rides `tests/gdeflate_page_writer.h` rather than
      carrying a second copy of the decoder's round order; `EmitPage` becomes a
      literals-only wrapper over `EmitPageTokens` rather than a sibling of it;
      the timing loop the new path needed already existed inside `RunLevel` and
      is lifted into `TimeCorpus` rather than repeated.
- [x] Self-documenting.
- [x] Conformance tests pass, and the new structural properties are locked:
      `bench_gdeflate_worst_selfcheck` inside the `set_tests_properties` TIMEOUT
      set that `cudec_assert_test_timeouts()` sweeps; `static_assert`s over every
      symbol index the generator writes, written so no subtraction they depend on
      can wrap before they are evaluated; and two run-time checks over the built
      code vectors - one that they spend the codespace exactly, one that every
      symbol the body emits carries the maximum codeword length.

## Verification

Local, in the WSL distribution the CUDA gate runs in (nvcc 13.3, no device):

```
cmake --build <build> -j 12          # clean, zero warnings under the strict flags
ctest --test-dir <build> -LE gpu --no-tests=error
100% tests passed, 0 tests failed out of 54
```

```
./bench_gdeflate --worstrounds --selfcheck
- refill density: 0.6152 refills per decoded byte over 161272 refills and
  262144 decoded bytes, worst page 0.6152, floor 0.6000 ...
- deferred copies: 86912, one per 3 decoded bytes past the opening literal run
  ... ARITHMETIC over the corpus's construction and not a count read out of the
  decode
EXIT=0
```

- [x] `cmake --build` - builds clean.
- [x] `ctest` - green on the host-side selection; the nine `gpu`-labelled
      entries cannot run here, which is #418.
- [x] Prettier for `**/*.{md,yml,yaml}` - `All matched files use Prettier code style!`
- [x] `sh scripts/check-doc-paths.sh` - PASS.
- [x] Docs synced: `docs/MASTERPLAN.md` 13.5 amended in this change.

### The seven refusals, each watched biting

Every gate is proven by a mutant that reds it. None is committed. All are runs
of `./bench_gdeflate --worstrounds --selfcheck` unless the corpus size is named.

1. **The density floor.** Every code capped at twelve bits instead of fifteen,
   both spines shortened so the codes stay complete - the same matches, the same
   whole page:

   ```
   the worst page of the worst-rounds corpus forces 0.5523 refills per decoded
   byte, under the 0.6000 floor this corpus exists to hold (the corpus mean is
   0.5523) ...
   ```

   This is the second panel's own reproduction: at the 0.55 the floor first
   carried, that page set **passed**.

2. **The depth claim, as a refusal.** Both codes balanced instead of maximal:

   ```
   the worst-rounds body emits literal/length symbol 230 at 9 bits and this
   corpus reports every symbol at the maximum 15; the page would be valid and
   the report would be false
   ```

3. **The emitted-word check.** One word cut off a page after emission:

   ```
   page 0 of worst-rounds consumed 40318 of its 40317 emitted words; the
   density this corpus locks is only the stream's expansion when every emitted
   word is read
   ```

4. **The whole-page requirement.** Pages that stop after one match group - the
   shape that cleared an earlier version of this floor at 0.7578 with no long
   codeword in it at all:

   ```
   page 0 of worst-rounds decodes to 448 bytes and this corpus is locked per
   decoded byte, so a page short of the 65536-byte page would clear any floor
   on the fixed per-page cost alone
   ```

5. **The oracle gate.** One flipped byte, in the shipped gate order:

   ```
   the reference refuses page 0 of worst-rounds
   ```

6. **cudec's own gate on the same page**, with the two readers swapped:

   ```
   page 0 of worst-rounds was refused by the page decoder, so no refill count
   can be read out of it
   ```

7. **The floor is per page and not per corpus.** One page of the 512 built
   all-literal, every codeword still maximal, run over the full corpus:

   ```
   the worst page of the worst-rounds corpus forces 0.4697 refills per decoded
   byte, under the 0.6000 floor this corpus exists to hold (the corpus mean is
   0.6149) ...
   ```

   The mean clears the floor. That is the whole reason the lock is taken on the
   worst page.

One mutant did **not** bite and is reported rather than counted: removing 8 of
the writer's 32 post-EOB drain rounds moves neither the refill count nor the
emitted word count, because those rounds refill nothing for this page shape.

## Review record

Two rounds, five refute-by-default lenses each - correctness, robustness,
integration, performance, and one that executes rather than reads - with
`cuda-reviewer` not run because the diff touches no kernel and no ABI. Every
lens of round 2 was a fresh instance with no implementation context.

**Round 1, over the first version: 1 FAIL, 4 NEEDS_IMPROVEMENT.**
**Round 2, over the post-fix state: 0 FAIL, 5 NEEDS_IMPROVEMENT.**

Round 2's findings have their own heading below; every one of them is fixed in
the third commit, and each fix carries a mutant above or a correction in the
text.

**There was no second human reader on this board tonight.** The panel and the
mutants above are the evidence in place of one, and this sentence stays.

Findings and their dispositions, most severe first:

- **FIX. The floor was cleared by a valid, easy page set.** Reproduced: a
  balanced 8/9-bit code with a 128-byte body measured 0.7578 against the 0.45
  floor and printed the full "ADVERSARIAL ... maximum codeword length" report
  with exit 0, because the fixed per-page cost divides by whatever the page
  produced. The denominator is pinned now (every page must fill its tile) and
  mutant 3 above is that reproduction refused. CONFIRMED.
- **FIX. The corpus was not the densest shape this writer can emit.** A
  match-carrying page from the same writer measured 0.5882 against the
  all-literal corpus's 0.4695, exercised the deferred-copy path the corpus never
  entered, and the omission was disclosed for the block-header ingredient but not
  for this one. The body is matches now and measures 0.6152. CONFIRMED.
- **FIX. The writer's zero tail was cut 128-fold on an unsound argument.** The
  first version trimmed 4096 words to 32 and justified it with cudec's cursor -
  the one measurement that cannot bound the reference, which refills without a
  check where cudec refuses. A guard-page probe drove the reference off the end
  of a 32-word-tailed page from this same writer. The tail is untouched now, and
  the ratio is kept honest the other way: padding is counted apart from the
  stream and printed on its own line. CONFIRMED.
- **FIX. The floor was taken on the corpus mean.** Up to 8.9% of pages could be
  the easiest the format admits with the aggregate still clearing. Taken per page
  now; mutant 2 above is the proof. CONFIRMED.
- **FIX. The reporting path had no digest.** Only `--selfcheck` compared one.
  Both corpora are pinned now and both are checked on every run. CONFIRMED.
- **FIX. "No page can fall under 1/32 rounds per decoded byte" is false.** A
  match costs two rounds on one lane and yields at least three bytes, so 1/32 is
  the maximum of that quantity. 13.5 and the code comment are corrected, and the
  argument that survives - an easy stored page and an adversarial literal page
  score identically - is stated on its own. CONFIRMED.
- **FIX. Refills were claimed to be independent of the compressed size.** For a
  page whose every emitted word is consumed they are that ratio over four. 13.5
  and the code now say so, and say what the refill count does buy: it is defined
  by decoder work, so it does not move with bytes no decoder reads. CONFIRMED.
- **FIX. The corpus was three distinct pages repeated.** `(n + page_index) % 3`
  has period 3 in the page index, so 512 pages were 3 distinct inputs timed on a
  cache-resident working set. The opening literal run is seeded per page now.
  CONFIRMED.
- **FIX. Assorted false or stale prose.** "Falls below the watermark on alternate
  rounds" (the rate is 15/32); a MASTERPLAN estimate of 0.28 beside a measurement
  of 0.2612; a truncated transcript presented as verbatim program output; the
  block-type walk giving the absence of a page decoder as its reason after #176
  and #182 landed; the page writer declaring itself test-only and sizing its lane
  storage for "a few hundred symbols"; the CMake comment attributing the
  single-copy rule to the wrong paragraph of the header. All corrected.
  CONFIRMED.
- **FIX. No `static_assert` tied the hand-built code's completeness to its
  constants**, and three `std::vector` writes indexed by constants from another
  header were unbounded. Five `static_assert`s now carry both. CONFIRMED /
  PLAUSIBLE.
- **FIX. `MeasureRefillDensity` read `source` at an offset it never bounded**,
  relying on an invariant established in whichever gate ran first. It bounds it
  itself now, so the gate order is a matter of cost rather than of safety.
  PLAUSIBLE.
- **DECLINE. "The row is a sixth the scale of the level-sweep rows and nothing
  says its GB/s is not comparable."** The scale stays: every page here is emitted
  a bit at a time as well as decoded, and 3200 pages would cost the build time
  and the memory for no coverage. The provenance string now states the
  incomparability where the number is printed, which is the half that was
  missing. PLAUSIBLE.
- **DEFER to #430. The block-header ingredient of 13.5's shape.** The page writer
  emits one final block per page; emitting a second means writing the inter-block
  round order, which no fixture in this tree has ever emitted. The earlier
  sentence claiming nothing in this tree settles it was wrong about the drain and
  is corrected. CONFIRMED.


### Round 2 findings and dispositions

- **FIX. The density floor did not lock codeword depth.** Reproduced: every code
  capped at twelve bits measured 0.5523 and cleared the 0.55 floor, printing
  "every symbol in it at DEFLATE's maximum codeword length" over 12-bit codes.
  Most of a minimum-length match's cost is its extra-bit fields, which do not
  move with the codewords, so the density separates the two shapes by a tenth.
  The floor moves to 0.6000 and, more to the point, the depth claim becomes a
  refusal: `WorstCodeIsMaximal` reads the length of every symbol the body emits
  out of the vector it is encoded from. Mutants 1 and 2 above. CONFIRMED.
- **FIX. The `static_assert` that claimed to carry the Kraft identity was a
  tautology**, and two of its neighbours were defeated by unsigned underflow -
  the literal/length one letting a heap write past the end of the vector. The
  bounds are rewritten so no subtraction they depend on can wrap before they are
  evaluated, and completeness is derived by `WorstCodeIsComplete` off the built
  vectors in integer arithmetic. CONFIRMED.
- **FIX. The digest was not a gate.** A corpus whose digest missed its pin was
  still timed and still printed a full throughput report. It returns before
  either now. CONFIRMED.
- **FIX. Both the code and 13.5 named a per-page check that every emitted word
  is consumed, and no such check existed** - it had been removed with the tail
  trim it belonged to. It is back, and compares against the writer's declared
  tail. Mutant 3 above. CONFIRMED.
- **FIX. "Deferred copies: N retired" is arithmetic over the generator's own
  constants, and the comment beside it asserted the opposite.**
  `GDeflatePageState` carries no retired-copy counter, so nothing observes a
  retirement. The printed line and the comment say so now. CONFIRMED.
- **FIX. The digest-mismatch message called a 512-page corpus "the selfcheck
  corpus".** CONFIRMED.
- **FIX. The page writer's new sizing paragraph quoted figures measured on the
  previous commit's literals-only corpus** - 65537 symbols, 0.94 MB of lane
  storage, 6.52 s wall, 173 MB peak - none of which describe the corpus that
  ships. It quotes no figure now: a cost that moves with the caller is not a
  property of that header. CONFIRMED.
- **FIX. "A maximum codeword plus a maximum extra-bit field per round" is
  false** for every literal round and for most distance rounds, in the code
  comment and in 13.5. Both now say which round spends what. CONFIRMED.
- **FIX. "The measured rate is printed with the row"** promised a per-round
  refill rate the report never prints. Removed. CONFIRMED.
- **FIX. The oracle was not "the sole authority on validity"** - cudec's decoder
  gated first, so #226's "corrupting one byte makes the oracle gate reject it
  before timing" was not what the code did. The oracle runs first now, which the
  writer's full-size tail makes safe, and mutant 6 keeps cudec's own verdict on
  the record. CONFIRMED.
- **FIX. The provenance pointed at "the level-sweep rows above"**, which this
  invocation never prints. CONFIRMED.
- **FIX. 13.5 presented a mixed-corpus mean as measured when it was
  arithmetic.** It now quotes a run: mutant 7 above. PLAUSIBLE.

## Notes

**Why `../tests` is on this target's include path.** `bench/CMakeLists.txt` is
consumer-only by rule - it links project targets and never modifies them.
Reading a header from `tests/` is inside that rule and is what `bench_zstd`
already does one step further, by compiling `../tests/zstd_corpus.cpp`. The
alternative was a second copy of the schedule mirror, which is the one thing
that header exists to prevent.

**What changed in the shared page writer.** `EmitPage` keeps its signature and
its behaviour and becomes a wrapper over `EmitPageTokens`, which takes a body of
tokens carrying extra-bit fields instead of bare symbols. That is what lets a
body carry matches at all; every existing consumer emits the same pages, which
is what the 54-test host suite says.
