### PR TITLE
Decode GDeflate pages on the device, one warp per page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,7 @@ jobs:
           test -x build-cuda/tests/termination_gpu &&
           test -x build-cuda/tests/determinism_gpu &&
           test -x build-cuda/tests/snappy_block_device &&
+          test -x build-cuda/tests/gdeflate_device &&
           test -x build-cuda/examples/example_decode_frame &&
           test -x build-cuda/examples/example_decode_batch
 
@@ -393,7 +394,8 @@ jobs:
           grep -E ': stream_twin$' gpu-deferred.txt &&
           grep -E ': termination_gpu$' gpu-deferred.txt &&
           grep -E ': determinism_gpu$' gpu-deferred.txt &&
-          grep -E ': snappy_block_device$' gpu-deferred.txt
+          grep -E ': snappy_block_device$' gpu-deferred.txt &&
+          grep -E ': gdeflate_device$' gpu-deferred.txt
 
   hip:
     # The job name is the required-check context the ruleset will name once
@@ -451,6 +453,7 @@ jobs:
           test -x build-hip/tests/termination_gpu &&
           test -x build-hip/tests/determinism_gpu &&
           test -x build-hip/tests/snappy_block_device &&
+          test -x build-hip/tests/gdeflate_device &&
           test -x build-hip/tests/wave_width_gpu &&
           test -x build-hip/bench/bench_lz4 &&
           test -x build-hip/bench/bench_snappy &&
@@ -489,6 +492,7 @@ jobs:
           grep -E ': termination_gpu$' hip-gpu-deferred.txt &&
           grep -E ': determinism_gpu$' hip-gpu-deferred.txt &&
           grep -E ': snappy_block_device$' hip-gpu-deferred.txt &&
+          grep -E ': gdeflate_device$' hip-gpu-deferred.txt &&
           grep -E ': wave_width_gpu$' hip-gpu-deferred.txt
 
   sanitize:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,20 @@ gaps. Everything in the entry is in the tree at that commit.
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- **GDeflate page batch decode on the GPU.** `cudec_gdeflate_decompress_batch`
+  decodes N independent raw GDeflate pages in one launch, one warp per page
+  with the 32 lanes as the format's 32 substreams, into caller-provided tiles
+  with a per-page `cudec_chunk_result`. The symbol, the signature and every
+  argument-reject class are the ones frozen in 0.1.0; only the answer to an
+  accepted batch moved, from `CUDEC_ERR_NOT_IMPLEMENTED` to the decode. A page
+  the decoder refuses reports `CUDEC_ERR_CORRUPT_INPUT`, or
+  `CUDEC_ERR_OUTPUT_TOO_SMALL` where the refusal is against the supplied
+  capacity, with `bytes_written` zero. The kernel runs the same block loop the
+  CPU twin runs, so the oracle parity and the reject ladder recorded for the
+  twin hold for the kernel by construction; the device test holds both to it,
+  page for page. No throughput is claimed for it yet.
 
 ## [0.1.0] - 2026-09-03
 

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -35,9 +35,10 @@ typedef enum cudec_status {
      * in this build. It is what a declared-but-unbuilt entry answers a
      * batch it has already accepted, so the freeze on that entry's symbol
      * and signature never depends on a build configuration:
-     * cudec_gdeflate_decompress_batch returns it today, and the value is
-     * fixed so a caller's switch stays exhaustive across the build that
-     * stops returning it. */
+     * cudec_zstd_decompress_batch returns it today, and the value is fixed
+     * so a caller's switch stays exhaustive across the build that stops
+     * returning it - which cudec_gdeflate_decompress_batch did when its
+     * kernel landed, with the symbol and every reject class unmoved. */
     CUDEC_ERR_NOT_IMPLEMENTED = 5,
     /* A well-formed frame that uses a feature cudec does not decode, or a
      * legal frame type it declines (block-linked mode, a dictionary id, a
@@ -183,17 +184,14 @@ cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
  * malformed page, CUDEC_ERR_OUTPUT_TOO_SMALL when the decode would pass
  * the supplied capacity, bytes_written == 0 on either, and the
  * destination contents then unspecified but never presented as a valid
- * decode.
+ * decode. A page is decoded by one warp, its 32 lanes being the format's
+ * 32 substreams, and a page that overlaps another chunk's destination is
+ * the caller's error exactly as it is for the two entries above.
  *
- * THIS BUILD CARRIES NO GDEFLATE KERNEL, AND THAT IS A DEFINED STATUS
- * RATHER THAN AN ABSENT SYMBOL. A batch that passes the validation above
- * returns CUDEC_ERR_NOT_IMPLEMENTED, having made no CUDA call at all - so
- * this entry, unlike the two above, also leaves the thread's pending CUDA
- * error state untouched on a call it accepts. The symbol, the signature
- * and every reject class above are frozen now and do not move when the
- * kernel lands; only the answer to an accepted batch does. A symbol that
- * was absent instead would make the freeze conditional on a build
- * configuration, which is two contracts wearing one name. */
+ * The contract was frozen before the kernel stood behind it, and the
+ * freeze held: the symbol, the signature and every reject class above did
+ * not move when the kernel landed; only the answer to an accepted batch
+ * did, from CUDEC_ERR_NOT_IMPLEMENTED to the launch. */
 cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
                                              const size_t* d_src_sizes,
                                              void* const* d_dst_ptrs,

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -1,6 +1,7 @@
 #include "cudec.h"
 #include "chunk_decode.cuh"
 #include "batch_limits.h"
+#include "gdeflate_decode.cuh"
 #include "lz4_block.h"
 #include "snappy_block.h"
 
@@ -8,29 +9,52 @@
 
 namespace {
 
-/* The launch, written once for both widths. The grid is a whole number of
- * blocks and each block is kBlockWarps waves at whichever width was selected,
- * so the geometry the kernel refuses - a block that is not a wave multiple -
- * cannot be produced by either arm. */
-template <class Parser, int WaveSize>
-void launch_decode(const void* const* d_src_ptrs, const size_t* d_src_sizes,
-                   void* const* d_dst_ptrs, const size_t* d_dst_capacities,
-                   size_t chunk_count, cudec_chunk_result* d_results,
-                   cudec_stream_t stream) {
-    cudec_detail::chunk_decode_batch<Parser, false, WaveSize>
-        <<<cudec_detail::decode_grid_blocks(chunk_count),
-           cudec_detail::kBlockThreadsFor<WaveSize>, 0,
-           cudec_rt::stream_from_abi(stream)>>>(
-            d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
-            d_results);
-}
-
-/* The two entries differ in one template argument and in nothing else, so
- * the body they share is written once. Templated rather than handed a
- * function pointer: a launch through an indirect call would put the kernel
- * address in device memory and cost the compiler the inlining the parser
- * depends on. */
+/* The launches, written once per kernel family and once for both widths.
+ * The grid is a whole number of blocks and each block is kBlockWarps waves at
+ * whichever width was selected, so the geometry the kernels refuse - a block
+ * that is not a wave multiple - cannot be produced by either arm. A launcher
+ * is a type with one static template rather than a function template,
+ * because the submission below is written once over the launcher and a
+ * function template cannot be a template argument. */
 template <class Parser>
+struct ChunkLaunch {
+    template <int WaveSize>
+    static void Run(const void* const* d_src_ptrs, const size_t* d_src_sizes,
+                    void* const* d_dst_ptrs, const size_t* d_dst_capacities,
+                    size_t chunk_count, cudec_chunk_result* d_results,
+                    cudec_stream_t stream) {
+        cudec_detail::chunk_decode_batch<Parser, false, WaveSize>
+            <<<cudec_detail::decode_grid_blocks(chunk_count),
+               cudec_detail::kBlockThreadsFor<WaveSize>, 0,
+               cudec_rt::stream_from_abi(stream)>>>(
+                d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities,
+                chunk_count, d_results);
+    }
+};
+
+/* One team per page rather than one lane-lockstep parse per chunk, and the
+ * same block shape: kBlockWarps teams to a block, so the grid arithmetic the
+ * chunk decoder settled serves the page decoder unchanged. */
+struct GDeflateLaunch {
+    template <int WaveSize>
+    static void Run(const void* const* d_src_ptrs, const size_t* d_src_sizes,
+                    void* const* d_dst_ptrs, const size_t* d_dst_capacities,
+                    size_t chunk_count, cudec_chunk_result* d_results,
+                    cudec_stream_t stream) {
+        cudec_detail::gdeflate_decode_batch<WaveSize>
+            <<<cudec_detail::decode_grid_blocks(chunk_count),
+               cudec_detail::kBlockThreadsFor<WaveSize>, 0,
+               cudec_rt::stream_from_abi(stream)>>>(
+                d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities,
+                chunk_count, d_results);
+    }
+};
+
+/* The entries differ in which launcher they name and in nothing else, so the
+ * body they share is written once. Templated rather than handed a function
+ * pointer: a launch through an indirect call would put the kernel address in
+ * device memory and cost the compiler the inlining the parser depends on. */
+template <class Launch>
 cudec_status submit_batch(const void* const* d_src_ptrs,
                           const size_t* d_src_sizes, void* const* d_dst_ptrs,
                           const size_t* d_dst_capacities, size_t chunk_count,
@@ -72,12 +96,12 @@ cudec_status submit_batch(const void* const* d_src_ptrs,
      * #212 holds the same property for the HIP binary. */
     switch (cudec_detail::select_wave_instantiation(reported_width)) {
         case cudec_detail::WaveInstantiation::kWave32:
-            launch_decode<Parser, cudec_detail::kWaveWidth32>(
+            Launch::template Run<cudec_detail::kWaveWidth32>(
                 d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities,
                 chunk_count, d_results, stream);
             break;
         case cudec_detail::WaveInstantiation::kWave64:
-            launch_decode<Parser, cudec_detail::kWaveWidth64>(
+            Launch::template Run<cudec_detail::kWaveWidth64>(
                 d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities,
                 chunk_count, d_results, stream);
             break;
@@ -97,7 +121,7 @@ cudec_status cudec_lz4_decompress_batch(const void* const* d_src_ptrs,
                                         size_t chunk_count,
                                         cudec_chunk_result* d_results,
                                         cudec_stream_t stream) {
-    return submit_batch<cudec_detail::Lz4Parser>(
+    return submit_batch<ChunkLaunch<cudec_detail::Lz4Parser> >(
         d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
         d_results, stream);
 }
@@ -109,18 +133,33 @@ cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
                                            size_t chunk_count,
                                            cudec_chunk_result* d_results,
                                            cudec_stream_t stream) {
-    return submit_batch<cudec_detail::SnappyParser>(
+    return submit_batch<ChunkLaunch<cudec_detail::SnappyParser> >(
         d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
         d_results, stream);
 }
 
-/* The GDeflate and Zstd entries are the frozen contracts without their
- * kernels behind them yet (issues #216 and #427). Each shares the validator
- * with the two above rather than growing its own, so the reject classes
- * cannot drift apart while they are being frozen, and then stops: no launch,
- * and deliberately no cudec_rt::get_last_error() drain either. Draining is how the entries above
- * buy a
- * post-launch check that reports their own submission; with nothing
+/* The GDeflate entry: the frozen contract with its kernel behind it (issues
+ * #216, #214). It shares the validator, the width query and the post-launch
+ * check with the two above, so the reject classes and the launch discipline
+ * cannot drift apart between the families. */
+cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
+                                             const size_t* d_src_sizes,
+                                             void* const* d_dst_ptrs,
+                                             const size_t* d_dst_capacities,
+                                             size_t chunk_count,
+                                             cudec_chunk_result* d_results,
+                                             cudec_stream_t stream) {
+    return submit_batch<GDeflateLaunch>(d_src_ptrs, d_src_sizes, d_dst_ptrs,
+                                        d_dst_capacities, chunk_count,
+                                        d_results, stream);
+}
+
+/* The Zstd entry is the frozen contract without its kernel behind it yet
+ * (issue #427). It shares the validator with the three above rather than
+ * growing its own, so the reject classes cannot drift apart while it is being
+ * frozen, and then stops: no launch, and deliberately no
+ * cudec_rt::get_last_error() drain either. Draining is how the entries above
+ * buy a post-launch check that reports their own submission; with nothing
  * submitted there is nothing to report, and consuming a caller's pending
  * error on the way to answering "not built here" would be this entry
  * altering CUDA state it never used.
@@ -130,26 +169,6 @@ cudec_status cudec_snappy_decompress_batch(const void* const* d_src_ptrs,
  * not-implemented answer there is the evidence that this path touches the
  * runtime at all only through the validator, which touches it not at
  * all. */
-cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
-                                             const size_t* d_src_sizes,
-                                             void* const* d_dst_ptrs,
-                                             const size_t* d_dst_capacities,
-                                             size_t chunk_count,
-                                             cudec_chunk_result* d_results,
-                                             cudec_stream_t stream) {
-    (void)stream;
-    const cudec_status valid = cudec_detail::validate_batch_args(
-        d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
-        d_results);
-    if (valid != CUDEC_OK) {
-        return valid;
-    }
-    return CUDEC_ERR_NOT_IMPLEMENTED;
-}
-
-/* The Zstd entry, the same shape and for the same reasons - the comment above
- * covers both, and the unit each accepts is the only thing that differs
- * between them. */
 cudec_status cudec_zstd_decompress_batch(const void* const* d_src_ptrs,
                                          const size_t* d_src_sizes,
                                          void* const* d_dst_ptrs,

--- a/src/gdeflate_block.h
+++ b/src/gdeflate_block.h
@@ -28,6 +28,20 @@
  * thirty-two rounds after end-of-block exist to drain the copies still
  * outstanding when the block ended.
  *
+ * ONE ROUND BODY FOR BOTH RESIDENCIES (issue #214). The loop below is written
+ * over the team contract at GDeflateHostTeam in src/gdeflate_tables.h: every
+ * lane resolves its symbol speculatively, the team names the first lane that
+ * hit end-of-block, and each lane commits only if it sits at or below that
+ * lane - a lane that must not have consumed keeps the bits it entered the
+ * round with, which is a select rather than a rollback (masterplan 13.2). The
+ * lanes above the end-of-block lane take the drain's first steps in the same
+ * round, and one more round over the lanes below it takes the rest, which is
+ * the reference's thirty-two drain steps starting at the end-of-block lane
+ * and read off in that order. Output positions come from the team in lane
+ * order, and the copies of one round are performed in lane order, because a
+ * copy's source lies before its own reservation and a lower lane's
+ * reservation of the same round may be what it reads.
+ *
  * FAIL-CLOSED, AND WHERE THE BOUNDS COME FROM. Every length is checked against
  * the output that remains before any byte is written, every distance is
  * checked against the output already produced before any byte is read, and the
@@ -114,11 +128,16 @@ CUDEC_HOST_DEVICE inline uint32_t GDeflateDistExtra(uint32_t sym) {
  * DEFLATE64 divergences, which move bases and extra bits rather than codeword
  * lengths). Built through the same construction every other table goes
  * through, so a static block and a dynamic block share one decoder. */
-CUDEC_HOST_DEVICE inline bool GDeflateStaticTables(GDeflateLitLenTable& litlen,
+CUDEC_HOST_DEVICE inline bool GDeflateStaticTables(GDeflateCodeLengths& scratch,
+                                                   GDeflateLitLenTable& litlen,
                                                    GDeflateDistTable& dist,
                                                    GDeflateReject* why =
                                                        nullptr) {
-    unsigned char lens[kGDeflateNumLitLenSyms];
+    /* The fixed lengths are written into the team's code-length buffer rather
+     * than a local array: on the device a local array of the alphabet's size
+     * is a per-thread stack frame paid on every page, static block or not,
+     * and the buffer is idle during a static block by construction. */
+    unsigned char* lens = scratch.lens;
     for (uint32_t i = 0; i < kGDeflateNumLitLenSyms; i++) {
         if (i < 144) {
             lens[i] = 8;
@@ -133,109 +152,145 @@ CUDEC_HOST_DEVICE inline bool GDeflateStaticTables(GDeflateLitLenTable& litlen,
     if (!GDeflateBuildTable(lens, kGDeflateNumLitLenSyms, litlen, why)) {
         return false;
     }
-    unsigned char dist_lens[kGDeflateNumDistSyms];
+    unsigned char* dist_lens = scratch.lens + kGDeflateNumLitLenSyms;
     for (uint32_t i = 0; i < kGDeflateNumDistSyms; i++) {
         dist_lens[i] = 5;
     }
     return GDeflateBuildTable(dist_lens, kGDeflateNumDistSyms, dist, why);
 }
 
-/* One lane's outstanding match: the length it reserved and where in the output
- * that reservation starts. Held per lane for the reason GDeflateSchedule holds
- * all 32 bit buffers - the CPU twin runs the lanes sequentially in one thread,
- * while in the warp kernel each lane owns its own copy state in registers. The
- * reference keeps the same thing as a rotating 32-bit mask beside a per-lane
- * array; a mask and a flag per lane are the same set, and the flag is the
- * shape that reads correctly in both residencies. */
-struct GDeflateDeferredCopy {
-    uint64_t out_pos;
-    uint32_t length;
-    bool pending;
+/* What a page turned out to hold: how many blocks, of which types, producing
+ * how many bytes each. It is what the decode produced rather than
+ * bookkeeping: a page is one block or several and nothing outside says which,
+ * so without this the multi-block case cannot be told from the single-block
+ * one by anything that reads a decode. A block boundary inside a page is not
+ * findable by scanning (docs/MASTERPLAN.md section 11.3), so a decode that
+ * walked to a block is the only thing that can attribute a byte to its type,
+ * and without this the attribution is unreadable from outside (issue #206).
+ * Written only on a successful decode. */
+struct GDeflateCensus {
+    uint32_t blocks;
+    uint32_t type_blocks[kGDeflateBlockTypeCount];
+    uint64_t type_bytes[kGDeflateBlockTypeCount];
 };
 
-/* Everything a page decode carries: the schedule, the two live tables, and the
- * 32 deferred copies. */
+/* Everything a sequential page decode carries: the schedule, the two live
+ * tables, the code-length vector, and the census. The deferred copies live in
+ * the team. */
 struct GDeflatePageState {
     GDeflateSchedule s;
     GDeflateLitLenTable litlen;
     GDeflateDistTable dist;
     GDeflateCodeLengths lens;
-    GDeflateDeferredCopy copies[kGDeflateNumStreams];
-    /* How many blocks the page turned out to hold. It is what the decode
-     * produced rather than bookkeeping: a page is one block or several and
-     * nothing outside says which, so without this the multi-block case cannot
-     * be told from the single-block one by anything that reads a decode. */
+    /* The census, flattened into this struct for the readers that had it
+     * here before the rounds moved into the team. */
     uint32_t blocks;
-    /* What the page turned out to be MADE OF, in the same sense `blocks` is
-     * what it turned out to hold: how many blocks of each type it carried and
-     * how many output bytes each type produced, indexed by the BTYPE
-     * constants above. A block boundary inside a page is not findable by
-     * scanning (docs/MASTERPLAN.md section 11.3), so a decode that walked to
-     * a block is the only thing that can attribute a byte to its type, and
-     * without this the attribution is unreadable from outside (issue #206).
-     * Written only on a successful decode, like `blocks`. */
     uint32_t type_blocks[kGDeflateBlockTypeCount];
     uint64_t type_bytes[kGDeflateBlockTypeCount];
 };
 
-/* Perform the copy the current lane reserved: decode the distance symbol off
- * this lane, add its extra bits, and move the bytes. */
-CUDEC_HOST_DEVICE inline bool GDeflateDoCopy(GDeflatePageState& st,
-                                             unsigned char* out) {
-    GDeflateSchedule& s = st.s;
-    GDeflateDeferredCopy& c = st.copies[s.idx];
-    const uint32_t sym = GDeflateDecodeSymbol(s, st.dist);
-    if (sym == kGDeflateNoSymbol) {
-        return false;
+/* What one lane resolved for the round ahead of it, before anything is
+ * committed: the symbol, how many bits it and its extra field span, the length
+ * or offset those extra bits complete, and the rung the read refused on. */
+struct GDeflateLaneStep {
+    GDeflateLaneRead read;
+    uint32_t sym;
+    uint32_t value;
+};
+
+/* Resolve the current lane's next literal/length symbol and, for a length,
+ * the extra bits behind it, consuming nothing. */
+template <class Team>
+CUDEC_HOST_DEVICE inline GDeflateLaneStep GDeflateResolveLitLen(Team& lane) {
+    GDeflateLaneStep step;
+    step.read.consumed = 0;
+    step.read.why = kGDeflateRejectNone;
+    step.value = 0;
+    const uint64_t buf = lane.Bits().Buf();
+    const uint32_t left = lane.Bits().Left();
+    step.sym = GDeflateResolveSymbol(lane.LitLen(), buf, left, step.read);
+    if (step.read.why == kGDeflateRejectNone &&
+        step.sym >= kGDeflateFirstLengthSym) {
+        const uint32_t index = step.sym - kGDeflateFirstLengthSym;
+        step.value = GDeflateLengthBase(index) +
+                     GDeflateReadAhead(buf, left, step.read,
+                                       GDeflateLengthExtra(index));
     }
-    const uint32_t offset = GDeflateDistBase(sym) +
-                            GDeflatePop(s, GDeflateDistExtra(sym));
-    if (s.failed) {
-        return false;
+    return step;
+}
+
+/* Resolve the current lane's distance symbol and its extra bits, which
+ * together are the offset of the copy this lane reserved, consuming nothing. */
+template <class Team>
+CUDEC_HOST_DEVICE inline GDeflateLaneStep GDeflateResolveDist(Team& lane) {
+    GDeflateLaneStep step;
+    step.read.consumed = 0;
+    step.read.why = kGDeflateRejectNone;
+    step.value = 0;
+    const uint64_t buf = lane.Bits().Buf();
+    const uint32_t left = lane.Bits().Left();
+    step.sym = GDeflateResolveSymbol(lane.Dist(), buf, left, step.read);
+    if (step.read.why == kGDeflateRejectNone) {
+        step.value = GDeflateDistBase(step.sym) +
+                     GDeflateReadAhead(buf, left, step.read,
+                                       GDeflateDistExtra(step.sym));
     }
+    return step;
+}
+
+/* What one lane does in a symbol round, decided after the team has named the
+ * end-of-block lane. */
+enum GDeflateLaneMode {
+    kGDeflateLaneIdle = 0,
+    kGDeflateLaneLiteral,
+    kGDeflateLaneReserve,
+    kGDeflateLaneEndOfBlock,
+    kGDeflateLaneCopy
+};
+
+/* Retire the current lane's reservation: commit the distance read, check the
+ * source against the output this page has produced, and hand the copy to the
+ * team. One function because the symbol round and the drain round both retire
+ * copies, and a rung named at two sites is what the ladder lock refuses. */
+template <class Team>
+CUDEC_HOST_DEVICE inline bool GDeflateRetireCopy(Team& lane,
+                                                 const GDeflateLaneStep& step,
+                                                 GDeflateDeferredCopy& c) {
+    auto& b = lane.Bits();
+    if (step.read.why != kGDeflateRejectNone) {
+        return GDeflateRefuseAs(b, step.read.why);
+    }
+    GDeflateRemove(b, step.read.consumed);
     /* The match source may not begin before this page's output. Compared in
      * the 64-bit width the output position is carried in, so the comparison
-     * cannot be the place a narrowing hides: `offset` is at most 65536 and
+     * cannot be the place a narrowing hides: the offset is at most 65536 and
      * `c.out_pos` is where the reservation started. */
-    if (static_cast<uint64_t>(offset) > c.out_pos) {
-        return GDeflateRefuse(s, kGDeflateRejectMatchBeforeOutput);
-    }
-    const uint64_t src = c.out_pos - offset;
-    /* Byte by byte, forwards, which is what an overlapping match MEANS: a
-     * distance below the length is a run that repeats what this copy is itself
-     * writing. A word-at-a-time copy would have to special-case that; this
-     * does not, and it is the same order on both residencies, which is what
-     * makes the output bit-identical (docs/DETERMINISM.md). */
-    for (uint32_t n = 0; n < c.length; n++) {
-        out[c.out_pos + n] = out[src + n];
+    if (static_cast<uint64_t>(step.value) > c.out_pos) {
+        return GDeflateRefuse(b, kGDeflateRejectMatchBeforeOutput);
     }
     c.pending = false;
     return true;
 }
 
-/* Decode one page into `out`, which is the tile it belongs to. Returns false
- * with the schedule failed for every page this decoder refuses; `*out_len` is
- * written only on success.
+/* Decode one page into `out`, which is the tile it belongs to, over the team
+ * `t`. Returns false with the team failed for every page this decoder refuses;
+ * `*out_len` and `census` are written only on success.
  *
  * `out_cap` is the caller's capacity and is the only bound the output is
  * checked against. It is never derived from the page: the format states no
  * uncompressed size anywhere inside a page, which is why the tile size lives
  * in the stream header that src/tilestream.h parses. */
-CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
-                                                 const unsigned char* page,
-                                                 uint64_t page_bytes,
-                                                 unsigned char* out,
-                                                 uint64_t out_cap,
-                                                 uint64_t* out_len) {
-    GDeflateSchedule& s = st.s;
-    if (!GDeflateInit(s, page, page_bytes)) {
+template <class Team>
+CUDEC_HOST_DEVICE inline bool GDeflateDecodePageRounds(Team& t,
+                                                       uint64_t page_bytes,
+                                                       unsigned char* out,
+                                                       uint64_t out_cap,
+                                                       uint64_t* out_len,
+                                                       GDeflateCensus* census) {
+    if (!t.Prime(page_bytes)) {
         return false;
     }
-    for (uint32_t n = 0; n < kGDeflateNumStreams; n++) {
-        st.copies[n].pending = false;
-        st.copies[n].length = 0;
-        st.copies[n].out_pos = 0;
-    }
+    t.ClearCopies();
     uint64_t out_pos = 0;
 
     /* A block costs lane 0 at least the three bits of its own header, and a
@@ -245,7 +300,7 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
      * therefore generous by a wide margin and exists to make termination a
      * property of the code rather than of an argument about the input. */
     const uint64_t block_fuel =
-        (s.word_count + 1u) * (kGDeflateMaxLaneBits / kGDeflateMinMatchLen);
+        (t.WordCount() + 1u) * (kGDeflateMaxLaneBits / kGDeflateMinMatchLen);
     bool final_block = false;
     uint32_t blocks_read = 0;
     uint32_t type_blocks[kGDeflateBlockTypeCount] = {0, 0, 0};
@@ -253,16 +308,29 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
     for (uint64_t block = 0; block < block_fuel && !final_block; block++) {
         blocks_read++;
         const uint64_t block_out_start = out_pos;
-        GDeflateReset(s);
-        final_block = GDeflatePop(s, 1) != 0;
-        const uint32_t block_type = GDeflatePop(s, 2);
-        if (s.failed) {
+        t.Reset();
+        /* BFINAL and BTYPE ride lane 0 and every lane needs them, packed into
+         * one word for one broadcast. */
+        uint32_t header = 0;
+        t.Lane0([&](Team& lane0) {
+            auto& b = lane0.Bits();
+            const uint32_t bfinal = GDeflatePop(b, 1);
+            const uint32_t type = GDeflatePop(b, 2);
+            header = bfinal | (type << 1);
+        });
+        header = t.Broadcast(header);
+        if (t.Failed()) {
             return false;
         }
-        GDeflateEnsure(s, page);
+        final_block = (header & 1u) != 0;
+        const uint32_t block_type = header >> 1;
+        t.EnsureLane0();
+        if (t.Failed()) {
+            return false;
+        }
 
         if (block_type == kGDeflateBlockReserved) {
-            return GDeflateRefuse(s, kGDeflateRejectBlockTypeReserved);
+            return GDeflateRefuse(t.Bits(), kGDeflateRejectBlockTypeReserved);
         }
 
         if (block_type == kGDeflateBlockStored) {
@@ -279,10 +347,14 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
              * check on this side could not be reached by any page and a guard
              * that cannot bite proves nothing. */
             const uint64_t reachable =
-                (s.word_count - s.cursor) * (kGDeflateBitsPerPacket / 8u) +
-                (GDeflateBufferedBits(s) + 7u) / 8u;
-            const uint32_t len = GDeflatePop(s, 16);
-            if (s.failed) {
+                (t.WordCount() - t.Cursor()) * (kGDeflateBitsPerPacket / 8u) +
+                (t.BufferedBits() + 7u) / 8u;
+            uint32_t len = 0;
+            t.Lane0([&](Team& lane0) {
+                len = GDeflatePop(lane0.Bits(), 16);
+            });
+            len = t.Broadcast(len);
+            if (t.Failed()) {
                 return false;
             }
             /* Two rungs rather than one condition, for the reason the pop
@@ -291,113 +363,195 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
              * can still supply are different defects, and a single rung would
              * let a negative for either stand in for the other. */
             if (len > out_cap - out_pos) {
-                return GDeflateRefuse(s, kGDeflateRejectStoredPastCap);
+                return GDeflateRefuse(t.Bits(), kGDeflateRejectStoredPastCap);
             }
             if (len > reachable) {
-                return GDeflateRefuse(s, kGDeflateRejectStoredPastPage);
+                return GDeflateRefuse(t.Bits(), kGDeflateRejectStoredPastPage);
             }
-            for (uint32_t n = 0; n < len; n++) {
-                out[out_pos] = static_cast<unsigned char>(GDeflatePop(s, 8));
-                out_pos++;
-                GDeflateAdvance(s, page);
-            }
-            if (s.failed) {
-                return false;
+            /* One byte per lane per round, lane order, each byte's lane
+             * refilled behind it: the reference's byte loop, thirty-two at a
+             * time. */
+            for (uint32_t done = 0; done < len;) {
+                const uint32_t batch = (len - done < kGDeflateNumStreams)
+                                           ? (len - done)
+                                           : kGDeflateNumStreams;
+                t.Round(batch, [&](Team& lane) -> bool {
+                    if (!lane.Active()) {
+                        return false;
+                    }
+                    const uint32_t byte = GDeflatePop(lane.Bits(), 8);
+                    if (!lane.Bits().failed) {
+                        out[out_pos + lane.Lane()] =
+                            static_cast<unsigned char>(byte);
+                    }
+                    return true;
+                });
+                if (t.Failed()) {
+                    return false;
+                }
+                out_pos += batch;
+                done += batch;
             }
         } else {
             if (block_type == kGDeflateBlockStatic) {
-                GDeflateReject static_why = kGDeflateRejectNone;
-                if (!GDeflateStaticTables(st.litlen, st.dist, &static_why)) {
-                    return GDeflateRefuseAs(s, static_why);
+                t.Build([&](Team& one) {
+                    GDeflateReject static_why = kGDeflateRejectNone;
+                    if (!GDeflateStaticTables(one.Lens(), one.LitLen(),
+                                              one.Dist(), &static_why)) {
+                        GDeflateRefuseAs(one.Bits(), static_why);
+                    }
+                });
+                if (t.Failed()) {
+                    return false;
                 }
-            } else if (!GDeflateReadDynamicTables(s, page, st.lens, st.litlen,
-                                                  st.dist)) {
+            } else if (!GDeflateReadDynamicTableRounds(t)) {
                 return false;
             }
 
-            GDeflateReset(s);
-            /* Every round either writes a byte, reserves a match of at least
-             * the minimum length, or retires a reservation an earlier round
-             * made - so the capacity bounds the reserving rounds and the
-             * retiring rounds alike, and the end-of-block round and the drain
-             * are the constant beside them. */
-            const uint64_t round_fuel = 2u * (out_cap + 1u) + kGDeflateNumStreams;
+            t.Reset();
+            /* Every step either writes a byte, reserves a match of at least
+             * the minimum length, or retires a reservation an earlier step
+             * made - so the capacity bounds the reserving steps and the
+             * retiring steps alike, and the end-of-block step and the drain
+             * are the constant beside them. A round is up to a lane's worth
+             * of steps, so the same cap counted in rounds is wider still. */
+            const uint64_t round_fuel =
+                (out_cap > (UINT64_MAX - kGDeflateNumStreams) / 2u - 1u)
+                    ? UINT64_MAX
+                    : 2u * (out_cap + 1u) + kGDeflateNumStreams;
             bool block_done = false;
             for (uint64_t round = 0; round < round_fuel && !block_done;
                  round++) {
-                if (st.copies[s.idx].pending) {
-                    if (!GDeflateDoCopy(st, out)) {
-                        return false;
+                uint32_t eob_lane = kGDeflateNoLane;
+                t.Round(kGDeflateNumStreams, [&](Team& lane) -> bool {
+                    GDeflateDeferredCopy& c = lane.Copy();
+                    const bool active = lane.Active();
+                    const bool pending = active && c.pending;
+                    GDeflateLaneStep step;
+                    step.read.consumed = 0;
+                    step.read.why = kGDeflateRejectNone;
+                    step.sym = kGDeflateNoSymbol;
+                    step.value = 0;
+                    if (pending) {
+                        step = GDeflateResolveDist(lane);
+                    } else if (active) {
+                        step = GDeflateResolveLitLen(lane);
                     }
-                    GDeflateAdvance(s, page);
-                    if (s.failed) {
-                        return false;
+                    /* The end-of-block lane is the lowest lane that resolved
+                     * code 256 while holding no reservation; a lane above it
+                     * must not have consumed, so it takes a drain step
+                     * instead, and the reference leaves the loop AT that lane
+                     * without advancing, so the drain starts there. */
+                    const bool hit_eob = !pending && active &&
+                                         step.read.why == kGDeflateRejectNone &&
+                                         step.sym == kGDeflateEndOfBlock;
+                    const uint32_t first_eob = lane.FirstLane(hit_eob);
+                    eob_lane = first_eob;
+                    GDeflateLaneMode mode = kGDeflateLaneIdle;
+                    if (pending) {
+                        mode = kGDeflateLaneCopy;
+                    } else if (active && lane.Lane() < first_eob) {
+                        mode = (step.read.why != kGDeflateRejectNone ||
+                                step.sym < kGDeflateEndOfBlock)
+                                   ? kGDeflateLaneLiteral
+                                   : kGDeflateLaneReserve;
+                    } else if (active && lane.Lane() == first_eob) {
+                        mode = kGDeflateLaneEndOfBlock;
                     }
-                    continue;
-                }
-                const uint32_t sym = GDeflateDecodeSymbol(s, st.litlen);
-                if (sym == kGDeflateNoSymbol) {
+                    /* The reservation, not the copy: the distance symbol this
+                     * match needs arrives on this same lane one round of its
+                     * own later, and the output cursor moves past the hole
+                     * now so the rounds in between write after it. A literal
+                     * claims its one byte the same way. */
+                    uint64_t claim = 0;
+                    if (mode == kGDeflateLaneLiteral) {
+                        claim = 1;
+                    } else if (mode == kGDeflateLaneReserve &&
+                               step.read.why == kGDeflateRejectNone) {
+                        claim = step.value;
+                    }
+                    const uint64_t pos = lane.Claim(out_pos, claim);
+                    bool copy_now = false;
+                    if (mode == kGDeflateLaneCopy) {
+                        copy_now = GDeflateRetireCopy(lane, step, c);
+                    } else if (mode != kGDeflateLaneIdle) {
+                        auto& b = lane.Bits();
+                        if (step.read.why != kGDeflateRejectNone) {
+                            GDeflateRefuseAs(b, step.read.why);
+                        } else {
+                            GDeflateRemove(b, step.read.consumed);
+                            if (mode == kGDeflateLaneLiteral) {
+                                if (pos >= out_cap) {
+                                    GDeflateRefuse(b, kGDeflateRejectLiteralPastCap);
+                                } else {
+                                    out[pos] =
+                                        static_cast<unsigned char>(step.sym);
+                                }
+                            } else if (mode == kGDeflateLaneReserve) {
+                                /* `pos` can exceed the capacity only on the
+                                 * warp, behind a lower lane that refused in
+                                 * this round and whose claim still moved the
+                                 * base; the team fails at the round's end,
+                                 * but the reservation must not be recorded
+                                 * past the tile even for that one round. */
+                                if (pos > out_cap ||
+                                    step.value > out_cap - pos) {
+                                    GDeflateRefuse(b, kGDeflateRejectMatchPastCap);
+                                } else {
+                                    c.pending = true;
+                                    c.length = step.value;
+                                    c.out_pos = pos;
+                                }
+                            }
+                        }
+                    }
+                    lane.CopyBytes(copy_now && !lane.Bits().failed, out,
+                                   c.out_pos, c.out_pos - step.value,
+                                   c.length);
+                    /* Every lane of the round steps, drain steps included:
+                     * the reference advances after each of the thirty-two
+                     * drain iterations whether or not that lane held a
+                     * reservation. */
+                    return active;
+                });
+                if (t.Failed()) {
                     return false;
                 }
-                if (sym < kGDeflateEndOfBlock) {
-                    if (out_pos == out_cap) {
-                        return GDeflateRefuse(s, kGDeflateRejectLiteralPastCap);
-                    }
-                    out[out_pos] = static_cast<unsigned char>(sym);
-                    out_pos++;
-                    GDeflateAdvance(s, page);
-                    if (s.failed) {
+                if (eob_lane != kGDeflateNoLane) {
+                    /* The rest of the drain: the lanes below the end-of-block
+                     * lane, in order, each retiring what it still holds. */
+                    t.Round(eob_lane, [&](Team& lane) -> bool {
+                        GDeflateDeferredCopy& c = lane.Copy();
+                        const bool active = lane.Active();
+                        const bool pending = active && c.pending;
+                        GDeflateLaneStep step;
+                        step.read.consumed = 0;
+                        step.read.why = kGDeflateRejectNone;
+                        step.sym = kGDeflateNoSymbol;
+                        step.value = 0;
+                        if (pending) {
+                            step = GDeflateResolveDist(lane);
+                        }
+                        bool copy_now = false;
+                        if (pending) {
+                            copy_now = GDeflateRetireCopy(lane, step, c);
+                        }
+                        lane.CopyBytes(copy_now && !lane.Bits().failed, out,
+                                       c.out_pos, c.out_pos - step.value,
+                                       c.length);
+                        return active;
+                    });
+                    if (t.Failed()) {
                         return false;
                     }
-                    continue;
-                }
-                if (sym == kGDeflateEndOfBlock) {
-                    /* The reference leaves the loop here WITHOUT advancing:
-                     * the drain below starts on this lane, not the next. */
                     block_done = true;
-                    continue;
-                }
-                const uint32_t index = sym - kGDeflateFirstLengthSym;
-                const uint32_t length =
-                    GDeflateLengthBase(index) +
-                    GDeflatePop(s, GDeflateLengthExtra(index));
-                if (s.failed) {
-                    return false;
-                }
-                if (length > out_cap - out_pos) {
-                    return GDeflateRefuse(s, kGDeflateRejectMatchPastCap);
-                }
-                /* The reservation, not the copy. The distance symbol this
-                 * match needs arrives on this same lane one round of its own
-                 * later, and the output cursor moves past the hole now so the
-                 * rounds in between write after it. */
-                st.copies[s.idx].pending = true;
-                st.copies[s.idx].length = length;
-                st.copies[s.idx].out_pos = out_pos;
-                out_pos += length;
-                GDeflateAdvance(s, page);
-                if (s.failed) {
-                    return false;
                 }
             }
             if (!block_done) {
                 /* The round cap was reached with no end-of-block. A page that
                  * ran that far has produced more rounds than its own capacity
                  * admits, so it is refused rather than reported as a decode. */
-                return GDeflateRefuse(s, kGDeflateRejectRoundFuelExhausted);
-            }
-
-            /* The drain: one round per lane, retiring whatever is still
-             * outstanding. A block that ends with copies pending is the normal
-             * case rather than an error - up to 31 lanes can hold one. */
-            for (uint32_t n = 0; n < kGDeflateNumStreams; n++) {
-                if (st.copies[s.idx].pending && !GDeflateDoCopy(st, out)) {
-                    return false;
-                }
-                GDeflateAdvance(s, page);
-                if (s.failed) {
-                    return false;
-                }
+                return GDeflateRefuse(t.Bits(), kGDeflateRejectRoundFuelExhausted);
             }
         }
 
@@ -411,14 +565,35 @@ CUDEC_HOST_DEVICE inline bool GDeflateDecodePage(GDeflatePageState& st,
         type_bytes[block_type] += out_pos - block_out_start;
     }
     if (!final_block) {
-        return GDeflateRefuse(s, kGDeflateRejectNoFinalBlock);
+        return GDeflateRefuse(t.Bits(), kGDeflateRejectNoFinalBlock);
     }
-    st.blocks = blocks_read;
+    census->blocks = blocks_read;
     for (uint32_t n = 0; n < kGDeflateBlockTypeCount; n++) {
-        st.type_blocks[n] = type_blocks[n];
-        st.type_bytes[n] = type_bytes[n];
+        census->type_blocks[n] = type_blocks[n];
+        census->type_bytes[n] = type_bytes[n];
     }
     *out_len = out_pos;
+    return true;
+}
+
+/* The sequential entry point, which the twins, the fuzz targets and the bench
+ * drive: the rounds above over the host team, and the census copied into the
+ * state where those readers find it. */
+inline bool GDeflateDecodePage(GDeflatePageState& st,
+                               const unsigned char* page, uint64_t page_bytes,
+                               unsigned char* out, uint64_t out_cap,
+                               uint64_t* out_len) {
+    GDeflateHostTeam t(st.s, page, &st.lens, &st.litlen, &st.dist);
+    GDeflateCensus census;
+    if (!GDeflateDecodePageRounds(t, page_bytes, out, out_cap, out_len,
+                                  &census)) {
+        return false;
+    }
+    st.blocks = census.blocks;
+    for (uint32_t n = 0; n < kGDeflateBlockTypeCount; n++) {
+        st.type_blocks[n] = census.type_blocks[n];
+        st.type_bytes[n] = census.type_bytes[n];
+    }
     return true;
 }
 

--- a/src/gdeflate_decode.cuh
+++ b/src/gdeflate_decode.cuh
@@ -1,0 +1,418 @@
+/* The warp-per-page GDeflate decoder (issue #214): one team of 32 lanes per
+ * raw page over a grid-stride loop, the 32 lanes being the format's 32
+ * substreams, one table set per team in shared memory at a footprint no input
+ * can grow, and the block loop, the copy engine and the failure contract
+ * shared with the CPU twin rather than restated (docs/MASTERPLAN.md section
+ * 13). Internal header, not part of the ABI; src/batch.cu instantiates it.
+ *
+ * WHAT IS DEVICE CODE HERE AND WHAT IS NOT. Nothing in this file decodes a
+ * bit. The rounds are src/gdeflate_block.h's and src/gdeflate_tables.h's,
+ * written once over the team contract stated at GDeflateHostTeam, and this
+ * file is the second residency of that contract: a lane's bits live in this
+ * thread's registers, the team's collectives are a ballot, a prefix sum and a
+ * shuffle, and a refill is one ballot over the lanes that stepped with each
+ * of them taking the word its rank among them names - which is exactly the
+ * word the sequential cursor would have handed it, because the schedule hands
+ * words out in lane order (src/gdeflate_schedule.h). So a page that decodes
+ * to different bytes on the two residencies is a defect in this file, and the
+ * rounds cannot be that defect: they are the same code.
+ *
+ * ONE TEAM PER WAVE, WHATEVER THE WAVE WIDTH. The format has 32 substreams, so
+ * a wave64 device leaves its upper 32 lanes with no substream to own. Those
+ * lanes run every round with nothing to do rather than being masked out of
+ * the collectives: the collectives here name the whole wave, a lane that
+ * dropped out of one would leave the rest waiting, and a wave64 device has
+ * never executed this decoder (issue #415). Two teams per wave, each decoding
+ * its own page, is a measurement for that hardware and not a change to make
+ * without it.
+ *
+ * FAIL-CLOSED, WITH THE BOUNDS WHERE THE TWIN HAS THEM. Every write of the
+ * rounds is bounded by the caller's capacity before it happens and every read
+ * of the page by the caller's size, per lane, so a lane that fails on the
+ * device after a lower lane already failed cannot reach memory it should not:
+ * the round finishes for every lane and the lowest refusing lane's rung is
+ * the team's, which is the verdict the sequential loop gives, because no
+ * lane's step depends on a higher lane's. On any refusal the page's result is
+ * a non-OK status with bytes_written zero, and the destination up to that
+ * point is unspecified and never presented as a decode. */
+#ifndef CUDEC_GDEFLATE_DECODE_CUH
+#define CUDEC_GDEFLATE_DECODE_CUH
+
+#include "chunk_decode.cuh"
+#include "cudec.h"
+#include "gdeflate_block.h"
+
+#include "vendor_rt.h"
+
+namespace cudec_detail {
+
+/* Every lane of the wave, in the width the backend's collectives take it. The
+ * name is the one the structural rule in tests/CMakeLists.txt admits as a
+ * mask, so a collective here can be read by that rule as naming the whole
+ * warp. */
+constexpr auto kFullWarpMask = CUDEC_RT_WAVE_FULL_MASK;
+
+/* The per-chunk status a refused page reports through the batch ABI. The
+ * three rungs that refuse against the caller's capacity are the output being
+ * too small for the page, which the ABI names apart from corruption so a
+ * caller can retry with a larger tile; every other rung is a page this decoder
+ * will not decode at any capacity. It lives beside the kernel rather than beside
+ * the ladder because the ladder's headers know no ABI status, and the twins,
+ * the bench and the fuzz targets that include them must not start to. */
+CUDEC_HOST_DEVICE inline cudec_status GDeflateStatusFor(GDeflateReject why) {
+    switch (why) {
+        case kGDeflateRejectStoredPastCap:
+        case kGDeflateRejectLiteralPastCap:
+        case kGDeflateRejectMatchPastCap:
+            return CUDEC_ERR_OUTPUT_TOO_SMALL;
+        default:
+            return CUDEC_ERR_CORRUPT_INPUT;
+    }
+}
+
+/* One lane's residency of the schedule primitives: its own buffer and
+ * occupancy in registers, and the verdict and the page's word count beside
+ * them. The verdict is per thread inside a round and team-uniform after it,
+ * which is what Unify below establishes. */
+struct GDeflateLane {
+    uint64_t bitbuf;
+    uint32_t bitsleft;
+    uint64_t word_count;
+    bool failed;
+    GDeflateReject reject;
+
+    __device__ uint64_t& Buf() { return bitbuf; }
+    __device__ const uint64_t& Buf() const { return bitbuf; }
+    __device__ uint32_t& Left() { return bitsleft; }
+    __device__ const uint32_t& Left() const { return bitsleft; }
+};
+
+/* One team's table set: the two live decode tables, the precode and the
+ * code-length vector it expands, and the precode's own lengths. Sized by the
+ * alphabets and by nothing a page says (docs/MASTERPLAN.md section 13.1). */
+struct GDeflateTeamTables {
+    GDeflateLitLenTable litlen;
+    GDeflateDistTable dist;
+    GDeflatePrecodeTable precode;
+    GDeflateCodeLengths lens;
+    unsigned char precode_lens[kGDeflateNumPrecodeSyms];
+};
+
+/* THE WARP RESIDENCY OF THE TEAM CONTRACT. Each method is the collective form
+ * of the sequential one at GDeflateHostTeam, and the two agree on every value
+ * a round can observe. The mask type is the wide one on both backends; a
+ * backend whose ballot answers in the narrow width is widened, and the team
+ * mask below keeps the upper lanes of a wider wave out of every answer. */
+template <int WaveSize>
+class GDeflateWarpTeam {
+   public:
+    using Mask = unsigned long long;
+
+    __device__ GDeflateWarpTeam(GDeflateTeamTables& tables,
+                                const unsigned char* page, uint32_t lane)
+        : tables_(tables),
+          page_(page),
+          lane_(lane),
+          active_(0),
+          cursor_(0) {
+        me_.bitbuf = 0;
+        me_.bitsleft = 0;
+        me_.word_count = 0;
+        me_.failed = false;
+        me_.reject = kGDeflateRejectNone;
+        ClearCopies();
+    }
+
+    __device__ GDeflateLane& Bits() { return me_; }
+    __device__ GDeflateDeferredCopy& Copy() { return copy_; }
+    __device__ uint32_t Lane() const { return lane_; }
+    __device__ bool Active() const { return lane_ < active_; }
+    __device__ bool Failed() const { return me_.failed; }
+    __device__ GDeflateReject Reject() const { return me_.reject; }
+    __device__ uint64_t Cursor() const { return cursor_; }
+    __device__ uint64_t WordCount() const { return me_.word_count; }
+    __device__ const unsigned char* Page() const { return page_; }
+
+    __device__ GDeflateLitLenTable& LitLen() { return tables_.litlen; }
+    __device__ GDeflateDistTable& Dist() { return tables_.dist; }
+    __device__ GDeflatePrecodeTable& Precode() { return tables_.precode; }
+    __device__ GDeflateCodeLengths& Lens() { return tables_.lens; }
+    __device__ unsigned char* PrecodeLens() { return tables_.precode_lens; }
+
+    /* The priming round: the page's shape checked by every lane alike, then
+     * lane n takes word n, which is what thirty-two sequential refills from a
+     * cursor at zero hand out. The lanes of a wider wave take nothing. */
+    __device__ bool Prime(uint64_t page_bytes) {
+        me_.bitbuf = 0;
+        me_.bitsleft = 0;
+        me_.failed = false;
+        me_.reject = kGDeflateRejectNone;
+        GDeflateReject why = kGDeflateRejectNone;
+        if (!GDeflatePageShape(page_bytes, &me_.word_count, &why)) {
+            return GDeflateRefuseAs(me_, why);
+        }
+        if (lane_ < kGDeflateNumStreams) {
+            me_.bitbuf = GDeflateWordAt(page_, lane_);
+            me_.bitsleft = kGDeflateBitsPerPacket;
+        }
+        cursor_ = kGDeflateNumStreams;
+        return true;
+    }
+
+    /* One round: every lane runs f, then the lanes that stepped and fell
+     * below the watermark take the next words in lane order. The word a lane
+     * takes is the cursor plus its rank among the takers, which is the
+     * sequential schedule's answer read off a ballot. */
+    template <class F>
+    __device__ void Round(uint32_t lanes, F f) {
+        active_ = lanes;
+        const bool stepped = f(*this);
+        const bool need = stepped && lane_ < kGDeflateNumStreams &&
+                          GDeflateLaneNeedsRefill(me_);
+        const Mask takers = Ballot(need);
+        if (need) {
+            const uint64_t word = cursor_ + __popcll(takers & LowerMask());
+            GDeflateRefillLane(me_, page_, word);
+        }
+        cursor_ += __popcll(takers);
+        Unify();
+        Sync();
+    }
+
+    template <class F>
+    __device__ void Lane0(F f) {
+        active_ = 1;
+        if (lane_ == 0) {
+            f(*this);
+        }
+        Unify();
+    }
+
+    __device__ void EnsureLane0() {
+        const bool need = lane_ == 0 && GDeflateLaneNeedsRefill(me_);
+        const Mask takers = Ballot(need);
+        if (need) {
+            GDeflateRefillLane(me_, page_, cursor_);
+        }
+        cursor_ += __popcll(takers);
+        Unify();
+    }
+
+    __device__ void Reset() {}
+
+    /* One lane builds, the rest wait: the construction is a walk over the
+     * alphabet that the sequential residency runs in one thread too, and
+     * making it cooperative is a measurement question (#204), not a
+     * correctness one. */
+    template <class F>
+    __device__ void Build(F f) {
+        if (lane_ == 0) {
+            f(*this);
+        }
+        Sync();
+        Unify();
+    }
+
+    template <class T>
+    __device__ T Broadcast(T value) const {
+        return Shfl(value, 0);
+    }
+
+    /* Positions in lane order: an inclusive prefix sum over the team, this
+     * lane's exclusive share added to the base, and the base advanced past
+     * every lane's claim - which is `base += len` thirty-two times over. */
+    __device__ uint64_t Claim(uint64_t& base, uint64_t len) {
+        uint64_t sum = (lane_ < kGDeflateNumStreams) ? len : 0;
+        for (uint32_t d = 1; d < kGDeflateNumStreams; d <<= 1) {
+            const uint64_t below = ShflUp(sum, d);
+            if (lane_ >= d) {
+                sum += below;
+            }
+        }
+        const uint64_t total = Shfl(sum, kGDeflateNumStreams - 1u);
+        const uint64_t pos = base + (sum - len);
+        base += total;
+        return pos;
+    }
+
+    /* The lowest flagging lane of the team, or kGDeflateNoLane. Team-wide
+     * rather than at-or-below, which the contract allows: every comparison
+     * the rounds make against the answer reads the same either way. */
+    __device__ uint32_t FirstLane(bool flag) {
+        const Mask flagged = Ballot(flag) & TeamMask();
+        if (flagged == 0) {
+            return kGDeflateNoLane;
+        }
+        return static_cast<uint32_t>(__ffsll(static_cast<long long>(flagged))) -
+               1u;
+    }
+
+    /* The copies of this round in lane order, each performed by the whole
+     * wave: the closed-form gather dst[i] = src[i mod offset] is what
+     * byte-by-byte forwards copying MEANS for an overlapping match, and the
+     * order between copies is what the deferred copy needs, since a lower
+     * lane's reservation of this same round may be what a higher lane's copy
+     * reads (src/gdeflate_block.h). The dst pointer is deliberately not
+     * __restrict__: the next copy may read what this one wrote, and the
+     * __syncwarp between them is what forces the reload. */
+    __device__ void CopyBytes(bool active, unsigned char* out, uint64_t dst,
+                              uint64_t src, uint64_t len) {
+        const Mask copying = Ballot(active) & TeamMask();
+        for (uint32_t j = 0; j < kGDeflateNumStreams; j++) {
+            if (((copying >> j) & 1u) == 0) {
+                continue;
+            }
+            const uint64_t d = Shfl(dst, j);
+            const uint64_t s = Shfl(src, j);
+            const uint64_t n = Shfl(len, j);
+            /* The distance is at most the 64 KiB tile and the length at most
+             * two bytes past it (src/gdeflate_block.h), so both fit the
+             * 32-bit modulo the LZ4 kernel measured as the cheaper one. The
+             * distance is at least one by the schedule's tables, so the
+             * modulo cannot be by zero. */
+            const uint32_t dist = static_cast<uint32_t>(d - s);
+            for (uint64_t i = lane_; i < n; i += static_cast<uint32_t>(WaveSize)) {
+                out[d + i] = out[s + (static_cast<uint32_t>(i) % dist)];
+            }
+            Sync();
+        }
+    }
+
+    /* The asking lanes in lane order, each one's writes visible to the next:
+     * one lane at a time behind a wave barrier, which is the only thing the
+     * code-length expansion's "repeat the previous length" needs. */
+    template <class F>
+    __device__ void Serial(bool active, F f) {
+        const Mask asking = Ballot(active) & TeamMask();
+        for (uint32_t j = 0; j < kGDeflateNumStreams; j++) {
+            if (((asking >> j) & 1u) == 0) {
+                continue;
+            }
+            if (lane_ == j) {
+                f(*this);
+            }
+            Sync();
+        }
+    }
+
+    __device__ uint64_t BufferedBits() const {
+        uint64_t sum = (lane_ < kGDeflateNumStreams) ? me_.bitsleft : 0;
+        for (uint32_t d = 1; d < static_cast<uint32_t>(WaveSize); d <<= 1) {
+            sum += ShflXor(sum, d);
+        }
+        return sum;
+    }
+
+    __device__ void ClearCopies() {
+        copy_.out_pos = 0;
+        copy_.length = 0;
+        copy_.pending = false;
+    }
+
+   private:
+    /* The team's verdict after a round: the lowest refusing lane's rung,
+     * raised on every other lane through the choke point. A lane that
+     * refused on its own keeps its rung, which is the team's if it is the
+     * lowest; lane 0 is therefore always carrying the team's rung, and it is
+     * the lane the kernel reports from. */
+    __device__ void Unify() {
+        const Mask refused = Ballot(me_.failed) & TeamMask();
+        if (refused == 0) {
+            return;
+        }
+        const uint32_t first =
+            static_cast<uint32_t>(__ffsll(static_cast<long long>(refused))) -
+            1u;
+        const uint32_t rung = Shfl(static_cast<uint32_t>(me_.reject), first);
+        GDeflateRefuseAs(me_, static_cast<GDeflateReject>(rung));
+    }
+
+    __device__ Mask Ballot(bool pred) const {
+        return static_cast<Mask>(__ballot_sync(kFullWarpMask, pred ? 1 : 0));
+    }
+    template <class T>
+    __device__ T Shfl(T value, uint32_t from) const {
+        return __shfl_sync(kFullWarpMask, value, static_cast<int>(from));
+    }
+    template <class T>
+    __device__ T ShflUp(T value, uint32_t delta) const {
+        return __shfl_up_sync(kFullWarpMask, value, delta);
+    }
+    template <class T>
+    __device__ T ShflXor(T value, uint32_t lanemask) const {
+        return __shfl_xor_sync(kFullWarpMask, value, static_cast<int>(lanemask));
+    }
+    __device__ void Sync() const { __syncwarp(); }
+
+    /* The team's lanes within the wave: all of a 32-lane wave, the lower half
+     * of a wider one. */
+    __device__ static Mask TeamMask() {
+        return static_cast<Mask>(-1) >>
+               (static_cast<uint32_t>(WaveSize) - kGDeflateNumStreams);
+    }
+    __device__ Mask LowerMask() const {
+        return (static_cast<Mask>(1) << lane_) - 1u;
+    }
+
+    GDeflateTeamTables& tables_;
+    const unsigned char* page_;
+    uint32_t lane_;
+    uint32_t active_;
+    uint64_t cursor_;
+    GDeflateLane me_;
+    GDeflateDeferredCopy copy_;
+};
+
+/* One team per page over a grid-stride loop. The geometry guards are the
+ * chunk decoder's, for the reasons it gives: fewer than one whole wave in the
+ * grid makes the stride zero, and a block that is not a wave multiple splits
+ * a team across blocks. A block wider than the launch shape is refused as
+ * well, because the shared table set is sized for that shape. */
+template <int WaveSize>
+__global__ void __launch_bounds__(kBlockThreadsFor<WaveSize>)
+    gdeflate_decode_batch(const void* const* src_ptrs, const size_t* src_sizes,
+                          void* const* dst_ptrs, const size_t* dst_caps,
+                          size_t chunk_count, cudec_chunk_result* results) {
+    constexpr unsigned kWaveSize = static_cast<unsigned>(WaveSize);
+    __shared__ GDeflateTeamTables tables[kBlockWarps];
+
+    const unsigned lane = threadIdx.x % kWaveSize;
+    const unsigned wave_in_block = threadIdx.x / kWaveSize;
+    const size_t wave_in_grid =
+        (blockIdx.x * blockDim.x + threadIdx.x) / kWaveSize;
+    const size_t total_waves =
+        (static_cast<size_t>(gridDim.x) * blockDim.x) / kWaveSize;
+    if (total_waves == 0 || blockDim.x % kWaveSize != 0 ||
+        blockDim.x > kBlockThreadsFor<WaveSize>) {
+        return;
+    }
+
+    for (size_t chunk = wave_in_grid; chunk < chunk_count;
+         chunk += total_waves) {
+        const unsigned char* src =
+            static_cast<const unsigned char*>(src_ptrs[chunk]);
+        unsigned char* dst = static_cast<unsigned char*>(dst_ptrs[chunk]);
+        GDeflateWarpTeam<WaveSize> team(tables[wave_in_block], src, lane);
+        uint64_t out_len = 0;
+        GDeflateCensus census;
+        const bool ok = GDeflateDecodePageRounds(team, src_sizes[chunk], dst,
+                                                 dst_caps[chunk], &out_len,
+                                                 &census);
+        /* The verdict is team-uniform after every round and lane 0 carries
+         * the team's rung; one lane writes the 16-byte result. bytes_written
+         * is set on full success only. */
+        if (lane == 0) {
+            results[chunk].status =
+                ok ? CUDEC_OK : GDeflateStatusFor(team.Reject());
+            results[chunk].reserved = 0;
+            results[chunk].bytes_written = ok ? out_len : 0;
+        }
+        /* The next page's table build must not overtake a lane still
+         * reading this page's tables. */
+        __syncwarp();
+    }
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_GDEFLATE_DECODE_CUH */

--- a/src/gdeflate_schedule.h
+++ b/src/gdeflate_schedule.h
@@ -40,14 +40,25 @@
  * malformed. Nothing here ever sizes anything from the stream.
  *
  * THE HOST SHAPE AND THE DEVICE SHAPE ARE THE SAME FUNCTION, NOT THE SAME
- * LAYOUT. This struct holds all 32 lane buffers because the CPU twin runs the
- * lanes sequentially in one thread. In the warp kernel each lane owns its own
- * bit buffer and occupancy in registers while the lane index and the cursor
- * are warp-uniform, so the kernel instantiates the same arithmetic over a
- * different residency. What must not fork is the schedule itself, which is why
- * it lives in one place. The cursor is 64-bit for the reason the other parsers
- * give: the caller's sizes are size_t, and mixing widths in a bound comparison
- * is where an overflow hides. */
+ * LAYOUT. GDeflateSchedule holds all 32 lane buffers because the CPU twin runs
+ * the lanes sequentially in one thread. In the warp kernel each lane owns its
+ * own bit buffer and occupancy in registers while the cursor is warp-uniform,
+ * so the kernel instantiates the same arithmetic over a different residency
+ * (issue #214). That is why every primitive below is a template over the
+ * residency `S` rather than a function of GDeflateSchedule: `S` supplies the
+ * current lane's buffer and occupancy through Buf() and Left(), the sticky
+ * verdict through `failed` and `reject`, and the page's word count through
+ * `word_count`, and the arithmetic is written once. What must not fork is the
+ * schedule itself, which is why it lives in one place. The cursor is 64-bit
+ * for the reason the other parsers give: the caller's sizes are size_t, and
+ * mixing widths in a bound comparison is where an overflow hides.
+ *
+ * WHERE A RUNG IS NAMED. Each refusal below is named at exactly one site, and
+ * the sites that both residencies reach - the width checks of a read, the
+ * occupancy check of a remove, the bound of a refill, the shape of a page -
+ * name their rung into a caller's slot the way the table construction in
+ * src/gdeflate_tables.h does, so that a sequential Pop and a per-lane read on
+ * the device raise the same branch from the same line. */
 #ifndef CUDEC_GDEFLATE_SCHEDULE_H
 #define CUDEC_GDEFLATE_SCHEDULE_H
 
@@ -175,7 +186,7 @@ static_assert(kGDeflateRejectCount == kGDeflateRejectBlockLast + 1,
  * that libdeflate's GDeflate decompressor decodes, and each one is a decision
  * argued at its own refusal site rather than an accident:
  *
- *   - kGDeflateRejectRefillPastEnd, at GDeflateEnsure below: the reference
+ *   - kGDeflateRejectRefillPastEnd, at GDeflateRefillLane below: the reference
  *     reads a word past the last one the page holds, which the format's
  *     watermark discipline makes safe on a well-formed page and nothing makes
  *     safe on a hostile one.
@@ -217,7 +228,12 @@ CUDEC_HOST_DEVICE inline bool GDeflateRejectIsDeclaredDeparture(
 /* The 32 lane bit buffers, the current lane, and the one shared word cursor.
  * The failure flag is sticky: once set, every operation is a no-op, so a
  * caller that checks it once at the end reads the same verdict as one that
- * checks after every call. */
+ * checks after every call.
+ *
+ * This is the HOST residency of the schedule: one thread, every lane. Buf()
+ * and Left() are what the primitives below are written against, and here they
+ * select the current lane; the device residency in src/gdeflate_decode.cuh
+ * answers them with the one lane the calling thread owns. */
 struct GDeflateSchedule {
     uint64_t bitbuf[kGDeflateNumStreams];
     uint32_t bitsleft[kGDeflateNumStreams];
@@ -231,6 +247,11 @@ struct GDeflateSchedule {
      * a test asserting that its negative reached the branch it was written
      * for. Set only through the choke point below. */
     GDeflateReject reject;
+
+    CUDEC_HOST_DEVICE uint64_t& Buf() { return bitbuf[idx]; }
+    CUDEC_HOST_DEVICE const uint64_t& Buf() const { return bitbuf[idx]; }
+    CUDEC_HOST_DEVICE uint32_t& Left() { return bitsleft[idx]; }
+    CUDEC_HOST_DEVICE const uint32_t& Left() const { return bitsleft[idx]; }
 };
 
 /* THE ONE PLACE A REFUSAL IS RECORDED, for the reason SnappyRefuse is one in
@@ -244,8 +265,8 @@ struct GDeflateSchedule {
  * FIRST REFUSAL WINS. The flag is sticky and every operation is a no-op once
  * it is set, so a later call could only overwrite the branch with a
  * consequence of the first one. */
-CUDEC_HOST_DEVICE inline bool GDeflateRefuse(GDeflateSchedule& s,
-                                             GDeflateReject branch) {
+template <class S>
+CUDEC_HOST_DEVICE inline bool GDeflateRefuse(S& s, GDeflateReject branch) {
     if (!s.failed) {
         s.failed = true;
         s.reject = branch;
@@ -261,7 +282,8 @@ CUDEC_HOST_DEVICE inline bool GDeflateRefuse(GDeflateSchedule& s,
  * branch off the call site: a site passing a variable would have to be
  * exempted from that read, and an exemption spelled the same way as the rule
  * is how the rule stops being read. */
-CUDEC_HOST_DEVICE inline bool GDeflateRefuseAs(GDeflateSchedule& s,
+template <class S>
+CUDEC_HOST_DEVICE inline bool GDeflateRefuseAs(S& s,
                                                GDeflateReject already_named) {
     if (!s.failed) {
         s.failed = true;
@@ -294,28 +316,153 @@ CUDEC_HOST_DEVICE inline uint32_t GDeflateWordAt(const unsigned char* page,
            (static_cast<uint32_t>(p[3]) << 24);
 }
 
+/* A READ AHEAD OF THE LANE, WITHOUT CONSUMING. `consumed` is how many bits the
+ * caller has already read ahead and not yet removed, so a caller can resolve a
+ * codeword and the extra bits behind it as one speculative read and then
+ * remove the whole width at once - or remove nothing, which is how the warp
+ * kernel discards the lanes that must not have consumed after an end-of-block
+ * (docs/MASTERPLAN.md section 13.2). `why` is the rung the read refused on, and
+ * a read past a refusal returns zero and reads nothing more.
+ *
+ * The two refusals here are the two GDeflatePop always carried, in the same
+ * order: a width past the format's widest field is a caller asking for
+ * something no page encodes, while a lane that cannot serve a legal width is a
+ * page that ran out of bits where the schedule says it should not have. A
+ * single rung would let a negative for either satisfy the other. */
+struct GDeflateLaneRead {
+    uint32_t consumed;
+    GDeflateReject why;
+};
+
+CUDEC_HOST_DEVICE inline uint32_t GDeflateReadAhead(uint64_t bitbuf,
+                                                    uint32_t bitsleft,
+                                                    GDeflateLaneRead& r,
+                                                    uint32_t n) {
+    if (r.why != kGDeflateRejectNone) {
+        return 0;
+    }
+    if (n > kGDeflateMaxPopBits) {
+        GDeflateTableRefuse(&r.why, kGDeflateRejectPopWidthPastFormat);
+        return 0;
+    }
+    if (n > bitsleft - r.consumed) {
+        GDeflateTableRefuse(&r.why, kGDeflateRejectPopPastLane);
+        return 0;
+    }
+    /* `consumed + n` is at most `bitsleft`, which is below the buffer width,
+     * so neither shift can reach the undefined range; n == 0 reads nothing and
+     * the mask below is zero for it. */
+    const uint64_t window = bitbuf >> r.consumed;
+    const uint64_t mask = (static_cast<uint64_t>(1) << n) - 1u;
+    r.consumed += n;
+    return static_cast<uint32_t>(window & mask);
+}
+
+/* Whether a lane holding `bitsleft` bits can give up `n`. The occupancy is
+ * unsigned, so an unchecked subtraction would wrap to a lane that appears to
+ * hold four billion bits; this is the one site that names that rung, and both
+ * the sequential remove and the accelerator hit in src/gdeflate_tables.h ask it
+ * before they shift. */
+CUDEC_HOST_DEVICE inline bool GDeflateRemoveCheck(uint32_t bitsleft, uint32_t n,
+                                                  GDeflateReject* why) {
+    if (n > bitsleft) {
+        return GDeflateTableRefuse(why, kGDeflateRejectRemovePastLane);
+    }
+    return true;
+}
+
+/* Remove n bits from the current lane. Refuses rather than underflowing. */
+template <class S>
+CUDEC_HOST_DEVICE inline void GDeflateRemove(S& s, uint32_t n) {
+    if (s.failed) {
+        return;
+    }
+    GDeflateReject why = kGDeflateRejectNone;
+    if (!GDeflateRemoveCheck(s.Left(), n, &why)) {
+        GDeflateRefuseAs(s, why);
+        return;
+    }
+    s.Buf() >>= n;
+    s.Left() -= n;
+}
+
+/* Read n bits from the current lane without removing them. The width bound is
+ * not a policy: a shift of 64 or more is undefined, and this is a const read
+ * with no failure flag to set, so the only fail-closed answer available here
+ * is to hand back nothing. A caller reaching this is asking for a width the
+ * format has no field for, and the Remove that follows a peek carries the
+ * refusal that stops it going further. */
+template <class S>
+CUDEC_HOST_DEVICE inline uint32_t GDeflatePeek(const S& s, uint32_t n) {
+    if (n == 0 || n > kGDeflateMaxPopBits) {
+        return 0;
+    }
+    return static_cast<uint32_t>(s.Buf() &
+                                 ((static_cast<uint64_t>(1) << n) - 1));
+}
+
+/* Peek and remove. No refill: refills belong to Advance, and a read that
+ * quietly topped a lane up would move a word at a point the format does not,
+ * which is precisely the off-by-one this header exists to prevent. The width
+ * checks are GDeflateReadAhead's, so the sequential pop and the speculative
+ * per-lane read refuse from one site each. */
+template <class S>
+CUDEC_HOST_DEVICE inline uint32_t GDeflatePop(S& s, uint32_t n) {
+    if (s.failed) {
+        return 0;
+    }
+    GDeflateLaneRead r = {0, kGDeflateRejectNone};
+    const uint32_t value = GDeflateReadAhead(s.Buf(), s.Left(), r, n);
+    if (r.why != kGDeflateRejectNone) {
+        GDeflateRefuseAs(s, r.why);
+        return 0;
+    }
+    GDeflateRemove(s, n);
+    return value;
+}
+
+/* Hand the current lane the word at `word`. The bound is the page's word
+ * count, which came from the caller's compressed size and never from the
+ * bits; a well-formed page cannot reach past it, so this is a refusal and not
+ * a tail case: a decoder that carried on with a short buffer would be reading
+ * the lane's stale bits as if the stream had supplied them. The sequential
+ * Ensure below and the warp kernel's collective refill both take their word
+ * through here, so the rung has one site. */
+template <class S>
+CUDEC_HOST_DEVICE inline void GDeflateRefillLane(S& s,
+                                                 const unsigned char* page,
+                                                 uint64_t word) {
+    if (s.failed) {
+        return;
+    }
+    if (word >= s.word_count) {
+        GDeflateRefuse(s, kGDeflateRejectRefillPastEnd);
+        return;
+    }
+    s.Buf() |= static_cast<uint64_t>(GDeflateWordAt(page, word)) << s.Left();
+    s.Left() += kGDeflateBitsPerPacket;
+}
+
+/* Whether a lane is due a word: below the watermark, and not already failed,
+ * since a failed lane consumes nothing more. Named so the kernel's collective
+ * refill and the sequential one ask the same question. */
+template <class S>
+CUDEC_HOST_DEVICE inline bool GDeflateLaneNeedsRefill(const S& s) {
+    return !s.failed && s.Left() < kGDeflateLowWatermarkBits;
+}
+
 /* Refill the CURRENT lane if it has fallen below the watermark. Consumes at
  * most one word and never runs past the page. */
 CUDEC_HOST_DEVICE inline void GDeflateEnsure(GDeflateSchedule& s,
                                              const unsigned char* page) {
+    if (!GDeflateLaneNeedsRefill(s)) {
+        return;
+    }
+    GDeflateRefillLane(s, page, s.cursor);
     if (s.failed) {
         return;
     }
-    if (s.bitsleft[s.idx] >= kGDeflateLowWatermarkBits) {
-        return;
-    }
-    if (s.cursor >= s.word_count) {
-        /* The page has no word left to give this lane. A well-formed page
-         * cannot reach here, so this is a refusal and not a tail case: a
-         * decoder that carried on with a short buffer would be reading the
-         * lane's stale bits as if the stream had supplied them. */
-        GDeflateRefuse(s, kGDeflateRejectRefillPastEnd);
-        return;
-    }
-    s.bitbuf[s.idx] |= static_cast<uint64_t>(GDeflateWordAt(page, s.cursor))
-                       << s.bitsleft[s.idx];
     s.cursor += 1;
-    s.bitsleft[s.idx] += kGDeflateBitsPerPacket;
 }
 
 /* Ensure the current lane, then rotate. This order IS the schedule: the word a
@@ -343,6 +490,27 @@ CUDEC_HOST_DEVICE inline void GDeflateReset(GDeflateSchedule& s) {
     s.idx = 0;
 }
 
+/* The shape a page must have before a lane is primed: whole words only, and
+ * at least one word per lane. A trailing partial word is not a word this
+ * schedule could hand a lane, and rounding down would leave those bytes
+ * reachable by nothing while the page still claimed them; and draft section
+ * 5.3 says the first round always loads 32 consecutive words, so a stream
+ * below 128 bytes cannot be valid and is refused here rather than discovered
+ * part-way through the priming round. Both residencies prime through this, so
+ * each rung has one site. */
+CUDEC_HOST_DEVICE inline bool GDeflatePageShape(uint64_t page_bytes,
+                                                uint64_t* word_count,
+                                                GDeflateReject* why) {
+    *word_count = page_bytes / 4u;
+    if (page_bytes % 4u != 0u) {
+        return GDeflateTableRefuse(why, kGDeflateRejectPagePartialWord);
+    }
+    if (*word_count < kGDeflateNumStreams) {
+        return GDeflateTableRefuse(why, kGDeflateRejectPageBelowPrimingRound);
+    }
+    return true;
+}
+
 /* The priming round: one word into each lane, in lane order, leaving the
  * cursor at word 32 and the current lane back at 0. Returns false and leaves
  * the schedule failed if the page cannot carry it. */
@@ -357,79 +525,14 @@ CUDEC_HOST_DEVICE inline bool GDeflateInit(GDeflateSchedule& s,
     s.cursor = 0;
     s.failed = false;
     s.reject = kGDeflateRejectNone;
-    s.word_count = page_bytes / 4u;
-    /* Whole words only. A trailing partial word is not a word this schedule
-     * could hand a lane, and rounding down would leave those bytes reachable
-     * by nothing while the page still claimed them. */
-    if (page_bytes % 4u != 0u) {
-        return GDeflateRefuse(s, kGDeflateRejectPagePartialWord);
-    }
-    if (s.word_count < kGDeflateNumStreams) {
-        /* Draft section 5.3: the first round always loads 32 consecutive
-         * words, so a stream below 128 bytes cannot be valid. Refused here
-         * rather than discovered part-way through the priming round. */
-        return GDeflateRefuse(s, kGDeflateRejectPageBelowPrimingRound);
+    GDeflateReject why = kGDeflateRejectNone;
+    if (!GDeflatePageShape(page_bytes, &s.word_count, &why)) {
+        return GDeflateRefuseAs(s, why);
     }
     for (uint32_t n = 0; n < kGDeflateNumStreams; ++n) {
         GDeflateAdvance(s, page);
     }
     return !s.failed;
-}
-
-/* Read n bits from the current lane without removing them. The width bound is
- * not a policy: a shift of 64 or more is undefined, and this is a const read
- * with no failure flag to set, so the only fail-closed answer available here
- * is to hand back nothing. A caller reaching this is asking for a width the
- * format has no field for, and the Remove that follows a peek carries the
- * refusal that stops it going further. */
-CUDEC_HOST_DEVICE inline uint32_t GDeflatePeek(const GDeflateSchedule& s,
-                                               uint32_t n) {
-    if (n == 0 || n > kGDeflateMaxPopBits) {
-        return 0;
-    }
-    return static_cast<uint32_t>(s.bitbuf[s.idx] &
-                                 ((static_cast<uint64_t>(1) << n) - 1));
-}
-
-/* Remove n bits from the current lane. Refuses rather than underflowing: the
- * occupancy is unsigned, so an unchecked subtraction would wrap to a lane that
- * appears to hold four billion bits. */
-CUDEC_HOST_DEVICE inline void GDeflateRemove(GDeflateSchedule& s, uint32_t n) {
-    if (s.failed) {
-        return;
-    }
-    if (n > s.bitsleft[s.idx]) {
-        GDeflateRefuse(s, kGDeflateRejectRemovePastLane);
-        return;
-    }
-    s.bitbuf[s.idx] >>= n;
-    s.bitsleft[s.idx] -= n;
-}
-
-/* Peek and remove. No refill: refills belong to Advance, and a read that
- * quietly topped a lane up would move a word at a point the format does not,
- * which is precisely the off-by-one this header exists to prevent. */
-CUDEC_HOST_DEVICE inline uint32_t GDeflatePop(GDeflateSchedule& s, uint32_t n) {
-    if (s.failed) {
-        return 0;
-    }
-    /* Two refusals rather than one condition, because they are different
-     * failures and the ladder is what says so: a width past the format's
-     * widest field is a caller asking for something no page encodes, while a
-     * lane that cannot serve a legal width is a page that ran out of bits
-     * where the schedule says it should not have. A single rung would let a
-     * negative for either satisfy the other. */
-    if (n > kGDeflateMaxPopBits) {
-        GDeflateRefuse(s, kGDeflateRejectPopWidthPastFormat);
-        return 0;
-    }
-    if (n > s.bitsleft[s.idx]) {
-        GDeflateRefuse(s, kGDeflateRejectPopPastLane);
-        return 0;
-    }
-    const uint32_t value = GDeflatePeek(s, n);
-    GDeflateRemove(s, n);
-    return value;
 }
 
 /* The sum of every lane's occupancy. The reference computes exactly this to

--- a/src/gdeflate_tables.h
+++ b/src/gdeflate_tables.h
@@ -33,9 +33,15 @@
  * so it admits up to 288 and builds a table over all of them. Parity with the
  * reference is the rule the whole M4 ladder rests on, so the capacity follows
  * the reference. Two extra symbols are four bytes, and the two `kind` fields
- * are two more each: 3144 bytes per warp against the 3200-byte budget, where
- * 13.1 computed 3132. The margin narrows from 68 bytes to 56 and the occupancy
- * arithmetic is unmoved.
+ * are two more each: 3144 bytes per warp for the two live tables against the
+ * 3200-byte budget, where 13.1 computed 3132. What 13.1 did not cost is the
+ * rest of a dynamic block's table set, which every lane reads and therefore
+ * lives beside them in shared memory: the precode table, the code-length
+ * vector and the precode's own lengths, 691 bytes more (src/gdeflate_decode.cuh
+ * carries the set). Measured at the kernel (issue #214), 3832 bytes per warp
+ * and 77 registers put six blocks on an sm_86 multiprocessor, 24 resident
+ * warps against the 32 the budget was derived for; the perf pass (#204,
+ * #205) is where either number moves.
  *
  * FAIL-CLOSED, AND EXACTLY WHERE THE REFERENCE IS. `build_decode_table` in the
  * pinned fork refuses an over-subscribed vector, refuses an incomplete one,
@@ -50,7 +56,19 @@
  * a block whose distance code is empty decodes to a distance symbol that the
  * stream never encoded. Here that table refuses on use instead. A block that
  * declares no distances and uses none is unaffected, which is the only shape a
- * compressor produces. */
+ * compressor produces.
+ *
+ * THE ROUNDS ARE WRITTEN ONCE, OVER A TEAM (issue #214). The code-length rounds
+ * at the bottom of this file and the block loop in src/gdeflate_block.h are
+ * templates over a `Team`: the thing that says which lane is current, hands
+ * out output positions in lane order, finds the first lane that flagged, and
+ * refills the lanes that stepped. GDeflateHostTeam below is the sequential
+ * residency, one thread walking the 32 lanes in order over a GDeflateSchedule,
+ * and it is what every CPU twin runs. The warp residency in
+ * src/gdeflate_decode.cuh answers the same calls with a ballot, a prefix sum
+ * and a shuffle. What the rounds may assume of a team, and what a team may
+ * assume of the rounds, is written at GDeflateHostTeam, because that is the
+ * one that can be read without a device. */
 #ifndef CUDEC_GDEFLATE_TABLES_H
 #define CUDEC_GDEFLATE_TABLES_H
 
@@ -289,51 +307,62 @@ CUDEC_HOST_DEVICE inline bool GDeflateBuildTable(
  * caught by the flag on its next operation. */
 constexpr uint32_t kGDeflateNoSymbol = 0xFFFFu;
 
-/* Decode one symbol from the current lane. The accelerator is a peek, so a
- * miss has consumed nothing and the walk starts at length 1 rather than
- * part-way through a codeword.
+/* Resolve one symbol out of a lane's buffer WITHOUT consuming it. `r` carries
+ * how far ahead of the lane the read has gone and the rung it refused on, so a
+ * caller can resolve a codeword and the extra bits behind it as one
+ * speculative read and then remove `r.consumed` bits at once - or remove
+ * nothing, which is how a lane that must not have consumed after an
+ * end-of-block keeps the bits it entered the round with (docs/MASTERPLAN.md
+ * section 13.2). The accelerator is a peek, so a miss has cost nothing and the
+ * walk starts at length 1 rather than part-way through a codeword.
  *
- * EVERY EXIT THAT IS NOT A SYMBOL SETS THE SCHEDULE'S FAILURE FLAG. A lane
- * that cannot supply the bits a resolved codeword needs is refused by
- * GDeflateRemove rather than allowed to shift a buffer it does not hold, and a
- * walk that reaches the maximum length without matching has read a codeword
- * that the code does not contain, which on a complete code means the bits were
- * not produced by this table. */
+ * EVERY EXIT THAT IS NOT A SYMBOL NAMES A RUNG INTO `r.why`. A lane that cannot
+ * supply the bits a resolved codeword needs is refused by the occupancy check
+ * the sequential remove uses rather than allowed to shift a buffer it does not
+ * hold, and a walk that reaches the maximum length without matching has read a
+ * codeword that the code does not contain, which on a complete code means the
+ * bits were not produced by this table. */
 template <uint32_t kCapSyms, uint32_t kRootBits, uint32_t kMaxLen>
-CUDEC_HOST_DEVICE inline uint32_t GDeflateDecodeSymbol(
-    GDeflateSchedule& s,
-    const GDeflateHuffTable<kCapSyms, kRootBits, kMaxLen>& t) {
-    if (s.failed) {
+CUDEC_HOST_DEVICE inline uint32_t GDeflateResolveSymbol(
+    const GDeflateHuffTable<kCapSyms, kRootBits, kMaxLen>& t, uint64_t bitbuf,
+    uint32_t bitsleft, GDeflateLaneRead& r) {
+    if (r.why != kGDeflateRejectNone) {
         return kGDeflateNoSymbol;
     }
     if (t.kind == kGDeflateTableEmpty) {
         /* Stricter than the reference, deliberately: it hands back a symbol
          * the stream never encoded, and a distance built from that symbol is
          * indistinguishable from one the page asked for. */
-        GDeflateRefuse(s, kGDeflateRejectEmptyTableUsed);
+        GDeflateTableRefuse(&r.why, kGDeflateRejectEmptyTableUsed);
         return kGDeflateNoSymbol;
     }
     if (t.kind == kGDeflateTableSingle) {
-        GDeflateRemove(s, 1);
-        if (s.failed) {
+        if (!GDeflateRemoveCheck(bitsleft - r.consumed, 1u, &r.why)) {
             return kGDeflateNoSymbol;
         }
+        r.consumed += 1u;
         return t.sorted[0];
     }
-    const uint32_t probe = GDeflatePeek(s, kRootBits);
+    /* The probe reads the buffer past the lane's occupancy, as the sequential
+     * peek always did: the bits above `bitsleft` are zero by the schedule's
+     * invariant, so a short lane resolves to some entry and the occupancy
+     * check below is what refuses it. */
+    const uint64_t window = bitbuf >> r.consumed;
+    const uint32_t probe =
+        static_cast<uint32_t>(window & ((1u << kRootBits) - 1u));
     const uint16_t entry = t.root[probe];
     const uint32_t hit_len = entry & kGDeflateRootLenMask;
     if (hit_len != 0) {
-        GDeflateRemove(s, hit_len);
-        if (s.failed) {
+        if (!GDeflateRemoveCheck(bitsleft - r.consumed, hit_len, &r.why)) {
             return kGDeflateNoSymbol;
         }
+        r.consumed += hit_len;
         return entry >> kGDeflateRootLenBits;
     }
     uint32_t code = 0;
     for (uint32_t len = 1; len <= kMaxLen; len++) {
-        const uint32_t bit = GDeflatePop(s, 1);
-        if (s.failed) {
+        const uint32_t bit = GDeflateReadAhead(bitbuf, bitsleft, r, 1u);
+        if (r.why != kGDeflateRejectNone) {
             return kGDeflateNoSymbol;
         }
         code = (code << 1) | bit;
@@ -342,10 +371,29 @@ CUDEC_HOST_DEVICE inline uint32_t GDeflateDecodeSymbol(
             return t.sorted[t.first_index[len] + (code - t.first_code[len])];
         }
     }
-    GDeflateRefuse(s, kGDeflateRejectCodewordNotInCode);
+    GDeflateTableRefuse(&r.why, kGDeflateRejectCodewordNotInCode);
     return kGDeflateNoSymbol;
 }
 
+/* Decode one symbol from the current lane, consuming it: the resolve above
+ * followed by the remove, with the rung the resolve named raised on the
+ * schedule. This is the sequential shape the twins drive; the rounds below
+ * resolve first and commit later, and go through the same resolve. */
+template <class S, uint32_t kCapSyms, uint32_t kRootBits, uint32_t kMaxLen>
+CUDEC_HOST_DEVICE inline uint32_t GDeflateDecodeSymbol(
+    S& s, const GDeflateHuffTable<kCapSyms, kRootBits, kMaxLen>& t) {
+    if (s.failed) {
+        return kGDeflateNoSymbol;
+    }
+    GDeflateLaneRead r = {0, kGDeflateRejectNone};
+    const uint32_t sym = GDeflateResolveSymbol(t, s.Buf(), s.Left(), r);
+    if (r.why != kGDeflateRejectNone) {
+        GDeflateRefuseAs(s, r.why);
+        return kGDeflateNoSymbol;
+    }
+    GDeflateRemove(s, r.consumed);
+    return sym;
+}
 
 /* THE DYNAMIC BLOCK'S CODE-LENGTH ROUNDS (issue #176). Everything above turns
  * a length vector into a table; this turns a page into the length vectors. It
@@ -360,7 +408,7 @@ CUDEC_HOST_DEVICE inline uint32_t GDeflateDecodeSymbol(
  * expanded length - a repeat code and its extra bits together - is its own
  * round as well. An extra-bit field read in the round AFTER its code would
  * decode a different page and raise no error, which is why the extra bits are
- * popped before the Advance rather than after it.
+ * read before the lane steps rather than after it.
  *
  * WHERE THIS IS STRICTER THAN THE REFERENCE, STATED RATHER THAN LEFT TO BE
  * FOUND. A repeat run reaching past HLIT + HDIST is refused here. The
@@ -415,17 +463,222 @@ struct GDeflateCodeLengths {
     uint32_t num_dist;
 };
 
+/* One lane's outstanding match: the length it reserved and where in the output
+ * that reservation starts. Held per lane for the reason GDeflateSchedule holds
+ * all 32 bit buffers - the CPU twin runs the lanes sequentially in one thread,
+ * while in the warp kernel each lane owns its own copy state in registers. The
+ * reference keeps the same thing as a rotating 32-bit mask beside a per-lane
+ * array; a mask and a flag per lane are the same set, and the flag is the
+ * shape that reads correctly in both residencies. */
+struct GDeflateDeferredCopy {
+    uint64_t out_pos;
+    uint32_t length;
+    bool pending;
+};
+
+/* The answer FirstLane gives when no lane flagged. One past the last lane, so
+ * that `lane < first` is true of every lane and `lane == first` of none. */
+constexpr uint32_t kGDeflateNoLane = kGDeflateNumStreams;
+
+/* THE SEQUENTIAL TEAM, and the contract both residencies keep.
+ *
+ * What a team owes the rounds: Bits() is the calling lane's residency of the
+ * schedule primitives (buffer, occupancy, verdict, word count); Copy() its
+ * deferred match; Lane() its index; Active() whether it takes part in the
+ * round in progress. LitLen(), Dist(), Precode(), Lens() and PrecodeLens() are
+ * the block's table set, one per team. Round(n, f) runs f once per lane on the
+ * first n lanes and then refills every lane that STEPPED - f returns whether
+ * its lane did, because a lane that took no step is not refilled by the
+ * format: the code-length rounds stop mid-round when the vector is full and
+ * the lanes after that point keep their bits. Lane0(f) runs f on lane 0 alone
+ * with no refill, which is the block header and the stored length; EnsureLane0
+ * is the reference's ENSURE_BITS on lane 0 with no rotation. Build(f) runs f
+ * once for the team, which is the table construction. Reset() returns the
+ * sequential residency to lane 0 and is nothing on the warp.
+ *
+ * What the rounds owe a team, and it is the discipline that makes the warp
+ * residency sound: inside f, every collective - Claim, FirstLane, CopyBytes,
+ * Serial, Broadcast - is called exactly once per lane per round, at the same
+ * point, by every lane whether or not it is Active(), with a neutral argument
+ * from a lane that has nothing to contribute. The sequential residency does
+ * not need that, because it runs one lane at a time; the warp residency needs
+ * it because a collective is a point every lane of the wave must reach.
+ *
+ * The collectives are PREFIX operations by definition: Claim(base, len) hands
+ * this lane the position after every LOWER lane's claim and advances `base`
+ * past every lane's; FirstLane(flag) names the lowest flagging lane at or below
+ * this one, or kGDeflateNoLane. On the warp both are computed over the whole
+ * team at once, so FirstLane may name a HIGHER lane there; every comparison
+ * the rounds make against its answer - below it, at it, above it - reads the
+ * same on both, which is what lets one round body serve two residencies.
+ *
+ * CopyBytes(active, out, dst, src, len) performs the copies of every lane that
+ * asked, in lane order, and a copy reads only bytes that lie before the
+ * reservation it fills, so the order is the whole of what the deferred copy
+ * needs. Serial(active, f) runs f on the asking lanes in lane order with each
+ * one's writes visible to the next, which is what the code-length expansion
+ * needs for "repeat the previous length".
+ *
+ * On the sequential residency a refusal stops the round at the lane that
+ * refused, exactly as the reference's loop stops; on the warp every lane
+ * finishes the round and the lowest refusing lane's rung is the team's, which
+ * is the same verdict because no lane's step depends on a higher lane. */
+class GDeflateHostTeam {
+   public:
+    CUDEC_HOST_DEVICE GDeflateHostTeam(GDeflateSchedule& s,
+                                       const unsigned char* page,
+                                       GDeflateCodeLengths* lens,
+                                       GDeflateLitLenTable* litlen,
+                                       GDeflateDistTable* dist)
+        : s_(s),
+          page_(page),
+          lens_(lens),
+          litlen_(litlen),
+          dist_(dist),
+          first_(kGDeflateNoLane) {
+        for (uint32_t n = 0; n < kGDeflateNumStreams; n++) {
+            copies_[n].out_pos = 0;
+            copies_[n].length = 0;
+            copies_[n].pending = false;
+        }
+    }
+
+    CUDEC_HOST_DEVICE GDeflateSchedule& Bits() { return s_; }
+    CUDEC_HOST_DEVICE GDeflateDeferredCopy& Copy() { return copies_[s_.idx]; }
+    CUDEC_HOST_DEVICE uint32_t Lane() const { return s_.idx; }
+    CUDEC_HOST_DEVICE bool Active() const { return true; }
+    CUDEC_HOST_DEVICE bool Failed() const { return s_.failed; }
+    CUDEC_HOST_DEVICE uint64_t Cursor() const { return s_.cursor; }
+    CUDEC_HOST_DEVICE uint64_t WordCount() const { return s_.word_count; }
+    CUDEC_HOST_DEVICE const unsigned char* Page() const { return page_; }
+
+    CUDEC_HOST_DEVICE GDeflateLitLenTable& LitLen() { return *litlen_; }
+    CUDEC_HOST_DEVICE GDeflateDistTable& Dist() { return *dist_; }
+    CUDEC_HOST_DEVICE GDeflatePrecodeTable& Precode() { return precode_; }
+    CUDEC_HOST_DEVICE GDeflateCodeLengths& Lens() { return *lens_; }
+    CUDEC_HOST_DEVICE unsigned char* PrecodeLens() { return precode_lens_; }
+
+    /* The priming round is GDeflateInit's, so the sequential team primes by
+     * calling it: one word into each lane in lane order, refused before any
+     * lane is touched when the page cannot carry it. */
+    CUDEC_HOST_DEVICE bool Prime(uint64_t page_bytes) {
+        return GDeflateInit(s_, page_, page_bytes);
+    }
+
+    template <class F>
+    CUDEC_HOST_DEVICE void Round(uint32_t lanes, F f) {
+        first_ = kGDeflateNoLane;
+        for (uint32_t l = 0; l < lanes; l++) {
+            s_.idx = l;
+            const bool stepped = f(*this);
+            if (s_.failed) {
+                return;
+            }
+            if (stepped) {
+                GDeflateAdvance(s_, page_);
+                if (s_.failed) {
+                    return;
+                }
+            }
+        }
+    }
+
+    template <class F>
+    CUDEC_HOST_DEVICE void Lane0(F f) {
+        s_.idx = 0;
+        f(*this);
+    }
+
+    CUDEC_HOST_DEVICE void EnsureLane0() {
+        s_.idx = 0;
+        GDeflateEnsure(s_, page_);
+    }
+
+    CUDEC_HOST_DEVICE void Reset() { GDeflateReset(s_); }
+
+    template <class F>
+    CUDEC_HOST_DEVICE void Build(F f) {
+        f(*this);
+    }
+
+    template <class T>
+    CUDEC_HOST_DEVICE T Broadcast(T value) const {
+        return value;
+    }
+
+    CUDEC_HOST_DEVICE uint64_t Claim(uint64_t& base, uint64_t len) {
+        const uint64_t pos = base;
+        base += len;
+        return pos;
+    }
+
+    CUDEC_HOST_DEVICE uint32_t FirstLane(bool flag) {
+        if (flag && first_ == kGDeflateNoLane) {
+            first_ = s_.idx;
+        }
+        return first_;
+    }
+
+    /* Byte by byte, forwards, which is what an overlapping match MEANS: a
+     * distance below the length is a run that repeats what this copy is
+     * itself writing. The warp residency copies the same bytes through the
+     * closed-form gather the LZ4 kernel uses, and the two agree byte for byte
+     * because every source byte of an overlapping copy is a byte this copy
+     * wrote earlier in that same order (docs/DETERMINISM.md). */
+    CUDEC_HOST_DEVICE void CopyBytes(bool active, unsigned char* out,
+                                     uint64_t dst, uint64_t src,
+                                     uint64_t len) {
+        if (!active) {
+            return;
+        }
+        for (uint64_t n = 0; n < len; n++) {
+            out[dst + n] = out[src + n];
+        }
+    }
+
+    template <class F>
+    CUDEC_HOST_DEVICE void Serial(bool active, F f) {
+        if (active) {
+            f(*this);
+        }
+    }
+
+    CUDEC_HOST_DEVICE uint64_t BufferedBits() const {
+        return GDeflateBufferedBits(s_);
+    }
+
+    CUDEC_HOST_DEVICE void ClearCopies() {
+        for (uint32_t n = 0; n < kGDeflateNumStreams; n++) {
+            copies_[n].pending = false;
+            copies_[n].length = 0;
+            copies_[n].out_pos = 0;
+        }
+    }
+
+   private:
+    GDeflateSchedule& s_;
+    const unsigned char* page_;
+    GDeflateCodeLengths* lens_;
+    GDeflateLitLenTable* litlen_;
+    GDeflateDistTable* dist_;
+    GDeflatePrecodeTable precode_;
+    unsigned char precode_lens_[kGDeflateNumPrecodeSyms];
+    GDeflateDeferredCopy copies_[kGDeflateNumStreams];
+    uint32_t first_;
+};
+
 /* Read a dynamic block's code-length vectors, entered immediately after BTYPE
- * has been popped off lane 0. Returns false with the schedule failed for every
- * shape this decoder refuses, and `out` is not to be read in that case.
+ * has been popped off lane 0. Returns false with the team failed for every
+ * shape this decoder refuses, and the team's Lens() is not to be read in that
+ * case.
  *
  * NOTHING HERE IS SIZED FROM THE STREAM. HLIT and HDIST are five-bit fields
  * and HCLEN is four, so the three counts are bounded by the field widths
  * rather than by a check: the static assertions below say that the capacities
  * this file declares are exactly the values those fields reach, which is the
  * form that fails at compile time if a capacity is ever changed alone. */
-CUDEC_HOST_DEVICE inline bool GDeflateReadCodeLengths(
-    GDeflateSchedule& s, const unsigned char* page, GDeflateCodeLengths& out) {
+template <class Team>
+CUDEC_HOST_DEVICE inline bool GDeflateReadCodeLengthRounds(Team& t) {
     static_assert(kGDeflateNumLitLenSyms == 257 + ((1u << 5) - 1u),
                   "HLIT is five bits above 257, so the literal/length "
                   "capacity must be the highest value that field reaches");
@@ -439,100 +692,170 @@ CUDEC_HOST_DEVICE inline bool GDeflateReadCodeLengths(
     /* The reference's ENSURE_BITS after BTYPE. Idempotent - a lane at or above
      * the watermark is left alone - so a caller that ensured already is not
      * charged a second word for calling this. */
-    GDeflateEnsure(s, page);
-
-    const uint32_t num_litlen = GDeflatePop(s, 5) + 257u;
-    const uint32_t num_dist = GDeflatePop(s, 5) + 1u;
-    const uint32_t num_explicit = GDeflatePop(s, 4) + 4u;
-    if (s.failed) {
+    t.EnsureLane0();
+    if (t.Failed()) {
         return false;
     }
-    GDeflateEnsure(s, page);
+
+    /* The three counts ride lane 0 and every lane needs them, so they travel
+     * as one packed word: the two five-bit fields and the four-bit one fit in
+     * fourteen bits, and one broadcast is what a lane-0 read costs the team. */
+    uint32_t header = 0;
+    t.Lane0([&](Team& lane0) {
+        auto& b = lane0.Bits();
+        const uint32_t num_litlen = GDeflatePop(b, 5);
+        const uint32_t num_dist = GDeflatePop(b, 5);
+        const uint32_t num_explicit = GDeflatePop(b, 4);
+        header = num_litlen | (num_dist << 5) | (num_explicit << 10);
+    });
+    header = t.Broadcast(header);
+    if (t.Failed()) {
+        return false;
+    }
+    const uint32_t num_litlen = (header & 0x1Fu) + 257u;
+    const uint32_t num_dist = ((header >> 5) & 0x1Fu) + 1u;
+    const uint32_t num_explicit = ((header >> 10) & 0xFu) + 4u;
+    t.EnsureLane0();
+    if (t.Failed()) {
+        return false;
+    }
 
     /* Every precode length the header does not state is zero: HCLEN says how
      * many of the nineteen are present, and an absent one is absent from the
-     * code rather than undefined. */
-    unsigned char precode_lens[kGDeflateNumPrecodeSyms];
-    for (uint32_t i = 0; i < kGDeflateNumPrecodeSyms; i++) {
-        precode_lens[i] = 0;
-    }
-    for (uint32_t i = 0; i < num_explicit; i++) {
-        precode_lens[GDeflatePrecodeOrder(i)] =
-            static_cast<unsigned char>(GDeflatePop(s, 3));
-        GDeflateAdvance(s, page);
-    }
-    if (s.failed) {
+     * code rather than undefined. Each explicit one is its own round on its
+     * own lane, lane i holding the i-th in the permuted order. */
+    t.Build([&](Team& one) {
+        unsigned char* precode_lens = one.PrecodeLens();
+        for (uint32_t i = 0; i < kGDeflateNumPrecodeSyms; i++) {
+            precode_lens[i] = 0;
+        }
+    });
+    t.Round(num_explicit, [&](Team& lane) -> bool {
+        if (!lane.Active()) {
+            return false;
+        }
+        const uint32_t len = GDeflatePop(lane.Bits(), 3);
+        if (!lane.Bits().failed) {
+            lane.PrecodeLens()[GDeflatePrecodeOrder(lane.Lane())] =
+                static_cast<unsigned char>(len);
+        }
+        return true;
+    });
+    if (t.Failed()) {
         return false;
     }
 
-    GDeflatePrecodeTable precode;
-    GDeflateReject precode_why = kGDeflateRejectNone;
-    if (!GDeflateBuildTable(precode_lens, kGDeflateNumPrecodeSyms, precode,
-                            &precode_why)) {
-        /* The flag, not just the return. A precode that is not a code is bad
-         * input like any other refusal here, and this header's own contract
-         * says a caller that checks the sticky flag once at the end reads the
-         * same verdict as one that checks after every call - so a refusal that
-         * left the flag clear would break that contract silently. Found by
-         * fuzz/fuzz_gdeflate_tables.cpp on its first seed replay. */
-        return GDeflateRefuseAs(s, precode_why);
+    t.Build([&](Team& one) {
+        GDeflateReject precode_why = kGDeflateRejectNone;
+        if (!GDeflateBuildTable(one.PrecodeLens(), kGDeflateNumPrecodeSyms,
+                                one.Precode(), &precode_why)) {
+            /* The flag, not just the return. A precode that is not a code is
+             * bad input like any other refusal here, and this header's own
+             * contract says a caller that checks the sticky flag once at the
+             * end reads the same verdict as one that checks after every call
+             * - so a refusal that left the flag clear would break that
+             * contract silently. Found by fuzz/fuzz_gdeflate_tables.cpp on its
+             * first seed replay. */
+            GDeflateRefuseAs(one.Bits(), precode_why);
+        }
+    });
+    if (t.Failed()) {
+        return false;
     }
 
     /* The expansion starts at a reset exactly as the header did, so the first
      * length rides lane 0. */
-    GDeflateReset(s);
+    t.Reset();
     const uint32_t total = num_litlen + num_dist;
-    /* The increment lives in the body because a round writes one length or a
-     * run of them, and which it was is not known until the symbol is decoded.
-     * It terminates on every input all the same: each pass either writes at
-     * least one length or returns, and the run bound below is what keeps the
-     * write inside the alphabet. */
-    for (uint32_t i = 0; i < total;) {
-        const uint32_t presym = GDeflateDecodeSymbol(s, precode);
-        if (presym == kGDeflateNoSymbol) {
-            return false;
-        }
-        if (presym < kGDeflateRepeatPrev) {
-            out.lens[i++] = static_cast<unsigned char>(presym);
-            GDeflateAdvance(s, page);
-            continue;
-        }
-
-        unsigned char rep_val = 0;
-        uint32_t rep_count = 0;
-        if (presym == kGDeflateRepeatPrev) {
-            if (i == 0) {
-                /* Nothing to repeat. The reference refuses this as well, and
-                 * it is the one repeat-code refusal the two decoders share. */
-                return GDeflateRefuse(s, kGDeflateRejectRepeatNothingBefore);
+    /* One length or one run per lane per round, and a lane whose position is
+     * already past the vector takes no step at all: the reference's loop
+     * stops at that lane, and the lanes after it keep their bits. Every
+     * round either advances `filled` by at least one or refuses, and the run
+     * bound below is what keeps the write inside the alphabet; the round cap
+     * is the vector's own length, since a round that fills nothing refuses. */
+    uint64_t filled = 0;
+    for (uint32_t round = 0; round <= total && filled < total; round++) {
+        t.Round(kGDeflateNumStreams, [&](Team& lane) -> bool {
+            GDeflateLaneRead r = {0, kGDeflateRejectNone};
+            GDeflateReject extra_why = kGDeflateRejectNone;
+            uint32_t presym = kGDeflateNoSymbol;
+            uint64_t count = 0;
+            unsigned char value = 0;
+            bool repeat_prev = false;
+            if (lane.Active()) {
+                const uint64_t buf = lane.Bits().Buf();
+                const uint32_t left = lane.Bits().Left();
+                presym = GDeflateResolveSymbol(lane.Precode(), buf, left, r);
+                if (r.why == kGDeflateRejectNone) {
+                    if (presym < kGDeflateRepeatPrev) {
+                        count = 1;
+                        value = static_cast<unsigned char>(presym);
+                    } else {
+                        uint32_t extra = 0;
+                        if (presym == kGDeflateRepeatPrev) {
+                            repeat_prev = true;
+                            extra = 3u + GDeflateReadAhead(buf, left, r, 2);
+                        } else if (presym == kGDeflateRepeatZeroShort) {
+                            extra = 3u + GDeflateReadAhead(buf, left, r, 3);
+                        } else {
+                            extra = 11u + GDeflateReadAhead(buf, left, r, 7);
+                        }
+                        /* The codeword resolved; a shortage here is the extra
+                         * bits', which the reference refuses AFTER the
+                         * nothing-to-repeat check below, so it is held apart
+                         * from the codeword's rung and raised in that order. */
+                        extra_why = r.why;
+                        count = (extra_why == kGDeflateRejectNone) ? extra : 0;
+                    }
+                } else {
+                    count = 0;
+                }
             }
-            rep_val = out.lens[i - 1];
-            rep_count = 3u + GDeflatePop(s, 2);
-        } else if (presym == kGDeflateRepeatZeroShort) {
-            rep_count = 3u + GDeflatePop(s, 3);
-        } else {
-            rep_count = 11u + GDeflatePop(s, 7);
-        }
-        if (s.failed) {
+            const uint64_t start = lane.Claim(filled, count);
+            const bool commit = lane.Active() && start < total;
+            if (commit) {
+                auto& b = lane.Bits();
+                if (r.why != kGDeflateRejectNone) {
+                    GDeflateRefuseAs(b, r.why);
+                } else if (repeat_prev && start == 0) {
+                    /* Nothing to repeat. The reference refuses this as well,
+                     * and it is the one repeat-code refusal the two decoders
+                     * share. */
+                    GDeflateRefuse(b, kGDeflateRejectRepeatNothingBefore);
+                } else if (extra_why != kGDeflateRejectNone) {
+                    GDeflateRefuseAs(b, extra_why);
+                } else if (count > total - start) {
+                    /* See the block comment above: refused rather than
+                     * absorbed into slack this alphabet does not carry.
+                     * Written as a subtraction on the side that cannot
+                     * overflow - `start` is below `total` here, so
+                     * `total - start` is what is left rather than a sum that
+                     * could wrap. */
+                    GDeflateRefuse(b, kGDeflateRejectRepeatRunPastAlphabet);
+                } else {
+                    GDeflateRemove(b, r.consumed);
+                }
+            }
+            const bool writes = commit && !lane.Bits().failed;
+            lane.Serial(writes, [&](Team& one) {
+                unsigned char* lens = one.Lens().lens;
+                if (repeat_prev) {
+                    value = lens[start - 1];
+                }
+                for (uint64_t n = 0; n < count; n++) {
+                    lens[start + n] = value;
+                }
+            });
+            return commit;
+        });
+        if (t.Failed()) {
             return false;
         }
-        if (rep_count > total - i) {
-            /* See the block comment above: refused rather than absorbed into
-             * slack this alphabet does not carry. Written as a subtraction on
-             * the side that cannot overflow - `i` is below `total` here, so
-             * `total - i` is what is left rather than a sum that could wrap. */
-            return GDeflateRefuse(s, kGDeflateRejectRepeatRunPastAlphabet);
-        }
-        for (uint32_t n = 0; n < rep_count; n++) {
-            out.lens[i++] = rep_val;
-        }
-        GDeflateAdvance(s, page);
     }
-    if (s.failed) {
-        return false;
-    }
-    out.num_litlen = num_litlen;
-    out.num_dist = num_dist;
+    t.Build([&](Team& one) {
+        one.Lens().num_litlen = num_litlen;
+        one.Lens().num_dist = num_dist;
+    });
     return true;
 }
 
@@ -540,28 +863,51 @@ CUDEC_HOST_DEVICE inline bool GDeflateReadCodeLengths(
  * Split from the read so the code-length round is provable on its own - a
  * vector recovered wrongly and a vector that merely fails to build a table are
  * different failures, and one entry point would report them as one. */
-CUDEC_HOST_DEVICE inline bool GDeflateReadDynamicTables(
-    GDeflateSchedule& s, const unsigned char* page, GDeflateCodeLengths& lens,
-    GDeflateLitLenTable& litlen, GDeflateDistTable& dist) {
-    if (!GDeflateReadCodeLengths(s, page, lens)) {
+template <class Team>
+CUDEC_HOST_DEVICE inline bool GDeflateReadDynamicTableRounds(Team& t) {
+    if (!GDeflateReadCodeLengthRounds(t)) {
         return false;
     }
-    GDeflateReject why = kGDeflateRejectNone;
-    if (!GDeflateBuildTable(lens.lens, lens.num_litlen, litlen, &why)) {
-        /* A vector that is not a code is bad input, so the schedule carries
-         * the same verdict a bad round would leave: a caller that checks only
-         * the flag must not read this as a page still worth decoding. The rung
-         * is the one the construction named, not a second one saying which of
-         * the two vectors carried it: what refused is the property of the
-         * lengths, and a rung per call site would be two rungs one negative
-         * could not tell apart. */
-        return GDeflateRefuseAs(s, why);
-    }
-    if (!GDeflateBuildTable(lens.lens + lens.num_litlen, lens.num_dist, dist,
-                            &why)) {
-        return GDeflateRefuseAs(s, why);
-    }
-    return true;
+    t.Build([&](Team& one) {
+        GDeflateReject why = kGDeflateRejectNone;
+        const GDeflateCodeLengths& lens = one.Lens();
+        if (!GDeflateBuildTable(lens.lens, lens.num_litlen, one.LitLen(),
+                                &why)) {
+            /* A vector that is not a code is bad input, so the schedule
+             * carries the same verdict a bad round would leave: a caller that
+             * checks only the flag must not read this as a page still worth
+             * decoding. The rung is the one the construction named, not a
+             * second one saying which of the two vectors carried it: what
+             * refused is the property of the lengths, and a rung per call
+             * site would be two rungs one negative could not tell apart. */
+            GDeflateRefuseAs(one.Bits(), why);
+            return;
+        }
+        if (!GDeflateBuildTable(lens.lens + lens.num_litlen, lens.num_dist,
+                                one.Dist(), &why)) {
+            GDeflateRefuseAs(one.Bits(), why);
+        }
+    });
+    return !t.Failed();
+}
+
+/* The sequential entry points, which the twins and the fuzz targets drive:
+ * the rounds above over the host team, on a schedule positioned immediately
+ * after BTYPE has been popped off lane 0. */
+inline bool GDeflateReadCodeLengths(GDeflateSchedule& s,
+                                    const unsigned char* page,
+                                    GDeflateCodeLengths& out) {
+    GDeflateHostTeam t(s, page, &out, nullptr, nullptr);
+    return GDeflateReadCodeLengthRounds(t);
+}
+
+inline bool GDeflateReadDynamicTables(GDeflateSchedule& s,
+                                      const unsigned char* page,
+                                      GDeflateCodeLengths& lens,
+                                      GDeflateLitLenTable& litlen,
+                                      GDeflateDistTable& dist) {
+    GDeflateHostTeam t(s, page, &lens, &litlen, &dist);
+    return GDeflateReadDynamicTableRounds(t);
 }
 
 }  // namespace cudec_detail

--- a/src/vendor_rt.h
+++ b/src/vendor_rt.h
@@ -66,6 +66,11 @@
 #define CUDEC_RT_DEVICE_GET_ATTRIBUTE hipDeviceGetAttribute
 #define CUDEC_RT_ATTR_WAVE_WIDTH hipDeviceAttributeWarpSize
 #define CUDEC_RT_FIXED_WAVE_WIDTH 0
+/* The mask that names every lane of a wave, in the width the backend's
+ * collectives take it: sixty-four bits here, where a wave may be sixty-four
+ * lanes wide. A kernel names its participants with this and never with a
+ * literal, so one spelling is right on both backends. */
+#define CUDEC_RT_WAVE_FULL_MASK 0xffffffffffffffffull
 
 #else
 #include <cuda_runtime.h>
@@ -98,6 +103,7 @@
 #define CUDEC_RT_DEVICE_GET_ATTRIBUTE cudaDeviceGetAttribute
 #define CUDEC_RT_ATTR_WAVE_WIDTH cudaDevAttrWarpSize
 #define CUDEC_RT_FIXED_WAVE_WIDTH 32
+#define CUDEC_RT_WAVE_FULL_MASK 0xffffffffu
 
 #endif
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,6 +234,15 @@ cudec_add_test(gdeflate_departure_lock SOURCES gdeflate_departure_lock.cpp LIBS
                gdeflate_oracle)
 target_include_directories(gdeflate_departure_lock
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The GDeflate warp kernel on the device (issue #214): the reference's
+# compressor makes the pages, every page goes through the batch entry into a
+# poisoned tile, and the answer is held to the source and to the host twin -
+# bytes on a decode, rung on a refusal - so the oracle parity and the reject
+# ladder the twin established become the kernel's. GPU-labelled: it drives the
+# shipped kernel. It links gdeflate_oracle for the compressor, and reaches
+# src/ for the twin it compares against.
+cudec_add_test(gdeflate_device SOURCES gdeflate_device.cu GPU LIBS
+               gdeflate_oracle)
 # The reference's own decode behaviours, executed rather than read (issue
 # #155). Host-side and GPU-less on purpose: it is the oracle answering, and
 # the answers are what the M3 fail-closed matrix is allowed to lock against.

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -129,17 +129,14 @@ int main(void) {
                                             aligned,
                                             0) == CUDEC_ERR_INVALID_ARGUMENT);
 
-    /* The ninth class, which exists on this entry and on neither of the
-     * others: a batch that PASSES validation while this build carries no
-     * GDeflate kernel is answered with the defined not-implemented status.
-     * Safe here for the same reason every call above is - the entry makes
-     * no CUDA call and dereferences none of these host pointers - and it is
-     * what freezes the contract: the day the kernel lands this line becomes
-     * an assertion about output, and until then it refuses both a silent
-     * CUDEC_OK over a batch nothing decoded and an absent symbol. */
-    REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 1,
-                                            aligned,
-                                            0) == CUDEC_ERR_NOT_IMPLEMENTED);
+    /* The ninth class this entry carried while it had no kernel - a
+     * validation-passing batch answered with the defined not-implemented
+     * status - is gone with the kernel (issue #214), and no call replaces it
+     * here: an accepted batch now reaches a launch, and these are host
+     * pointers this GPU-less test must never hand to one. What that class
+     * froze still holds and is asserted where a device can read it: the
+     * symbol and the eight reject classes above did not move, and
+     * tests/launch_fail.cpp holds the launch half on a GPU-less process. */
 
     /* The same nine classes on the Zstd entry (issue #427), written out call
      * for call for the reason the two blocks above are: a future entry wired

--- a/tests/gdeflate_device.cu
+++ b/tests/gdeflate_device.cu
@@ -1,0 +1,575 @@
+/* The GDeflate warp kernel against the oracle and against its own twin
+ * (issue #214). The reference's compressor produces the pages, the reference's
+ * decompressor and the source say what they mean, and every page goes through
+ * cudec_gdeflate_decompress_batch on the device with a poisoned destination:
+ * the bytes must equal the source, the poison beyond bytes_written must
+ * survive, and the answer must equal what src/gdeflate_block.h produces on the
+ * host for the same page - byte for byte on a decode, rung for rung on a
+ * refusal. The twin is the thing the oracle diff and the reject ladder were
+ * established on, so agreeing with it is what makes those results the
+ * kernel's.
+ *
+ * WHAT IS AND IS NOT HERE. The corpus reaches all three block types - counted
+ * off the twin's own census and REQUIRED rather than reported, so a generator
+ * that stops reaching one reds instead of costing that arm its coverage in
+ * silence - several blocks in a page and several pages in a stream, at five
+ * compression levels including the level 0 that forces the stored arm, plus
+ * every page the kernel refuses being refused for the twin's reason. The
+ * standing device gate set - determinism across launches, the two-directional
+ * mutant parity, the capacity adversarials driven at and beyond the tile - is
+ * #218 and is not restated here. Nothing here is timed. */
+#include "cudec.h"
+#include "gdeflate_decode.cuh"
+#include "gdeflate_page_writer.h"
+#include "require.h"
+
+#include "vendor_rt_test.h"
+
+#include <libdeflate.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+using cudec_detail::GDeflateDecodePage;
+using cudec_detail::GDeflatePageState;
+using cudec_detail::GDeflateStatusFor;
+using cudec_detail::kGDeflateBlockDynamic;
+using cudec_detail::kGDeflateBlockStatic;
+using cudec_detail::kGDeflateBlockStored;
+using cudec_detail::kGDeflateBlockTypeCount;
+using cudec_test::GDeflatePageWriter;
+
+constexpr size_t kTileBytes = 64u * 1024u;
+constexpr unsigned char kDstPoison = 0xA5;
+
+/* The same deterministic generators the block twin draws its corpus from: a
+ * named recurrence rather than a library one, so the corpus is identical on
+ * every machine and a parity failure reproduces. */
+class Lcg {
+   public:
+    explicit Lcg(unsigned seed) : state_(seed) {}
+    unsigned Next() {
+        state_ = state_ * 1103515245u + 12345u;
+        return (state_ >> 16) & 0xFFFFu;
+    }
+
+   private:
+    unsigned state_;
+};
+
+std::vector<unsigned char> Incompressible(unsigned seed, size_t n) {
+    Lcg lcg(seed);
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; i++) {
+        v[i] = static_cast<unsigned char>(lcg.Next() & 0xFFu);
+    }
+    return v;
+}
+
+std::vector<unsigned char> MixedEntropy(unsigned seed, size_t n) {
+    Lcg lcg(seed);
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; i++) {
+        const unsigned r = lcg.Next();
+        v[i] = static_cast<unsigned char>((r % 4u == 0u) ? (r & 0xFFu)
+                                                         : ('a' + (r % 5u)));
+    }
+    return v;
+}
+
+std::vector<unsigned char> ShortRepeats(unsigned seed, size_t n) {
+    Lcg lcg(seed);
+    std::vector<unsigned char> v;
+    v.reserve(n);
+    while (v.size() < n) {
+        const size_t run = 3u + (lcg.Next() % 60u);
+        const unsigned char b = static_cast<unsigned char>('a' + lcg.Next() % 6u);
+        for (size_t i = 0; i < run && v.size() < n; i++) {
+            v.push_back(b);
+        }
+        const size_t noise = lcg.Next() % 8u;
+        for (size_t i = 0; i < noise && v.size() < n; i++) {
+            v.push_back(static_cast<unsigned char>(lcg.Next() & 0xFFu));
+        }
+    }
+    return v;
+}
+
+/* A seven-byte alphabet repeated with no noise at all, which is the input
+ * character bench/bench_gdeflate.cpp's forced-static family uses: at a low
+ * level a dynamic table description costs more than the fixed code it would
+ * replace. It is a second route to the static arm rather than the only one -
+ * measured, the corpus below reaches 20 static blocks without it and 24 with
+ * it - and a second route is what keeps that arm's coverage from resting on
+ * one generator. */
+std::vector<unsigned char> LowEntropy(size_t n) {
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; i++) {
+        v[i] = static_cast<unsigned char>('a' + (i % 7u));
+    }
+    return v;
+}
+
+/* Long runs of one byte, which is what draws the deepest overlapping copies:
+ * a distance of one under a length reaching the DEFLATE64 maximum. */
+std::vector<unsigned char> LongRuns(unsigned seed, size_t n) {
+    Lcg lcg(seed);
+    std::vector<unsigned char> v;
+    v.reserve(n);
+    while (v.size() < n) {
+        const size_t run = 200u + (lcg.Next() % 70000u);
+        const unsigned char b = static_cast<unsigned char>(lcg.Next() & 0xFFu);
+        for (size_t i = 0; i < run && v.size() < n; i++) {
+            v.push_back(b);
+        }
+    }
+    return v;
+}
+
+bool CompressPages(int level, const std::vector<unsigned char>& in,
+                   std::vector<std::vector<unsigned char> >* pages) {
+    libdeflate_gdeflate_compressor* c =
+        libdeflate_alloc_gdeflate_compressor(level);
+    if (c == nullptr) {
+        return false;
+    }
+    size_t npages = 0;
+    const size_t bound =
+        libdeflate_gdeflate_compress_bound(c, in.size(), &npages);
+    if (bound == 0 || npages == 0) {
+        libdeflate_free_gdeflate_compressor(c);
+        return false;
+    }
+    /* The bound is over the WHOLE input and the per-page bound is its share
+     * of it, which is what the reference's own header says and what a corpus
+     * of a hundred megabytes finds out: a pool of bound times pages is the
+     * square of the input. */
+    const size_t per_page = (bound + npages - 1u) / npages;
+    std::vector<unsigned char> pool(per_page * npages, 0);
+    std::vector<libdeflate_gdeflate_out_page> out(npages);
+    for (size_t i = 0; i < npages; i++) {
+        out[i].data = pool.data() + i * per_page;
+        out[i].nbytes = per_page;
+    }
+    const size_t total = libdeflate_gdeflate_compress(c, in.data(), in.size(),
+                                                      out.data(), npages);
+    libdeflate_free_gdeflate_compressor(c);
+    if (total == 0) {
+        return false;
+    }
+    pages->clear();
+    for (size_t i = 0; i < npages; i++) {
+        const unsigned char* p =
+            static_cast<const unsigned char*>(out[i].data);
+        pages->push_back(std::vector<unsigned char>(p, p + out[i].nbytes));
+    }
+    return true;
+}
+
+struct Chunk {
+    const std::vector<unsigned char>* src;
+    size_t dst_capacity;
+};
+
+/* One batch through the real plumbing: device pointer tables, per-page sizes
+ * and capacities, poisoned destinations, the results primed with a non-OK
+ * sentinel so an entry the kernel never wrote reads as a failure. */
+int RunBatch(const std::vector<Chunk>& chunks,
+             std::vector<cudec_chunk_result>* results,
+             std::vector<std::vector<unsigned char> >* dst_bytes) {
+    const size_t n = chunks.size();
+    std::vector<const void*> h_srcs(n);
+    std::vector<void*> h_dsts(n);
+    std::vector<size_t> h_sizes(n);
+    std::vector<size_t> h_caps(n);
+    for (size_t i = 0; i < n; i++) {
+        void* d_src = nullptr;
+        void* d_dst = nullptr;
+        const size_t src_size = chunks[i].src->size();
+        REQUIRE_RT(cudec_rt::device_malloc(&d_src, src_size ? src_size : 1));
+        if (src_size) {
+            REQUIRE_RT(cudec_rt::memcpy(d_src, chunks[i].src->data(), src_size,
+                                        cudec_rt::memcpy_h2d));
+        }
+        const size_t cap = chunks[i].dst_capacity;
+        REQUIRE_RT(cudec_rt::device_malloc(&d_dst, cap ? cap : 1));
+        if (cap) {
+            REQUIRE_RT(cudec_rt::device_memset(d_dst, kDstPoison, cap));
+        }
+        h_srcs[i] = d_src;
+        h_dsts[i] = d_dst;
+        h_sizes[i] = src_size;
+        h_caps[i] = cap;
+    }
+    const void** d_srcs;
+    void** d_dsts;
+    size_t* d_sizes;
+    size_t* d_caps;
+    cudec_chunk_result* d_results;
+    REQUIRE_RT(cudec_rt::device_malloc(&d_srcs, n * sizeof(*d_srcs)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_dsts, n * sizeof(*d_dsts)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_sizes, n * sizeof(*d_sizes)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_caps, n * sizeof(*d_caps)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_results, n * sizeof(*d_results)));
+    REQUIRE_RT(cudec_rt::memcpy(d_srcs, h_srcs.data(), n * sizeof(*d_srcs),
+                                cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_dsts, h_dsts.data(), n * sizeof(*d_dsts),
+                                cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_sizes, h_sizes.data(), n * sizeof(*d_sizes),
+                                cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_caps, h_caps.data(), n * sizeof(*d_caps),
+                                cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::device_memset(d_results, 0xFF, n * sizeof(*d_results)));
+
+    cudec_rt::stream_t stream;
+    REQUIRE_RT(cudec_rt::stream_create(&stream));
+    REQUIRE(cudec_gdeflate_decompress_batch(d_srcs, d_sizes, d_dsts, d_caps, n,
+                                            d_results,
+                                            cudec_rt::abi_stream(stream)) ==
+            CUDEC_OK);
+    REQUIRE_RT(cudec_rt::stream_synchronize(stream));
+    REQUIRE_RT(cudec_rt::stream_destroy(stream));
+
+    results->assign(n, cudec_chunk_result{});
+    REQUIRE_RT(cudec_rt::memcpy(results->data(), d_results,
+                                n * sizeof(*d_results), cudec_rt::memcpy_d2h));
+    dst_bytes->assign(n, std::vector<unsigned char>());
+    for (size_t i = 0; i < n; i++) {
+        (*dst_bytes)[i].assign(h_caps[i], 0);
+        if (h_caps[i]) {
+            REQUIRE_RT(cudec_rt::memcpy((*dst_bytes)[i].data(), h_dsts[i],
+                                        h_caps[i], cudec_rt::memcpy_d2h));
+        }
+        REQUIRE_RT(cudec_rt::device_free(h_dsts[i]));
+        REQUIRE_RT(cudec_rt::device_free(const_cast<void*>(h_srcs[i])));
+    }
+    REQUIRE_RT(cudec_rt::device_free(d_srcs));
+    REQUIRE_RT(cudec_rt::device_free(d_dsts));
+    REQUIRE_RT(cudec_rt::device_free(d_sizes));
+    REQUIRE_RT(cudec_rt::device_free(d_caps));
+    REQUIRE_RT(cudec_rt::device_free(d_results));
+    return 0;
+}
+
+/* The host twin's verdict on one page: the bytes on a decode, the rung on a
+ * refusal, and the block types the page turned out to be made of. The census
+ * is the twin's because the twin is what says what a page CONTAINS; the
+ * kernel's job is to agree with it, which is what every check below asks. */
+struct TwinVerdict {
+    bool ok;
+    cudec_status status;
+    std::vector<unsigned char> bytes;
+    uint32_t type_blocks[kGDeflateBlockTypeCount];
+};
+
+TwinVerdict TwinDecode(const std::vector<unsigned char>& page, size_t cap) {
+    TwinVerdict v;
+    GDeflatePageState st;
+    uint64_t out_len = 0;
+    v.bytes.assign(cap, 0);
+    v.ok = GDeflateDecodePage(st, page.data(), page.size(), v.bytes.data(),
+                              cap, &out_len);
+    for (uint32_t t = 0; t < kGDeflateBlockTypeCount; t++) {
+        v.type_blocks[t] = v.ok ? st.type_blocks[t] : 0;
+    }
+    if (v.ok) {
+        v.bytes.resize(static_cast<size_t>(out_len));
+        v.status = CUDEC_OK;
+    } else {
+        v.bytes.clear();
+        v.status = GDeflateStatusFor(st.s.reject);
+    }
+    return v;
+}
+
+/* One page's device result against its twin verdict and, on a decode, against
+ * the expected bytes: status, bytes_written, the bytes, and the poison. */
+int CheckPage(const char* ctx, const cudec_chunk_result& result,
+              const std::vector<unsigned char>& dst, const TwinVerdict& twin,
+              const std::vector<unsigned char>* expected) {
+    REQUIRE_CTX(result.reserved == 0, "%s", ctx);
+    REQUIRE_CTX(result.status == twin.status, "%s device status %d twin %d",
+                ctx, static_cast<int>(result.status),
+                static_cast<int>(twin.status));
+    if (!twin.ok) {
+        REQUIRE_CTX(result.bytes_written == 0, "%s", ctx);
+        return 0;
+    }
+    REQUIRE_CTX(result.bytes_written == twin.bytes.size(),
+                "%s bytes_written %llu twin %zu", ctx,
+                static_cast<unsigned long long>(result.bytes_written),
+                twin.bytes.size());
+    REQUIRE_CTX(dst.size() >= twin.bytes.size(), "%s", ctx);
+    REQUIRE_CTX(std::memcmp(dst.data(), twin.bytes.data(),
+                            twin.bytes.size()) == 0,
+                "%s device bytes differ from the twin", ctx);
+    if (expected != nullptr) {
+        REQUIRE_CTX(expected->size() == twin.bytes.size(), "%s", ctx);
+        REQUIRE_CTX(std::memcmp(dst.data(), expected->data(),
+                                expected->size()) == 0,
+                    "%s device bytes differ from the source", ctx);
+    }
+    for (size_t j = twin.bytes.size(); j < dst.size(); j++) {
+        REQUIRE_CTX(dst[j] == kDstPoison, "%s poison at %zu", ctx, j);
+    }
+    return 0;
+}
+
+/* What a corpus run turned out to have covered: pages decoded, and blocks of
+ * each type inside them. The second half is the reason it exists - a corpus
+ * whose pages all happen to be dynamic proves nothing about the stored and
+ * static arms, and a generator that stops reaching one costs that coverage
+ * silently unless somebody counts. */
+struct Coverage {
+    size_t pages;
+    uint64_t type_blocks[kGDeflateBlockTypeCount];
+};
+
+/* Every page of a compressed stream in ONE batch, one page per chunk, each
+ * into its own poisoned tile. */
+int CheckStream(const char* name, int level,
+                const std::vector<unsigned char>& in, Coverage* cov) {
+    std::vector<std::vector<unsigned char> > pages;
+    REQUIRE_CTX(CompressPages(level, in, &pages), "%s level %d", name, level);
+    std::vector<Chunk> chunks(pages.size());
+    for (size_t i = 0; i < pages.size(); i++) {
+        chunks[i].src = &pages[i];
+        chunks[i].dst_capacity = kTileBytes;
+    }
+    std::vector<cudec_chunk_result> results;
+    std::vector<std::vector<unsigned char> > dst;
+    REQUIRE(RunBatch(chunks, &results, &dst) == 0);
+    for (size_t i = 0; i < pages.size(); i++) {
+        char ctx[128];
+        std::snprintf(ctx, sizeof(ctx), "%s level %d page %zu", name, level, i);
+        const size_t consumed = i * kTileBytes;
+        const size_t want =
+            in.size() - consumed < kTileBytes ? in.size() - consumed : kTileBytes;
+        const std::vector<unsigned char> tile(in.begin() + consumed,
+                                              in.begin() + consumed + want);
+        const TwinVerdict twin = TwinDecode(pages[i], kTileBytes);
+        REQUIRE_CTX(twin.ok, "%s: the twin refused a page the oracle made",
+                    ctx);
+        REQUIRE(CheckPage(ctx, results[i], dst[i], twin, &tile) == 0);
+        for (uint32_t t = 0; t < kGDeflateBlockTypeCount; t++) {
+            cov->type_blocks[t] += twin.type_blocks[t];
+        }
+    }
+    cov->pages += pages.size();
+    return 0;
+}
+
+int PristineCorpus() {
+    /* Level 0 is in the set because the reference's own header says it emits
+     * uncompressed blocks by construction, which is the only way to force the
+     * stored arm rather than hope an input reaches it. */
+    const int levels[] = {0, 1, 6, 9, 12};
+    Coverage cov;
+    cov.pages = 0;
+    for (uint32_t t = 0; t < kGDeflateBlockTypeCount; t++) {
+        cov.type_blocks[t] = 0;
+    }
+    for (size_t l = 0; l < sizeof(levels) / sizeof(levels[0]); l++) {
+        const int level = levels[l];
+        REQUIRE(CheckStream("incompressible-60k", level,
+                            Incompressible(2, 60000), &cov) == 0);
+        REQUIRE(CheckStream("mixed-60k", level, MixedEntropy(4, 60000),
+                            &cov) == 0);
+        REQUIRE(CheckStream("short-repeats-60k", level, ShortRepeats(5, 60000),
+                            &cov) == 0);
+        REQUIRE(CheckStream("low-entropy-60k", level, LowEntropy(60000),
+                            &cov) == 0);
+        REQUIRE(CheckStream("long-runs-3tiles", level,
+                            LongRuns(9, 3u * kTileBytes), &cov) == 0);
+        REQUIRE(CheckStream("mixed-multi-page", level,
+                            MixedEntropy(6, 3u * kTileBytes + 7u),
+                            &cov) == 0);
+        REQUIRE(CheckStream("exact-tile", level, ShortRepeats(7, kTileBytes),
+                            &cov) == 0);
+        REQUIRE(CheckStream("one-byte", level, MixedEntropy(11, 1),
+                            &cov) == 0);
+    }
+    /* More pages than teams in the launch shape, so the grid-stride loop and
+     * the reuse of one team's shared tables across pages are exercised. */
+    REQUIRE(CheckStream("mixed-40-tiles", 6, MixedEntropy(12, 40u * kTileBytes),
+                        &cov) == 0);
+    /* The three block types are REQUIRED rather than reported: a change to a
+     * generator, to the level set or to the reference that stopped reaching
+     * one of them would otherwise cost that arm its whole-corpus coverage and
+     * say nothing. */
+    std::printf("gdeflate_device: block census over the corpus: %llu stored, "
+                "%llu static, %llu dynamic\n",
+                static_cast<unsigned long long>(
+                    cov.type_blocks[kGDeflateBlockStored]),
+                static_cast<unsigned long long>(
+                    cov.type_blocks[kGDeflateBlockStatic]),
+                static_cast<unsigned long long>(
+                    cov.type_blocks[kGDeflateBlockDynamic]));
+    REQUIRE(cov.type_blocks[kGDeflateBlockStored] > 0);
+    REQUIRE(cov.type_blocks[kGDeflateBlockStatic] > 0);
+    REQUIRE(cov.type_blocks[kGDeflateBlockDynamic] > 0);
+    const size_t pages_seen = cov.pages;
+    std::printf("gdeflate_device: %zu pages decoded on the device, each equal "
+                "to the source and to the host twin\n",
+                pages_seen);
+    return 0;
+}
+
+/* Pages the kernel must refuse, each held to the twin's rung through the
+ * status it maps to and to the failure contract: bytes_written zero, poison
+ * intact. The negatives are the shapes the reject ladder reaches through a
+ * page: a reserved block type, a stored length past the capacity, a literal
+ * past the capacity, a page cut short, a page below the priming round, and a
+ * TileStream envelope handed in as if it were a page. */
+std::vector<unsigned char> PageWithBlockType(uint32_t block_type) {
+    GDeflatePageWriter w;
+    w.Reset();
+    w.Push(1, 1);
+    w.Push(2, block_type);
+    return w.Finish();
+}
+
+std::vector<unsigned char> StoredPage(uint32_t len) {
+    GDeflatePageWriter w;
+    w.Reset();
+    w.Push(1, 1);
+    w.Push(2, 0);
+    w.Ensure();
+    w.Push(16, len);
+    return w.Finish();
+}
+
+int Negatives() {
+    std::vector<std::vector<unsigned char> > pages;
+    std::vector<size_t> caps;
+    std::vector<const char*> names;
+
+    pages.push_back(PageWithBlockType(3));
+    caps.push_back(64);
+    names.push_back("reserved block type");
+
+    pages.push_back(StoredPage(8));
+    caps.push_back(4);
+    names.push_back("stored length past the capacity");
+
+    std::vector<std::vector<unsigned char> > real;
+    REQUIRE(CompressPages(6, MixedEntropy(4, 60000), &real));
+    REQUIRE(real.size() == 1);
+    pages.push_back(real[0]);
+    caps.push_back(100);
+    names.push_back("decode past a 100-byte capacity");
+
+    std::vector<unsigned char> cut(real[0].begin(),
+                                   real[0].begin() + (real[0].size() / 2u) / 4u * 4u);
+    pages.push_back(cut);
+    caps.push_back(kTileBytes);
+    names.push_back("page cut in half");
+
+    pages.push_back(std::vector<unsigned char>(64, 0));
+    caps.push_back(kTileBytes);
+    names.push_back("page below the priming round");
+
+    std::vector<unsigned char> partial(real[0].begin(), real[0].begin() + 131);
+    pages.push_back(partial);
+    caps.push_back(kTileBytes);
+    names.push_back("page with a trailing partial word");
+
+    /* Zero capacity: a decode that must write nothing has nowhere to write
+     * even one literal, and the twin says which rung answers. */
+    pages.push_back(real[0]);
+    caps.push_back(0);
+    names.push_back("zero capacity");
+
+    std::vector<Chunk> chunks(pages.size());
+    for (size_t i = 0; i < pages.size(); i++) {
+        chunks[i].src = &pages[i];
+        chunks[i].dst_capacity = caps[i];
+    }
+    std::vector<cudec_chunk_result> results;
+    std::vector<std::vector<unsigned char> > dst;
+    REQUIRE(RunBatch(chunks, &results, &dst) == 0);
+    for (size_t i = 0; i < pages.size(); i++) {
+        const TwinVerdict twin = TwinDecode(pages[i], caps[i]);
+        REQUIRE_CTX(!twin.ok, "%s: the twin accepted a negative", names[i]);
+        /* The destination is unspecified on a refusal by contract, so no
+         * poison is asserted here; what the contract does promise, and what
+         * CheckPage holds, is the status and a bytes_written of zero. */
+        REQUIRE(CheckPage(names[i], results[i], dst[i], twin, nullptr) == 0);
+        std::printf("gdeflate_device: refused '%s' with status %d, as the "
+                    "twin does\n",
+                    names[i], static_cast<int>(results[i].status));
+    }
+    return 0;
+}
+
+/* Whole files handed on the command line, each compressed at the recorded M4
+ * level set and every page decoded on the device: the whole-corpus diff the
+ * kernel's Done-when asks for, over the corpora the bench records, run by hand
+ * and pasted rather than registered, because ctest carries no corpus. */
+std::vector<unsigned char> ReadFile(const char* path) {
+    std::vector<unsigned char> bytes;
+    FILE* f = std::fopen(path, "rb");
+    if (f == nullptr) {
+        return bytes;
+    }
+    unsigned char buf[65536];
+    for (;;) {
+        const size_t got = std::fread(buf, 1, sizeof(buf), f);
+        if (got == 0) {
+            break;
+        }
+        bytes.insert(bytes.end(), buf, buf + got);
+    }
+    std::fclose(f);
+    return bytes;
+}
+
+int FileCorpus(int argc, char** argv) {
+    const int levels[] = {1, 6, 12};
+    Coverage cov;
+    cov.pages = 0;
+    for (uint32_t t = 0; t < kGDeflateBlockTypeCount; t++) {
+        cov.type_blocks[t] = 0;
+    }
+    for (int a = 1; a < argc; a++) {
+        const std::vector<unsigned char> in = ReadFile(argv[a]);
+        REQUIRE_CTX(!in.empty(), "%s: unreadable or empty", argv[a]);
+        for (size_t l = 0; l < sizeof(levels) / sizeof(levels[0]); l++) {
+            REQUIRE(CheckStream(argv[a], levels[l], in, &cov) == 0);
+        }
+        std::printf("gdeflate_device: %s, %zu bytes, three levels, %zu pages "
+                    "so far\n",
+                    argv[a], in.size(), cov.pages);
+    }
+    std::printf("gdeflate_device: block census over the files: %llu stored, "
+                "%llu static, %llu dynamic\n",
+                static_cast<unsigned long long>(
+                    cov.type_blocks[kGDeflateBlockStored]),
+                static_cast<unsigned long long>(
+                    cov.type_blocks[kGDeflateBlockStatic]),
+                static_cast<unsigned long long>(
+                    cov.type_blocks[kGDeflateBlockDynamic]));
+    std::printf("gdeflate_device: %zu file pages decoded on the device, each "
+                "equal to the source and to the host twin, 0 mismatches\n",
+                cov.pages);
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc > 1) {
+        return FileCorpus(argc, argv) != 0 ? 1 : 0;
+    }
+    if (PristineCorpus() != 0) {
+        return 1;
+    }
+    if (Negatives() != 0) {
+        return 1;
+    }
+    std::printf("PASS: gdeflate_device\n");
+    return 0;
+}

--- a/tests/launch_fail.cpp
+++ b/tests/launch_fail.cpp
@@ -50,23 +50,20 @@ int main() {
     REQUIRE(cudec_snappy_decompress_batch(srcs, sizes, dsts, caps, 1, results,
                                           nullptr) == CUDEC_ERR_CUDA);
 
-    /* The GDeflate entry, whose second half is the OPPOSITE assertion and
-     * is why it belongs in this file at all (issue #216). With no visible
-     * device, any CUDA call this entry made would fail, so an entry that
-     * launched, or merely drained the pending error state, would answer
-     * CUDEC_ERR_CUDA here. Answering the defined not-implemented status
-     * instead is the evidence that a batch it accepts reaches the CUDA
-     * runtime not at all. Twice, for the reason the calls above are twice:
-     * a first-touch context init failing once would look the same. */
+    /* The GDeflate entry's two halves, the same shape as the two above now
+     * that its kernel stands behind the frozen contract (issues #216, #214).
+     * Until then the second half was the OPPOSITE assertion - the defined
+     * not-implemented status, as the evidence that an accepted batch reached
+     * the runtime not at all - and the day the kernel landed it flipped to
+     * the launch-failure answer, which is the cleanest record of the landing
+     * this file can hold. Twice, for the reason the calls above are twice. */
     REQUIRE(cudec_gdeflate_decompress_batch(nullptr, sizes, dsts, caps, 1,
                                             results, nullptr) ==
             CUDEC_ERR_INVALID_ARGUMENT);
     REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 1,
-                                            results, nullptr) ==
-            CUDEC_ERR_NOT_IMPLEMENTED);
+                                            results, nullptr) == CUDEC_ERR_CUDA);
     REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 1,
-                                            results, nullptr) ==
-            CUDEC_ERR_NOT_IMPLEMENTED);
+                                            results, nullptr) == CUDEC_ERR_CUDA);
 
     /* The Zstd entry, the same opposite assertion and for the same reason
      * (issue #427). Written out rather than folded into a loop over the two
@@ -80,8 +77,8 @@ int main() {
     REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, results,
                                         nullptr) == CUDEC_ERR_NOT_IMPLEMENTED);
 
-    std::printf("PASS: with zero visible devices the two kernel-backed batch "
-                "entries report CUDEC_ERR_CUDA and the GDeflate and Zstd "
-                "entries report CUDEC_ERR_NOT_IMPLEMENTED\n");
+    std::printf("PASS: with zero visible devices the three kernel-backed batch "
+                "entries report CUDEC_ERR_CUDA and the Zstd entry reports "
+                "CUDEC_ERR_NOT_IMPLEMENTED\n");
     return 0;
 }


### PR DESCRIPTION
Closes #214.

`cudec_gdeflate_decompress_batch` answered `CUDEC_ERR_NOT_IMPLEMENTED` to every batch it accepted. It launches now: one team of 32 lanes per raw page over a grid-stride loop, the 32 lanes being the format's 32 substreams, one table set per team in shared memory at a footprint no input can grow.

## What the new file is, and what it is not

Nothing in `src/gdeflate_decode.cuh` decodes a bit. The rounds are `src/gdeflate_block.h`'s and `src/gdeflate_tables.h`'s, written once over the team contract at `GDeflateHostTeam`, and this is that contract's second residency: a lane's bits in registers, the team's collectives a ballot, a prefix sum and a shuffle, and a refill one ballot over the lanes that stepped with each taking the word its rank among them names - which is the word the sequential cursor hands it, because the schedule hands words out in lane order. So the oracle parity and the reject ladder recorded for the CPU twin are the kernel's, and a page that decodes differently on the two residencies is a defect in the new file rather than in the rounds.

`tests/gdeflate_device.cu` holds every page to the twin as well as to the source - bytes on a decode, rung on a refusal - so a stream the twin refuses and the kernel accepts is a test failure rather than a silent fail-open.

## The ABI contract does not move

The symbol, the signature and all eight reject classes are the ones frozen in 0.1.0; only the answer to an accepted batch changed. `tests/conformance_c.c` loses the ninth class it could assert only while no kernel existed, and `tests/launch_fail.cpp` flips that entry to the launch-failure answer the other kernel-backed entries give with no visible device.

## The means

CUDA C++ in the headers the CPU twin already compiles as `__host__ __device__`, because the alternative - a second decode written for the device - is the thing this repository's oracle-parity rule exists to prevent, and because a warp-collective residency of an existing contract is testable by the suite that already exists rather than by a parallel apparatus.

## Whole-corpus device diff against the oracle

Silesia's twelve files plus enwik8, each compressed by the vendored reference at levels 1, 6 and 12 and every emitted page decoded on the device, each page compared byte for byte against the source and against the host twin:

```
$ ~/af08-214/tests/gdeflate_device bench/corpora/silesia/* bench/corpora/enwik8
gdeflate_device: bench/corpora/silesia/dickens, 10192446 bytes, three levels, 468 pages so far
gdeflate_device: bench/corpora/silesia/mozilla, 51220480 bytes, three levels, 2814 pages so far
gdeflate_device: bench/corpora/silesia/mr, 9970564 bytes, three levels, 3273 pages so far
gdeflate_device: bench/corpora/silesia/nci, 33553445 bytes, three levels, 4809 pages so far
gdeflate_device: bench/corpora/silesia/ooffice, 6152192 bytes, three levels, 5091 pages so far
gdeflate_device: bench/corpora/silesia/osdb, 10085684 bytes, three levels, 5553 pages so far
gdeflate_device: bench/corpora/silesia/reymont, 6627202 bytes, three levels, 5859 pages so far
gdeflate_device: bench/corpora/silesia/samba, 21606400 bytes, three levels, 6849 pages so far
gdeflate_device: bench/corpora/silesia/sao, 7251944 bytes, three levels, 7182 pages so far
gdeflate_device: bench/corpora/silesia/webster, 41458703 bytes, three levels, 9081 pages so far
gdeflate_device: bench/corpora/silesia/x-ray, 8474240 bytes, three levels, 9471 pages so far
gdeflate_device: bench/corpora/silesia/xml, 5345280 bytes, three levels, 9717 pages so far
gdeflate_device: bench/corpora/enwik8, 100000000 bytes, three levels, 14295 pages so far
gdeflate_device: block census over the files: 2 stored, 3 static, 34256 dynamic
gdeflate_device: 14295 file pages decoded on the device, each equal to the source and to the host twin, 0 mismatches
```

That census is why the registered test does not rest on real files: 14295 pages of real data reach the stored arm twice and the static arm three times. The registered corpus reaches all three types deliberately, at five levels including the level 0 the reference emits uncompressed blocks at by construction, and it requires each of the three rather than reporting them:

```
$ ~/af08-214/tests/gdeflate_device
gdeflate_device: block census over the corpus: 24 stored, 24 static, 100 dynamic
gdeflate_device: 105 pages decoded on the device, each equal to the source and to the host twin
gdeflate_device: refused 'reserved block type' with status 2, as the twin does
gdeflate_device: refused 'stored length past the capacity' with status 3, as the twin does
gdeflate_device: refused 'decode past a 100-byte capacity' with status 3, as the twin does
gdeflate_device: refused 'page cut in half' with status 2, as the twin does
gdeflate_device: refused 'page below the priming round' with status 2, as the twin does
gdeflate_device: refused 'page with a trailing partial word' with status 2, as the twin does
gdeflate_device: refused 'zero capacity' with status 3, as the twin does
PASS: gdeflate_device
```

The three-type requirement is proven to bite rather than asserted. Accumulating zero static blocks - the shape a generator that stopped reaching that arm produces - reds the test:

```
$ sed -i 's|cov->type_blocks[t] += twin.type_blocks[t];|cov->type_blocks[t] += (t == kGDeflateBlockStatic) ? 0u : twin.type_blocks[t];|' tests/gdeflate_device.cu
$ cmake --build ~/af08-214 -j8 --target gdeflate_device && ~/af08-214/tests/gdeflate_device
FAIL /mnt/g/Github/cudec/tests/gdeflate_device.cu:410: cov.type_blocks[kGDeflateBlockStatic] > 0
gdeflate_device: block census over the corpus: 24 stored, 0 static, 100 dynamic
run exit=1
```

The edit was reverted; the branch carries the accumulation unmodified.

## Registers and occupancy, read out against 13.1

The design panel's arithmetic in `docs/MASTERPLAN.md` section 13.1 budgets 3132 bytes of shared memory per warp against a 3200-byte target, predicts 12528 bytes for a four-warp block, and reads that as eight blocks and 32 resident warps per SM on sm_86. Section 9 targets at most 64 registers per thread.

Both numbers are missed, and the miss is recorded rather than argued away.

```
$ cuobjdump -res-usage ~/af08-214/CMakeFiles/cudec.dir/src/batch.cu.o    # arch = sm_86
 Function _ZN12cudec_detail21gdeflate_decode_batchILi32EEEvPKPKvPKmPKPvS6_mP18cudec_chunk_result:
  REG:77 STACK:176 SHARED:15328 LOCAL:0 CONSTANT[2]:8 CONSTANT[0]:400 TEXTURE:0 SURFACE:0 SAMPLER:0
```

and the achieved occupancy, asked of the runtime rather than computed by hand:

```
device: NVIDIA GeForce RTX 3080 sm_86, SMs 68, maxThreadsPerSM 1536, sharedPerSM 102400
kernel: regs/thread 77, static shared/block 15328, local/thread 176, maxThreadsPerBlock 128
occupancy at 128 threads/block: 6 blocks/SM = 24 warps/SM of 48 = 50.0%
```

Where the shared-memory gap is, measured on the structures themselves:

```
GDeflateTeamTables 3832 = litlen 2722 + dist 418 + precode 344 + lens 328 + precode_lens 19
block of 4 teams: 15328 bytes
```

The two live tables come to 3140 bytes, eight bytes over the 3132 the panel budgeted, so 13.1's arithmetic for the thing it was about is right. What it did not budget is the code-length decode's own scratch - the precode table, the code-length vector and the precode lengths, 691 bytes per team - and that is the whole of the 700-byte-per-warp miss. A block is 15328 rather than 12528 bytes, which is six blocks in 100 KiB rather than eight.

The register limit binds at the same six independently: at 77 registers per thread a 128-thread block wants 9856 registers before granularity, and an SM's 65536 hold six of those. So reaching 13.1's 32 warps needs both numbers moved, not either.

Neither is a blocker under this issue's own Done-when, which asks for the achieved figure whether or not it matches. The table layout that would move the first is #204, which is open and explicitly a measured question.

## No throughput

Nothing here is timed and no number in this branch is a throughput figure. The measured pass is #101.

## Gate

Taken in WSL against the one local device, at the head of this branch.

```
$ cmake -S . -B ~/af08-214 -DCUDEC_ENABLE_CUDA=ON && cmake --build ~/af08-214 -j8
$ ctest --test-dir ~/af08-214 --output-on-failure
100% tests passed, 0 tests failed out of 66
Label Time Summary:
gpu    =  14.63 sec*proc (10 tests)
```

The GPU-less subset CI runs, on the same build:

```
$ ctest --test-dir ~/af08-214 -LE gpu --no-tests=error --output-on-failure
100% tests passed, 0 tests failed out of 56
```

and the host-only configuration, which registers no tests by construction:

```
$ cmake -S . -B ~/af08-host && cmake --build ~/af08-host -j8
build exit=0
```

Prettier over the two non-source files this touches:

```
$ npx --yes prettier@3 --check CHANGELOG.md .github/workflows/ci.yml
All matched files use Prettier code style!
```

The device this ran on: `NVIDIA GeForce RTX 3080`, driver `610.88`, nvcc from `/usr/local/cuda`, `-arch=sm_86`. `CLAUDE.md` and #418 record the local device gate as having no device; `/dev/dxg` exists on this host today and `nvidia-smi` answers, which is why an on-device reading is in this body at all.

## Not covered here

The standing device gate set for this path - determinism across launches, two-directional armed-mutant reject parity, and the capacity adversarials driven at and beyond the tile bound - is #218 and is not in this branch. The compute-sanitizer half of the gate is parked and unproducible on this host (#258, #127), so this change carries the recorded substitute - the whole-corpus diff and the twin parity above - and no sanitizer evidence. No AMD device has executed any of this; the HIP arm is compiled by the `hip` job and nothing more (#415).

## No second reader

Nobody but the hand that wrote it has read this change. The evidence above stands in place of a reader rather than beside one, and that is a weaker thing: the whole-corpus diff, the twin parity, the reject ladder and the proven-to-bite census say the code does what the tests ask, and none of them says the tests ask the right questions. The `cuda-reviewer` lens this issue's Surfaces section makes mandatory on a kernel diff has not been run.
