### PR TITLE
Build the fourth ingredient of the GDeflate worst case: many dynamic blocks per page [#430]

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -239,6 +239,20 @@ add_test(NAME bench_gdeflate_blockmix_selfcheck COMMAND bench_gdeflate
 add_test(NAME bench_gdeflate_worst_selfcheck COMMAND bench_gdeflate
                                               --worstrounds --selfcheck)
 
+# The same worst case with the fourth ingredient of masterplan 13.5 in it
+# (issue #430): the same page cut into one dynamic block per group of matches,
+# so it pays a block header every 96 decoded bytes. Its own entry rather than a
+# widening of the one above, because it locks its own quantities - a higher
+# refill floor, its own digests, and a block count per page read out of cudec's
+# decode - and an entry that ran both would report one verdict over two
+# corpora. It is also the entry that rots if the page writer's INTER-BLOCK
+# round order drifts: nothing else in this tree emits a second block into a
+# page, so a wrong boundary reds here and nowhere else.
+#
+# CPU-only, like the entries above.
+add_test(NAME bench_gdeflate_worstheaders_selfcheck
+         COMMAND bench_gdeflate --worstheaders --selfcheck)
+
 # The Zstd worst-case corpus (issue #229). No CUDA in it at all: the frames
 # are constructed on the host, emitted through the reference's own
 # sequence-compression entry point and decoded by the reference, so the
@@ -318,6 +332,6 @@ set_tests_properties(
   bench_snappy_worst_selfcheck bench_snappy_worstlit_selfcheck
   bench_gdeflate_selfcheck bench_gdeflate_assetlike_selfcheck
   bench_gdeflate_blocktypes_selfcheck bench_gdeflate_blockmix_selfcheck
-  bench_gdeflate_worst_selfcheck
+  bench_gdeflate_worst_selfcheck bench_gdeflate_worstheaders_selfcheck
   PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 cudec_assert_test_timeouts()

--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -572,17 +572,18 @@ std::vector<unsigned char> MakeAssetlikeSource(size_t pages) {
     return out;
 }
 
-/* THE WORST-ROUNDS CORPUS (issue #226), and what it locks.
+/* THE WORST-CASE CORPORA (issues #226 and #430), and what they lock.
  *
- * WHY IT IS NOT COMPRESSED BY THE REFERENCE. Every other corpus in this file
- * is what the pinned compressor chose to emit; a compressor picks the code
- * that costs the FEWEST bits, which is the opposite of what this row is for.
- * The security-posture question is what a page an attacker fully controls can
- * force out of a decoder, so the page is emitted here and the reference is
- * kept as the authority on whether it is valid at all.
+ * WHY THEY ARE NOT COMPRESSED BY THE REFERENCE. Every other corpus in this
+ * file is what the pinned compressor chose to emit; a compressor picks the
+ * code that costs the FEWEST bits, which is the opposite of what these rows
+ * are for. The security-posture question is what a page an attacker fully
+ * controls can force out of a decoder, so the page is emitted here and the
+ * reference is kept as the authority on whether it is valid at all.
  *
  * WHAT THE SHAPE IS, against the four ingredients MASTERPLAN section 13.5
- * names. Three of them are here and the fourth is not:
+ * names. One generator builds all four, and the two rows it reports are the
+ * two ends of the last of them:
  *
  *  - CODE LENGTHS LONG ENOUGH THAT THE ROOT ACCELERATOR MISSES. Every symbol
  *    this page emits - literal, length and distance alike - sits at DEFLATE's
@@ -600,10 +601,15 @@ std::vector<unsigned char> MakeAssetlikeSource(size_t pages) {
  *    the deferred-copy machinery is exercised rather than skipped. Length
  *    symbol 285 is DEFLATE64's base 3 with SIXTEEN extra bits, which is the
  *    most expensive way the format has of asking for three bytes.
- *  - FREQUENT BLOCK HEADERS is the one that is NOT here. The page writer this
- *    generator rides on emits one final block per page; extending it to
- *    several is unbuilt, and this corpus claims nothing about that ingredient.
- *    Issue #430 holds it.
+ *  - FREQUENT BLOCK HEADERS, which is what separates the two rows.
+ *    `--worstrounds` (#226) puts one final dynamic block on a page and claims
+ *    nothing about this ingredient; `--worstheaders` (#430) cuts the same page
+ *    into one dynamic block per group of 32 matches - a header every 96
+ *    decoded bytes, which is the most this construction admits, since a block
+ *    carries whole groups. A header is bits that produce no output at all and
+ *    it rides lane 0 while the other 31 lanes do nothing, so the many-block
+ *    page is strictly the harder one: measured, 0.7026 refills per decoded
+ *    byte against 0.6152, on pages that decode to the same bytes.
  *
  * THE QUANTITY IS REFILLS PER DECODED BYTE, AND IT IS NOT THE ONE THE PLAN
  * FIRST NAMED. Section 13.5 fixed rounds per decoded byte. That quantity does
@@ -740,8 +746,9 @@ uint32_t WorstGroups() {
  * printed. */
 constexpr size_t kWorstRoundsPages = 512;
 
-/* The floor the corpus is required to clear, in refills per decoded byte, and
- * what sits under it.
+/* The floor the SINGLE-BLOCK corpus is required to clear, in refills per
+ * decoded byte, and what sits under it. The many-block row carries its own,
+ * beside its own digests, at kWorstHeadersRefillFloor below.
  *
  * A refill hands a lane 32 bits, so a page spending b bits per decoded byte
  * sits at b/32; a stored block spends 8 and lands at 0.250. This corpus
@@ -857,8 +864,31 @@ bool WorstDistSymFor(uint64_t out_pos, uint32_t* sym) {
     return false;
 }
 
-/* One page: an opening literal run, then `kWorstGroups` groups of 32 minimum
- * matches, then end-of-block.
+/* How many dynamic blocks the header row cuts a page into, DERIVED from the
+ * page's own shape rather than chosen: a block has to carry whole groups, or
+ * a lane would hold a reservation across a block boundary that the drain
+ * cannot retire, so one group is the smallest a block can be and the group
+ * count is therefore the most block headers a page of this construction can
+ * hold. The frequency is the maximum for the same reason the codewords are the
+ * maximum - this is the adversarial extreme of the ingredient, not a sample
+ * of it. */
+uint32_t WorstHeaderBlocks() { return WorstGroups(); }
+
+/* One page: an opening literal run, then `WorstGroups()` groups of 32 minimum
+ * matches, then end-of-block - cut into `blocks` dynamic blocks, each carrying
+ * whole groups and stating its own end.
+ *
+ * `blocks` IS THE ONE INGREDIENT THAT VARIES, and the two rows this file
+ * reports are the two ends of it: 1 is #226's single final block per page, and
+ * WorstHeaderBlocks() is #430's page of many. Everything else - the code
+ * vectors, the literal run, the group construction, the distance choice - is
+ * shared, because two generators would be two things to keep adversarial and
+ * only one of them would be read when the other drifted.
+ *
+ * A BLOCK BOUNDARY COSTS OUTPUT NOTHING AND COSTS BITS A HEADER, which is why
+ * cutting the page changes the density without changing the bytes: the source
+ * a page decodes to does not depend on `blocks` at all, and the two rows
+ * therefore differ in exactly the ingredient they are being compared on.
  *
  * THE GROUP SHAPE IS THE DECODER'S AND NOT A CHOICE. A body token at position
  * p rides lane p mod 32, and the distance a reserved match needs is read on
@@ -869,9 +899,9 @@ bool WorstDistSymFor(uint64_t out_pos, uint32_t* sym) {
  *
  * `page_index` seeds the literal run, so the pages of a corpus differ from one
  * another in their bytes as well as in their index. */
-bool BuildWorstRoundsPage(size_t page_index,
-                          std::vector<unsigned char>* original,
-                          std::vector<unsigned char>* page) {
+bool BuildWorstPage(size_t page_index, uint32_t blocks,
+                    std::vector<unsigned char>* original,
+                    std::vector<unsigned char>* page) {
     const std::vector<unsigned char> litlen_lens = WorstLitLenLengths();
     const std::vector<unsigned char> dist_lens = WorstDistLengths();
 
@@ -889,62 +919,108 @@ bool BuildWorstRoundsPage(size_t page_index,
 
     const uint32_t lead = WorstLeadBytes();
     const uint32_t groups = WorstGroups();
-    std::vector<cudec_test::BodyToken> body;
-    body.reserve(lead + 2u * groups * kWorstGroupMatches + 1u);
+    if (blocks == 0 || blocks > groups) {
+        std::fprintf(stderr,
+                     "a worst-case page of %u groups cannot be cut into %u "
+                     "blocks: a block carries whole groups, so one group is "
+                     "the smallest a block can be\n",
+                     groups, blocks);
+        return false;
+    }
     original->assign(kPageBytes, 0);
+
+    /* Every block states the same header. The vectors and the token stream are
+     * built once above and copied into each, so a page of many blocks pays the
+     * header's bits many times over - which is the cost this row exists to
+     * measure - without this generator holding two descriptions of one code. */
+    cudec_test::PageBlock proto;
+    proto.litlen_lens = litlen_lens;
+    proto.dist_lens = dist_lens;
+    proto.toks = toks;
+    std::memcpy(proto.precode_lens, precode_lens, sizeof(proto.precode_lens));
+    proto.num_explicit = num_explicit;
+
+    std::vector<cudec_test::PageBlock> page_blocks;
+    page_blocks.reserve(blocks);
 
     /* The opening run. A fixed LCG seeded by the page index, so every page of
      * a corpus is different bytes and every corpus is reproducible. */
     uint64_t state = 0x9E3779B97F4A7C15ull + page_index;
     uint64_t out_pos = 0;
-    for (uint32_t n = 0; n < lead; n++) {
-        state = state * 6364136223846793005ull + 1442695040888963407ull;
-        const uint32_t sym =
-            kWorstFirstDeepLiteral +
-            static_cast<uint32_t>((state >> 33) % kWorstDeepLiterals);
-        body.push_back(cudec_test::BodyToken{sym, false, 0, 0});
-        (*original)[out_pos] = static_cast<unsigned char>(sym);
-        out_pos++;
+    uint32_t groups_placed = 0;
+    for (uint32_t b = 0; b < blocks; b++) {
+        cudec_test::PageBlock blk = proto;
+        /* The groups spread as evenly as they divide, remainder to the front.
+         * Every block therefore holds at least one, which is what the bound
+         * above refused a `blocks` too large for. */
+        const uint32_t take =
+            groups / blocks + (b < groups % blocks ? 1u : 0u);
+        if (b == 0) {
+            blk.body.reserve(lead + 2u * take * kWorstGroupMatches + 1u);
+            for (uint32_t n = 0; n < lead; n++) {
+                state = state * 6364136223846793005ull +
+                        1442695040888963407ull;
+                const uint32_t sym =
+                    kWorstFirstDeepLiteral +
+                    static_cast<uint32_t>((state >> 33) % kWorstDeepLiterals);
+                blk.body.push_back(cudec_test::BodyToken{sym, false, 0, 0});
+                (*original)[out_pos] = static_cast<unsigned char>(sym);
+                out_pos++;
+            }
+        } else {
+            blk.body.reserve(2u * take * kWorstGroupMatches + 1u);
+        }
+
+        for (uint32_t g = 0; g < take; g++) {
+            uint64_t reserved[kWorstGroupMatches];
+            uint32_t dist_sym[kWorstGroupMatches];
+            for (uint32_t m = 0; m < kWorstGroupMatches; m++) {
+                if (!WorstDistSymFor(out_pos, &dist_sym[m])) {
+                    std::fprintf(stderr,
+                                 "no deep distance symbol reaches back over "
+                                 "%llu bytes of output\n",
+                                 static_cast<unsigned long long>(out_pos));
+                    return false;
+                }
+                reserved[m] = out_pos;
+                out_pos += kWorstMatchLen;
+                blk.body.push_back(cudec_test::BodyToken{
+                    kWorstLengthSym, false,
+                    cudec_detail::GDeflateLengthExtra(kWorstLengthIndex), 0});
+            }
+            for (uint32_t m = 0; m < kWorstGroupMatches; m++) {
+                const uint32_t s = dist_sym[m];
+                const uint64_t offset = cudec_detail::GDeflateDistBase(s);
+                /* Mirrors GDeflateDoCopy exactly, in the same order the
+                 * decoder retires the group, so the expected bytes are what a
+                 * decode produces rather than what this generator meant. */
+                for (uint32_t i = 0; i < kWorstMatchLen; i++) {
+                    (*original)[reserved[m] + i] =
+                        (*original)[reserved[m] - offset + i];
+                }
+                blk.body.push_back(cudec_test::BodyToken{
+                    s, true, cudec_detail::GDeflateDistExtra(s), 0});
+            }
+        }
+        groups_placed += take;
+        /* Every block states its own end. A group is 32 reservations followed
+         * by the 32 retirements that pay for them, so no lane holds a
+         * reservation across this boundary and the drain that follows it
+         * consumes nothing - which is what makes a block boundary placeable
+         * here at all. */
+        blk.body.push_back(
+            cudec_test::BodyToken{cudec_test::kEndOfBlock, false, 0, 0});
+        if (!WorstCodeIsMaximal(blk.body, litlen_lens, dist_lens)) {
+            return false;
+        }
+        page_blocks.push_back(std::move(blk));
     }
 
-    for (uint32_t g = 0; g < groups; g++) {
-        uint64_t reserved[kWorstGroupMatches];
-        uint32_t dist_sym[kWorstGroupMatches];
-        for (uint32_t m = 0; m < kWorstGroupMatches; m++) {
-            if (!WorstDistSymFor(out_pos, &dist_sym[m])) {
-                std::fprintf(stderr,
-                             "no deep distance symbol reaches back over %llu "
-                             "bytes of output\n",
-                             static_cast<unsigned long long>(out_pos));
-                return false;
-            }
-            reserved[m] = out_pos;
-            out_pos += kWorstMatchLen;
-            body.push_back(cudec_test::BodyToken{
-                kWorstLengthSym, false,
-                cudec_detail::GDeflateLengthExtra(kWorstLengthIndex), 0});
-        }
-        for (uint32_t m = 0; m < kWorstGroupMatches; m++) {
-            const uint32_t s = dist_sym[m];
-            const uint64_t offset = cudec_detail::GDeflateDistBase(s);
-            /* Mirrors GDeflateDoCopy exactly, in the same order the decoder
-             * retires the group, so the expected bytes are what a decode
-             * produces rather than what this generator meant. */
-            for (uint32_t i = 0; i < kWorstMatchLen; i++) {
-                (*original)[reserved[m] + i] =
-                    (*original)[reserved[m] - offset + i];
-            }
-            body.push_back(cudec_test::BodyToken{
-                s, true, cudec_detail::GDeflateDistExtra(s), 0});
-        }
-    }
-    body.push_back(
-        cudec_test::BodyToken{cudec_test::kEndOfBlock, false, 0, 0});
-
-    if (out_pos != kPageBytes) {
+    if (groups_placed != groups || out_pos != kPageBytes) {
         std::fprintf(stderr,
-                     "the worst-rounds page produces %llu bytes and the page "
-                     "is %zu\n",
+                     "the worst-case page places %u of %u groups and produces "
+                     "%llu bytes, and the page is %zu\n",
+                     groups_placed, groups,
                      static_cast<unsigned long long>(out_pos), kPageBytes);
         return false;
     }
@@ -957,11 +1033,7 @@ bool BuildWorstRoundsPage(size_t page_index,
                      "\n");
         return false;
     }
-    if (!WorstCodeIsMaximal(body, litlen_lens, dist_lens)) {
-        return false;
-    }
-    if (!cudec_test::EmitPageTokens(litlen_lens, dist_lens, toks, precode_lens,
-                                    num_explicit, body, page)) {
+    if (!cudec_test::EmitPageBlocks(page_blocks, page)) {
         std::fprintf(stderr, "the page writer refused page %zu\n", page_index);
         return false;
     }
@@ -978,12 +1050,12 @@ bool BuildWorstRoundsPage(size_t page_index,
 /* The whole corpus, plus the source it is required to decode back to. The
  * source is assembled here rather than handed in, because these pages are not
  * a cut of anything - the bytes exist because the page says them. */
-bool BuildWorstRoundsCorpus(size_t pages, std::vector<unsigned char>* source,
-                            Corpus* corpus) {
+bool BuildWorstCorpus(size_t pages, uint32_t blocks,
+                      std::vector<unsigned char>* source, Corpus* corpus) {
     for (size_t i = 0; i < pages; i++) {
         std::vector<unsigned char> original;
         std::vector<unsigned char> page;
-        if (!BuildWorstRoundsPage(i, &original, &page)) {
+        if (!BuildWorstPage(i, blocks, &original, &page)) {
             return false;
         }
         source->insert(source->end(), original.begin(), original.end());
@@ -1009,6 +1081,18 @@ struct RefillDensity {
      * that clears a floor can hold a page set where most pages are trivial. */
     double worst_page = 0.0;
     uint64_t copies = 0;
+    /* How many blocks the pages turned out to hold, and how many of those were
+     * dynamic. READ OUT OF THE DECODE (GDeflatePageState::blocks and its
+     * per-type census) rather than out of the construction, because a block
+     * boundary inside a page is not findable by scanning and only a decode
+     * that walked to a block can count it (issue #206). The extremes rather
+     * than a mean: a corpus whose pages disagree about their block count is
+     * the thing a mean would hide, and the headers row below refuses on
+     * exactly that. */
+    uint32_t min_blocks = 0;
+    uint32_t max_blocks = 0;
+    uint64_t blocks = 0;
+    uint64_t dynamic_blocks = 0;
 };
 
 double PerDecodedByte(const RefillDensity& d) {
@@ -1078,6 +1162,15 @@ bool MeasureRefillDensity(const std::vector<unsigned char>& source,
         if (i == 0 || page_density < density->worst_page) {
             density->worst_page = page_density;
         }
+        if (i == 0 || st.blocks < density->min_blocks) {
+            density->min_blocks = st.blocks;
+        }
+        if (i == 0 || st.blocks > density->max_blocks) {
+            density->max_blocks = st.blocks;
+        }
+        density->blocks += st.blocks;
+        density->dynamic_blocks +=
+            st.type_blocks[cudec_detail::kGDeflateBlockDynamic];
         /* EVERY EMITTED WORD IS CONSUMED, and this is where that stops
          * being a sentence. The page carries the writer's declared zero tail
          * past the words it handed out; the cursor says how far a mirror of
@@ -1124,18 +1217,42 @@ bool MeasureRefillDensity(const std::vector<unsigned char>& source,
  * the easiest page this generator can build: with one page of the 512 built
  * all-literal, the run prints a mean of 0.6149 - above the floor - beside a
  * worst page of 0.4697. */
-bool CheckRefillFloor(const RefillDensity& density) {
-    if (density.worst_page >= kWorstRefillFloor) {
+bool CheckRefillFloor(const char* name, const RefillDensity& density,
+                      double floor) {
+    if (density.worst_page >= floor) {
         return true;
     }
     std::fprintf(stderr,
-                 "the worst page of the worst-rounds corpus forces %.4f "
+                 "the worst page of the %s corpus forces %.4f "
                  "refills per decoded byte, under the %.4f floor this corpus "
                  "exists to hold (the corpus mean is %.4f): it is still a "
                  "valid page set and it is no longer the adversarial one the "
                  "report names\n",
-                 density.worst_page, kWorstRefillFloor,
-                 PerDecodedByte(density));
+                 name, density.worst_page, floor, PerDecodedByte(density));
+    return false;
+}
+
+/* THE BLOCK-COUNT CLAIM, AS A REFUSAL, and it is the headers row's equivalent
+ * of WorstCodeIsMaximal above. That row's whole reason to exist is that its
+ * pages carry many dynamic block headers, and the refill floor cannot carry
+ * that sentence on its own: a header is a few hundred bits against a page of
+ * half a million, so a generator that collapsed back to one block per page
+ * loses a tenth of the density rather than most of it, and a floor low enough
+ * to be robust would not notice. This reads the count out of the decode's own
+ * census and requires EVERY page to hold exactly what the construction says,
+ * so a corpus that stopped emitting the ingredient is named by what it stopped
+ * being rather than by a number that drifted. */
+bool CheckBlocksPerPage(const char* name, const RefillDensity& density,
+                        uint32_t want) {
+    if (density.min_blocks == want && density.max_blocks == want) {
+        return true;
+    }
+    std::fprintf(stderr,
+                 "the %s corpus holds between %u and %u blocks per page and "
+                 "its construction emits %u; the frequent-block-header "
+                 "ingredient this row is named for is not in the pages it "
+                 "built\n",
+                 name, density.min_blocks, density.max_blocks, want);
     return false;
 }
 
@@ -1147,7 +1264,7 @@ bool CheckRefillFloor(const RefillDensity& density) {
  * not exist. */
 void PrintReport(const Corpus& corpus, int level,
                  const std::vector<double>& sorted, size_t warmup, size_t runs,
-                 const RefillDensity* density) {
+                 const RefillDensity* density, double floor) {
     std::vector<size_t> sizes;
     sizes.reserve(corpus.originals.size());
     for (const auto& original : corpus.originals) {
@@ -1217,7 +1334,18 @@ void PrintReport(const Corpus& corpus, int level,
                     PerDecodedByte(*density),
                     static_cast<unsigned long long>(density->refills),
                     static_cast<unsigned long long>(density->out_bytes),
-                    density->worst_page, kWorstRefillFloor);
+                    density->worst_page, floor);
+        /* Read out of the decode and not out of the generator, for the reason
+         * --blockmix exists: a block boundary inside a page is not findable by
+         * scanning, so a walk that stopped at the opening header could report
+         * one block per page and be believed. */
+        std::printf("- blocks per page: min %u / max %u, %llu blocks over the "
+                    "corpus of which %llu dynamic, counted by cudec's own page "
+                    "decode (src/gdeflate_block.h) rather than by the "
+                    "construction that emitted them\n",
+                    density->min_blocks, density->max_blocks,
+                    static_cast<unsigned long long>(density->blocks),
+                    static_cast<unsigned long long>(density->dynamic_blocks));
         std::printf("- deferred copies: %llu, one per %u decoded bytes past "
                     "the opening literal run - the length round reserves and "
                     "the distance round on the same lane retires. ARITHMETIC "
@@ -1306,7 +1434,8 @@ bool RunLevel(const std::vector<unsigned char>& source, const std::string& name,
     if (!TimeCorpus(corpus, warmup, runs, &times)) {
         return false;
     }
-    PrintReport(corpus, level, times, warmup, runs, /*density=*/nullptr);
+    PrintReport(corpus, level, times, warmup, runs, /*density=*/nullptr,
+                /*floor=*/0.0);
     return true;
 }
 
@@ -1436,7 +1565,8 @@ bool ParseCount(const char* text, size_t lo, size_t hi, size_t* out) {
 void Usage(const char* argv0) {
     std::fprintf(stderr,
                  "usage: %s [--warmup N] [--runs N] [--assetlike] "
-                 "[--blocktypes] [--blockmix] [--worstrounds] [--selfcheck] "
+                 "[--blocktypes] [--blockmix] [--worstrounds] "
+                 "[--worstheaders] [--selfcheck] "
                  "[corpus files...]\n",
                  argv0);
 }
@@ -1694,21 +1824,43 @@ int RunBlockmix(const std::vector<unsigned char>& source,
     return ok ? 0 : 1;
 }
 
-/* The digests of the two worst-rounds corpora, the four-page one the ctest
- * entry builds and the full one the reported row is taken on. They are
+/* The digests of the four worst-case corpora - each row's four-page selfcheck
+ * corpus and the full one its reported row is taken on. They are
  * constants for the reason the level sweep's digests are: this page set is
  * emitted from fixed constants by code in this tree, so a change to the
  * generator, to either length vector or to the page writer's round order moves
  * one of them, and none of those would stop the pages round-tripping.
  *
- * BOTH ARE CHECKED ON EVERY RUN, and that is a departure from the sibling
+ * EACH IS CHECKED ON EVERY RUN, and that is a departure from the sibling
  * paths, which check a digest only under --selfcheck. It is deliberate: the
  * full corpus is the one a reported number is taken on, and a reporting path
  * whose corpus nothing pins is a number attesting a page set nobody fixed. */
 constexpr uint64_t kWorstRoundsSelfcheckDigest = 0x925326a21c48a952ull;
 constexpr uint64_t kWorstRoundsFullDigest = 0x6e2f2850f76891bbull;
+constexpr uint64_t kWorstHeadersSelfcheckDigest = 0xdda9f7867d7bd574ull;
+constexpr uint64_t kWorstHeadersFullDigest = 0xc79e0a872dba2ca3ull;
 
-/* The worst-rounds path. Four gates, all of them before anything is timed and
+/* The floor the many-block row is required to clear, and why it is its own
+ * number rather than the single-block row's.
+ *
+ * A BLOCK HEADER IS BITS THAT PRODUCE NO OUTPUT AT ALL, so cutting a page into
+ * many blocks raises refills per decoded byte without moving the bytes the
+ * page decodes to. That makes the two rows comparable in exactly one
+ * ingredient, and it makes the single-block row's measurement the thing this
+ * floor has to sit above: 0.6152 is what the same generator reaches with
+ * `blocks` set to 1, measured rather than argued, and a floor under it would
+ * be cleared by a generator that had lost its headers entirely. This floor is
+ * therefore set between that reading and the one the many-block shape reaches,
+ * so the weakening the row is most likely to suffer is refused by the number
+ * as well as by CheckBlocksPerPage above. */
+constexpr double kWorstHeadersRefillFloor = 0.66;
+static_assert(kWorstHeadersRefillFloor > kWorstRefillFloor,
+              "a many-block page spends strictly more bits per decoded byte "
+              "than the single-block page of the same construction, so a "
+              "headers floor at or under the rounds floor would refuse "
+              "nothing the rounds row does not already refuse");
+
+/* The worst-case rows. Five gates, all of them before anything is timed and
  * before anything is printed:
  *
  *  - the reference accepts every page and it round-trips to the source. It is
@@ -1719,31 +1871,34 @@ constexpr uint64_t kWorstRoundsFullDigest = 0x6e2f2850f76891bbull;
  *    drifted into a read of zeros;
  *  - cudec's own decode reproduces the source, fills a whole page, consumes
  *    exactly the emitted words, and yields the refill count;
+ *  - every page holds exactly the blocks the construction says, counted out of
+ *    that same decode. It runs BEFORE the floor because it names the
+ *    ingredient a drifted corpus stopped carrying, where the floor names a
+ *    number that moved;
  *  - the refill density clears its floor, on the worst page and not the mean;
  *  - the digest matches the pin for the corpus size that was built.
  *
  * A corpus that drifted is therefore named by what it stopped being before it
- * is named by a number that moved, and a corpus that failed any of the four
+ * is named by a number that moved, and a corpus that failed any of the five
  * prints no report at all - a throughput row beside a refused gate is the one
- * thing this path may not emit. */
-int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
+ * thing this path may not emit.
+ *
+ * ONE FUNCTION FOR BOTH ROWS. They differ in the block count, the floor, the
+ * digests and the sentence they print about themselves, and in nothing else;
+ * a second copy of the five gates would be the place one of them silently
+ * stopped running. */
+int RunWorstShape(const char* name, const std::string& provenance,
+                  uint32_t blocks, double floor, uint64_t selfcheck_digest,
+                  uint64_t full_digest, size_t warmup, size_t runs,
+                  bool selfcheck) {
     const size_t pages = selfcheck ? kSelfcheckPages : kWorstRoundsPages;
     Corpus corpus;
-    corpus.name = "worst-rounds";
-    corpus.provenance =
-        "HAND-CONSTRUCTED by this harness and validated by the pinned "
-        "gdeflate fork, not produced by any compressor: one final dynamic "
-        "block per page, every symbol in it at DEFLATE's maximum codeword "
-        "length, and a body of minimum-length matches asked for through the "
-        "sixteen-extra-bit length symbol, so the deferred-copy path runs once "
-        "per three decoded bytes; ADVERSARIAL, the M4 security-posture row "
-        "and never a headline throughput figure, and NOT scale-comparable "
-        "with this harness's other corpora, which are recorded on their own "
-        "invocations and are several times this one in pages";
+    corpus.name = name;
+    corpus.provenance = provenance;
     corpus.composition = kCompositionNotAsserted;
 
     std::vector<unsigned char> source;
-    if (!BuildWorstRoundsCorpus(pages, &source, &corpus)) {
+    if (!BuildWorstCorpus(pages, blocks, &source, &corpus)) {
         return 1;
     }
     if (!CorpusRoundTrips(source, corpus)) {
@@ -1753,27 +1908,71 @@ int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
     if (!MeasureRefillDensity(source, corpus, &density)) {
         return 1;
     }
-    if (!CheckRefillFloor(density)) {
+    if (!CheckBlocksPerPage(name, density, blocks)) {
         return 1;
     }
-    /* Every page opens with the dynamic block this generator emits, and it is
-     * the whole page: the writer puts BFINAL on the one block it writes. That
-     * is asserted rather than narrated, so a generator that started emitting
-     * something else is caught here and not in the prose. */
+    if (!CheckRefillFloor(name, density, floor)) {
+        return 1;
+    }
+    /* Every page opens with the dynamic block this generator emits. That is
+     * asserted rather than narrated, so a generator that started emitting
+     * something else is caught here and not in the prose. What the walk can
+     * say beyond the opening is decided by BFINAL and printed by
+     * AssertComposition itself: on the single-block row the opening block IS
+     * the page, and on the many-block row the walk reports a lower bound while
+     * the census above carries the count.  */
     if (!AssertComposition(&corpus, kBlockDynamic)) {
         return 1;
     }
     if (!CheckDigest(CorpusDigest(corpus), corpus.name, /*level=*/-1,
-                     selfcheck ? kWorstRoundsSelfcheckDigest
-                               : kWorstRoundsFullDigest)) {
+                     selfcheck ? selfcheck_digest : full_digest)) {
         return 1;
     }
     std::vector<double> times;
     if (!TimeCorpus(corpus, warmup, runs, &times)) {
         return 1;
     }
-    PrintReport(corpus, /*level=*/-1, times, warmup, runs, &density);
+    PrintReport(corpus, /*level=*/-1, times, warmup, runs, &density, floor);
     return 0;
+}
+
+/* The three ingredients of MASTERPLAN section 13.5 that do not need a block
+ * boundary, in a page that is one final dynamic block (issue #226). */
+int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
+    return RunWorstShape(
+        "worst-rounds",
+        "HAND-CONSTRUCTED by this harness and validated by the pinned "
+        "gdeflate fork, not produced by any compressor: one final dynamic "
+        "block per page, every symbol in it at DEFLATE's maximum codeword "
+        "length, and a body of minimum-length matches asked for through the "
+        "sixteen-extra-bit length symbol, so the deferred-copy path runs once "
+        "per three decoded bytes; ADVERSARIAL, the M4 security-posture row "
+        "and never a headline throughput figure, and NOT scale-comparable "
+        "with this harness's other corpora, which are recorded on their own "
+        "invocations and are several times this one in pages",
+        /*blocks=*/1, kWorstRefillFloor, kWorstRoundsSelfcheckDigest,
+        kWorstRoundsFullDigest, warmup, runs, selfcheck);
+}
+
+/* The same page with the fourth ingredient added (issue #430): the same
+ * output, the same symbols and the same matches, cut into as many dynamic
+ * blocks as whole groups of matches allow, so every group pays a block header
+ * and the one-active-lane header rounds are a real share of the total. */
+int RunWorstHeaders(size_t warmup, size_t runs, bool selfcheck) {
+    return RunWorstShape(
+        "worst-headers",
+        "HAND-CONSTRUCTED by this harness and validated by the pinned "
+        "gdeflate fork, not produced by any compressor: the worst-rounds page "
+        "cut into one dynamic block per group of 32 minimum-length matches, "
+        "so it carries that row's maximum-length codewords and its "
+        "deferred-copy-per-three-bytes body AND a dynamic block header every "
+        "96 decoded bytes; ADVERSARIAL, the M4 security-posture row and never "
+        "a headline throughput figure, and NOT scale-comparable with this "
+        "harness's other corpora, which are recorded on their own invocations "
+        "and are several times this one in pages",
+        WorstHeaderBlocks(), kWorstHeadersRefillFloor,
+        kWorstHeadersSelfcheckDigest, kWorstHeadersFullDigest, warmup, runs,
+        selfcheck);
 }
 
 }  // namespace
@@ -1786,6 +1985,7 @@ int main(int argc, char** argv) {
     bool blocktypes = false;
     bool blockmix = false;
     bool worstrounds = false;
+    bool worstheaders = false;
     std::vector<std::string> files;
 
     for (int i = 1; i < argc; i++) {
@@ -1798,6 +1998,8 @@ int main(int argc, char** argv) {
             blockmix = true;
         } else if (arg == "--worstrounds") {
             worstrounds = true;
+        } else if (arg == "--worstheaders") {
+            worstheaders = true;
         } else if (arg == "--selfcheck") {
             selfcheck = true;
         } else if (arg == "--runs" && i + 1 < argc) {
@@ -1832,11 +2034,26 @@ int main(int argc, char** argv) {
         return 2;
     }
 
-    if (worstrounds && (assetlike || blocktypes || blockmix || !files.empty())) {
+    if ((worstrounds || worstheaders) &&
+        (assetlike || blocktypes || blockmix || !files.empty())) {
         std::fprintf(stderr,
-                     "--worstrounds emits its own corpus and no compressor "
-                     "runs on that path; do not pass corpus files or any of "
-                     "the compressor-driven modes with it\n");
+                     "--worstrounds and --worstheaders emit their own corpora "
+                     "and no compressor runs on those paths; do not pass "
+                     "corpus files or any of the compressor-driven modes with "
+                     "them\n");
+        return 2;
+    }
+
+    /* Two shapes of one construction, differing in the ingredient each is
+     * named for, so a run that asked for both would print two rows and leave
+     * the reader to work out which quantity each locked. They are asked for
+     * one at a time. */
+    if (worstrounds && worstheaders) {
+        std::fprintf(stderr,
+                     "--worstrounds and --worstheaders are the same generator "
+                     "at one block per page and at one block per group of "
+                     "matches; each locks its own refill floor and its own "
+                     "digests, so they are run separately\n");
         return 2;
     }
 
@@ -1862,6 +2079,10 @@ int main(int argc, char** argv) {
 
     if (worstrounds) {
         return RunWorstRounds(warmup, runs, selfcheck);
+    }
+
+    if (worstheaders) {
+        return RunWorstHeaders(warmup, runs, selfcheck);
     }
 
     std::vector<unsigned char> source;

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1954,10 +1954,33 @@ lane once per three decoded bytes: 21728 of them per page by the corpus's own
 construction, which is arithmetic rather than a count any decoder here
 reports.
 
-The frequent-block-header ingredient is NOT in it: the page writer it rides
-on emits one final block per page, and emitting a second means writing the
-inter-block round order, which no fixture in this tree has ever emitted.
-#430 holds that, and this paragraph is removed when it lands.
+**The fourth ingredient is a second row rather than a change to that one, and
+it is `bench_gdeflate --worstheaders` (#430).** The page writer now emits
+several blocks into one page - the inter-block round order mirrored off the
+block loop in `src/gdeflate_block.h`, the reset a block opens with and the
+drain it closes with - and the same generator cuts the page above into one
+dynamic block per group of 32 matches, which is a block header every 96
+decoded bytes and the most this construction admits, since a block carries
+whole groups or a lane would hold a reservation the drain cannot retire. The
+page decodes to the same bytes as the single-block one, so the two rows differ
+in exactly the ingredient they are compared on:
+
+    bench_gdeflate --worstheaders --selfcheck
+    - refill density: 0.7026 refills per decoded byte over 184176 refills and
+      262144 decoded bytes, worst page 0.7026, floor 0.6600 ...
+    - blocks per page: min 679 / max 679, 2716 blocks over the corpus of which
+      2716 dynamic, counted by cudec's own page decode
+
+Two rows with two floors rather than one row with a moved floor, because they
+lock different quantities: 0.6152 is what this construction reaches with no
+block boundary in it, so a headers floor under that reading would be cleared by
+a corpus that had lost its headers entirely, and the single-block row's own
+floor would be meaningless above it. The 0.66 between them was watched refusing
+that weakening. **A floor cannot carry the block-count claim either**, for the
+same reason it cannot carry the codeword-depth one: a header is a few hundred
+bits against a page of half a million. What refuses a collapsed corpus outright
+is a check that reads the block count out of the decode's own census and
+requires every page to hold exactly what the construction says.
 
 What would falsify this design, recorded before it is built:
 

--- a/tests/gdeflate_block_twin.cpp
+++ b/tests/gdeflate_block_twin.cpp
@@ -950,6 +950,231 @@ int RunTruncatedPage() {
 
 }  // namespace
 
+/* TWO DYNAMIC BLOCKS IN ONE HAND-EMITTED PAGE (issue #430), which is the first
+ * page in this tree whose block boundary was WRITTEN rather than read.
+ *
+ * WHY IT IS NOT COVERED BY WHAT IS ABOVE. RunCorpus decodes multi-block pages
+ * and CheckBlockBoundaries attributes their first block, but every one of those
+ * pages came out of the reference's compressor: where a block ends is the
+ * compressor's decision and both decoders merely follow it. Nothing had ever
+ * PRODUCED a boundary, so the inter-block round order - the reset a block opens
+ * with, the drain it closes with - was a property of this tree's decoder alone,
+ * with no second reader. The page below is emitted by
+ * tests/gdeflate_page_writer.h and handed to both, so a writer that put the
+ * second block's header one round early or late is refused by the reference
+ * rather than agreed with by cudec.
+ *
+ * WHAT IT ASSERTS BEYOND THE BYTES. The second block opens with a match that
+ * reaches back over the FIRST block's output, so a decoder that restarted its
+ * output cursor at a block boundary would refuse it (a match before the page's
+ * own output) rather than quietly produce a shorter page; and the block count
+ * is read off cudec's own census, so a page that collapsed into one block
+ * fails here rather than passing on identical bytes. */
+int RunTwoBlockPage() {
+    /* A complete code over the 258 symbols these bodies need - the literals,
+     * end-of-block, and the shortest length symbol - beside a two-symbol
+     * distance code whose symbol 0 is distance 1, the nearest match there is
+     * and the one that lands inside the first block's output. */
+    const std::vector<unsigned char> litlen_lens =
+        cudec_test::CompleteLengths(258);
+    const std::vector<unsigned char> dist_lens = cudec_test::CompleteLengths(2);
+
+    std::vector<unsigned char> all(litlen_lens);
+    all.insert(all.end(), dist_lens.begin(), dist_lens.end());
+    const std::vector<cudec_test::LenToken> toks = cudec_test::BuildTokens(all);
+    unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms];
+    uint32_t num_explicit = 0;
+    REQUIRE(cudec_test::PlanPrecode(toks, /*forced_explicit=*/0, precode_lens,
+                                    &num_explicit));
+
+    cudec_test::PageBlock proto;
+    proto.litlen_lens = litlen_lens;
+    proto.dist_lens = dist_lens;
+    proto.toks = toks;
+    std::memcpy(proto.precode_lens, precode_lens, sizeof(precode_lens));
+    proto.num_explicit = num_explicit;
+
+    /* The first block: a run of literals short enough to sit inside one round
+     * of the 32 lanes plus a few, so the block ends mid-round and the drain
+     * that follows it is the thing the second block has to start after. */
+    const uint32_t kFirstLiterals = 40;
+    std::vector<unsigned char> want;
+    cudec_test::PageBlock first = proto;
+    for (uint32_t i = 0; i < kFirstLiterals; i++) {
+        const uint32_t sym = 'a' + (i % 26u);
+        first.body.push_back(cudec_test::BodyToken{sym, false, 0, 0});
+        want.push_back(static_cast<unsigned char>(sym));
+    }
+    first.body.push_back(
+        cudec_test::BodyToken{cudec_test::kEndOfBlock, false, 0, 0});
+
+    /* The second block: lane 0 reserves the shortest match the format has,
+     * 31 literals ride the other lanes, and lane 0's next round retires the
+     * reservation. The match's source is the byte before it, which the FIRST
+     * block wrote. */
+    cudec_test::PageBlock second = proto;
+    second.body.push_back(cudec_test::BodyToken{
+        cudec_detail::kGDeflateFirstLengthSym, false, 0, 0});
+    const uint64_t reserved = want.size();
+    want.resize(want.size() + cudec_detail::kGDeflateMinMatchLen, 0);
+    for (uint32_t i = 1; i < cudec_detail::kGDeflateNumStreams; i++) {
+        const uint32_t sym = 'A' + (i % 26u);
+        second.body.push_back(cudec_test::BodyToken{sym, false, 0, 0});
+        want.push_back(static_cast<unsigned char>(sym));
+    }
+    second.body.push_back(cudec_test::BodyToken{0u, true, 0, 0});
+    second.body.push_back(
+        cudec_test::BodyToken{cudec_test::kEndOfBlock, false, 0, 0});
+    /* The copy, mirrored byte by byte forwards exactly as GDeflateDoCopy runs
+     * it, and placed here rather than where the reservation was made: the
+     * bytes land in the hole the reservation left, after the literals that
+     * followed it were already written. */
+    for (uint32_t i = 0; i < cudec_detail::kGDeflateMinMatchLen; i++) {
+        want[reserved + i] = want[reserved + i - 1];
+    }
+
+    std::vector<cudec_test::PageBlock> blocks;
+    blocks.push_back(first);
+    blocks.push_back(second);
+    std::vector<unsigned char> page;
+    REQUIRE(cudec_test::EmitPageBlocks(blocks, &page));
+
+    libdeflate_result status = LIBDEFLATE_BAD_DATA;
+    size_t produced = 0;
+    REQUIRE(OracleVerdictPadded(page, want.size(), &status, &produced));
+    REQUIRE_CTX(status == LIBDEFLATE_SUCCESS, "oracle status %d",
+                static_cast<int>(status));
+    REQUIRE_CTX(produced == want.size(), "oracle produced %zu of %zu", produced,
+                want.size());
+
+    std::vector<unsigned char> out(want.size(), 0);
+    GDeflatePageState st;
+    uint64_t got = 0;
+    REQUIRE(GDeflateDecodePage(st, page.data(), page.size(), out.data(),
+                               out.size(), &got));
+    REQUIRE_CTX(got == want.size(), "cudec produced %llu of %zu",
+                static_cast<unsigned long long>(got), want.size());
+    REQUIRE(equal_bytes(out.data(), want.data(), want.size()));
+    /* The page really is two blocks rather than one that happened to produce
+     * the same bytes, read off the decode's own census. */
+    REQUIRE_CTX(st.blocks == 2u, "cudec walked %u blocks", st.blocks);
+    REQUIRE(st.type_blocks[cudec_detail::kGDeflateBlockDynamic] == 2u);
+    return 0;
+}
+
+/* THE THREE WAYS A CALLER CAN ASK FOR A PAGE THE TWO DECODERS WOULD READ
+ * DIFFERENTLY, and the proof that the writer refuses each of them.
+ *
+ * WHY THEY ARE REFUSALS IN THE WRITER RATHER THAN NEGATIVES AGAINST A DECODER.
+ * Every one of them produces a page that is still WELL FORMED as a word
+ * sequence: the words handed out and the words asked for still match, so the
+ * reference reads bits that are there and gets a different, valid-looking
+ * page. The failure would therefore surface as a fixture that decodes to
+ * unexpected bytes somewhere else entirely, or - worse for a corpus - not at
+ * all. Each is paired with RunTwoBlockPage above, which differs from all three
+ * in exactly the field being broken and must decode.
+ *
+ * DELETING ANY OF THE THREE REFUSALS TURNS THE MATCHING CASE HERE GREEN-TO-RED
+ * IN THE OTHER DIRECTION: the REQUIRE below is that the writer said no. */
+int RunWriterRefusesDriftedBodies() {
+    const std::vector<unsigned char> litlen_lens =
+        cudec_test::CompleteLengths(258);
+    const std::vector<unsigned char> dist_lens = cudec_test::CompleteLengths(2);
+    std::vector<unsigned char> all(litlen_lens);
+    all.insert(all.end(), dist_lens.begin(), dist_lens.end());
+    const std::vector<cudec_test::LenToken> toks = cudec_test::BuildTokens(all);
+    unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms];
+    uint32_t num_explicit = 0;
+    REQUIRE(cudec_test::PlanPrecode(toks, /*forced_explicit=*/0, precode_lens,
+                                    &num_explicit));
+
+    cudec_test::PageBlock proto;
+    proto.litlen_lens = litlen_lens;
+    proto.dist_lens = dist_lens;
+    proto.toks = toks;
+    std::memcpy(proto.precode_lens, precode_lens, sizeof(precode_lens));
+    proto.num_explicit = num_explicit;
+
+    const cudec_test::BodyToken kEob{cudec_test::kEndOfBlock, false, 0, 0};
+    const cudec_test::BodyToken kLiteral{'x', false, 0, 0};
+    const cudec_test::BodyToken kLength{cudec_detail::kGDeflateFirstLengthSym,
+                                        false, 0, 0};
+    const cudec_test::BodyToken kDistance{0u, true, 0, 0};
+
+    std::vector<unsigned char> page;
+
+    /* A block with a successor that never states its end. The decoder would
+     * read on past the tokens this block declared, and where the next block's
+     * header begins would be decided by the bits rather than by the sequence
+     * the caller handed over. */
+    {
+        cudec_test::PageBlock unterminated = proto;
+        unterminated.body.push_back(kLiteral);
+        cudec_test::PageBlock last = proto;
+        last.body.push_back(kLiteral);
+        last.body.push_back(kEob);
+        std::vector<cudec_test::PageBlock> blocks;
+        blocks.push_back(unterminated);
+        blocks.push_back(last);
+        REQUIRE(!cudec_test::EmitPageBlocks(blocks, &page));
+    }
+
+    /* A block that ends while a lane still holds a reservation. The 32 drain
+     * rounds emit no bits, so the decoder would take whatever follows - the
+     * next block's header, or the page's zero tail - as that lane's distance
+     * symbol. The end-of-block rides lane 1, which holds nothing, so it is the
+     * end of the block that is wrong rather than the round it sits on. */
+    {
+        cudec_test::PageBlock stranded = proto;
+        stranded.body.push_back(kLength);
+        stranded.body.push_back(kEob);
+        REQUIRE(!cudec_test::EmitPageBlocks(
+            std::vector<cudec_test::PageBlock>(1, stranded), &page));
+    }
+
+    /* A distance symbol on a lane that reserved nothing. The decoder reads a
+     * distance only on a lane holding a copy, so it would read this one as a
+     * literal or a length out of the OTHER code entirely. */
+    {
+        cudec_test::PageBlock misspaced = proto;
+        misspaced.body.push_back(kDistance);
+        misspaced.body.push_back(kEob);
+        REQUIRE(!cudec_test::EmitPageBlocks(
+            std::vector<cudec_test::PageBlock>(1, misspaced), &page));
+    }
+
+    /* The pair for all three: the same three bodies made correct, in one page
+     * that must be emitted and must decode. A writer refusing everything would
+     * pass the three cases above and fail here. */
+    {
+        cudec_test::PageBlock ok_first = proto;
+        ok_first.body.push_back(kLiteral);
+        ok_first.body.push_back(kEob);
+        cudec_test::PageBlock ok_second = proto;
+        ok_second.body.push_back(kLength);
+        for (uint32_t i = 1; i < cudec_detail::kGDeflateNumStreams; i++) {
+            ok_second.body.push_back(kLiteral);
+        }
+        ok_second.body.push_back(kDistance);
+        ok_second.body.push_back(kEob);
+        std::vector<cudec_test::PageBlock> blocks;
+        blocks.push_back(ok_first);
+        blocks.push_back(ok_second);
+        REQUIRE(cudec_test::EmitPageBlocks(blocks, &page));
+
+        const size_t kCapacity =
+            1u + cudec_detail::kGDeflateMinMatchLen +
+            (cudec_detail::kGDeflateNumStreams - 1u);
+        libdeflate_result status = LIBDEFLATE_BAD_DATA;
+        size_t produced = 0;
+        REQUIRE(OracleVerdictPadded(page, kCapacity, &status, &produced));
+        REQUIRE_CTX(status == LIBDEFLATE_SUCCESS, "oracle status %d",
+                    static_cast<int>(status));
+        REQUIRE(produced == kCapacity);
+    }
+    return 0;
+}
+
 int main() {
     if (RunCorpus() != 0) {
         return 1;
@@ -979,6 +1204,12 @@ int main() {
         return 1;
     }
     if (RunEndOfBlockFromTheTail() != 0) {
+        return 1;
+    }
+    if (RunTwoBlockPage() != 0) {
+        return 1;
+    }
+    if (RunWriterRefusesDriftedBodies() != 0) {
         return 1;
     }
     std::printf("gdeflate_block_twin: ok\n");

--- a/tests/gdeflate_page_writer.h
+++ b/tests/gdeflate_page_writer.h
@@ -1,7 +1,7 @@
-/* A GDeflate page writer, for the tests and the bench (issues #175, #226).
- * It exists because the
- * reference's answer to "is this a code?" is not callable: the pinned fork
- * compiles `gdeflate_decompress.c` with `HIDE_INTERFACE` defined, so
+/* A GDeflate page writer, for the tests and the bench (issues #175, #226,
+ * #430). It exists because the reference's answer to "is this a code?" is
+ * not callable: the pinned fork compiles `gdeflate_decompress.c` with
+ * `HIDE_INTERFACE` defined, so
  * `build_decode_table` is static inside that translation unit and the plain
  * DEFLATE entry points are not compiled at all. The only door into the
  * reference's table construction is a whole GDeflate page, so a test that
@@ -10,9 +10,16 @@
  *
  * WHO READS IT. tests/ drives it for the fixtures below; fuzz/ drives it
  * through fuzz/gdeflate_structure.h; and bench/bench_gdeflate.cpp drives it for
- * the adversarial corpus (#226), which is why the header is not test-only any
- * more. The bench consumer is also the one that broke the size assumption
- * stated at LaneBits below.
+ * the adversarial corpora (#226, #430), which is why the header is not
+ * test-only any more. The bench consumer is also the one that broke the size
+ * assumption stated at LaneBits below.
+ *
+ * IT EMITS SEVERAL BLOCKS INTO ONE PAGE (#430) AND IT IS THE ONLY THING THAT
+ * DOES. Every multi-block page this project had seen before came out of the
+ * reference's compressor, so where a block ended was the compressor's decision
+ * and both decoders merely followed it. Writing one means holding the
+ * INTER-BLOCK round order, which is at EmitBlock below and is read off
+ * src/gdeflate_block.h rather than chosen.
  *
  * WHAT MAKES THIS SAFE TO TRUST. A writer that is wrong produces pages the
  * reference rejects, and a reject is exactly what a negative test is looking
@@ -141,6 +148,13 @@ class GDeflatePageWriter {
     }
 
     bool ok() const { return ok_; }
+
+    /* Which lane the next Push rides. Exposed because a body carrying matches
+     * has a per-lane invariant - a lane holding a reservation reads a distance
+     * on its next round and nothing else - and the emitter below cannot check
+     * that invariant without naming the lane. Nothing here decides anything on
+     * it; it is read, never written. */
+    uint32_t lane() const { return idx_; }
 
     /* Lane streams padded to whole words, then interleaved in the order the
      * decoder took them. */
@@ -371,18 +385,189 @@ struct BodyToken {
     uint32_t extra_value;
 };
 
-/* Emit one whole page: a single final dynamic block whose header carries
- * `toks` and whose body encodes `body`. Every round here mirrors
- * gdeflate_decompress_template.h in the pinned fork - the header fields ride
- * lane 0 with no round between them, each precode length is its own round,
- * and a repeat code's extra bits are pushed before the round ends.
+/* One block of a page: the header fields the writer must state and the body it
+ * must emit. BFINAL is deliberately NOT among them - which block is final is
+ * its position in the sequence handed to EmitPageBlocks, so a caller cannot
+ * declare one thing in the field and emit another after it. */
+struct PageBlock {
+    std::vector<unsigned char> litlen_lens;
+    std::vector<unsigned char> dist_lens;
+    std::vector<LenToken> toks;
+    unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms];
+    uint32_t num_explicit;
+    std::vector<BodyToken> body;
+};
+
+/* Emit one dynamic block into a page already in progress. Every round here
+ * mirrors gdeflate_decompress_template.h in the pinned fork and the block loop
+ * in src/gdeflate_block.h - the header fields ride lane 0 with no round
+ * between them, each precode length is its own round, and a repeat code's
+ * extra bits are pushed before the round ends.
+ *
+ * THE INTER-BLOCK ORDER IS THE RESET THIS FUNCTION OPENS WITH AND THE DRAIN IT
+ * CLOSES WITH, and both are read off the decoder rather than chosen here.
+ * src/gdeflate_block.h enters every block with GDeflateReset - back to lane 0,
+ * consuming nothing - and leaves each compressed block through 32 rounds that
+ * retire whatever is still outstanding. So a block's last emitted round and
+ * the next block's first are separated by exactly the drain, and a second
+ * block starts on lane 0 exactly as the first one did.
  *
  * THE BODY IS A TOKEN STREAM AND NOT A SYMBOL LIST, because a match is two
  * rounds on one lane rather than one symbol: the token at position p rides
  * lane p mod 32, so a length token at p has its distance token at p+32 by
  * construction. A caller that gets that spacing wrong emits a page the
- * reference reads differently from this writer, which is the failure the
- * single-copy rule for this file exists to keep to one place. */
+ * reference reads differently from this writer, which is why the spacing is
+ * REFUSED here rather than left to the caller: the decoder reads a distance
+ * and nothing else on a lane that holds a reservation, so a distance token
+ * arriving on a lane that holds none - or a symbol arriving on a lane that
+ * does - is the two sides having drifted apart. */
+inline bool EmitBlock(GDeflatePageWriter& w, const PageBlock& b,
+                      bool final_block) {
+    cudec_detail::GDeflatePrecodeTable precode;
+    if (!cudec_detail::GDeflateBuildTable(b.precode_lens,
+                                          cudec_detail::kGDeflateNumPrecodeSyms,
+                                          precode)) {
+        return false;
+    }
+    cudec_detail::GDeflateLitLenTable litlen;
+    const bool litlen_ok = cudec_detail::GDeflateBuildTable(
+        b.litlen_lens.data(), static_cast<uint32_t>(b.litlen_lens.size()),
+        litlen);
+    cudec_detail::GDeflateDistTable dist;
+    const bool dist_ok = cudec_detail::GDeflateBuildTable(
+        b.dist_lens.data(), static_cast<uint32_t>(b.dist_lens.size()), dist);
+
+    w.Reset();
+    w.Push(1, final_block ? 1u : 0u); /* BFINAL */
+    w.Push(2, kBlockTypeDynamic);     /* BTYPE */
+    w.Ensure();
+    w.Push(5, static_cast<uint32_t>(b.litlen_lens.size()) - 257u); /* HLIT */
+    w.Push(5, static_cast<uint32_t>(b.dist_lens.size()) - 1u);     /* HDIST */
+    w.Push(4, b.num_explicit - 4u);                                /* HCLEN */
+    w.Ensure();
+    for (uint32_t i = 0; i < b.num_explicit; i++) {
+        w.Push(3, b.precode_lens[cudec_detail::GDeflatePrecodeOrder(i)]);
+        w.Advance();
+    }
+    w.Reset();
+    for (size_t i = 0; i < b.toks.size(); i++) {
+        uint32_t code = 0;
+        uint32_t len = 0;
+        if (!CodewordOf(precode, b.precode_lens, b.toks[i].presym, &code,
+                        &len)) {
+            return false;
+        }
+        w.PushCode(code, len);
+        if (b.toks[i].extra_bits != 0) {
+            w.Push(b.toks[i].extra_bits, b.toks[i].extra_value);
+        }
+        w.Advance();
+    }
+
+    if (b.body.empty()) {
+        /* A header and nothing after it, which is what the header negatives
+         * need. It can only be the LAST block of a page: a block that emits no
+         * end-of-block leaves no boundary for a successor to start after, so a
+         * page claiming one would be emitting a block the decoder never
+         * reaches the front of. */
+        return final_block;
+    }
+    if (!litlen_ok) {
+        return false;
+    }
+    /* The body starts at a reset exactly as the header did, so the first
+     * symbol rides lane 0 (src/gdeflate_block.h: GDeflateReset between the
+     * tables and the round loop). */
+    w.Reset();
+    /* Which lanes hold a reservation, mirroring GDeflatePageState::copies. */
+    bool pending[cudec_detail::kGDeflateNumStreams];
+    for (uint32_t n = 0; n < cudec_detail::kGDeflateNumStreams; n++) {
+        pending[n] = false;
+    }
+    bool ended = false;
+    for (size_t i = 0; i < b.body.size(); i++) {
+        const BodyToken& t = b.body[i];
+        const uint32_t lane = w.lane();
+        if (t.from_dist != pending[lane]) {
+            return false;
+        }
+        if (t.from_dist && !dist_ok) {
+            return false;
+        }
+        uint32_t code = 0;
+        uint32_t len = 0;
+        const bool found =
+            t.from_dist
+                ? CodewordOf(dist, b.dist_lens.data(), t.sym, &code, &len)
+                : CodewordOf(litlen, b.litlen_lens.data(), t.sym, &code, &len);
+        if (!found) {
+            return false;
+        }
+        w.PushCode(code, len);
+        if (t.extra_bits != 0) {
+            w.Push(t.extra_bits, t.extra_value);
+        }
+        if (t.from_dist) {
+            pending[lane] = false;
+        } else if (t.sym == kEndOfBlock) {
+            /* The reference leaves the decode loop on end-of-block without
+             * advancing, then runs 32 rounds to drain deferred copies.
+             * Those rounds refill, so the writer owes their words. */
+            ended = true;
+            break;
+        } else if (t.sym > kEndOfBlock) {
+            pending[lane] = true;
+        }
+        w.Advance();
+    }
+    for (uint32_t n = 0; n < cudec_detail::kGDeflateNumStreams; n++) {
+        if (pending[n]) {
+            /* A lane still holding a reservation when the block ended reads a
+             * distance symbol in the drain, and the drain below emits no bits
+             * for it - so the decoder would take the next block's header, or
+             * the tail, as that distance. The words this writer hands out and
+             * the words the decoder asks for still MATCH in that case, which
+             * is why nothing downstream catches it and it is caught here. */
+            return false;
+        }
+    }
+    if (!final_block && !ended) {
+        /* A block with a successor must state its own end. Without the
+         * end-of-block symbol the decoder reads on past the tokens this block
+         * declared, and where the next block's header begins is then decided
+         * by the bits rather than by this sequence. */
+        return false;
+    }
+    for (uint32_t i = 0; i < cudec_detail::kGDeflateNumStreams; i++) {
+        w.Advance();
+    }
+    return true;
+}
+
+/* Emit one whole page out of `blocks`, in order, with BFINAL set on the last
+ * of them and clear on every other. One block is the shape every fixture
+ * written before issue #430 needs, and is what EmitPageTokens below asks
+ * for. */
+inline bool EmitPageBlocks(const std::vector<PageBlock>& blocks,
+                           std::vector<unsigned char>* page) {
+    if (blocks.empty()) {
+        return false;
+    }
+    GDeflatePageWriter w;
+    for (size_t i = 0; i < blocks.size(); i++) {
+        if (!EmitBlock(w, blocks[i], i + 1u == blocks.size())) {
+            return false;
+        }
+    }
+    if (!w.ok()) {
+        return false;
+    }
+    *page = w.Finish();
+    return true;
+}
+
+/* One final dynamic block, which is the whole page. The round order is
+ * EmitBlock's above rather than a second copy of it. */
 inline bool EmitPageTokens(
     const std::vector<unsigned char>& litlen_lens,
     const std::vector<unsigned char>& dist_lens,
@@ -390,88 +575,14 @@ inline bool EmitPageTokens(
     const unsigned char precode_lens[cudec_detail::kGDeflateNumPrecodeSyms],
     uint32_t num_explicit, const std::vector<BodyToken>& body,
     std::vector<unsigned char>* page) {
-    cudec_detail::GDeflatePrecodeTable precode;
-    if (!cudec_detail::GDeflateBuildTable(precode_lens, cudec_detail::kGDeflateNumPrecodeSyms, precode)) {
-        return false;
-    }
-    cudec_detail::GDeflateLitLenTable litlen;
-    const bool litlen_ok =
-        cudec_detail::GDeflateBuildTable(litlen_lens.data(),
-                           static_cast<uint32_t>(litlen_lens.size()), litlen);
-    cudec_detail::GDeflateDistTable dist;
-    const bool dist_ok =
-        cudec_detail::GDeflateBuildTable(dist_lens.data(),
-                           static_cast<uint32_t>(dist_lens.size()), dist);
-
-    GDeflatePageWriter w;
-    w.Reset();
-    w.Push(1, 1);                 /* BFINAL: one block per page here. */
-    w.Push(2, kBlockTypeDynamic); /* BTYPE */
-    w.Ensure();
-    w.Push(5, static_cast<uint32_t>(litlen_lens.size()) - 257u); /* HLIT */
-    w.Push(5, static_cast<uint32_t>(dist_lens.size()) - 1u);     /* HDIST */
-    w.Push(4, num_explicit - 4u);                                /* HCLEN */
-    w.Ensure();
-    for (uint32_t i = 0; i < num_explicit; i++) {
-        w.Push(3, precode_lens[cudec_detail::GDeflatePrecodeOrder(i)]);
-        w.Advance();
-    }
-    w.Reset();
-    for (size_t i = 0; i < toks.size(); i++) {
-        uint32_t code = 0;
-        uint32_t len = 0;
-        if (!CodewordOf(precode, precode_lens, toks[i].presym, &code, &len)) {
-            return false;
-        }
-        w.PushCode(code, len);
-        if (toks[i].extra_bits != 0) {
-            w.Push(toks[i].extra_bits, toks[i].extra_value);
-        }
-        w.Advance();
-    }
-
-    if (!body.empty()) {
-        if (!litlen_ok) {
-            return false;
-        }
-        w.Reset();
-        for (size_t i = 0; i < body.size(); i++) {
-            const BodyToken& t = body[i];
-            if (t.from_dist && !dist_ok) {
-                return false;
-            }
-            uint32_t code = 0;
-            uint32_t len = 0;
-            const bool found =
-                t.from_dist
-                    ? CodewordOf(dist, dist_lens.data(), t.sym, &code, &len)
-                    : CodewordOf(litlen, litlen_lens.data(), t.sym, &code,
-                                 &len);
-            if (!found) {
-                return false;
-            }
-            w.PushCode(code, len);
-            if (t.extra_bits != 0) {
-                w.Push(t.extra_bits, t.extra_value);
-            }
-            if (!t.from_dist && t.sym == kEndOfBlock) {
-                /* The reference leaves the decode loop on end-of-block without
-                 * advancing, then runs 32 rounds to drain deferred copies.
-                 * Those rounds refill, so the writer owes their words. */
-                break;
-            }
-            w.Advance();
-        }
-        for (uint32_t i = 0; i < cudec_detail::kGDeflateNumStreams; i++) {
-            w.Advance();
-        }
-    }
-
-    if (!w.ok()) {
-        return false;
-    }
-    *page = w.Finish();
-    return true;
+    PageBlock block;
+    block.litlen_lens = litlen_lens;
+    block.dist_lens = dist_lens;
+    block.toks = toks;
+    std::memcpy(block.precode_lens, precode_lens, sizeof(block.precode_lens));
+    block.num_explicit = num_explicit;
+    block.body = body;
+    return EmitPageBlocks(std::vector<PageBlock>(1, block), page);
 }
 
 /* The literals-only body, which is what every fixture written before matches


### PR DESCRIPTION
Closes #430.

MASTERPLAN section 13.5 names four ingredients for the M4 adversarial page.
`bench_gdeflate --worstrounds` (#226) carries three of them and says so; the
fourth - block headers frequent enough that the one-active-lane header rounds
are a real share of the total - was unbuildable, because the page writer it
rides on emits one final block per page and nothing in this tree had ever
emitted a second.

## The page writer now writes a block boundary

Every multi-block page this project had decoded came out of the reference's
compressor, where the boundary is the compressor's decision and both decoders
merely follow it. So the inter-block round order was a property of cudec's own
decoder with no second reader.

`EmitBlock` writes one block into a page in progress and `EmitPageBlocks`
sequences them. BFINAL comes from the position in the sequence rather than from
a field, so a caller cannot declare one thing and emit another after it. The
order is read off the block loop in `src/gdeflate_block.h` - the reset a block
opens with, the 32-round drain it closes with - rather than chosen, and
`EmitPageTokens` is a one-block call into it. That last point is measured
rather than argued: the two `--worstrounds` corpus digests are byte-identical
across the refactor, `925326a21c48a952` on four pages and `6e2f2850f76891bb` on
512.

Three ways a caller can ask for a page the two decoders would read differently
are refused in the writer. Each of them still hands out exactly the words the
decoder asks for, so the page stays well formed as a word SEQUENCE while being
wrong as a symbol stream - which fails somewhere else entirely, or not at all:

- a distance token on a lane holding no reservation,
- a block ending while a lane still holds one (the drain emits no bits for it,
  so the decoder would take the next header as that distance),
- a non-final block that never states its end.

## The many-block row

One generator builds both rows and the block count is the only thing that
varies - the same code vectors, the same opening literal run, the same body of
minimum-length matches. `--worstheaders` cuts the page into one dynamic block
per group of 32 matches: a header every 96 decoded bytes, and the most this
construction admits, since a block carries whole groups or a lane would hold a
reservation across the boundary. The two pages decode to the SAME bytes, so the
rows differ in exactly the ingredient they are compared on.

```
bench_gdeflate --worstheaders --warmup 1 --runs 5
- corpus: worst-headers, 512 pages, 33.55 MB original, 94.30 MB compressed
  (ratio 2.8103) ...
- corpus digest: c79e0a872dba2ca3
- refill density: 0.7026 refills per decoded byte over 23574528 refills and
  33554432 decoded bytes, worst page 0.7026, floor 0.6600 taken on the worst
  page rather than on the mean
- blocks per page: min 679 / max 679, 347648 blocks over the corpus of which
  347648 dynamic, counted by cudec's own page decode (src/gdeflate_block.h)
  rather than by the construction that emitted them
- decode throughput: p50 0.060 GB/s / p90 0.058 GB/s / p99 0.058 GB/s
```

The same 33.55 MB through `--worstrounds` on this machine measures p50 0.350
GB/s, so the many-block page is 5.8 times slower to decode for identical
output. Both figures are the CPU reference, single thread, on an AMD Ryzen 9
5950X - there is no GDeflate kernel yet and neither number is a headline.

Two floors rather than one moved floor, because the rows lock different
quantities: 0.6152 is what this construction reaches with no block boundary in
it, so a headers floor under that reading would be cleared by a corpus that had
lost its headers entirely, and the single-block row's floor would be meaningless
above it. 0.66 sits between the two readings.

A floor cannot carry the block-count claim on its own, for the reason it cannot
carry the codeword-depth one: a header is a few hundred bits against a page of
half a million. So the count is read out of the decode's own census and every
page must hold exactly what the construction says. It runs BEFORE the floor,
because it names the ingredient a drifted corpus stopped carrying where the
floor names a number that moved.

## Means

C++17 in `bench/` and `tests/`, which is what the harness, the page writer and
the oracle already are. Nothing else could hold the round order beside the
decoder it mirrors, and a second language here would need a second oracle
binding for no gain.

## Every guard was deleted and watched failing

| weakening | verdict |
| --- | --- |
| writer's distance-on-idle-lane refusal removed | `gdeflate_block_twin.cpp:1142` red |
| writer's stranded-reservation refusal removed | `gdeflate_block_twin.cpp:1131` red |
| writer's unterminated-non-final refusal removed | `gdeflate_block_twin.cpp:1119` red |
| generator collapsed to one block per page | `the worst page of the worst-headers corpus forces 0.6152 refills per decoded byte, under the 0.6600 floor` |
| generator ignores the block count the row declares | `the worst-headers corpus holds between 1 and 1 blocks per page and its construction emits 679` |

## Gate

Built and run in WSL Ubuntu-24.04, cmake 3.28.3, g++ 13.3.0, nvcc 13.3.73,
`-DCUDEC_ENABLE_CUDA=ON`:

```
ctest --output-on-failure -LE gpu
100% tests passed, 0 tests failed out of 55
```

`bench_gdeflate_worstheaders_selfcheck` is entry 60 and passes.
`fuzz/gdeflate_structure.h`, the other consumer of the page writer, compiles
clean under `-Wall -Wextra -Werror` after the change.
`npx prettier@3 --check "**/*.{md,yml,yaml}"` is clean.

**The nine `gpu`-labelled entries did NOT run.** `/dev/dxg` does not exist in
the running WSL kernel on this machine, which is #418, so there is no device
here to run them on. Nothing in this change is device code - the page writer,
the reference decode and the refill count are all host code - but the skip is
stated rather than left to be inferred from a green line.

**There is no second reader on this change.** No review beyond the author's own
was run, and the table above is offered in place of one rather than as an
equivalent to one.
