### PR TITLE
Take an AMD validation result in a shape it cannot arrive incomplete in

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-amd-validation-result.yml
+++ b/.github/ISSUE_TEMPLATE/4-amd-validation-result.yml
@@ -1,0 +1,124 @@
+# No AMD GPU has ever executed this project, so every AMD result comes from
+# somebody else's hardware and arrives once. A throughput number in a comment
+# with the hardware unstated cannot be recorded and cannot be asked back for
+# reliably, which is why the four axes a result is worthless without are
+# required fields rather than a request in prose.
+#
+# The field set is docs/AMD-VALIDATION.md's section 6 and nothing else: that
+# document is the instruction and this form is the intake, so a field here that
+# the runbook never told a reporter to capture would be asking for something
+# they were never told to keep. Two things a reader might expect are therefore
+# absent - the driver version and the commit built - because the runbook does
+# not ask for either. That is a gap in the runbook, recorded on issue #246, and
+# not one this form may close on its own.
+name: AMD validation result
+description:
+  Output from running the suite or the benchmarks on an AMD GPU, following
+  docs/AMD-VALIDATION.md.
+labels: ["area:tests", "area:build"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you. You are running something nobody here can run.
+
+        This form is the end of
+        [docs/AMD-VALIDATION.md](https://github.com/iderex/cudec/blob/main/docs/AMD-VALIDATION.md).
+        If you have not worked through it, start there - it is a clean clone to
+        a pasteable result in one sitting, and every field below is something
+        one of its steps printed.
+
+        **A failure is a result.** A red `ctest`, a build that does not
+        compile, a benchmark that refuses its own self-check: paste it exactly
+        as it happened. Do not fix it and do not leave it out. The point of
+        this exercise is to find out what happens, and the first run of
+        anything is where that is decided.
+
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU and gfx target
+      description:
+        Both, from step 2 - `rocminfo | grep -E 'Marketing Name|^\s+Name:\s+gfx|Wavefront Size'`.
+        The `gfx` target is what the build was told to target and the marketing
+        name is what a later reader recognises.
+      placeholder: AMD Instinct MI210, gfx90a
+    validations:
+      required: true
+
+  - type: dropdown
+    id: wave-width
+    attributes:
+      label: Wave width
+      description:
+        The wavefront size step 2 printed. This is the axis the port is
+        parameterized on - both instantiations ship in one binary and a wave64
+        device reaches an arm a wave32 device never does - so it is the axis a
+        result is indexed by rather than a detail.
+      options:
+        - "32 (RDNA, gfx1100, gfx1201)"
+        - "64 (CDNA, gfx90a, gfx942)"
+    validations:
+      required: true
+
+  - type: input
+    id: rocm
+    attributes:
+      label: ROCm version
+      description:
+        7.2.4 if you used the pinned image from step 3 unchanged; otherwise the
+        version you actually built with.
+      placeholder: 7.2.4
+    validations:
+      required: true
+
+  - type: textarea
+    id: invocation
+    attributes:
+      label: The container invocation you used
+      description:
+        Step 3's `docker run` line as you actually ran it. The runbook's
+        `--device` flags have never been exercised by anybody here, so if yours
+        differed, this field is the most valuable thing in the report after the
+        output itself.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: ctest
+    attributes:
+      label: The whole ctest output
+      description:
+        Step 4, unedited and complete, passes included - `ctest --test-dir
+        build-hip --no-tests=error --output-on-failure`. Which entries ran is
+        as much of the result as which ones passed, so a summary line on its
+        own cannot be recorded.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: bench
+    attributes:
+      label: The benchmark report blocks
+      description:
+        Step 5, every block whole and unedited, one per invocation. The harness
+        prints its methodology inseparably from its numbers on purpose
+        (docs/BENCHMARK-METHODOLOGY.md), so an edited or summarised block will
+        not be recorded. Leave this empty if you ran the tests and not the
+        benchmarks - that is a complete result of its own.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything the runbook got wrong
+      description:
+        It is meant to be executable without correspondence. A step that did
+        not work on your machine is a defect in that document, and saying so
+        here is worth as much as the numbers.
+    validations:
+      required: false


### PR DESCRIPTION
Closes #246.

A fourth entry in `.github/ISSUE_TEMPLATE/`: `4-amd-validation-result.yml`. No AMD GPU has ever executed this project, so every AMD result comes from somebody else's hardware and arrives once; until now it arrived as prose, and a throughput number in a comment with the hardware unstated cannot be recorded and cannot reliably be asked back for.

## What the form refuses

Submission without the GPU and its `gfx` target, the wave width, or the ROCm version. Wave width is a dropdown over the two that matter rather than free text, because it is the axis the port is parameterized on - both instantiations ship in one binary, and a wave64 device reaches an arm a wave32 device never does (#415).

The `ctest` output and the container invocation are required too. The invocation because the runbook says in its own words that the `--device` flags have never been exercised by anybody here; the `ctest` output whole and unedited because which entries ran is as much of the result as which ones passed.

## The field set is the runbook's, one for one

This issue's third Done-when is that the field set matches what `docs/AMD-VALIDATION.md` tells a reporter to collect, with no field asked for that the runbook never told them to capture. Section 6 of the runbook names six things, and the form has exactly those six plus one optional free-text field for a step of the runbook that did not work:

| Runbook section 6                                | Field         | Required |
| ------------------------------------------------ | ------------- | -------- |
| GPU marketing name and `gfx` target, from step 2 | `gpu`         | yes      |
| the wave width, from step 2                      | `wave-width`  | yes      |
| the ROCm version                                 | `rocm`        | yes      |
| the `docker run` invocation actually used        | `invocation`  | yes      |
| the whole `ctest` output, passes included        | `ctest`       | yes      |
| every report block whole and unedited            | `bench`       | no       |

`bench` is optional because the runbook's step 4 and step 5 are separable and a test-only run is a complete result of its own; the form says so where a reporter reads it.

**Two fields a reader might expect are deliberately absent, and this is the part to read rather than skim.** The Required-fields list on #246 asks for the **driver version**; the runbook does not tell a reporter to collect it, so it is not here. Nothing in the runbook tells a reporter to record the **commit they built**, either, so the form cannot ask for that and a result will arrive pinned to a date rather than to a sha. Both are gaps in the instruction rather than in the intake - the form may not invent a field, because that inverts the sequencing this issue's Constraint section sets out - and #451 holds them.

The form's own header comment carries that disclosure, so somebody meeting the file rather than this body meets it too.

## What is not touched

`config.yml`. Its `blank_issues_enabled: true` and the private-vulnerability contact link `SECURITY.md` requires are load-bearing, and the two earlier comments on this issue exist because the body said to ship a new one alongside. What this owed was one more entry in an existing directory:

```
$ git ls-tree --name-only origin/main .github/ISSUE_TEMPLATE/
.github/ISSUE_TEMPLATE/1-bug-report.yml
.github/ISSUE_TEMPLATE/2-decode-divergence.yml
.github/ISSUE_TEMPLATE/3-feature-request.yml
.github/ISSUE_TEMPLATE/config.yml
```

The numeric prefix orders the chooser and `4-` puts this after the feature request, which is where a form for a report almost nobody will file belongs.

## The means

A GitHub issue form, because the required-field refusal is the whole point and it is the one mechanism on this surface that refuses rather than asks. A prose section in the runbook saying "please include these four facts" is what the tracker has today and is what this issue exists because of.

## Gate

```
$ npx --yes prettier@3 --check .github/ISSUE_TEMPLATE/4-amd-validation-result.yml
All matched files use Prettier code style!
```

and the shape, checked against what GitHub's form schema requires rather than by eye - every non-markdown element carrying a unique lowercase id and a label, the dropdown carrying its options, the top level carrying `name`, `description` and `body`:

```
top keys: ['body', 'description', 'labels', 'name']
  markdown - required= None
  input gpu required= True
  dropdown wave-width required= True
  input rocm required= True
  textarea invocation required= True
  textarea ctest required= True
  textarea bench required= False
  textarea anything-else required= False
labels: ['area:tests', 'area:build']
OK
```

Nothing in the library changed, so `build`, `hip` and `sanitize` on this pull request are re-runs of the mainline's own state rather than evidence about this diff; `format` is the one that reads the file.

The first Done-when - that opening a new issue offers "AMD validation result" as a choice - is a statement about the rendered chooser, which only exists once this is on the default branch. It is checked after the merge and the reading goes on the issue.

## No second reader

Nobody but the hand that wrote it has read this. The two checks above are what stands in place of one, and neither of them can tell whether the six fields are the right six.
