### PR TITLE
Record the first GDeflate GPU baselines

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -131,16 +131,23 @@ add_test(NAME bench_snappy_worst_selfcheck COMMAND bench_snappy --worst
 add_test(NAME bench_snappy_worstlit_selfcheck COMMAND bench_snappy --worstlit
                                                       --selfcheck)
 
-# The GDeflate CPU denominator (issue #224). No CUDA in it at all: there is
-# no GDeflate kernel yet, so the reference decodes on the host and the binary
-# needs neither a device nor a cudec entry point. When the kernel lands, the
-# device rows join this binary the way they joined bench_snappy.
+# The GDeflate CPU denominator and, since issue #228, the device rows beside
+# it. The sentence that stood here said the binary needs neither a device nor
+# a cudec entry point because no GDeflate kernel existed, and said the device
+# rows would join it the way they joined bench_snappy when one landed. One
+# landed under #214 and they have, in exactly that way: gpu_bench.cu is
+# compiled in, --gpu adds the rows, and without the flag this is the
+# denominator alone as it always was.
 #
-# It links gdeflate_oracle alone - the same target tests/ pins - because the
+# It links gdeflate_oracle - the same target tests/ pins - because the
 # GDeflate streams in this project have ONE provenance, and a bench that
-# reached for a second compressor would be a second one nobody reconciles.
-add_executable(bench_gdeflate bench_gdeflate.cpp)
-target_link_libraries(bench_gdeflate PRIVATE gdeflate_oracle)
+# reached for a second compressor would be a second one nobody reconciles. It
+# links cudec because the device rows go through the shipped batch entry and
+# through nothing else.
+add_executable(bench_gdeflate bench_gdeflate.cpp gpu_bench.cu)
+target_link_libraries(
+  bench_gdeflate PRIVATE cudec gdeflate_oracle
+                         ${CUDEC_DEVICE_RUNTIME_TARGET})
 # ../src for the corpus digest, which reads src/xxhash64.h - the hash already
 # in the tree rather than a new dependency for a bench.
 #
@@ -172,10 +179,15 @@ target_compile_definitions(
   bench_gdeflate PRIVATE CUDEC_GDEFLATE_COMMIT="${CUDEC_GDEFLATE_COMMIT}")
 set_target_properties(bench_gdeflate PROPERTIES CXX_STANDARD 17
                                                 CXX_STANDARD_REQUIRED ON)
+cudec_device_target(bench_gdeflate)
 # -O2 unconditionally for the reason bench_lz4 gives above: the documented
 # container command sets no CMAKE_BUILD_TYPE, and an -O0 reference decoder
-# would be timed instead of the reference decoder.
-target_compile_options(bench_gdeflate PRIVATE -Wall -Wextra -Werror -O2)
+# would be timed instead of the reference decoder. The host flags are scoped
+# to the host language now that this target carries a device translation
+# unit, exactly as bench_lz4 and bench_snappy scope theirs; the device path
+# carries the project's strict device flags through cudec_device_target.
+target_compile_options(
+  bench_gdeflate PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror;-O2>)
 
 # Same rot protection as the entries above. The selfcheck builds the whole
 # level set from a fixed source and asserts the digest of each, so a moved

--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -51,12 +51,19 @@
  * the ratio is half the pitch, and a throughput-only table would misreport
  * what the format is for.
  *
- * No CUDA in this binary at all: the reference decodes on the host, and there
- * is no cudec GDeflate path to launch.
+ * THIS PARAGRAPH SAID THERE WAS NO CUDA IN THIS BINARY AT ALL, because no
+ * cudec GDeflate path existed to launch. One landed under #214 and `--gpu`
+ * times it (issue #228): the reference still decodes on the host and is still
+ * the denominator, the device rows are printed under the same methodology
+ * block so the two cannot be quoted apart, and without the flag this binary
+ * is what it always was. The device rows go through
+ * `cudec_gdeflate_decompress_batch` and through nothing else.
  *
  * Bench-only. Nothing here is compiled into the library. */
 #include "assetlike_source.h"
 #include "bench_stats.h"
+#include "cudec.h"
+#include "gpu_bench.h"
 
 #include <libdeflate.h>
 
@@ -1264,7 +1271,7 @@ bool CheckBlocksPerPage(const char* name, const RefillDensity& density,
  * not exist. */
 void PrintReport(const Corpus& corpus, int level,
                  const std::vector<double>& sorted, size_t warmup, size_t runs,
-                 const RefillDensity* density, double floor) {
+                 const RefillDensity* density, double floor, bool gpu) {
     std::vector<size_t> sizes;
     sizes.reserve(corpus.originals.size());
     for (const auto& original : corpus.originals) {
@@ -1273,13 +1280,23 @@ void PrintReport(const Corpus& corpus, int level,
     std::sort(sizes.begin(), sizes.end());
     const double gb = static_cast<double>(corpus.original_bytes) / 1e9;
 
+    char device[256];
+    (void)cudec_bench_gpu_device_line(device, sizeof(device));
+
     std::printf("## bench_gdeflate report\n");
     std::printf("- decoder: CPU oracle, libdeflate_gdeflate_decompress (the "
                 "pinned NVIDIA/libdeflate gdeflate fork, commit %s), single "
-                "thread. cudec has no GDeflate kernel yet, so this report is "
-                "the denominator and carries no cudec number\n",
-                CUDEC_GDEFLATE_COMMIT);
+                "thread%s\n",
+                CUDEC_GDEFLATE_COMMIT,
+                gpu ? ". The GPU rows below time cudec's own decoder through "
+                      "cudec_gdeflate_decompress_batch, and the CPU rows are "
+                      "the denominator they are read against"
+                    : ". This run timed no cudec kernel - it is the "
+                      "denominator alone, and --gpu is what adds the device "
+                      "rows");
     std::printf("- host CPU: %s\n", cudec_bench::HostCpuName().c_str());
+    std::printf("- CUDA device: %s\n", device);
+    std::printf("- cudec: %d\n", cudec_version());
     /* The ratio is taken over the STREAM and never over the buffer: a
      * hand-emitted page carries a zero tail no decoder reads, and counting it
      * would attest bytes that are not stream. It is disclosed on its own line
@@ -1403,13 +1420,72 @@ bool TimeCorpus(const Corpus& corpus, size_t warmup, size_t runs,
     return true;
 }
 
+/* The device rows for one corpus, printed under the same methodology block as
+ * the CPU rows above them so the two cannot be quoted apart. The GPU decode is
+ * device-resident (H2D and D2H excluded) and CUDA-event timed, and
+ * cudec_bench_gpu_gdeflate refuses to time a batch whose pages did not all
+ * decode to their original size - so a number here is never from an unverified
+ * decode.
+ *
+ * THE PAGE HANDED TO THE KERNEL IS THE ONE IN THE CORPUS, TAIL AND ALL. A
+ * hand-emitted corpus carries a zero tail per page for the reference's
+ * unchecked refill, and the ratio line above holds that apart from the stream.
+ * The kernel is handed the whole buffer with its own size, and its refills are
+ * bounded by that size rather than by a convention, so the tail is words it
+ * never reads. What it does affect is nothing in the number below: throughput
+ * here is per DECODED byte, which the tail does not touch.
+ *
+ * NO PARSE-ONLY ROW, AND THE REASON RATHER THAN A SILENT OMISSION. #228 asks
+ * for the split variant if the design admits one. It does not: the two chunk
+ * formats get a parse-only ceiling from a template flag in
+ * src/chunk_decode.cuh that elides the copies while running the identical
+ * parse, and the GDeflate round loop's next round depends on bytes the
+ * previous round's copies produced, so eliding them would decode different
+ * symbols and ceiling nothing. */
+bool PrintGpuRows(const Corpus& corpus, double cpu_p50_seconds, size_t warmup,
+                  size_t runs) {
+    std::vector<const unsigned char*> comp_ptrs(corpus.compressed.size());
+    std::vector<size_t> comp_sizes(corpus.compressed.size());
+    std::vector<size_t> orig_sizes(corpus.originals.size());
+    for (size_t i = 0; i < corpus.compressed.size(); i++) {
+        comp_ptrs[i] = corpus.compressed[i].data();
+        comp_sizes[i] = corpus.compressed[i].size();
+        orig_sizes[i] = corpus.originals[i].size();
+    }
+    cudec_gpu_result g;
+    if (!cudec_bench_gpu_gdeflate(comp_ptrs.data(), comp_sizes.data(),
+                                  orig_sizes.data(), corpus.originals.size(),
+                                  static_cast<int>(warmup),
+                                  static_cast<int>(runs), &g)) {
+        std::fprintf(stderr, "GPU bench failed\n");
+        return false;
+    }
+    std::printf("- GPU decode (device-resident, CUDA-event timed, %zu warmup "
+                "+ %zu runs, %zu pages, every page verified to its original "
+                "size before timing): p50 %.3f ms, %.3f GB/s\n",
+                warmup, runs, g.chunks, g.full_ms_p50, g.full_gbps_p50);
+    std::printf("- GPU parse-only ceiling: not instantiable for this format - "
+                "the round loop's next round reads bytes the previous round's "
+                "copies produced, so a variant with the copies elided decodes "
+                "different symbols and ceilings nothing. The row is absent "
+                "rather than filled with the full decode timed twice\n");
+    /* The ratio the milestone is read on: the device number against this
+     * report's own CPU denominator, computed from the two rows above rather
+     * than from a number quoted out of another run. */
+    std::printf("- GPU vs the CPU denominator in this report: %.2fx (CPU p50 "
+                "%.3f ms, GPU p50 %.3f ms)\n",
+                cpu_p50_seconds * 1e3 / g.full_ms_p50, cpu_p50_seconds * 1e3,
+                g.full_ms_p50);
+    return true;
+}
+
 /* Reports the digest of the corpus it built through `digest_out` rather than
  * judging it here, so the caller can walk every level and name all of the
  * ones that moved. Stopping at the first would report one drifted level and
  * leave the rest unexamined, which reads as "only that one moved". */
 bool RunLevel(const std::vector<unsigned char>& source, const std::string& name,
               const std::string& provenance, int level, int want_block_type,
-              size_t warmup, size_t runs, uint64_t* digest_out) {
+              size_t warmup, size_t runs, bool gpu, uint64_t* digest_out) {
     Corpus corpus;
     corpus.name = name;
     corpus.provenance = provenance;
@@ -1435,7 +1511,11 @@ bool RunLevel(const std::vector<unsigned char>& source, const std::string& name,
         return false;
     }
     PrintReport(corpus, level, times, warmup, runs, /*density=*/nullptr,
-                /*floor=*/0.0);
+                /*floor=*/0.0, gpu);
+    if (gpu && !PrintGpuRows(corpus, cudec_bench::Percentile(times, 50),
+                             warmup, runs)) {
+        return false;
+    }
     return true;
 }
 
@@ -1564,7 +1644,7 @@ bool ParseCount(const char* text, size_t lo, size_t hi, size_t* out) {
 
 void Usage(const char* argv0) {
     std::fprintf(stderr,
-                 "usage: %s [--warmup N] [--runs N] [--assetlike] "
+                 "usage: %s [--gpu] [--warmup N] [--runs N] [--assetlike] "
                  "[--blocktypes] [--blockmix] [--worstrounds] "
                  "[--worstheaders] [--selfcheck] "
                  "[corpus files...]\n",
@@ -1574,7 +1654,7 @@ void Usage(const char* argv0) {
 /* The forced-block-type path. Each family is its own corpus at its own
  * level, so this walks the family table instead of the level list the
  * other paths sweep. */
-int RunBlocktypes(size_t warmup, size_t runs, bool selfcheck) {
+int RunBlocktypes(size_t warmup, size_t runs, bool selfcheck, bool gpu) {
     const size_t pages = selfcheck ? kSelfcheckPages : kBlocktypePages;
     bool ok = true;
     for (size_t i = 0; i < kForcedFamilyCount; i++) {
@@ -1582,7 +1662,7 @@ int RunBlocktypes(size_t warmup, size_t runs, bool selfcheck) {
         const std::vector<unsigned char> source = f.source(pages * kPageBytes);
         uint64_t digest = 0;
         if (!RunLevel(source, f.name, f.provenance, f.level,
-                      static_cast<int>(f.want_type), warmup, runs,
+                      static_cast<int>(f.want_type), warmup, runs, gpu,
                       &digest)) {
             return 1;
         }
@@ -1890,7 +1970,7 @@ static_assert(kWorstHeadersRefillFloor > kWorstRefillFloor,
 int RunWorstShape(const char* name, const std::string& provenance,
                   uint32_t blocks, double floor, uint64_t selfcheck_digest,
                   uint64_t full_digest, size_t warmup, size_t runs,
-                  bool selfcheck) {
+                  bool selfcheck, bool gpu) {
     const size_t pages = selfcheck ? kSelfcheckPages : kWorstRoundsPages;
     Corpus corpus;
     corpus.name = name;
@@ -1932,13 +2012,18 @@ int RunWorstShape(const char* name, const std::string& provenance,
     if (!TimeCorpus(corpus, warmup, runs, &times)) {
         return 1;
     }
-    PrintReport(corpus, /*level=*/-1, times, warmup, runs, &density, floor);
+    PrintReport(corpus, /*level=*/-1, times, warmup, runs, &density, floor,
+                gpu);
+    if (gpu && !PrintGpuRows(corpus, cudec_bench::Percentile(times, 50),
+                             warmup, runs)) {
+        return 1;
+    }
     return 0;
 }
 
 /* The three ingredients of MASTERPLAN section 13.5 that do not need a block
  * boundary, in a page that is one final dynamic block (issue #226). */
-int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
+int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck, bool gpu) {
     return RunWorstShape(
         "worst-rounds",
         "HAND-CONSTRUCTED by this harness and validated by the pinned "
@@ -1951,14 +2036,14 @@ int RunWorstRounds(size_t warmup, size_t runs, bool selfcheck) {
         "with this harness's other corpora, which are recorded on their own "
         "invocations and are several times this one in pages",
         /*blocks=*/1, kWorstRefillFloor, kWorstRoundsSelfcheckDigest,
-        kWorstRoundsFullDigest, warmup, runs, selfcheck);
+        kWorstRoundsFullDigest, warmup, runs, selfcheck, gpu);
 }
 
 /* The same page with the fourth ingredient added (issue #430): the same
  * output, the same symbols and the same matches, cut into as many dynamic
  * blocks as whole groups of matches allow, so every group pays a block header
  * and the one-active-lane header rounds are a real share of the total. */
-int RunWorstHeaders(size_t warmup, size_t runs, bool selfcheck) {
+int RunWorstHeaders(size_t warmup, size_t runs, bool selfcheck, bool gpu) {
     return RunWorstShape(
         "worst-headers",
         "HAND-CONSTRUCTED by this harness and validated by the pinned "
@@ -1972,7 +2057,7 @@ int RunWorstHeaders(size_t warmup, size_t runs, bool selfcheck) {
         "and are several times this one in pages",
         WorstHeaderBlocks(), kWorstHeadersRefillFloor,
         kWorstHeadersSelfcheckDigest, kWorstHeadersFullDigest, warmup, runs,
-        selfcheck);
+        selfcheck, gpu);
 }
 
 }  // namespace
@@ -1986,11 +2071,14 @@ int main(int argc, char** argv) {
     bool blockmix = false;
     bool worstrounds = false;
     bool worstheaders = false;
+    bool gpu = false;
     std::vector<std::string> files;
 
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
-        if (arg == "--assetlike") {
+        if (arg == "--gpu") {
+            gpu = true;
+        } else if (arg == "--assetlike") {
             assetlike = true;
         } else if (arg == "--blocktypes") {
             blocktypes = true;
@@ -2066,6 +2154,28 @@ int main(int argc, char** argv) {
         return 2;
     }
 
+    /* The selfcheck is the rot check the GPU-less CI runner runs, so it stays
+     * CPU-only by refusal rather than by convention: a --gpu --selfcheck that
+     * quietly dropped the device rows would report green on a runner where
+     * nothing device-side ran, which is the shape of a check that has stopped
+     * checking. */
+    if (selfcheck && gpu) {
+        std::fprintf(stderr, "--gpu and --selfcheck are exclusive: the "
+                             "selfcheck runs on the GPU-less runner\n");
+        return 2;
+    }
+
+    /* --blockmix censuses the block types of a corpus and times no decode, so
+     * it has no row a device number would go beside. Refused rather than
+     * ignored, for the reason above: a flag that is accepted and does nothing
+     * is read afterwards as a measurement that was taken. */
+    if (blockmix && gpu) {
+        std::fprintf(stderr, "--gpu and --blockmix are exclusive: the census "
+                             "times no decode, so there is no row for a "
+                             "device number to go beside\n");
+        return 2;
+    }
+
     if (selfcheck) {
         /* Short and fixed, so the rot check stays fast on the GPU-less runner
          * and its verdict is a digest rather than a timing. */
@@ -2074,15 +2184,15 @@ int main(int argc, char** argv) {
     }
 
     if (blocktypes) {
-        return RunBlocktypes(warmup, runs, selfcheck);
+        return RunBlocktypes(warmup, runs, selfcheck, gpu);
     }
 
     if (worstrounds) {
-        return RunWorstRounds(warmup, runs, selfcheck);
+        return RunWorstRounds(warmup, runs, selfcheck, gpu);
     }
 
     if (worstheaders) {
-        return RunWorstHeaders(warmup, runs, selfcheck);
+        return RunWorstHeaders(warmup, runs, selfcheck, gpu);
     }
 
     std::vector<unsigned char> source;
@@ -2137,7 +2247,7 @@ int main(int argc, char** argv) {
     for (size_t i = 0; i < kLevelCount; i++) {
         uint64_t digest = 0;
         if (!RunLevel(source, name, provenance, kLevels[i],
-                      /*want_block_type=*/-1, warmup, runs, &digest)) {
+                      /*want_block_type=*/-1, warmup, runs, gpu, &digest)) {
             return 1;
         }
         if (selfcheck && !CheckDigest(digest, name, kLevels[i], expected[i])) {

--- a/bench/gpu_bench.cu
+++ b/bench/gpu_bench.cu
@@ -10,6 +10,7 @@
 #include "bench_stats.h"
 #include "cudec.h"
 #include "chunk_decode.cuh"
+#include "gdeflate_decode.cuh"
 #include "lz4_block.h"
 #include "snappy_block.h"
 #include "vendor_rt_test.h"
@@ -111,6 +112,14 @@ cudec_status LaunchFullSnappy(const void* const* s, const size_t* ss,
                               cudec_rt::stream_t stream) {
     return cudec_snappy_decompress_batch(s, ss, d, dc, n, r,
                                          cudec_rt::abi_stream(stream));
+}
+
+cudec_status LaunchFullGDeflate(const void* const* s, const size_t* ss,
+                                void* const* d, const size_t* dc, size_t n,
+                                cudec_chunk_result* r,
+                                cudec_rt::stream_t stream) {
+    return cudec_gdeflate_decompress_batch(s, ss, d, dc, n, r,
+                                           cudec_rt::abi_stream(stream));
 }
 
 double Median(std::vector<double>* t) {
@@ -261,7 +270,12 @@ bool BenchBatch(LaunchFn full, LaunchFn parse_only,
                     &full_ms)) {
         return false;
     }
-    if (!TimeKernel(parse_only, d_s, d_ss, d_d, d_dc, n, d_r, stream, warmup,
+    /* A format whose kernel has no parse-only variant passes none, and the
+     * two fields carry the sentinel rather than a number nothing measured.
+     * The alternative - timing the full decode twice and calling one of them
+     * a ceiling - is the shape of dishonesty this harness exists against. */
+    if (parse_only != nullptr &&
+        !TimeKernel(parse_only, d_s, d_ss, d_d, d_dc, n, d_r, stream, warmup,
                     runs, &parse_ms)) {
         return false;
     }
@@ -270,10 +284,13 @@ bool BenchBatch(LaunchFn full, LaunchFn parse_only,
     out->chunks = n;
     out->output_bytes = total_out;
     out->full_ms_p50 = full_ms;
-    out->parse_only_ms_p50 = parse_ms;
+    out->parse_only_ms_p50 =
+        parse_only != nullptr ? parse_ms : kCudecBenchNoParseOnly;
     /* GbpsFromMs carries the sub-microsecond guard (bench/bench_stats.h). */
     out->full_gbps_p50 = cudec_bench::GbpsFromMs(gb, full_ms);
-    out->parse_only_gbps_p50 = cudec_bench::GbpsFromMs(gb, parse_ms);
+    out->parse_only_gbps_p50 =
+        parse_only != nullptr ? cudec_bench::GbpsFromMs(gb, parse_ms)
+                              : kCudecBenchNoParseOnly;
     /* Buffers are reclaimed at process exit; the bench is a short-lived
      * one-shot, like the test harness. */
     return true;
@@ -326,6 +343,14 @@ bool cudec_bench_gpu_snappy(const unsigned char* const* comp,
     return BenchBatch(LaunchFullSnappy,
                       LaunchParseOnly<cudec_detail::SnappyParser>, comp,
                       comp_sizes, orig_sizes, n, warmup, runs, out);
+}
+
+bool cudec_bench_gpu_gdeflate(const unsigned char* const* comp,
+                              const size_t* comp_sizes,
+                              const size_t* orig_sizes, size_t n, int warmup,
+                              int runs, cudec_gpu_result* out) {
+    return BenchBatch(LaunchFullGDeflate, nullptr, comp, comp_sizes,
+                      orig_sizes, n, warmup, runs, out);
 }
 
 bool cudec_bench_gpu_stream_ctx(const unsigned char* const* comp,

--- a/bench/gpu_bench.h
+++ b/bench/gpu_bench.h
@@ -40,6 +40,29 @@ bool cudec_bench_gpu_snappy(const unsigned char* const* comp,
                             size_t n, int warmup, int runs,
                             cudec_gpu_result* out);
 
+/* The value the two parse-only fields carry when the format under measurement
+ * has no parse-only variant to time. Negative so it cannot be mistaken for a
+ * measurement and cannot be divided into: a zero would read as an
+ * infinitely fast parse, which is the wrong direction for a missing number to
+ * fail in. A caller prints the absence and its reason rather than the value. */
+const double kCudecBenchNoParseOnly = -1.0;
+
+/* GDeflate (issue #228): the shipped cudec_gdeflate_decompress_batch, one
+ * warp per 64 KiB page, timed by the identical protocol.
+ *
+ * NO PARSE-ONLY CEILING, AND THE ABSENCE IS THE MEASUREMENT'S RATHER THAN
+ * THIS FUNCTION'S. The two chunk formats get one because
+ * src/chunk_decode.cuh is templated on a ParseOnly flag that elides the
+ * copies while running the identical parse. The GDeflate kernel is not that
+ * shape: its parse is a warp-cooperative round loop whose next round depends
+ * on bytes the previous round's copies produced, so a variant with the copies
+ * elided would not decode the same symbols and would ceiling nothing. Both
+ * parse_only fields therefore come back as kCudecBenchNoParseOnly. */
+bool cudec_bench_gpu_gdeflate(const unsigned char* const* comp,
+                              const size_t* comp_sizes,
+                              const size_t* orig_sizes, size_t n, int warmup,
+                              int runs, cudec_gpu_result* out);
+
 struct cudec_stream_ctx_result {
     size_t chunks;
     size_t output_bytes;

--- a/docs/BENCHMARK-METHODOLOGY.md
+++ b/docs/BENCHMARK-METHODOLOGY.md
@@ -1,6 +1,7 @@
 # Benchmark methodology
 
-The performance write-up for cudec's LZ4 decode path: what is measured, on
+The performance write-up for cudec's decode paths - LZ4 throughout, and the
+GDeflate rows added under issue #228: what is measured, on
 what hardware, how to reproduce it, and how to read the numbers honestly.
 The raw baseline record - every number with the full methodology block the
 harness emits - lives in [BENCHMARKS.md](BENCHMARKS.md); this page is the
@@ -232,6 +233,49 @@ kernel throughput. Read it plainly:
   decode against the decoded-**output** readback, not the input - a change
   for those milestones, with its own test when it lands.
 
+### GDeflate (M4, one warp per 64 KiB page)
+
+The first recorded device numbers for the GDeflate path, on the same platform
+and the same protocol as the rows above. The full blocks are in
+[BENCHMARKS.md](BENCHMARKS.md) under "M4: the first recorded GDeflate GPU
+baselines"; this is the summary and it adds nothing that was not measured.
+
+| Corpus, level             | Ratio  | CPU oracle | GPU decode   | Relative |
+| ------------------------- | ------ | ---------- | ------------ | -------- |
+| Silesia, level 6          | 0.3343 | 0.327 GB/s | 8.056 GB/s   | ~24.7×   |
+| Silesia, level 0 (stored) | 1.0021 | 0.660 GB/s | 106.412 GB/s | ~161×    |
+| asset-like, level 6       | 0.7029 | 0.275 GB/s | 5.930 GB/s   | ~21.6×   |
+| worst-headers             | 2.8103 | 0.055 GB/s | 0.497 GB/s   | ~9.0×    |
+
+**Read the level-0 row as the copy path and not as GDeflate.** The reference
+emits uncompressed blocks by construction at level 0, so a page is a memcpy
+with a header; 106 GB/s at a ratio of 1.0021 is the ceiling the copy engine
+imposes on this kernel and says nothing about entropy decoding.
+
+**The working number is the level-6 row, 8.06 GB/s at a ratio of 0.334.**
+Against the LZ4 rows above that is roughly half the throughput at roughly half
+the size, which is the trade the format exists for; the two are not comparable
+as a single figure and no ratio between them is quoted here.
+
+**`worst-headers` is the margin, at 0.497 GB/s.** That corpus emits one
+dynamic block per group of matches, so a page pays a whole header decode for a
+handful of decoded bytes and the kernel spends its time in table construction
+rather than in the round loop. It is two orders of magnitude below the
+headline row and it is the number a denial-of-service argument is made from.
+
+**There is no parse-only ceiling for this path**, and its absence is a result.
+The LZ4 and Snappy rows get one from a template flag that elides the copies
+while running the identical parse; the GDeflate round loop's next round reads
+bytes the previous round's copies produced, so a variant with the copies
+elided would decode different symbols and ceiling nothing. Where the time
+actually goes inside this kernel is therefore not settled by these numbers,
+and the layout question that would move it is issue #204.
+
+**No perf conclusion is drawn about the kernel's shape from this run.** The
+achieved occupancy of the kernel these numbers were taken on is 24 of 48 warps
+per SM on sm_86, recorded on #214 against the design panel's prediction of 32;
+whether that costs throughput is a measurement nobody has taken.
+
 ## The design rationale (single-pass)
 
 cudec's LZ4 kernel is a single-pass, warp-cooperative design: each chunk is
@@ -319,6 +363,29 @@ and locked against rot by the `bench_worst4b_selfcheck` ctest on the GPU-less
 runner, so the adversarial number cannot silently drift. The asset-like corpus
 is held the same way by `bench_assetlike_selfcheck`, over the four quantities
 that define its regime rather than over validity alone.
+
+4. **The GDeflate rows** come out of a second binary with the same flag
+   vocabulary, and every one of its corpora is compressed by the pinned
+   reference or emitted by the harness itself - never by a second compressor:
+
+   | Invocation                            | What it measures                            |
+   | ------------------------------------- | ------------------------------------------- |
+   | `bench_gdeflate <files...>`           | CPU oracle denominator over the given files |
+   | `bench_gdeflate --gpu <files...>`     | + device-resident GPU decode per level      |
+   | `bench_gdeflate --gpu --assetlike`    | the game-asset model, per level             |
+   | `bench_gdeflate --gpu --blocktypes`   | the forced-block-type coverage rows         |
+   | `bench_gdeflate --gpu --worstrounds`  | the refill-bound adversarial corpus         |
+   | `bench_gdeflate --gpu --worstheaders` | the header-bound adversarial corpus         |
+   | `bench_gdeflate --selfcheck`          | the CI rot check (CPU-only, digest-locked)  |
+
+   `--gpu` is refused together with `--selfcheck` and with `--blockmix`: the
+   first runs on the GPU-less runner and the second times no decode, so in
+   both cases the flag would be accepted and do nothing, which reads
+   afterwards as a measurement that was taken.
+
+   The device rows print under the same methodology block as the CPU rows of
+   the same run, so the two cannot be quoted apart, and the harness refuses to
+   time a batch whose pages did not all decode to their original size.
 
 ## The nvCOMP comparison (not published)
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1614,6 +1614,14 @@ There is no GDeflate kernel yet. This entry is the denominator a later device
 number will be read against, and the harness says so in its own report rather
 than leaving a reader to infer it from the absence of a GPU row.
 
+**THE SENTENCE ABOVE WAS TRUE WHEN THIS ENTRY WAS RECORDED AND IS NOT TRUE
+NOW.** A kernel landed under #214 and the device numbers it was the denominator
+for are the section immediately below, taken over these same corpora at these
+same digests. The sentence is left standing rather than edited because the
+blocks under it are a record of a run and the run said what it said; this
+paragraph is the pointer a reader needs so nobody plans work off an expired
+absence.
+
 Eight cells, two corpora crossed with the level set section 11.8 of the
 [MASTERPLAN](MASTERPLAN.md) records. Silesia is the general-purpose half;
 `asset-like` is the generated game-asset model (issue #139), which is the one
@@ -1780,6 +1788,377 @@ carries the methodology its own numbers were taken under.
 - block-type composition: not asserted here; reading it needs a walk over the emitted page and that lock is issue #225's
 - wall per run: p50 626.935 ms / p90 666.084 ms / p99 682.146 ms
 - decode throughput: p50 0.335 GB/s / p90 0.315 GB/s / p99 0.307 GB/s
+```
+
+## M4: the first recorded GDeflate GPU baselines (issue #228)
+
+The kernel that landed under #214 decodes one 64 KiB page per warp, its 32
+lanes being the format's 32 substreams. These are its first numbers. The CPU
+denominator above is the same corpus set at the same digests, so the two
+sections are one measurement read two ways rather than two measurements.
+
+**Ratio is printed beside throughput on every row, and that is not decoration.**
+GDeflate's pitch over LZ4 and Snappy is DEFLATE-class ratio; a throughput-only
+table would misreport what the format is for. The level-0 rows are the extreme
+case of that: the reference emits uncompressed blocks by construction there, so
+a page is a memcpy with a header and the decoder reaches 106 GB/s at a ratio of
+1.0021 - a number that says nothing about decoding and everything about the
+copy engine. Read it as the ceiling the copy path imposes and never as a
+GDeflate figure.
+
+**There is no parse-only row and the absence is a result rather than an
+omission.** The LZ4 and Snappy rows carry one because `src/chunk_decode.cuh` is
+templated on a `ParseOnly` flag that elides the copies while running the
+identical parse, so the two numbers bracket where the time goes. The GDeflate
+kernel is not that shape: its round loop's next round reads bytes the previous
+round's copies produced, so a variant with the copies elided would decode
+different symbols and ceiling nothing. The harness prints that sentence in
+place of the row rather than filling it with the full decode timed twice.
+
+**What was measured and what was not.** Every number below is a device-resident
+decode: the pages are already on the GPU, so H2D and D2H are excluded and the
+figure is kernel decode throughput. Timing is CUDA-event, 3 warmup plus 30
+measured runs, p50 nearest-rank - the same protocol and the same percentile
+definition the CPU rows above use, so the ratio column is a division of two
+numbers that mean the same thing. Before a single run is timed, every page is
+decoded by the shipped batch entry and its `bytes_written` compared against the
+page's original size; the harness refuses to time a batch that failed that, so
+no number here is from an unverified decode.
+
+Recorded 2026-09-05 in the Ubuntu-24.04 WSL distribution, on
+`NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3`, host CPU
+`AMD Ryzen 9 5950X 16-Core Processor`, against the gdeflate fork pinned at
+`8ba9502fb30d2bf728592d121f0d402e40c8cb05`, at `dfda2c7`. Reproduce with
+
+```
+bench_gdeflate --gpu --warmup 3 --runs 30 bench/corpora/silesia/*
+bench_gdeflate --gpu --warmup 3 --runs 30 --assetlike
+bench_gdeflate --gpu --warmup 3 --runs 30 --blocktypes
+bench_gdeflate --gpu --warmup 3 --runs 30 --worstrounds
+bench_gdeflate --gpu --warmup 3 --runs 30 --worstheaders
+```
+
+**Read the p50 and treat the CPU tail with the same suspicion the section above
+asks for.** The asset-like level-1 cell spreads from 724 ms at p50 to 1796 ms at
+p99, which is host contention rather than a property of either decoder. The GPU
+rows are event-timed on an otherwise idle device and their p50 is the figure;
+the harness prints no GPU tail, so nothing here claims one.
+
+### The headline rows
+
+| corpus     | level | ratio  | CPU p50    | GPU p50   | GPU throughput | GPU vs CPU | corpus digest      |
+| ---------- | ----- | ------ | ---------- | --------- | -------------- | ---------- | ------------------ |
+| Silesia    | 0     | 1.0021 | 0.660 GB/s | 1.992 ms  | 106.412 GB/s   | 161.14x    | `88ed82d5ec9df3ad` |
+| Silesia    | 1     | 0.3581 | 0.310 GB/s | 28.187 ms | 7.519 GB/s     | 24.26x     | `131124d155e6672b` |
+| Silesia    | 6     | 0.3343 | 0.327 GB/s | 26.308 ms | 8.056 GB/s     | 24.66x     | `042b2473240db0b0` |
+| Silesia    | 12    | 0.3198 | 0.348 GB/s | 26.810 ms | 7.905 GB/s     | 22.70x     | `4b88e13a215ed884` |
+| asset-like | 0     | 1.0021 | 0.637 GB/s | 1.995 ms  | 105.133 GB/s   | 165.06x    | `08ac6ec118b60189` |
+| asset-like | 1     | 0.7105 | 0.289 GB/s | 35.573 ms | 5.895 GB/s     | 20.37x     | `45690d97a5d3b054` |
+| asset-like | 6     | 0.7029 | 0.275 GB/s | 35.368 ms | 5.930 GB/s     | 21.58x     | `47dad3ea983dc577` |
+| asset-like | 12    | 0.6995 | 0.296 GB/s | 36.078 ms | 5.813 GB/s     | 19.63x     | `cb272ab3765d8378` |
+
+The digests are the ones the CPU section above recorded on 2026-08-26, cell for
+cell, so the two sections are attested against identical bytes.
+
+**What the level columns say.** Away from level 0 the decoder sits between 5.8
+and 8.1 GB/s and barely moves with the level: 7.52, 8.06 and 7.91 GB/s on
+Silesia at levels 1, 6 and 12. The table description gets denser as the level
+rises and the throughput does not fall with it, which is a reading about this
+corpus at this kernel and not a claim that table construction is free -
+whether it is, and whether a different table layout moves it, is #204's
+measurement and nothing here answers it.
+
+### Decode-path coverage rows, not headline numbers
+
+The forced-block-type corpora (#225) are here because a level list is a plan
+for coverage and not the coverage argument. Each family asserts the block type
+it actually reached by walking the emitted page's first block header. They are
+64 pages against the headline set's 3200, so their absolute figures carry the
+launch's fixed cost in a way the large corpora do not; they are coverage and a
+ratio, never a throughput claim.
+
+| family             | level | ratio  | CPU p50    | GPU p50  | GPU throughput | GPU vs CPU | corpus digest      |
+| ------------------ | ----- | ------ | ---------- | -------- | -------------- | ---------- | ------------------ |
+| stored-by-level    | 0     | 1.0021 | 0.610 GB/s | 0.730 ms | 5.745 GB/s     | 9.42x      | `c29d43ce8a158356` |
+| stored-by-input    | 6     | 1.0021 | 0.681 GB/s | 0.729 ms | 5.753 GB/s     | 8.45x      | `aa7dc860c5cb5db8` |
+| static-low-entropy | 1     | 0.0026 | 1.239 GB/s | 0.289 ms | 14.525 GB/s    | 11.72x     | `5a39a208be933f45` |
+
+### The adversarial rows
+
+The two hand-emitted corpora are the DoS-resistance margin, and under the #36
+rule they outrank an average-case win: a change that improves Silesia and
+regresses either of these is refused. Neither is produced by a compressor -
+both are emitted by the harness and validated against the reference before
+timing - and both are in the record so a later perf pass has a before.
+
+| corpus        | ratio  | CPU p50    | GPU p50   | GPU throughput | GPU vs CPU | corpus digest      |
+| ------------- | ------ | ---------- | --------- | -------------- | ---------- | ------------------ |
+| worst-rounds  | 2.4608 | 0.301 GB/s | 9.377 ms  | 3.578 GB/s     | 11.88x     | `6e2f2850f76891bb` |
+| worst-headers | 2.8103 | 0.055 GB/s | 67.579 ms | 0.497 GB/s     | 8.96x      | `c79e0a872dba2ca3` |
+
+`worst-headers` is the floor and it is two orders of magnitude below the
+headline: 0.497 GB/s against 8.056. That is the kernel spending its time in
+table construction rather than in the round loop, which is what the corpus is
+built to force - one block per group of matches, so a page pays a whole
+dynamic-header decode for a handful of decoded bytes. The margin the format's
+worst case leaves is this row and not the Silesia one.
+
+The tables above are a reading aid. The thirteen blocks below are the record,
+and each one carries the methodology its own numbers were taken under.
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, 212.38 MB compressed (ratio 1.0021), cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- granularity: 64 KiB pages, compression level 0
+- corpus digest: 88ed82d5ec9df3ad (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted on this path; the four-level sweep claims no block type, which is section 11.8's rule that a level list is a plan for coverage and not the coverage argument
+- wall per run: p50 320.933 ms / p90 348.782 ms / p99 359.458 ms
+- decode throughput: p50 0.660 GB/s / p90 0.608 GB/s / p99 0.590 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3234 pages, every page verified to its original size before timing): p50 1.992 ms, 106.412 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 161.14x (CPU p50 320.933 ms, GPU p50 1.992 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, 75.89 MB compressed (ratio 0.3581), cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- granularity: 64 KiB pages, compression level 1
+- corpus digest: 131124d155e6672b (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted on this path; the four-level sweep claims no block type, which is section 11.8's rule that a level list is a plan for coverage and not the coverage argument
+- wall per run: p50 683.930 ms / p90 713.092 ms / p99 743.880 ms
+- decode throughput: p50 0.310 GB/s / p90 0.297 GB/s / p99 0.285 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3234 pages, every page verified to its original size before timing): p50 28.187 ms, 7.519 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 24.26x (CPU p50 683.930 ms, GPU p50 28.187 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, 70.84 MB compressed (ratio 0.3343), cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- granularity: 64 KiB pages, compression level 6
+- corpus digest: 042b2473240db0b0 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted on this path; the four-level sweep claims no block type, which is section 11.8's rule that a level list is a plan for coverage and not the coverage argument
+- wall per run: p50 648.837 ms / p90 696.670 ms / p99 741.220 ms
+- decode throughput: p50 0.327 GB/s / p90 0.304 GB/s / p99 0.286 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3234 pages, every page verified to its original size before timing): p50 26.308 ms, 8.056 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 24.66x (CPU p50 648.837 ms, GPU p50 26.308 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, 3234 pages, 211.94 MB original, 67.77 MB compressed (ratio 0.3198), cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- granularity: 64 KiB pages, compression level 12
+- corpus digest: 4b88e13a215ed884 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 60692 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted on this path; the four-level sweep claims no block type, which is section 11.8's rule that a level list is a plan for coverage and not the coverage argument
+- wall per run: p50 608.638 ms / p90 673.915 ms / p99 793.415 ms
+- decode throughput: p50 0.348 GB/s / p90 0.314 GB/s / p99 0.267 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3234 pages, every page verified to its original size before timing): p50 26.810 ms, 7.905 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 22.70x (CPU p50 608.638 ms, GPU p50 26.810 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: asset-like, 3200 pages, 209.72 MB original, 210.15 MB compressed (ratio 1.0021), generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- granularity: 64 KiB pages, compression level 0
+- corpus digest: 08ac6ec118b60189 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted on this path; the four-level sweep claims no block type, which is section 11.8's rule that a level list is a plan for coverage and not the coverage argument
+- wall per run: p50 329.262 ms / p90 406.229 ms / p99 428.289 ms
+- decode throughput: p50 0.637 GB/s / p90 0.516 GB/s / p99 0.490 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3200 pages, every page verified to its original size before timing): p50 1.995 ms, 105.133 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 165.06x (CPU p50 329.262 ms, GPU p50 1.995 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: asset-like, 3200 pages, 209.72 MB original, 149.00 MB compressed (ratio 0.7105), generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- granularity: 64 KiB pages, compression level 1
+- corpus digest: 45690d97a5d3b054 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted on this path; the four-level sweep claims no block type, which is section 11.8's rule that a level list is a plan for coverage and not the coverage argument
+- wall per run: p50 724.627 ms / p90 799.562 ms / p99 1796.250 ms
+- decode throughput: p50 0.289 GB/s / p90 0.262 GB/s / p99 0.117 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3200 pages, every page verified to its original size before timing): p50 35.573 ms, 5.895 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 20.37x (CPU p50 724.627 ms, GPU p50 35.573 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: asset-like, 3200 pages, 209.72 MB original, 147.40 MB compressed (ratio 0.7029), generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- granularity: 64 KiB pages, compression level 6
+- corpus digest: 47dad3ea983dc577 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted on this path; the four-level sweep claims no block type, which is section 11.8's rule that a level list is a plan for coverage and not the coverage argument
+- wall per run: p50 763.128 ms / p90 816.742 ms / p99 849.770 ms
+- decode throughput: p50 0.275 GB/s / p90 0.257 GB/s / p99 0.247 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3200 pages, every page verified to its original size before timing): p50 35.368 ms, 5.930 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 21.58x (CPU p50 763.128 ms, GPU p50 35.368 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: asset-like, 3200 pages, 209.72 MB original, 146.70 MB compressed (ratio 0.6995), generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- granularity: 64 KiB pages, compression level 12
+- corpus digest: cb272ab3765d8378 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: not asserted on this path; the four-level sweep claims no block type, which is section 11.8's rule that a level list is a plan for coverage and not the coverage argument
+- wall per run: p50 708.035 ms / p90 740.773 ms / p99 758.982 ms
+- decode throughput: p50 0.296 GB/s / p90 0.283 GB/s / p99 0.276 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 3200 pages, every page verified to its original size before timing): p50 36.078 ms, 5.813 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 19.63x (CPU p50 708.035 ms, GPU p50 36.078 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: stored-by-level, 64 pages, 4.19 MB original, 4.20 MB compressed (ratio 1.0021), generated in-harness from a fixed PRNG and compressed at level 0, which the reference's own header says emits uncompressed blocks by construction; DECODE-PATH COVERAGE, not a throughput figure
+- granularity: 64 KiB pages, compression level 0
+- corpus digest: c29d43ce8a158356 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: every page opens with a stored block, and BFINAL is clear on it in every page, so every page carries at least one more block that this walk does not reach - a lower bound on the count, never a census (a later block in the same page is neither asserted nor denied, because reaching one means decoding to it)
+- wall per run: p50 6.874 ms / p90 7.331 ms / p99 8.081 ms
+- decode throughput: p50 0.610 GB/s / p90 0.572 GB/s / p99 0.519 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 64 pages, every page verified to its original size before timing): p50 0.730 ms, 5.745 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 9.42x (CPU p50 6.874 ms, GPU p50 0.730 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: stored-by-input, 64 pages, 4.19 MB original, 4.20 MB compressed (ratio 1.0021), generated in-harness from a xorshift PRNG, incompressible by construction, compressed at the DEFAULT level 6 - the stored block here is forced by the input and not by the level; DECODE-PATH COVERAGE, not a throughput figure
+- granularity: 64 KiB pages, compression level 6
+- corpus digest: aa7dc860c5cb5db8 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: every page opens with a stored block, and BFINAL is clear on it in every page, so every page carries at least one more block that this walk does not reach - a lower bound on the count, never a census (a later block in the same page is neither asserted nor denied, because reaching one means decoding to it)
+- wall per run: p50 6.162 ms / p90 6.827 ms / p99 6.979 ms
+- decode throughput: p50 0.681 GB/s / p90 0.614 GB/s / p99 0.601 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 64 pages, every page verified to its original size before timing): p50 0.729 ms, 5.753 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 8.45x (CPU p50 6.162 ms, GPU p50 0.729 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: static-low-entropy, 64 pages, 4.19 MB original, 0.01 MB compressed (ratio 0.0026), generated in-harness as a seven-byte repeating alphabet with no noise, compressed at level 1, where a dynamic table description costs more than the fixed code it would replace; DECODE-PATH COVERAGE, not a throughput figure
+- granularity: 64 KiB pages, compression level 1
+- corpus digest: 5a39a208be933f45 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: every page opens with a static block, and BFINAL is set on it in every page, so each page is that one block and this is the page's whole composition rather than its opening
+- wall per run: p50 3.386 ms / p90 3.688 ms / p99 4.567 ms
+- decode throughput: p50 1.239 GB/s / p90 1.137 GB/s / p99 0.918 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 64 pages, every page verified to its original size before timing): p50 0.289 ms, 14.525 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 11.72x (CPU p50 3.386 ms, GPU p50 0.289 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: worst-rounds, 512 pages, 33.55 MB original, 82.57 MB compressed (ratio 2.4608), HAND-CONSTRUCTED by this harness and validated by the pinned gdeflate fork, not produced by any compressor: one final dynamic block per page, every symbol in it at DEFLATE's maximum codeword length, and a body of minimum-length matches asked for through the sixteen-extra-bit length symbol, so the deferred-copy path runs once per three decoded bytes; ADVERSARIAL, the M4 security-posture row and never a headline throughput figure, and NOT scale-comparable with this harness's other corpora, which are recorded on their own invocations and are several times this one in pages
+- padding: 8.39 MB on top of the compressed figure above, a zero tail per page for the reference's unchecked refill; no decoder reads it and the ratio does not count it
+- granularity: 64 KiB pages, emitted by this harness - no compressor and therefore no compression level
+- corpus digest: 6e2f2850f76891bb (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: every page opens with a dynamic block, and BFINAL is set on it in every page, so each page is that one block and this is the page's whole composition rather than its opening
+- refill density: 0.6152 refills per decoded byte over 20642816 refills and 33554432 decoded bytes, worst page 0.6152, floor 0.6000 taken on the worst page rather than on the mean, counted by cudec's own schedule (src/gdeflate_schedule.h) on a decode required to reproduce the source and to fill a whole page; this is the quantity the corpus is locked on and not a timing
+- blocks per page: min 1 / max 1, 512 blocks over the corpus of which 512 dynamic, counted by cudec's own page decode (src/gdeflate_block.h) rather than by the construction that emitted them
+- deferred copies: 11124736, one per 3 decoded bytes past the opening literal run - the length round reserves and the distance round on the same lane retires. ARITHMETIC over the corpus's construction and not a count read out of the decode: no decoder in this tree reports a retirement
+- wall per run: p50 111.394 ms / p90 147.333 ms / p99 158.893 ms
+- decode throughput: p50 0.301 GB/s / p90 0.228 GB/s / p99 0.211 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 512 pages, every page verified to its original size before timing): p50 9.377 ms, 3.578 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 11.88x (CPU p50 111.394 ms, GPU p50 9.377 ms)
+```
+
+```
+## bench_gdeflate report
+- decoder: CPU oracle, libdeflate_gdeflate_decompress (the pinned NVIDIA/libdeflate gdeflate fork, commit 8ba9502fb30d2bf728592d121f0d402e40c8cb05), single thread. The GPU rows below time cudec's own decoder through cudec_gdeflate_decompress_batch, and the CPU rows are the denominator they are read against
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: worst-headers, 512 pages, 33.55 MB original, 94.30 MB compressed (ratio 2.8103), HAND-CONSTRUCTED by this harness and validated by the pinned gdeflate fork, not produced by any compressor: the worst-rounds page cut into one dynamic block per group of 32 minimum-length matches, so it carries that row's maximum-length codewords and its deferred-copy-per-three-bytes body AND a dynamic block header every 96 decoded bytes; ADVERSARIAL, the M4 security-posture row and never a headline throughput figure, and NOT scale-comparable with this harness's other corpora, which are recorded on their own invocations and are several times this one in pages
+- padding: 8.39 MB on top of the compressed figure above, a zero tail per page for the reference's unchecked refill; no decoder reads it and the ratio does not count it
+- granularity: 64 KiB pages, emitted by this harness - no compressor and therefore no compression level
+- corpus digest: c79e0a872dba2ca3 (XXH64 over per-page length and XXH64, little-endian, in corpus order)
+- page sizes: min 65536 / median 65536 / max 65536 bytes uncompressed
+- method: 3 warmup + 30 measured runs, wall clock per whole-batch decode; the timed region is libdeflate_gdeflate_decompress only (destinations allocated outside it); every page round-trip-verified against the source once before timing; percentiles are nearest-rank
+- block-type composition: every page opens with a dynamic block, and BFINAL is clear on it in every page, so every page carries at least one more block that this walk does not reach - a lower bound on the count, never a census (a later block in the same page is neither asserted nor denied, because reaching one means decoding to it)
+- refill density: 0.7026 refills per decoded byte over 23574528 refills and 33554432 decoded bytes, worst page 0.7026, floor 0.6600 taken on the worst page rather than on the mean, counted by cudec's own schedule (src/gdeflate_schedule.h) on a decode required to reproduce the source and to fill a whole page; this is the quantity the corpus is locked on and not a timing
+- blocks per page: min 679 / max 679, 347648 blocks over the corpus of which 347648 dynamic, counted by cudec's own page decode (src/gdeflate_block.h) rather than by the construction that emitted them
+- deferred copies: 11124736, one per 3 decoded bytes past the opening literal run - the length round reserves and the distance round on the same lane retires. ARITHMETIC over the corpus's construction and not a count read out of the decode: no decoder in this tree reports a retirement
+- wall per run: p50 605.236 ms / p90 700.178 ms / p99 883.518 ms
+- decode throughput: p50 0.055 GB/s / p90 0.048 GB/s / p99 0.038 GB/s
+- GPU decode (device-resident, CUDA-event timed, 3 warmup + 30 runs, 512 pages, every page verified to its original size before timing): p50 67.579 ms, 0.497 GB/s
+- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
+- GPU vs the CPU denominator in this report: 8.96x (CPU p50 605.236 ms, GPU p50 67.579 ms)
 ```
 
 ## M4 perf lever: the block-type mix, retired on the census (issue #206)


### PR DESCRIPTION
Closes #228.

The GDeflate kernel landed under #214 with no number attached, on purpose - numbers and kernel never move in the same pull request. This is the number, and nothing under `src/` changes here.

## The headline rows

Recorded 2026-09-05 in the Ubuntu-24.04 WSL distribution, on `NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3`, host CPU `AMD Ryzen 9 5950X 16-Core Processor`, gdeflate fork pinned at `8ba9502fb30d2bf728592d121f0d402e40c8cb05`, at `dfda2c7`.

| corpus     | level | ratio  | CPU p50    | GPU p50   | GPU throughput | GPU vs CPU |
| ---------- | ----- | ------ | ---------- | --------- | -------------- | ---------- |
| Silesia    | 0     | 1.0021 | 0.660 GB/s | 1.992 ms  | 106.412 GB/s   | 161.14x    |
| Silesia    | 1     | 0.3581 | 0.310 GB/s | 28.187 ms | 7.519 GB/s     | 24.26x     |
| Silesia    | 6     | 0.3343 | 0.327 GB/s | 26.308 ms | 8.056 GB/s     | 24.66x     |
| Silesia    | 12    | 0.3198 | 0.348 GB/s | 26.810 ms | 7.905 GB/s     | 22.70x     |
| asset-like | 0     | 1.0021 | 0.637 GB/s | 1.995 ms  | 105.133 GB/s   | 165.06x    |
| asset-like | 1     | 0.7105 | 0.289 GB/s | 35.573 ms | 5.895 GB/s     | 20.37x     |
| asset-like | 6     | 0.7029 | 0.275 GB/s | 35.368 ms | 5.930 GB/s     | 21.58x     |
| asset-like | 12    | 0.6995 | 0.296 GB/s | 36.078 ms | 5.813 GB/s     | 19.63x     |

Plus three forced-block-type coverage rows and the two adversarial corpora:

| corpus             | ratio  | CPU p50    | GPU p50   | GPU throughput | GPU vs CPU |
| ------------------ | ------ | ---------- | --------- | -------------- | ---------- |
| stored-by-level    | 1.0021 | 0.610 GB/s | 0.730 ms  | 5.745 GB/s     | 9.42x      |
| stored-by-input    | 1.0021 | 0.681 GB/s | 0.729 ms  | 5.753 GB/s     | 8.45x      |
| static-low-entropy | 0.0026 | 1.239 GB/s | 0.289 ms  | 14.525 GB/s    | 11.72x     |
| worst-rounds       | 2.4608 | 0.301 GB/s | 9.377 ms  | 3.578 GB/s     | 11.88x     |
| worst-headers      | 2.8103 | 0.055 GB/s | 67.579 ms | 0.497 GB/s     | 8.96x      |

**Read the level-0 rows as the copy path and not as GDeflate.** The reference emits uncompressed blocks by construction at level 0, so a page is a memcpy with a header; 106 GB/s at a ratio of 1.0021 is the ceiling the copy engine imposes and says nothing about entropy decoding. The working number is the level-6 row, **8.06 GB/s at a ratio of 0.334**.

**`worst-headers` is the margin, at 0.497 GB/s** - two orders of magnitude below the headline. That corpus emits one dynamic block per group of matches, so a page pays a whole header decode for a handful of decoded bytes. It is the number a denial-of-service argument gets made from, and it is in the record so a later perf pass has a before under the #36 rule.

**The level-sweep digests are the ones the CPU denominator recorded on 2026-08-26, cell for cell** - `88ed82d5ec9df3ad`, `131124d155e6672b`, `042b2473240db0b0`, `4b88e13a215ed884`, `08ac6ec118b60189`, `45690d97a5d3b054`, `47dad3ea983dc577`, `cb272ab3765d8378` - so the two sections are attested against identical bytes rather than against two corpora that look alike.

## No parse-only row, and the absence is a result

`docs/BENCHMARKS.md` records it as one rather than omitting it, which is what this issue's scope asks for. The two chunk formats get a ceiling from a `ParseOnly` template flag in `src/chunk_decode.cuh` that elides the copies while running the identical parse. The GDeflate round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided would decode different symbols and ceiling nothing. `cudec_bench_gpu_gdeflate` therefore passes no parse-only launcher, `BenchBatch` fills both fields with a negative sentinel rather than a zero, and the harness prints the sentence where the row would be:

```
- GPU parse-only ceiling: not instantiable for this format - the round loop's next round reads bytes the previous round's copies produced, so a variant with the copies elided decodes different symbols and ceilings nothing. The row is absent rather than filled with the full decode timed twice
```

So where the time goes inside this kernel is **not settled by these numbers**, and this body claims nothing about it. The layout question that would move it is #204.

## Two flag combinations are refused rather than ignored

```
$ bench_gdeflate --gpu --selfcheck
--gpu and --selfcheck are exclusive: the selfcheck runs on the GPU-less runner
exit=2
$ bench_gdeflate --gpu --blockmix bench/corpora/silesia/xml
--gpu and --blockmix are exclusive: the census times no decode, so there is no row for a device number to go beside
exit=2
```

The first would report green on a runner where nothing device-side ran; the second would accept the flag and print no device row. A flag that is accepted and does nothing is read afterwards as a measurement that was taken.

## An expired sentence the section above carried

`docs/BENCHMARKS.md`'s M4 CPU denominator opens with "There is no GDeflate kernel yet". It stopped being true at `b52ba1d`. The sentence is left standing and a paragraph beside it now points at the device numbers: the blocks under it record a run and the run said what it said, but a reader planning work off an expired absence is exactly the cost #442 was about. The same expired claim in `bench/bench_gdeflate.cpp`'s own header ("No CUDA in this binary at all") is replaced, because that one is a statement about the file rather than about a run.

## What was measured and what was not

Every figure is a device-resident decode: pages already on the GPU, so H2D and D2H are excluded. CUDA-event timed, 3 warmup plus 30 measured runs, p50 nearest-rank - the same protocol and percentile definition the CPU rows use, so the ratio column divides two numbers that mean the same thing. Before a single run is timed, every page is decoded through the shipped batch entry and its `bytes_written` compared against the page's original size; the harness refuses to time a batch that failed that.

**The CPU tail on this run carries host contention, not a decoder property.** The asset-like level-1 cell spreads from 724 ms at p50 to 1796 ms at p99. The p50 is the denominator; the tail is reported because the block reports it. The GPU rows are event-timed on an otherwise idle device and the harness prints no GPU tail, so nothing here claims one.

**No nvCOMP comparison appears anywhere in this change**, per §8.9 of the NVIDIA SLA and `docs/BENCHMARK-METHODOLOGY.md`'s own policy section.

## The means

The bench harness that already exists, with the device rows wired into `bench_gdeflate` exactly the way `bench/CMakeLists.txt`'s own comment said they would be when a kernel arrived - `gpu_bench.cu` compiled into the target rather than made a shared library, which is the trade that file already argues for `bench_snappy`. No new dependency, no second timing apparatus, and the reference's provenance is unchanged: `gdeflate_oracle` and nothing else.

## Gate

```
$ cmake --build ~/af08-214 -j8 && ctest --test-dir ~/af08-214 --output-on-failure
100% tests passed, 0 tests failed out of 67
Label Time Summary:
gpu    =  14.09 sec*proc (11 tests)

$ ctest --test-dir ~/af08-214 -LE gpu --no-tests=error
100% tests passed, 0 tests failed out of 56

$ npx --yes prettier@3 --check docs/BENCHMARK-METHODOLOGY.md docs/BENCHMARKS.md
All matched files use Prettier code style!

$ sh scripts/check-doc-paths.sh
PASS: every path a tense-present document names resolves, and every declared forward reference names an open issue
```

Reproduce the numbers with:

```
bench_gdeflate --gpu --warmup 3 --runs 30 bench/corpora/silesia/*
bench_gdeflate --gpu --warmup 3 --runs 30 --assetlike
bench_gdeflate --gpu --warmup 3 --runs 30 --blocktypes
bench_gdeflate --gpu --warmup 3 --runs 30 --worstrounds
bench_gdeflate --gpu --warmup 3 --runs 30 --worstheaders
```

## What is not covered

The issue's constraint asks for all kernel gates green first and names compute-sanitizer memcheck and racecheck among them. **Those were not run and could not be**: the sanitizer cannot attach on this host and the gate is parked (#127, #258). The gates that were producible are green and landed before this: the whole-corpus GPU-vs-oracle diff over 14295 pages (#214), and the determinism, two-directional mutant parity, crafted ladder and capacity adversarials (#218, merged as `dfda2c7`). A race in shared memory that those do not happen to expose is not excluded by anything in this branch, and no number here would notice one.

The README's status-table row does not flip here; that happens when the M4 milestone closes.

## No second reader

Nobody but the hand that wrote it has read this. The reproduce lines above stand in place of one: they are what somebody else would run to disagree with the numbers, and nothing here can tell whether the corpora are the right ones to have measured.
