### PR TITLE
Write the AMD validation runbook and link it from the README [#245]

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,10 @@ It compiles for `gfx90a`, `gfx942`, `gfx1100` and `gfx1201` unless
 has been compiled, not run: no AMD GPU has executed this decoder, so the
 command below runs the host-side subset only, and the gpu-labeled tests exist
 in that build as binaries nothing has yet executed. On-device AMD validation
-is the community's to produce, and the runbook and result intake for it are
-not written yet (#245, #246).
+is the community's to produce:
+[docs/AMD-VALIDATION.md](docs/AMD-VALIDATION.md) is the runbook that takes an
+AMD GPU owner from a clean clone to a pasteable result, and the purpose-built
+result intake is still to come (#246).
 
 ```sh
 docker run --rm -v "$PWD:/w" -w /w \

--- a/docs/AMD-VALIDATION.md
+++ b/docs/AMD-VALIDATION.md
@@ -1,0 +1,192 @@
+# AMD validation runbook
+
+cudec compiles for AMD through HIP and **no AMD GPU has ever executed it**.
+Every on-device AMD correctness result and every AMD performance number in
+this project has to come from somebody else's hardware, so this document is
+the apparatus for producing one: a clean clone to a pasteable result, in one
+sitting, without asking anybody anything.
+
+You need an AMD GPU, a container runtime, and disk for the container image
+and the two benchmark corpora. You do not need to know anything about this
+project.
+
+## What has run and what has not
+
+Read this before you read a command, because it decides how to take a
+failure you hit.
+
+- **The build and the host-side tests run green in exactly this image, on
+  every pull request.** The `hip` job in `.github/workflows/ci.yml` uses the
+  same digest quoted below, on a runner with no AMD GPU, and it compiles
+  every test source and runs the label-excluded subset.
+- **Nothing below has run on an AMD device.** The `gpu`-labelled tests and
+  the benchmarks exist in the HIP build as binaries nothing has executed.
+  You are the first.
+- **The container's device-passthrough flags are the unverified part.** No
+  machine in this project has an AMD GPU, so the `--device` lines in step 3
+  have never been exercised here. If your setup needs a different set, use
+  yours, and paste the invocation you actually ran with your result.
+
+If something below is wrong, that is a defect in this document and worth an
+issue on its own - it is meant to be executable without correspondence.
+
+## 1. Clone
+
+```sh
+git clone https://github.com/iderex/cudec.git
+cd cudec
+```
+
+## 2. Find your device's `gfx` target and wave width
+
+Both go in your report, and the first one goes in the build command. On a
+host with ROCm installed:
+
+```sh
+rocminfo | grep -E 'Marketing Name|^\s+Name:\s+gfx|Wavefront Size'
+```
+
+If ROCm is only inside the container, run the same line inside the container
+from step 3 instead.
+
+The wave width matters to this project more than it usually does: the decode
+kernel is a `WaveSize` template and both instantiations ship in the same
+binary, so a wave64 device (CDNA, `gfx90a`, `gfx942`) exercises an arm that a
+wave32 device (RDNA, `gfx1100`, `gfx1201`) never reaches, and no device has
+ever executed the wave64 one.
+
+## 3. Build in the pinned container
+
+The image is pinned by digest, and it is the same digest CI uses, so your run
+and CI are one environment rather than two:
+
+```sh
+docker run --rm -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --security-opt seccomp=unconfined \
+  -v "$PWD:/w" -w /w \
+  rocm/dev-ubuntu-24.04:7.2.4@sha256:bdc8e61026cbb844ede93d44d2c50055f51ebb2041906b60182bf3bee3139054 \
+  bash
+```
+
+Everything from here to step 6 runs inside that shell. The image carries the
+HIP toolchain; install what the build and the corpus fetcher need on top of
+it - `git` and `cmake` are the step the CI job runs, `curl` and `unzip` are
+what step 5 uses:
+
+```sh
+apt-get update -q && apt-get install -yq --no-install-recommends \
+  git cmake curl unzip
+```
+
+Build for your own device, and name the architecture explicitly:
+
+```sh
+cmake -B build-hip -DCUDEC_ENABLE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx90a
+cmake --build build-hip -j
+```
+
+Substitute the `gfx` target step 2 printed. Leaving
+`CMAKE_HIP_ARCHITECTURES` off builds the four-architecture fat binary CI
+builds (`gfx90a;gfx942;gfx1100;gfx1201`), which is slower and buys you
+nothing here; the build never auto-detects a device, so an unset list is a
+default rather than a probe.
+
+## 4. Run the tests
+
+The whole suite, device tests included. This is the line no AMD device has
+run:
+
+```sh
+ctest --test-dir build-hip --no-tests=error --output-on-failure
+```
+
+`--no-tests=error` is what turns an empty selection red instead of green.
+Keep the whole output; it is what you paste.
+
+The entries that carry the `gpu` label are the ones that touch your device,
+and they are the point of the exercise:
+
+```sh
+ctest --test-dir build-hip -L gpu -N
+```
+
+CI's own HIP listing names eight of them - `smoke`, `gpu_fixture`,
+`frame_twin`, `stream_twin`, `termination_gpu`, `determinism_gpu`,
+`snappy_block_device` and `wave_width_gpu` - and the CUDA build registers the
+same eight plus `bench_frame_selfcheck`.
+`frame_twin` and `stream_twin` are the oracle diffs
+against liblz4, `determinism_gpu` is the bit-identical-across-geometry run,
+`termination_gpu` is the hostile-corpus watchdog, and `wave_width_gpu`
+decodes at the width your runtime reports. The rest of the suite -
+`oracle_lz4`, `parser_twin`, `snappy_parser_twin`, `tilestream_host_negative`,
+`termination`, `launch_fail`, `conformance_c` and the twin and probe sets -
+is host-side, runs without a device, and is green in CI on both backends
+already.
+
+A failure in any of them is a result and worth reporting exactly as much as a
+pass. Do not fix it, do not skip it, paste it.
+
+## 5. Fetch the corpora and run the benchmarks
+
+The corpora are SHA-256-pinned and never committed; the script refuses any
+file whose hash does not match:
+
+```sh
+sh bench/get-corpora.sh
+```
+
+Then the four runs, each of which prints its own methodology block:
+
+```sh
+./build-hip/bench/bench_lz4 --gpu bench/corpora/silesia/*
+./build-hip/bench/bench_lz4 --gpu --gpu-stream-ctx bench/corpora/silesia/*
+./build-hip/bench/bench_lz4 --gpu --worst4b
+./build-hip/bench/bench_lz4 --gpu --longmatch
+```
+
+The first two time the real corpus; `--worst4b` and `--longmatch` build their
+adversarial corpora in-harness and validate them against the oracle before
+timing, so they take no files. Every run is 3 warmup plus 30 measured
+iterations by default - `--runs N` and `--warmup N` change that, and a report
+that changed either says so.
+
+## 6. What to paste, and where
+
+**Paste every report block whole and unedited.** The harness emits its
+methodology inseparably from its numbers, on purpose
+([BENCHMARK-METHODOLOGY.md](BENCHMARK-METHODOLOGY.md)): a summarised or
+hand-trimmed block is not a usable result and will not be recorded. The same
+goes for the `ctest` output - the whole thing, passes included.
+
+With it, four facts that no output above carries on its own:
+
+- the GPU's marketing name and its `gfx` target, from step 2;
+- the wave width, from step 2;
+- the ROCm version: 7.2.4 if you used the image above unchanged, otherwise
+  the one you built with;
+- the `docker run` invocation you actually used, if it differs from step 3.
+
+Open an issue on <https://github.com/iderex/cudec/issues> with all of it. A
+result from wave64 silicon has an address of its own, issue #415, which is
+open precisely because that dispatch arm has never executed anywhere; the
+purpose-built intake form is #246.
+
+## What an hour buys, measured where it could be measured
+
+The build half is measured, in this image, on a GitHub `ubuntu-latest`
+runner with no GPU - the `hip` job of CI run 33747806509, at `b1400ff`:
+
+| Step                            | Duration |
+| ------------------------------- | -------- |
+| Pull and start the container    | 28 s     |
+| `apt-get install git cmake`     | 7 s      |
+| Configure and build, four `gfx` | 64 s     |
+| Host-side `ctest` (`-LE gpu`)   | 16 s     |
+
+Under two minutes for everything except the parts that need your device.
+What is added on your side - the `gpu`-labelled tests, the corpus download,
+and four benchmark runs at 33 iterations each - **has never been timed by
+anybody**, because no AMD device has run it. The hour this runbook is written
+to fit in is therefore a budget rather than a measurement, and a report
+saying it took longer is itself a useful result.


### PR DESCRIPTION
## What this is

`docs/AMD-VALIDATION.md`, plus the README link that replaces the sentence
saying the runbook was not written yet. It takes an AMD GPU owner from a
clean clone to a pasteable result in six ordered steps, with no
correspondence: find the `gfx` target and the wave width, build in the ROCm
image CI pins by digest, run the whole `ctest` suite including the
`gpu`-labelled entries, fetch the hash-pinned corpora, run the four
`bench_lz4` regimes, and paste every methodology block whole.

## Why it is needed and what it prevents

No AMD GPU has executed this decoder. Every on-device AMD correctness result
and every AMD performance number therefore has to come from community
hardware, which makes the instructions project apparatus rather than a favour
asked in a comment thread. The failure the document prevents is a community
result that cannot be used: a run made in a different image, at a different
iteration count, or reported as an edited summary is comparable with nothing
this project records, and each of those is decided before the reporter starts
rather than discovered afterwards.

## Where every fact in it comes from

Nothing in the document is written from recollection. The pieces and their
sources:

- The image digest is the one the CI `hip` job pins, quoted from the same
  file:

      git grep -n 'rocm/dev-ubuntu-24.04' origin/main -- .github/workflows/ci.yml
      origin/main:.github/workflows/ci.yml:340:      image: rocm/dev-ubuntu-24.04:7.2.4@sha256:bdc8e61026cbb844ede93d44d2c50055f51ebb2041906b60182bf3bee3139054

- The default architecture list is read from the configure that sets it:

      git grep -n 'set(CMAKE_HIP_ARCHITECTURES' origin/main -- CMakeLists.txt
      origin/main:CMakeLists.txt:255:    set(CMAKE_HIP_ARCHITECTURES gfx90a gfx942 gfx1100 gfx1201)

- The eight `gpu`-labelled entries the document names on the HIP build are
  the ones CI's own listing greps for by name in the `hip` job; the ninth,
  `bench_frame_selfcheck`, is named as the CUDA build's, which is where it
  was read:

      ctest --test-dir build-cuda -L gpu -N | tail -12
        Test #17: snappy_block_device
        Test #40: smoke
        Test #41: gpu_fixture
        Test #42: wave_width_gpu
        Test #43: frame_twin
        Test #44: stream_twin
        Test #45: termination_gpu
        Test #46: determinism_gpu
        Test #51: bench_frame_selfcheck
        Total Tests: 9

- The bench flags are the ones the harness parses, and the 3-warmup /
  30-measured defaults are what `docs/BENCHMARK-METHODOLOGY.md` records.

## The timing table is measured, and only the half that could be

The document's last section carries four step durations, read from the `hip`
job of CI run 33747806509 at `b1400ff` - the same image, on a GitHub
`ubuntu-latest` runner with no GPU:

    gh api repos/iderex/cudec/actions/runs/33747806509/jobs \
      --jq '.jobs[] | select(.name=="hip") | .steps[] | "\(.name)\t\(.started_at)\t\(.completed_at)"'
    Initialize containers          2026-09-03T11:05:50Z  2026-09-03T11:06:18Z
    Install git and CMake          2026-09-03T11:06:18Z  2026-09-03T11:06:25Z
    Configure and build (HIP)      2026-09-03T11:06:26Z  2026-09-03T11:07:30Z
    Host-side tests                2026-09-03T11:07:30Z  2026-09-03T11:07:46Z

Everything the reporter adds on top - the `gpu`-labelled tests, the corpus
download and four benchmark runs at 33 iterations each - **has never been
timed by anybody**, and the document says exactly that instead of estimating
it. The hour is stated as a budget, not as a measurement.

## What the document declines to claim

Three negative disclosures are load-bearing and are at the top of the file
rather than in a footnote:

- nothing in it has run on an AMD device;
- the container's device-passthrough flags (`--device=/dev/kfd`,
  `--device=/dev/dri`, `--group-add video`) are unverified here, because no
  machine in this project has an AMD GPU, and the reporter is asked to paste
  the invocation they actually used;
- the `gpu`-labelled binaries in the HIP build are binaries nothing has
  executed.

## Gate

Local, at the commit being pushed:

    npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

    sh scripts/check-doc-paths.sh .
    PASS: every path a tense-present document names resolves, and every declared forward reference names an open issue

The CUDA suite was run on the device at `eada5d6`, the mainline commit this
branch sits on, in the WSL CUDA 13.3 route (RTX 3080, driver 610.88):

    ctest --test-dir build-cuda --no-tests=error --output-on-failure
    100% tests passed, 0 tests failed out of 64
    Label Time Summary:  gpu = 9.82 sec*proc (9 tests)

That run says nothing about this change, which touches two documents and no
code; it is here because the device was reachable this session and a green
suite at the base commit is worth recording where somebody will find it.

## What this does NOT close

#245 stays open. Its third done-when asks the whole run to be timed honestly
on one GPU - container pull, build, `ctest`, four bench runs, inside an hour -
and that needs an AMD device nobody in this project has. The first two
bullets, the document existing with every command copy-pasteable in order and
the README linking to it, are what this lands.

## Review

There is no second reader on this board tonight; the evidence above stands in
place of one.
