### PR TITLE
Record that a HIP compiler now builds the library's vendor seam

### DIFF
--- a/src/vendor_rt.h
+++ b/src/vendor_rt.h
@@ -13,13 +13,24 @@
  * the columns by eye, and a configure-time rule (tests/CMakeLists.txt, issue
  * #240) reds the build when one column grows an entry the other does not.
  *
- * WHAT THIS HEADER DOES NOT CLAIM. No hipcc has ever compiled the HIP arm: no
- * ROCm toolchain exists on the machine this landed from, and CMakeLists.txt
- * refuses CUDEC_ENABLE_HIP fail-closed for the same reason. The mapping is
- * proven CONSISTENT (both arms define the same operations, the CUDA arm builds
- * and passes the whole gate) and is NOT proven CORRECT: a name mapped to the
- * wrong HIP entry point compiles clean on CUDA and reds only under a compiler
- * nobody here has. Issue #210 is the route to that compiler.
+ * WHAT THIS HEADER DOES NOT CLAIM, AND THE COMPILER HALF HAS EXPIRED. It said
+ * no hipcc had ever compiled the HIP arm, because no ROCm toolchain exists on
+ * the machine it landed from. A hipcc compiles this arm on every pull request
+ * now: the CI hip job configures CUDEC_ENABLE_HIP in a digest-pinned ROCm
+ * image and builds the library's translation units, which include this header
+ * (issue #210). So a name this table spells wrongly enough to break
+ * compilation reds there, and the absence of a toolchain on any one machine is
+ * no longer what decides it.
+ *
+ * WHAT THE COMPILER DID NOT DECIDE IS THE HALF THAT MATTERS. The mapping is
+ * proven CONSISTENT - both arms define the same operations, the CUDA arm
+ * builds and passes the whole gate, and a configure-time rule reds when one
+ * column grows an entry the other does not - and is still NOT proven CORRECT:
+ * a name mapped to the WRONG HIP entry point of the right shape compiles clean
+ * on both backends and reds only where the call runs. No AMD device has ever
+ * executed one line of it. That answer comes from hardware, which is issue
+ * #415 and the runbook at docs/AMD-VALIDATION.md; a compiler was never going
+ * to give it.
  *
  * INTERNAL - never part of the public C ABI in include/cudec.h. The public
  * status CUDEC_ERR_CUDA keeps its name on both backends: it is an ABI


### PR DESCRIPTION
Closes #442.

`src/vendor_rt.h` opened its disclosure block with a sentence that had expired: "No hipcc has ever compiled the HIP arm: no ROCm toolchain exists on the machine this landed from". One compiles it on every pull request.

## The readings

The job landed under #210 and is closed:

```
$ gh issue view 210 --repo iderex/cudec --json state,title --jq '"\(.state)  \(.title)"'
CLOSED  HIP compile job in CI: digest-pinned ROCm container, explicit offload-arch matrix, host-side subset
$ git grep -n 'rocm/dev-ubuntu-24.04\|Configure and build (HIP engine)' origin/main -- .github/workflows/ci.yml
origin/main:.github/workflows/ci.yml:413:      image: rocm/dev-ubuntu-24.04:7.2.4@sha256:bdc8e61026cbb844ede93d44d2c50055f51ebb2041906b60182bf3bee3139054
origin/main:.github/workflows/ci.yml:442:      - name: Configure and build (HIP engine)
```

and this header is inside what that job compiles, because the library's translation units reach it:

```
$ git grep -l 'vendor_rt.h' origin/main -- src/ | tr '\n' ' '
origin/main:src/batch.cu origin/main:src/chunk_decode.cuh origin/main:src/frame.cpp origin/main:src/lz4_frame.h origin/main:src/stream.cpp origin/main:src/vendor_raii.h
```

## What changed and what did not

The compiler half of the disclosure is replaced by what is true: a hipcc builds this arm on every pull request, named by the job rather than by a machine, so a name spelled wrongly enough to break compilation reds there.

The other half is kept and sharpened, not softened. The mapping is proven CONSISTENT and is still **not proven CORRECT** - a name mapped to the wrong HIP entry point of the right shape compiles clean on both backends and reds only where the call runs, and no AMD device has executed one line of it. `#210` is no longer named as the route to that answer; `#415` and `docs/AMD-VALIDATION.md` are, and both exist:

```
$ ls docs/AMD-VALIDATION.md
docs/AMD-VALIDATION.md
$ gh issue view 415 --repo iderex/cudec --json number,state,title --jq '"#\(.number) \(.state) \(.title)"'
#415 OPEN First wave64 run: the dispatch arm that has never executed on a device
```

The sentence claiming `CMakeLists.txt` refuses `CUDEC_ENABLE_HIP` fail-closed "for the same reason" goes with it: the reason it gave was the absent toolchain, and the hip job configures that option and builds.

## The means

A comment in the file the claim is about. The alternative - recording the correction anywhere else - is what put an expired sentence in front of a reader in the first place, and this repository's rule is that a mark lives at the thing it concerns.

## Gate

The change is a block comment; nothing executable moved.

```
$ g++ -fsyntax-only -std=c++17 -Iinclude -Isrc -I/usr/local/cuda/include src/frame.cpp
syntax ok
```

`build`, `hip`, `sanitize` and `format` on this pull request are the gate that matters here - the hip job is what the new sentence is a claim about - and this body is written before they report. No `.md`, `.yml` or `.yaml` file is touched, so Prettier has nothing new to read.

## Not covered here

`tests/vendor_rt_test.h` carried the same expired sentence; that half landed under #243 and is not touched. Nothing here brings an AMD device any closer, and the correctness half of the disclosure is unchanged in substance.

## No second reader

Nobody but the hand that wrote it has read this. What stands in place of one is the pair of readings above and the `hip` job itself, which is the thing the new sentence is a claim about; neither can tell whether the surviving half of the disclosure is sharp enough.
