### PR TITLE
Compile the HIP configuration on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # CI - the fail-closed pull-request gate.
 #
 # Runs only on pull requests to `main`, so the mainline scaffolding push does
-# not trigger it. Every PR must build both configurations, pass the host-side
-# test subset, and pass the format check before it can merge; the bench step
-# is added by the PR that introduces bench/ and becomes part of these
-# required checks.
+# not trigger it. Every PR must build the host-only, the CUDA and the HIP
+# configurations, pass the host-side test subset on the two device flavours,
+# and pass the format check before it can merge; the bench step is added by
+# the PR that introduces bench/ and becomes part of these required checks.
 
 name: CI
 
@@ -394,6 +394,102 @@ jobs:
           grep -E ': termination_gpu$' gpu-deferred.txt &&
           grep -E ': determinism_gpu$' gpu-deferred.txt &&
           grep -E ': snappy_block_device$' gpu-deferred.txt
+
+  hip:
+    # The job name is the required-check context the ruleset will name once
+    # this has been green on main (issue #210) - keep it stable.
+    name: hip
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # The production ROCm stream, pinned by digest: the plain tag is 1.2 GB,
+    # its -complete sibling is 7.4 GB of math libraries nothing here links,
+    # and `latest` is the preview stream this job excludes by name. The
+    # runner has no AMD GPU, and no AMD GPU has ever run this decoder: this
+    # job proves the one set of sources compiles as HIP for both wave widths'
+    # architectures and runs the host-side subset, the same selection the
+    # build job runs, with the gpu-labelled entries deferred to a device
+    # nobody here has.
+    container:
+      image: rocm/dev-ubuntu-24.04:7.2.4@sha256:bdc8e61026cbb844ede93d44d2c50055f51ebb2041906b60182bf3bee3139054
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # Tools BEFORE checkout, git among them, for the reason the build job
+      # gives. This image carries no vendor apt repository to drop.
+      - name: Install git and CMake
+        run: >-
+          apt-get update -q -o Acquire::Retries=3 &&
+          apt-get install -yq -o Acquire::Retries=3 --no-install-recommends
+          git cmake
+
+      - name: Check out the source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Explicit offload architectures, always: the compiler's own device
+      # auto-detection is what breaks on a GPU-less machine, not compilation.
+      # CDNA (gfx90a, gfx942) is wave64 and RDNA (gfx1100, gfx1201) is wave32,
+      # so one fat binary carries both instantiations of the kernel family,
+      # and hip_wave_instantiations below reads them back out of it. The
+      # `test -x` lines are the fail-closed half: a renamed or unknown CMake
+      # option is a warning and not an error, so the binaries are proven to
+      # exist rather than assumed. example_decode_batch is absent on purpose -
+      # it is a CUDA consumer example, written against that runtime.
+      - name: Configure and build (HIP engine)
+        run: >-
+          cmake -B build-hip -DCUDEC_ENABLE_HIP=ON
+          "-DCMAKE_HIP_ARCHITECTURES=gfx90a;gfx942;gfx1100;gfx1201" &&
+          cmake --build build-hip -j &&
+          test -x build-hip/tests/smoke &&
+          test -x build-hip/tests/gpu_fixture &&
+          test -x build-hip/tests/frame_twin &&
+          test -x build-hip/tests/stream_twin &&
+          test -x build-hip/tests/termination_gpu &&
+          test -x build-hip/tests/determinism_gpu &&
+          test -x build-hip/tests/snappy_block_device &&
+          test -x build-hip/tests/wave_width_gpu &&
+          test -x build-hip/bench/bench_lz4 &&
+          test -x build-hip/bench/bench_snappy &&
+          test -x build-hip/examples/example_decode_frame
+
+      # The same per-name identity greps as the build job, so a host test that
+      # silently drops out of the selection reds this lane too, plus the one
+      # entry that exists on this flavour only: the device-code read of both
+      # wave widths (issue #212).
+      - name: Host-side tests (runner has no GPU)
+        run: >-
+          ctest --test-dir build-hip -LE gpu --no-tests=error
+          --output-on-failure &&
+          ctest --test-dir build-hip -LE gpu -N | tee hip-host-selected.txt &&
+          grep -E ': conformance_c$' hip-host-selected.txt &&
+          grep -E ': oracle_lz4$' hip-host-selected.txt &&
+          grep -E ': parser_twin$' hip-host-selected.txt &&
+          grep -E ': snappy_parser_twin$' hip-host-selected.txt &&
+          grep -E ': tilestream_host_negative$' hip-host-selected.txt &&
+          grep -E ': termination$' hip-host-selected.txt &&
+          grep -E ': launch_fail$' hip-host-selected.txt &&
+          grep -E ': bench_selfcheck$' hip-host-selected.txt &&
+          grep -E ': bench_worst4b_selfcheck$' hip-host-selected.txt &&
+          grep -E ': oracle_gdeflate$' hip-host-selected.txt &&
+          grep -E ': gdeflate_probes$' hip-host-selected.txt &&
+          grep -E ': gdeflate_schedule_twin$' hip-host-selected.txt &&
+          grep -E ': gdeflate_header_twin$' hip-host-selected.txt &&
+          grep -E ': gdeflate_block_twin$' hip-host-selected.txt &&
+          grep -E ': hip_wave_instantiations$' hip-host-selected.txt &&
+          echo "Compiled for HIP, never executed on an AMD device:" &&
+          ctest --test-dir build-hip -L gpu -N | tee hip-gpu-deferred.txt &&
+          grep -E ': smoke$' hip-gpu-deferred.txt &&
+          grep -E ': gpu_fixture$' hip-gpu-deferred.txt &&
+          grep -E ': frame_twin$' hip-gpu-deferred.txt &&
+          grep -E ': stream_twin$' hip-gpu-deferred.txt &&
+          grep -E ': termination_gpu$' hip-gpu-deferred.txt &&
+          grep -E ': determinism_gpu$' hip-gpu-deferred.txt &&
+          grep -E ': snappy_block_device$' hip-gpu-deferred.txt &&
+          grep -E ': wave_width_gpu$' hip-gpu-deferred.txt
 
   sanitize:
     # The host-side ASan/UBSan gate over the untrusted-input decode path (issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,9 +196,10 @@ otherwise reads as a legal start-from-scratch run and exits 0 on.
 through CMake's HIP language, for an explicit architecture list, and refuses
 the configure where no HIP toolchain is found rather than handing back a
 host-only library that looks like a working port. No machine this project has
-been built on carries that toolchain, so the HIP configuration is proven only
-where a ROCm container compiles it (#210) and has never executed on an AMD
-device. The two options are mutually exclusive in one build tree.
+been built on carries that toolchain, so the HIP configuration is proven where
+the `hip` job compiles it on every pull request, in the digest-pinned
+production ROCm container for four architectures, and it has never executed on
+an AMD device. The two options are mutually exclusive in one build tree.
 
 ### Documents and the paths they name
 


### PR DESCRIPTION
Closes #210.

## What this changes

I added a `hip` job to `.github/workflows/ci.yml`, in the shape of the `build` job and in the shape #210 fixed:

- container `rocm/dev-ubuntu-24.04:7.2.4@sha256:bdc8e61026cbb844ede93d44d2c50055f51ebb2041906b60182bf3bee3139054` - the production stream, pinned by digest, re-read from the registry today; the plain tag (1.2 GB), not the `-complete` sibling (7.4 GB of math libraries nothing here links) and not `latest`, which is the preview stream #210 excludes by name;
- git and cmake before the checkout, `actions/checkout` SHA-pinned with `persist-credentials: false`, `permissions: contents: read`, `shell: bash`, `timeout-minutes: 45`;
- explicit offload architectures on the configure line, always: `gfx90a`, `gfx942` (CDNA, wave64), `gfx1100`, `gfx1201` (RDNA, wave32), so one fat binary carries both instantiations;
- fail-closed `test -x` assertions over the seven gpu-labelled test binaries, `wave_width_gpu`, the two bench harnesses and the frame example (`example_decode_batch` is absent on purpose: it is a CUDA consumer example);
- the host-side subset, `ctest -LE gpu --no-tests=error`, followed by the same per-name identity greps the CUDA lane runs plus `hip_wave_instantiations` (#212, HIP only), and the eight gpu-labelled entries listed as deferred;
- the job name `hip` is the context a ruleset would name; whether it becomes required is branch-ruleset state, which this pull request does not touch.

I also changed the CI header and the CONTRIBUTING paragraph on `CUDEC_ENABLE_HIP` to say three configurations instead of two.

## Means

I used a job in the existing workflow file, in the shape of the job beside it; no new tooling.

## What is verified where

**On this pull request:** the `hip` job runs on its own head like every other job, and its result is on the checks tab. At `c76b93c` it is green: https://github.com/iderex/cudec/actions/runs/33746592068, the four jobs `build`, `hip`, `sanitize` and `format` all successful.

**Before it existed:** the same steps ran as temporary workflows in the same image at three heads tonight and were removed before each merge - https://github.com/iderex/cudec/actions/runs/33740421540 (#433, the build body), https://github.com/iderex/cudec/actions/runs/33742855958 (#434, the README's command as written) and https://github.com/iderex/cudec/actions/runs/33743911897 (#436, the instantiation check with its negative). A run of the same shape red on a deliberate break at https://github.com/iderex/cudec/actions/runs/33744381741 (probe #435, closed unmerged).

**The probe pull request #210 asks for**, a deliberate break of the seam that only this lane can see, is #437, closed unmerged; its run is https://github.com/iderex/cudec/actions/runs/33746407294: `hip` red in its configure-and-build step on `'hipMallocX' was not declared in this scope`, `build`, `sanitize` and `format` green.

## What is not covered

- No AMD GPU runs anything: the eight gpu-labelled entries are compiled and deferred, exactly as the CUDA lane defers its nine to the local gate, except that no local gate exists for this flavour.
- The install-and-consume legs are not run against a HIP prefix here; the README says no consumer has been built against one, and that stays true.
- Making `hip` a required check is a branch-ruleset change, which I do not make here; #210 says it becomes one once the job is green on main.

This change had no second reader tonight; the runs above stand in place of one.
