### PR TITLE
Record that a HIP compiler now builds the harness's vendor seam [#243]

### DIFF
--- a/tests/vendor_rt_test.h
+++ b/tests/vendor_rt_test.h
@@ -15,12 +15,21 @@
  * line of it, and is the single exemption of the tests/-side rule that
  * mirrors #240's (issue #243).
  *
- * WHAT THIS FILE DOES NOT CLAIM. No hipcc has compiled the HIP arm below, for
- * the same reason src/vendor_rt.h states about its own: no ROCm toolchain
- * exists on the machine this landed from. The two arms are proven CONSISTENT
- * - the configure-time rule in tests/CMakeLists.txt reds when one arm carries
- * an entry the other does not - and are NOT proven CORRECT. Issue #210 is the
- * route to the compiler that would decide it.
+ * WHAT THIS FILE DOES NOT CLAIM, AND THE FIRST HALF OF IT HAS EXPIRED. It
+ * said no hipcc had compiled the HIP arm below. One does now, on every pull
+ * request: the CI hip job builds this harness in a digest-pinned ROCm image
+ * (issue #210), so the arm typechecks under a HIP compiler and a name this
+ * table spells wrongly enough to break compilation reds there.
+ *
+ * WHAT THE COMPILER DID NOT DECIDE IS THE PART THAT MATTERS, and the note it
+ * replaces was right about it. The two arms are proven CONSISTENT - the
+ * configure-time rule in tests/CMakeLists.txt reds when one arm carries an
+ * entry the other does not - and are still NOT proven CORRECT: a name mapped
+ * to the WRONG HIP entry point of the right shape compiles clean on both
+ * backends and reds only where the call runs. No AMD device has ever executed
+ * any of it, which is issue #415 and the runbook at docs/AMD-VALIDATION.md,
+ * and #210 is no longer the route to that answer because a compiler was never
+ * going to be one.
  *
  * INTERNAL to the test harness; nothing here is part of the public C ABI. */
 #ifndef CUDEC_TESTS_VENDOR_RT_TEST_H


### PR DESCRIPTION
## What changed

One comment block, at the head of `tests/vendor_rt_test.h`. It opened with

    WHAT THIS FILE DOES NOT CLAIM. No hipcc has compiled the HIP arm below

and that half has expired. The other half - that the two arms are consistent
and NOT proven correct - is kept, and is stated more sharply than before.

## Why it is a defect and not a nicety

An expired negative disclosure costs whatever the next reader does with it. A
reader planning the AMD ladder would have taken it that nothing had ever
compiled this table, and that #210 was the route to the compiler that would
decide it - a question settled on 2026-09-03. The expensive half of a stale
sentence is the work it invites.

## The reading that shows it expired

The ROCm job on `main` builds this harness's translation units in a
digest-pinned image on every pull request:

    git grep -n 'rocm/dev-ubuntu-24.04\|Configure and build (HIP engine)' origin/main -- .github/workflows/ci.yml
    origin/main:.github/workflows/ci.yml:340:      image: rocm/dev-ubuntu-24.04:7.2.4@sha256:bdc8e61026cbb844ede93d44d2c50055f51ebb2041906b60182bf3bee3139054
    origin/main:.github/workflows/ci.yml:369:      - name: Configure and build (HIP engine)

    gh issue view 210 --repo iderex/cudec --json state,title --jq '"\(.state)\t\(.title)"'
    CLOSED   HIP compile job in CI: digest-pinned ROCm container, explicit offload-arch matrix, host-side subset

and it ran green at the head of this very branch's base, which is the run this
pull request's own `hip` check repeats.

`tests/vendor_rt_test.h` is compiled by that job because every GPU test source
includes it:

    git grep -l 'vendor_rt_test.h' origin/main -- tests/ | tr '\n' ' '
    origin/main:tests/determinism_gpu.cu origin/main:tests/frame_twin.cu origin/main:tests/gpu_fixture.cu origin/main:tests/smoke.cu origin/main:tests/snappy_block_device.cu origin/main:tests/stream_twin.cu origin/main:tests/termination_gpu.cu origin/main:tests/vendor_rt_test.h origin/main:tests/wave_width_gpu.cu

## What is deliberately NOT turned positive

The compiler decided one thing and not the other, and the replacement says so
in more words than the original did:

- a name mapped to the **wrong** HIP entry point of the right shape compiles
  clean on both backends and reds only where the call runs;
- **no AMD device has executed any of it**;
- the answer now points at #415 and `docs/AMD-VALIDATION.md` rather than at
  #210, because a compiler was never the route to a correctness answer.

## What is not touched

`src/vendor_rt.h` opens with the same expired sentence about its own arm:

    git show origin/main:src/vendor_rt.h | sed -n '16,17p'
     * WHAT THIS HEADER DOES NOT CLAIM. No hipcc has ever compiled the HIP arm: no
     * ROCm toolchain exists on the machine this landed from, and CMakeLists.txt

That file is the library's seam rather than the harness's, and it is a
different topic; it is named here so the second half of the defect is on the
record rather than lost with this change.

## Gate

    npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

The change is a comment, so no behaviour moves; the `build`, `hip` and
`sanitize` checks on this pull request are what say the file still compiles on
both backends. The full CUDA suite was run on the device at the base commit
`eada5d6` earlier tonight (RTX 3080, driver 610.88, CUDA 13.3 through WSL):
64 of 64 passed with nine `gpu`-labelled entries executed.

## Review

There is no second reader on this board tonight; the readings above stand in
place of one.
