### PR TITLE
Probe: the HIP instantiation check must red when the 64-wide arm is gone

### DIFF
--- a/.github/workflows/hip-212-diag.yml
+++ b/.github/workflows/hip-212-diag.yml
@@ -70,4 +70,3 @@ jobs:
           fi
           grep -q 'MISSING:Lz4Parser<64>' neg.log && grep -q 'MISSING:SnappyParser<64>' neg.log && ! grep -q 'MISSING:Lz4Parser<32>' neg.log
           cat neg.log
-          git checkout -- src/batch.cu

--- a/.github/workflows/hip-212-diag.yml
+++ b/.github/workflows/hip-212-diag.yml
@@ -1,17 +1,20 @@
-# TEMPORARY, issue #212: a diagnostic run, on pushes to this branch only, that
-# prints what each ROCm binary tool sees in the HIP archive's device code, so
-# the instantiation check is written from a reading rather than from memory.
-# Removed before anything merges.
+# TEMPORARY, issue #212: runs the instantiation check inside the production
+# ROCm image on pushes to this branch - the positive, the negative (the
+# 64-wide arm compiled out of src/batch.cu) and the fail-closed legs - so the
+# check is proven to bite before it lands. Removed before anything merges;
+# the standing container job is issue #210's.
 name: hip-212-diag
 
 on:
   push:
     branches: [ci/212-hip-wave-instantiations]
+  pull_request:
+    branches: [main]
 
 permissions: {}
 
 jobs:
-  diag:
+  check:
     name: hip-212-diag
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -34,29 +37,37 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure and build the library only (HIP engine)
-        run: >-
-          cmake -B build-hip -DCUDEC_ENABLE_HIP=ON &&
-          cmake --build build-hip -j --target cudec
+      - name: Configure and build (HIP engine)
+        run: cmake -B build-hip -DCUDEC_ENABLE_HIP=ON && cmake --build build-hip -j
 
-      - name: What the tools see
+      - name: Positive, as ctest runs it in the host-side subset
+        run: >-
+          ctest --test-dir build-hip -R '^hip_wave_instantiations$'
+          --no-tests=error --output-on-failure &&
+          ctest --test-dir build-hip -LE gpu -N | grep -E ': hip_wave_instantiations$'
+
+      - name: Fail-closed legs, each must red for the reason it names
         run: |
-          set +e
-          L=/opt/rocm/lib/llvm/bin
+          s=scripts/check-hip-wave-instantiations.sh
           obj=$(find build-hip -name 'batch.cu.o' | head -1)
-          echo "== object: $obj"; ls -l "$obj" build-hip/libcudec.a
-          echo "== llvm tools present"; ls $L | grep -E 'nm$|objdump|objcopy|readelf|offload|bundler|dis'
-          echo "== rocm bin tools"; ls /opt/rocm/bin | grep -E 'roc-obj|bundler'
-          echo "== sections"; $L/llvm-readelf -S "$obj" | grep -i -E 'hip|offload|fatbin|bundle'
-          echo "== host symbols naming the kernel"; $L/llvm-nm "$obj" | grep chunk_decode_batch | $L/llvm-cxxfilt | cut -c1-200
-          echo "== roc-obj-ls -v"; /opt/rocm/bin/roc-obj-ls -v "$obj"; echo "exit=$?"
-          echo "== roc-obj-ls -v on the archive"; /opt/rocm/bin/roc-obj-ls -v build-hip/libcudec.a; echo "exit=$?"
-          echo "== bundler --list --type=o on the object"; $L/clang-offload-bundler --list --type=o --input="$obj"; echo "exit=$?"
-          echo "== dump .hip_fatbin"; $L/llvm-objcopy --dump-section .hip_fatbin=fb.bin "$obj" /dev/null; echo "exit=$?"; ls -l fb.bin; head -c 24 fb.bin | od -c | head -2
-          for t in o bc s hipfb; do echo "== bundler --list --type=$t on fb.bin"; $L/clang-offload-bundler --list --type=$t --input=fb.bin; echo "exit=$?"; done
-          echo "== llvm-objdump --offloading"; $L/llvm-objdump --offloading "$obj"; echo "exit=$?"; ls -la . | grep -v '^d' | head -20
-          echo "== roc-obj extract"; mkdir -p rocobj && /opt/rocm/bin/roc-obj -o rocobj "$obj"; echo "exit=$?"; ls -l rocobj
-          for f in rocobj/*; do echo "== nm $f"; $L/llvm-nm "$f" | grep -i chunk_decode | $L/llvm-cxxfilt | cut -c1-200; done
-          echo "== roc-obj-extract via URIs"; /opt/rocm/bin/roc-obj-ls "$obj" | grep -v host | while read -r n id uri; do echo "$id $uri"; /opt/rocm/bin/roc-obj-extract "$uri"; done; echo "exit=$?"; ls -l *.co 2>/dev/null
-          for f in *.co; do [ -f "$f" ] && { echo "== nm $f"; $L/llvm-nm "$f" | grep -i chunk_decode | $L/llvm-cxxfilt | cut -c1-200; }; done
-          true
+          host=$(find build-hip -name 'version.c.o' | head -1)
+          tools=$(dirname "$(grep '^CMAKE_HIP_COMPILER:' build-hip/CMakeCache.txt | cut -d= -f2)")
+          echo "tools=$tools obj=$obj host=$host"
+          ! bash $s /nonexistent "gfx90a" "$obj" 2>&1 | tee leg1.log; grep -q 'no executable llvm-objdump' leg1.log
+          ! bash $s "$tools" "" "$obj" 2>&1 | tee leg2.log; grep -q 'no offload architectures' leg2.log
+          ! bash $s "$tools" "gfx90a" "$host" 2>&1 | tee leg3.log; grep -q 'no object yielded a code object' leg3.log
+          ! bash $s "$tools" "gfx90a;gfx1234" "$obj" 2>&1 | tee leg4.log; grep -q 'MISSING' leg4.log
+          ! bash $s "$tools" "gfx90a" "/nonexistent.o" 2>&1 | tee leg5.log; grep -q 'object does not exist' leg5.log
+          echo "PASS: five fail-closed legs red for their own reasons"
+
+      - name: Negative, the 64-wide arm compiled out of the batch entry
+        run: |
+          sed -i 's/launch_decode<Parser, cudec_detail::kWaveWidth64>/launch_decode<Parser, cudec_detail::kWaveWidth32>/' src/batch.cu
+          grep -c 'kWaveWidth64>' src/batch.cu || true
+          cmake --build build-hip -j --target cudec
+          if ctest --test-dir build-hip -R '^hip_wave_instantiations$' --no-tests=error --output-on-failure > neg.log 2>&1; then
+            echo "FAIL: the check stayed green with the 64-wide instantiation removed"; cat neg.log; exit 1
+          fi
+          grep -q 'MISSING:Lz4Parser<64>' neg.log && grep -q 'MISSING:SnappyParser<64>' neg.log && ! grep -q 'MISSING:Lz4Parser<32>' neg.log
+          cat neg.log
+          git checkout -- src/batch.cu

--- a/.github/workflows/hip-212-diag.yml
+++ b/.github/workflows/hip-212-diag.yml
@@ -1,0 +1,62 @@
+# TEMPORARY, issue #212: a diagnostic run, on pushes to this branch only, that
+# prints what each ROCm binary tool sees in the HIP archive's device code, so
+# the instantiation check is written from a reading rather than from memory.
+# Removed before anything merges.
+name: hip-212-diag
+
+on:
+  push:
+    branches: [ci/212-hip-wave-instantiations]
+
+permissions: {}
+
+jobs:
+  diag:
+    name: hip-212-diag
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: rocm/dev-ubuntu-24.04:7.2.4@sha256:bdc8e61026cbb844ede93d44d2c50055f51ebb2041906b60182bf3bee3139054
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Install git and CMake
+        run: >-
+          apt-get update -q -o Acquire::Retries=3 &&
+          apt-get install -yq -o Acquire::Retries=3 --no-install-recommends
+          git cmake
+
+      - name: Check out the source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Configure and build the library only (HIP engine)
+        run: >-
+          cmake -B build-hip -DCUDEC_ENABLE_HIP=ON &&
+          cmake --build build-hip -j --target cudec
+
+      - name: What the tools see
+        run: |
+          set +e
+          L=/opt/rocm/lib/llvm/bin
+          obj=$(find build-hip -name 'batch.cu.o' | head -1)
+          echo "== object: $obj"; ls -l "$obj" build-hip/libcudec.a
+          echo "== llvm tools present"; ls $L | grep -E 'nm$|objdump|objcopy|readelf|offload|bundler|dis'
+          echo "== rocm bin tools"; ls /opt/rocm/bin | grep -E 'roc-obj|bundler'
+          echo "== sections"; $L/llvm-readelf -S "$obj" | grep -i -E 'hip|offload|fatbin|bundle'
+          echo "== host symbols naming the kernel"; $L/llvm-nm "$obj" | grep chunk_decode_batch | $L/llvm-cxxfilt | cut -c1-200
+          echo "== roc-obj-ls -v"; /opt/rocm/bin/roc-obj-ls -v "$obj"; echo "exit=$?"
+          echo "== roc-obj-ls -v on the archive"; /opt/rocm/bin/roc-obj-ls -v build-hip/libcudec.a; echo "exit=$?"
+          echo "== bundler --list --type=o on the object"; $L/clang-offload-bundler --list --type=o --input="$obj"; echo "exit=$?"
+          echo "== dump .hip_fatbin"; $L/llvm-objcopy --dump-section .hip_fatbin=fb.bin "$obj" /dev/null; echo "exit=$?"; ls -l fb.bin; head -c 24 fb.bin | od -c | head -2
+          for t in o bc s hipfb; do echo "== bundler --list --type=$t on fb.bin"; $L/clang-offload-bundler --list --type=$t --input=fb.bin; echo "exit=$?"; done
+          echo "== llvm-objdump --offloading"; $L/llvm-objdump --offloading "$obj"; echo "exit=$?"; ls -la . | grep -v '^d' | head -20
+          echo "== roc-obj extract"; mkdir -p rocobj && /opt/rocm/bin/roc-obj -o rocobj "$obj"; echo "exit=$?"; ls -l rocobj
+          for f in rocobj/*; do echo "== nm $f"; $L/llvm-nm "$f" | grep -i chunk_decode | $L/llvm-cxxfilt | cut -c1-200; done
+          echo "== roc-obj-extract via URIs"; /opt/rocm/bin/roc-obj-ls "$obj" | grep -v host | while read -r n id uri; do echo "$id $uri"; /opt/rocm/bin/roc-obj-extract "$uri"; done; echo "exit=$?"; ls -l *.co 2>/dev/null
+          for f in *.co; do [ -f "$f" ] && { echo "== nm $f"; $L/llvm-nm "$f" | grep -i chunk_decode | $L/llvm-cxxfilt | cut -c1-200; }; done
+          true

--- a/scripts/check-hip-wave-instantiations.sh
+++ b/scripts/check-hip-wave-instantiations.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Both wave-width instantiations of the chunk decoder, for both parsers, in
+# every offload architecture's code object of the HIP archive (issue #212).
+#
+# The source can request both widths while the build emits one: a dropped
+# arm, an architecture list that lost a width, a seam that compiled a launch
+# out. No NVIDIA device can notice, so this reads the BINARY - the symbol
+# table of each extracted code object - and never the source, where grepping
+# for the template argument would pass on exactly the failure it exists to
+# catch.
+#
+# Fail-closed in every direction: a missing tool, an object that yields no
+# code object, an architecture with no code object, a listing with no kernel
+# symbol at all, or one width short reds this. Nothing here reads as "no
+# missing instantiations" by accident.
+#
+# Usage: check-hip-wave-instantiations.sh <llvm-bin-dir> <arch;list> <object;list>
+#   llvm-bin-dir  the directory of the HIP compiler, which carries
+#                 llvm-objdump and llvm-readelf beside it
+#   arch;list     the offload architectures the build was asked for
+#   object;list   the archive's object files; the ones carrying a fat binary
+#                 are read, the host-only ones are skipped and said so
+set -u
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+[ "$#" -eq 3 ] || fail "want 3 arguments: <llvm-bin-dir> <arch;list> <object;list>, got $#"
+tooldir="$1"
+objdump="$tooldir/llvm-objdump"
+readelf="$tooldir/llvm-readelf"
+[ -x "$objdump" ] || fail "no executable llvm-objdump at $objdump"
+[ -x "$readelf" ] || fail "no executable llvm-readelf at $readelf"
+
+IFS=';' read -r -a archs <<< "$2"
+[ "${#archs[@]}" -gt 0 ] && [ -n "${archs[0]}" ] || fail "no offload architectures given"
+IFS=';' read -r -a objects <<< "$3"
+[ "${#objects[@]}" -gt 0 ] && [ -n "${objects[0]}" ] || fail "no objects given"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# One counter per (architecture, parser, width): how many FUNC symbols named
+# the instantiation across every code object of that architecture.
+declare -A found
+extracted_any=0
+for obj in "${objects[@]}"; do
+    [ -f "$obj" ] || fail "object does not exist: $obj"
+    cp "$obj" "$work/" || fail "cannot copy $obj"
+    base="$work/$(basename "$obj")"
+    # Writes <base>.<n>.<target> beside the copy for every bundle the
+    # object's fat binary carries, and names each one on stdout.
+    out="$("$objdump" --offloading "$base" 2>&1)" || fail "llvm-objdump --offloading failed on $obj: $out"
+    for co in "$base".*amdgcn-amd-amdhsa--*; do
+        [ -f "$co" ] || continue
+        extracted_any=1
+        arch="${co##*--}"
+        syms="$("$readelf" --symbols --wide "$co" 2>&1)" || fail "llvm-readelf failed on $co: $syms"
+        kernels="$(printf '%s\n' "$syms" | grep -E 'FUNC' | grep 'chunk_decode_batch' || true)"
+        [ -n "$kernels" ] || fail "$obj carries a $arch code object with no chunk_decode_batch kernel symbol at all"
+        for parser in Lz4Parser SnappyParser; do
+            for width in 32 64; do
+                n="$(printf '%s\n' "$kernels" | grep "$parser" | grep -c "Lb0ELi${width}E")"
+                key="$arch/$parser/$width"
+                found["$key"]=$(( ${found["$key"]:-0} + n ))
+            done
+        done
+    done
+done
+[ "$extracted_any" -eq 1 ] || fail "no object yielded a code object; nothing was checked"
+
+status=0
+for arch in "${archs[@]}"; do
+    line="$arch:"
+    for parser in Lz4Parser SnappyParser; do
+        for width in 32 64; do
+            key="$arch/$parser/$width"
+            n="${found["$key"]:-0}"
+            if [ "$n" -ge 1 ]; then
+                line="$line $parser<$width>"
+            else
+                line="$line MISSING:$parser<$width>"
+                status=1
+            fi
+        done
+    done
+    echo "$line"
+done
+[ "$status" -eq 0 ] || fail "an instantiation is missing from the device code (see the lines above)"
+echo "PASS: both wave widths of both parsers are in the device code of every architecture (${archs[*]})"

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -77,7 +77,7 @@ cudec_status submit_batch(const void* const* d_src_ptrs,
                 chunk_count, d_results, stream);
             break;
         case cudec_detail::WaveInstantiation::kWave64:
-            launch_decode<Parser, cudec_detail::kWaveWidth64>(
+            launch_decode<Parser, cudec_detail::kWaveWidth32>(
                 d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities,
                 chunk_count, d_results, stream);
             break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -535,6 +535,25 @@ endif()
 # This test makes the second instantiation a build product and runs the
 # shipped one.
 cudec_add_test(wave_width_gpu SOURCES wave_width_gpu.cu GPU)
+# The same property read off the HIP archive's DEVICE CODE, with no device
+# at all (issue #212): the fat binary is unbundled per offload architecture
+# and each code object's symbol table must carry both widths of both
+# parsers. HIP only, because it is the binary where a width can go missing
+# without this machine noticing - the CUDA build runs wave_width_gpu on a
+# device instead - and host-side, so the GPU-less container job runs it.
+# The tools are the HIP compiler's own neighbours, so the entry cannot pass
+# by finding some other llvm-objdump on the PATH.
+if(CUDEC_DEVICE_LANGUAGE STREQUAL "HIP")
+  get_filename_component(_cudec_hip_tool_dir "${CMAKE_HIP_COMPILER}" DIRECTORY)
+  add_test(
+    NAME hip_wave_instantiations
+    COMMAND
+      bash ${PROJECT_SOURCE_DIR}/scripts/check-hip-wave-instantiations.sh
+      "${_cudec_hip_tool_dir}" "${CUDEC_DEVICE_ARCHITECTURES}"
+      "$<TARGET_OBJECTS:cudec>")
+  set_tests_properties(hip_wave_instantiations
+                       PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
+endif()
 # frame_twin verifies the library's own xxhash32.h against liblz4's XXH32,
 # which it reaches through the src/ include every device test is granted.
 cudec_add_test(frame_twin SOURCES frame_twin.cu LIBS lz4_frame_oracle GPU)


### PR DESCRIPTION
Deliberately wrong and never to merge (#212). The batch entry's 64-wide launch is rewritten to the 32-wide instantiation, so the HIP archive's device code carries no 64-wide kernel; the temporary hip-212-diag job on this branch must red in its positive step, and that red is the evidence #212 asks for. Closed unmerged once the run has finished.