### PR TITLE
Stop saying no ROCm image is pinned here, because one is [#445]

### DIFF
--- a/docs/BENCHMARK-METHODOLOGY.md
+++ b/docs/BENCHMARK-METHODOLOGY.md
@@ -427,10 +427,13 @@ been run.
 1. **One device, one container, one session.** Both libraries are built and
    run inside the same ROCm container image, pinned by `sha256` digest, on the
    same GPU, in one sitting. Two runs on the same model of card on different
-   days are not a same-hardware comparison. The digest is deliberately **not**
-   written here, because no ROCm image is pinned in this repository yet - that
-   pin arrives with the HIP CI job and this section takes it from there rather
-   than inventing a second one.
+   days are not a same-hardware comparison. The image is the one the HIP CI
+   job pins, and this section takes it from there rather than inventing a
+   second one - read the digest out of `.github/workflows/ci.yml` at the
+   commit you are running, because a digest restated in prose here is a second
+   pin the moment the job moves. `docs/AMD-VALIDATION.md` does write it out,
+   because a runbook has to be copy-pasteable; it is the same digest, taken
+   from the same line.
 
 2. **The same corpora, hash-pinned.** `sh bench/get-corpora.sh`, which refuses
    any file whose SHA-256 does not match its pin. Both sides read the same


### PR DESCRIPTION
Closes #445.

## The defect

Step 1 of the hipCOMP comparison protocol in `docs/BENCHMARK-METHODOLOGY.md`
declined to write a digest, and gave a reason that has expired:

    git show origin/main:docs/BENCHMARK-METHODOLOGY.md | sed -n '430,433p'
       days are not a same-hardware comparison. The digest is deliberately **not**
       written here, because no ROCm image is pinned in this repository yet - that
       pin arrives with the HIP CI job and this section takes it from there rather
       than inventing a second one.

The job it was waiting for has landed, and the pin is in the tree:

    gh issue view 210 --repo iderex/cudec --json state,title --jq '"\(.state)\t\(.title)"'
    CLOSED   HIP compile job in CI: digest-pinned ROCm container, explicit offload-arch matrix, host-side subset

    git grep -n 'rocm/dev-ubuntu-24.04' origin/main -- .github/workflows/ci.yml
    origin/main:.github/workflows/ci.yml:340:      image: rocm/dev-ubuntu-24.04:7.2.4@sha256:bdc8e61026cbb844ede93d44d2c50055f51ebb2041906b60182bf3bee3139054

## Why it costs something

Step 1 exists to stop a second pin. Saying no pin exists is what produces one:
a reporter following the protocol reads that this project pins no ROCm image
and picks one, which is the outcome the step is written to prevent. It also
left two documents on this board disagreeing about the same fact -
`docs/AMD-VALIDATION.md` quotes that digest out of the workflow file while this
section said it did not exist.

## What the repair keeps

The rule the sentence carried is right and is now the whole of it: the image is
the one the CI job pins, and the digest is read out of that file at the commit
being run rather than restated in prose, because a copy here becomes a second
pin the moment the job moves.

Why the runbook writes the digest out anyway - a runbook has to be
copy-pasteable, and it is the same digest from the same line - is stated rather
than left as an apparent contradiction between the two documents.

## What does not change

Nothing about what the section declines to claim. It still states no result,
there is still no cudec HIP backend that has been benchmarked, and no AMD
device here has run one. The paragraph two lines above this edit still says
"Nothing below has been run", and it is untouched.

## Gate

    npx --yes prettier@3 --check "**/*.{md,yml,yaml}"
    All matched files use Prettier code style!

    sh scripts/check-doc-paths.sh .
    PASS: every path a tense-present document names resolves, and every declared forward reference names an open issue

## Review

There is no second reader on this board tonight; the readings above stand in
place of one.
