### PR TITLE
Bound every network call in the format gate, and red on a timeout [#443]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,6 +595,14 @@ jobs:
   format:
     name: format
     runs-on: ubuntu-latest
+    # A required check that hangs is worse than one that reds: a red gate is
+    # read and a pending one is waited on. Without this the job inherits
+    # GitHub's six-hour default, and the schema step below - which reaches the
+    # network - sat in progress for more than eleven minutes on two pull
+    # requests in one hour against a four-second norm (issue #443). The bound
+    # is generous against that norm on purpose; it is a ceiling on a hang, not
+    # a performance budget.
+    timeout-minutes: 15
     permissions:
       contents: read
       # Read-only, and needed by one step: a document may declare a path the

--- a/scripts/check-dependabot-config.sh
+++ b/scripts/check-dependabot-config.sh
@@ -27,6 +27,22 @@
 # exactly like a clean one: an absent config file, a failed fetch, a hash
 # mismatch, an unparseable file, and a validator that cannot refuse a known
 # bad document are all hard errors here and never skips.
+#
+# EVERY CALL THAT LEAVES THIS MACHINE IS TIME-BOUNDED, AND EXCEEDING A BOUND
+# REDS RATHER THAN SKIPS. Three of them do: the schema fetch and the two npx
+# invocations, which resolve and install a package before they run it. Without
+# a bound this step inherits the job's, and the job inherited GitHub's six-hour
+# default - it sat in progress for more than eleven minutes on two pull
+# requests in one hour against a four-second norm, and both were ended by a
+# person cancelling the run rather than by anything here (issue #443). A
+# pending required check is worse than a red one, because a red one is read.
+#
+# The bound is a ceiling on a hang and not a performance budget, which is why
+# it is generous: a slow mirror must still pass. What it may never become is a
+# skip - a timeout takes the same route as an unreachable host, into die(),
+# because "upstream was slow" and "the config validates" are not the same
+# statement and this check exists to stop the second being inferred from the
+# first.
 set -eu
 
 cfg="${1:-.github/dependabot.yml}"
@@ -57,6 +73,14 @@ die() {
 command -v curl >/dev/null 2>&1 || die "curl is not on PATH"
 command -v sha256sum >/dev/null 2>&1 || die "sha256sum is not on PATH"
 command -v npx >/dev/null 2>&1 || die "npx is not on PATH"
+command -v timeout >/dev/null 2>&1 || die "timeout is not on PATH. It is what
+bounds the npx invocations below, so its absence would silently restore the
+unbounded wait rather than degrade it."
+
+# Seconds. One number for the fetch and one for a package install, named here
+# rather than spelled at each call site.
+fetch_timeout=60
+npx_timeout=300
 
 [ -f "$cfg" ] ||
     die "$cfg does not exist. Deleting or renaming the config is the silent
@@ -66,8 +90,14 @@ skipped."
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-curl -fsSL "$schema_url" -o "$work/schema.json" ||
-    die "could not fetch $schema_url"
+# --max-time bounds the whole transfer and --retry covers the transient this
+# is most often up against; three attempts of at most $fetch_timeout seconds
+# each is the worst case, and it reds rather than hanging.
+curl -fsSL --max-time "$fetch_timeout" --retry 3 --retry-connrefused \
+    "$schema_url" -o "$work/schema.json" ||
+    die "could not fetch $schema_url within ${fetch_timeout}s per attempt.
+The schema is what this check validates against, so an unreachable one is a
+run that would have checked nothing - refused rather than skipped."
 echo "$schema_sha256  $work/schema.json" | sha256sum -c - >/dev/null ||
     die "the schema at $schema_url does not match the recorded SHA-256.
 Read what changed upstream, then move the pin in this file deliberately."
@@ -75,13 +105,32 @@ Read what changed upstream, then move the pin in this file deliberately."
 # ajv reads JSON, the config is YAML, and js-yaml is the conversion. A parse
 # failure here is the malformed-file case and stops the run.
 to_json() {
-    npx --yes --package="$yaml_pkg" -- js-yaml "$1" >"$2" ||
-        die "$1 is not parseable as YAML"
+    timeout "$npx_timeout" npx --yes --package="$yaml_pkg" -- js-yaml "$1" \
+        >"$2" ||
+        die "$1 is not parseable as YAML, or the converter did not finish
+within ${npx_timeout}s"
 }
 
+# The verdict here is the caller's to read - the self-test below requires a
+# refusal and the real run requires an acceptance - so a timeout is separated
+# from a refusal instead of being returned as one. 124 is the status timeout
+# uses, and letting it through as an ordinary non-zero would read as "the
+# document was refused", which is the one misreading that turns a hang into a
+# green self-test.
+#
+# THE VALIDATOR OUTPUT IS CAPTURED RATHER THAN LET THROUGH, and the callers
+# print it when they need it. It used to be redirected at the self-test call
+# site, which swallowed this function's own refusal along with it: a hang
+# then reded the step with an empty log and no reason in it.
 validate() {
-    npx --yes --package="$ajv_pkg" -- ajv validate \
-        --spec=draft7 --strict=false -s "$work/schema.json" -d "$1"
+    timeout "$npx_timeout" npx --yes --package="$ajv_pkg" -- ajv validate \
+        --spec=draft7 --strict=false -s "$work/schema.json" -d "$1" \
+        >"$work/validate.log" 2>&1
+    validate_status=$?
+    if [ "$validate_status" -eq 124 ]; then
+        die "the validator did not finish within ${npx_timeout}s on $1"
+    fi
+    return "$validate_status"
 }
 
 # The validator proves itself on every run before it is trusted with the real
@@ -100,8 +149,8 @@ updates:
       default_days: 7
 EOF
 to_json "$work/self-test.yml" "$work/self-test.json"
-if validate "$work/self-test.json" >"$work/self-test.log" 2>&1; then
-    cat "$work/self-test.log" >&2
+if validate "$work/self-test.json"; then
+    cat "$work/validate.log" >&2
     die "the self-test document was accepted. It carries default_days where
 the schema takes default-days, so a validator that accepts it is not
 refusing anything and its verdict on the real config means nothing."
@@ -109,9 +158,11 @@ fi
 echo "PASS: self-test - the validator refuses a known-bad config"
 
 to_json "$cfg" "$work/config.json"
-validate "$work/config.json" ||
+validate "$work/config.json" || {
+    cat "$work/validate.log" >&2
     die "$cfg does not validate against the published Dependabot schema.
 The report above names the key. A config the schema refuses is one the
 platform is likely to reject, and a rejected config is not in force."
+}
 
 echo "PASS: $cfg validates against $schema_url"


### PR DESCRIPTION
Closes #443.

## The defect

`format` is a required check, and nothing in this tree bounded how long it
could take. Its schema step normally runs in four seconds:

    gh api repos/iderex/cudec/actions/runs/33747806509/jobs \
      --jq '.jobs[] | select(.name=="format") | .steps[] | select(.name | startswith("Dependabot")) | "\(.started_at) \(.completed_at)"'
    2026-09-03T11:05:58Z 2026-09-03T11:06:02Z

On 2026-09-04 it sat `in_progress` for more than eleven minutes on two pull
requests within one hour, and both runs were ended by cancelling them rather
than by anything here:

    gh api repos/iderex/cudec/actions/jobs/101009708278 --jq '.steps[] | select(.status!="completed") | "\(.status) \(.name) \(.started_at)"'
    in_progress Dependabot config validates against the published schema 2026-09-04T11:37:23Z

    gh api repos/iderex/cudec/actions/jobs/101011129587 --jq '.steps[] | select(.status!="completed") | "\(.status) \(.name) \(.started_at)"'
    in_progress Dependabot config validates against the published schema 2026-09-04T11:43:25Z

A red gate is read. A pending one is waited on, and the only way past it was a
person noticing.

## What was unbounded

The job declared no `timeout-minutes` where its three siblings do, so it
inherited GitHub's six-hour default; and neither the schema fetch nor the two
`npx` package installs carried a bound of their own.

## What this changes

Three bounds, each of which **reds rather than skipping**:

- `curl --max-time "$fetch_timeout" --retry 3 --retry-connrefused`, so an
  unreachable schema is refused instead of waited on;
- `timeout "$npx_timeout"` on both `npx` invocations, with `timeout`'s absence
  from PATH refused up front so the bound cannot vanish silently;
- `timeout-minutes: 15` on the job - a ceiling on a hang, not a performance
  budget. The worst case the fetch can now produce is four attempts of sixty
  seconds, which fits inside it.

And one correctness point that is the whole reason the bound is not a one-liner:
**a timeout must not be readable as a verdict.** The self-test requires `ajv` to
REFUSE a planted-bad document, so a timeout returned as an ordinary non-zero
reads as that refusal and the run walks on as if the validator had proved
itself. Exit 124 is caught and dies. The validator's output is captured and
printed by the callers rather than redirected at the call site, which used to
swallow this function's own refusal with it.

## Proof that the guards bite, for the reason they name

**The `124` branch, by deleting it.** A stub `npx` that never returns, with
`npx_timeout=2`:

    PATH=/tmp/shim3:$PATH sh /tmp/probe3.sh .github/dependabot.yml
    check-dependabot-config: the validator did not finish within 2s on /tmp/tmp.snYlN9VeRL/self-test.json
    EXIT=1 ELAPSED=2s

The same run with the four lines of the guard removed:

    PATH=/tmp/shim3:$PATH sh /tmp/probe4.sh .github/dependabot.yml
    PASS: self-test - the validator refuses a known-bad config
    check-dependabot-config: .github/dependabot.yml does not validate against the published Dependabot schema.
    EXIT=1

That is the failure in full. The self-test announces that the validator refuses
a known-bad config when the validator did nothing at all, and the run then reds
on the REAL config for a reason that is not true - the config is fine and the
validator hung. A reader of that output would go and edit `dependabot.yml`.

**The `to_json` bound**, same stub, `npx_timeout=2`:

    check-dependabot-config: /tmp/tmp.O8J8zvQa2j/self-test.yml is not parseable as YAML, or the converter did not finish
    within 2s
    EXIT=1 ELAPSED=2s

**The fetch bound**, against a black-hole address with the real
`fetch_timeout=60`:

    sed -i 's#^schema_url=.*#schema_url="https://10.255.255.1/dependabot-2.0.json"#' /tmp/probe-fetch.sh
    sh /tmp/probe-fetch.sh .github/dependabot.yml
    curl: (28) Connection timed out after 60000 milliseconds     (x4)
    check-dependabot-config: could not fetch https://10.255.255.1/dependabot-2.0.json within 60s per attempt.
    EXIT=1 ELAPSED=245s

Four attempts, refused, 245 seconds - inside the job's 15-minute ceiling, which
is what makes the two bounds compose rather than one hiding the other.

## What is NOT proven here

`timeout-minutes: 15` is not shown to bite. Demonstrating it would mean hanging
a job for fifteen minutes on purpose, and it is a platform setting rather than
logic in this tree; what stands behind it is the same three-line shape the
`build`, `hip` and `sanitize` jobs already carry. The three bounds that ARE this
repository's own logic are each proven above.

The stub runs use a fake `npx` on PATH, so they exercise this script's control
flow and not the real validator. The real validator is exercised by this pull
request's own `format` check.

Why upstream was slow on 2026-09-04 is not established and is not claimed. What
is established is that this tree put no bound on how long it would wait.

## Gate

    npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

    sh -n scripts/check-dependabot-config.sh    (exit 0)

## Review

There is no second reader on this board tonight; the executed proofs above
stand in place of one.
