### PR TITLE
Cut the 0.1.0 entry and record the gate readings it stands on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@ recorded numbers can observe. Internal refactors, test-net work and process
 changes stay in the git history and in their issues, where they are already
 readable.
 
-No version has been released yet. `include/cudec.h` reports 0.1.0 and no tag
-exists, so the entry below sits under Unreleased rather than under a number and
-a date this project has not chosen: the released heading is the release's to
-write (#82). Everything in it is in the tree today.
+0.1.0 is the first release, cut on 2026-09-03: releases were authorised that
+day (#82), and the tag `v0.1.0` is set on the merge commit of the release pull
+request, which carries the gate readings this entry summarises under Known
+gaps. Everything in the entry is in the tree at that commit.
 
 ## [Unreleased]
+
+Nothing yet.
+
+## [0.1.0] - 2026-09-03
 
 ### Added
 
@@ -153,8 +157,16 @@ write (#82). Everything in it is in the tree today.
 - **Termination.** Every parser call consumes at least one byte, asserted per
   call over the truncation ladder, the mutant corpus and the crafted streams, so
   a decode loop cannot hang the device on any input.
+- **Fuzz-tested, read from a run rather than from a status.** Ten libFuzzer
+  differential targets under `fuzz/` - LZ4 block and frame, Snappy block,
+  GDeflate page, tables and tile stream, Zstd frame, FSE, literals and decode -
+  replay a hash-pinned seed corpus bounded on every pull request and long on a
+  schedule (`.github/workflows/fuzz.yml`). That workflow is not a required
+  check, so the claim is cut from the run on the release pull request's head,
+  which that pull request names with its conclusion and its link, and never
+  from a run older than the commit it is made about.
 - **Structural invariants locked as tests rather than as prose.** The C ABI
-  carries no dependency beyond the CUDA runtime, the decode path is
+  carries no dependency beyond the device runtime, the decode path is
   integer-only, warp collectives may not take their participation metadata from
   parsed input, no bare wave-width literal is allowed outside the line that
   names it, and every ctest entry carries a timeout. These are configure-time
@@ -172,9 +184,16 @@ measured and **rejected**, which is the part a changelog usually loses.
 
 ### Known gaps
 
-- Compute Sanitizer cannot attach to the device on my machine, so
-  the four-tool sweep has never produced a clean run there. The runner script is
-  in the tree and the blocker is tracked; nothing in this release is claimed to
-  have passed it.
-- The GPU tests run on my hardware, not in CI, which has no GPU.
-  CI builds both configurations and runs the host-side subset.
+- **The sanitizer block is empty, and says so.** Compute Sanitizer cannot
+  attach to the device on my machine, which #258 closed with as its negative
+  result, so the four-tool sweep has never produced a run there. The gate is
+  parked and owed, not waived: the runner script is in the tree, #127 holds the
+  block, and nothing in this release is claimed to have passed it. The release
+  pull request records that absence with this reason rather than a coverage no
+  run backs.
+- **The GPU tests run on my hardware, not in CI.** CI builds the host-only,
+  CUDA and HIP configurations and runs the host-side subset on the GPU-less
+  runner; the device gate is a local run. At this release's commit the device
+  was not reachable from the build environment (#418), so the device gate this
+  release stands on is the last one recorded on #82, from 2026-08-25, and not a
+  run on this commit; the release pull request says so in the same words.


### PR DESCRIPTION
The release pull request for v0.1.0, issue #82. The tag is set by the release-holder on this pull request's merge commit, and the issue stays open until that tag; I name the sha on #82 once this is on the mainline. CORRECTED AFTER THE MERGE: this line first said the pull request would not close the issue, and spelled that with the keyword GitHub acts on before the number, so the merge closed #82 and it was reopened by hand with the reason. The wording here is the repair.

## What this changes

`CHANGELOG.md` only. The `## [Unreleased]` entry becomes `## [0.1.0] - 2026-09-03`, with an empty Unreleased section above it, and the preamble that said no version had been released says instead when releases were authorised and where the tag goes. Under Guarantees the fuzz-tested claim is written the way the ruling on #82 cuts it - from a run, named on this pull request, never from a status - and under Known gaps the sanitizer block and the device gate say, in the words of that ruling, what is absent and why. The structural-invariant bullet says "device runtime" instead of "CUDA runtime", which is what the tree has held since the HIP build landed (#432). No other file moves: `include/cudec.h` already reports 0.1.0 and `CMakeLists.txt` reads it, the README's milestone table already says M2 is done, and `docs/MASTERPLAN.md`'s milestone table carries no status column.

## The release checklist, as this board holds it

The release policy this issue points at is a handbook outside this tree, which I could not read tonight; what I ran is the acceptance criteria written on #82 and the three rulings the release-holder gave there on 2026-09-03.

- **CHANGELOG.md carries the 0.1.0 entry; the version reports 0.1.0 consistently.** `grep -n 'define CUDEC_VERSION_' include/cudec.h` gives `0`, `1`, `0`; the top-level CMake derives `PROJECT_VERSION` from those three lines and `tests/conformance_c.c` checks the derivation at run time in every CI build.
- **Full gate green on this pull request:** `build` (host-only, CUDA, the install-and-consume legs), `hip`, `sanitize`, `format` (Prettier and the doc-path check) and the fuzz smoke - the rows below.
- **GPU gate results recorded on the release pull request:** recorded as absent, below.
- **The tag is not pushed by this pull request.**

## The sanitizer block

Empty, in these words: Compute Sanitizer cannot attach to the device on the build machine, which #258 closed with as its negative result; the gate is parked and owed, not waived; the runner script `scripts/sanitize-gpu.sh` is in the tree; #127 holds the block and its maintenance-window date; and no run on that machine can produce the evidence today, for the reason #418 records. Nothing in this release is claimed to have passed the four-tool sweep. The `sanitize` job on this pull request is the host-side ASan+UBSan gate over the untrusted-input decode path, which is a different thing and is green.

## The fuzz-tested claim

READ FROM THE RUN ON THIS PULL REQUEST'S HEAD, and the words in the notes stand or fall with it: the Fuzz workflow is not a required check (`.github/workflows/fuzz.yml`, its own header says so), so a green run here is the reading and a red or absent one takes the words out. The run on the head this body was last edited for, `b1400ff`: https://github.com/iderex/cudec/actions/runs/33747806524, conclusion `success`.

## The device gate

NOT PRODUCED ON THIS COMMIT. The device is not reachable from the build environment on the machine that has it (#418: the WSL kernel carries no dxgkrnl, so `/dev/dxg` does not exist and NVML answers `GPU access blocked by the operating system`), so the nine `gpu`-labelled ctest entries compiled on this pull request and did not run. The device gate this release stands on is the one recorded on #82 on 2026-08-25, at `e915c9b`, `100% tests passed, 0 tests failed out of 49` with eight gpu-labelled entries on the RTX 3080; every kernel change since is covered by the host-side twins and the CPU twin tests on every pull request, and by no device run. Whether that is acceptable for the tag is the release-holder's reading, and this body does not decide it.

## What is not covered

- No device run on this commit, as above.
- No AMD device has ever run this decoder; the HIP flavour is compiled, and the README says so.
- The release notes GitHub attaches to the tag are the release-holder's to write from this entry.

This change had no second reader tonight; the gate readings above stand in place of one.
