### PR TITLE
Tell an AMD reporter to record the driver and the commit built

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-amd-validation-result.yml
+++ b/.github/ISSUE_TEMPLATE/4-amd-validation-result.yml
@@ -7,10 +7,9 @@
 # The field set is docs/AMD-VALIDATION.md's section 6 and nothing else: that
 # document is the instruction and this form is the intake, so a field here that
 # the runbook never told a reporter to capture would be asking for something
-# they were never told to keep. Two things a reader might expect are therefore
-# absent - the driver version and the commit built - because the runbook does
-# not ask for either. That is a gap in the runbook, recorded on issue #246, and
-# not one this form may close on its own.
+# they were never told to keep. Two of the six arrived that way rather than
+# being invented here - the kernel driver version and the commit built, which
+# the runbook did not ask for until issue #451 put them in it, in that order.
 name: AMD validation result
 description:
   Output from running the suite or the benchmarks on an AMD GPU, following
@@ -82,6 +81,29 @@ body:
         differed, this field is the most valuable thing in the report after the
         output itself.
       render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: driver
+    attributes:
+      label: Kernel driver version
+      description:
+        Not the ROCm version - the userspace stack and the kernel module ship
+        separately. Step 6 has the line that prints it. "Not readable on this
+        host" is a complete answer.
+      placeholder: 6.10.5
+    validations:
+      required: false
+
+  - type: input
+    id: commit
+    attributes:
+      label: The commit you built
+      description:
+        Step 6's `git rev-parse HEAD`, inside the clone step 1 made. Without
+        it the result is pinned to a day rather than to a tree.
+      placeholder: dfda2c709124bdd763b0a852e6fbc092e2539f30
     validations:
       required: true
 

--- a/docs/AMD-VALIDATION.md
+++ b/docs/AMD-VALIDATION.md
@@ -190,8 +190,10 @@ With it, six facts that no output above carries on its own:
 - the `docker run` invocation you actually used, if it differs from step 3.
 
 Open an issue on <https://github.com/iderex/cudec/issues> with all of it. The
-form built for exactly this, which cannot be submitted without the first three
-of those, is under "AMD validation result" in the New Issue chooser. A result
+form built for exactly this is under "AMD validation result" in the New Issue
+chooser, and it refuses to submit without five of the six - the driver version
+is the one it accepts empty, because it is the one you may genuinely be unable
+to read. A result
 from wave64 silicon has an address of its own, issue #415, which is open
 precisely because that dispatch arm has never executed anywhere.
 

--- a/docs/AMD-VALIDATION.md
+++ b/docs/AMD-VALIDATION.md
@@ -159,18 +159,41 @@ methodology inseparably from its numbers, on purpose
 hand-trimmed block is not a usable result and will not be recorded. The same
 goes for the `ctest` output - the whole thing, passes included.
 
-With it, four facts that no output above carries on its own:
+With it, six facts that no output above carries on its own:
 
 - the GPU's marketing name and its `gfx` target, from step 2;
 - the wave width, from step 2;
 - the ROCm version: 7.2.4 if you used the image above unchanged, otherwise
   the one you built with;
+- **the kernel driver version**, which is not the ROCm version and can differ
+  from it - the userspace stack and the kernel module ship separately, and
+  every CUDA number this project records carries its driver for the same
+  reason (`docs/BENCHMARKS.md`). One line, on the host rather than in the
+  container:
+
+  ```sh
+  cat /sys/module/amdgpu/version 2>/dev/null || modinfo amdgpu | grep ^version
+  ```
+
+  If neither prints anything, say so - "not readable on this host" is a
+  complete answer and better than a guess;
+
+- **the commit you built**, from inside the clone step 1 made:
+
+  ```sh
+  git rev-parse HEAD
+  ```
+
+  Without it a result is pinned to the day it was run rather than to a tree,
+  and a row in `docs/BENCHMARKS.md` that nobody can reproduce is not a row;
+
 - the `docker run` invocation you actually used, if it differs from step 3.
 
-Open an issue on <https://github.com/iderex/cudec/issues> with all of it. A
-result from wave64 silicon has an address of its own, issue #415, which is
-open precisely because that dispatch arm has never executed anywhere; the
-purpose-built intake form is #246.
+Open an issue on <https://github.com/iderex/cudec/issues> with all of it. The
+form built for exactly this, which cannot be submitted without the first three
+of those, is under "AMD validation result" in the New Issue chooser. A result
+from wave64 silicon has an address of its own, issue #415, which is open
+precisely because that dispatch arm has never executed anywhere.
 
 ## What an hour buys, measured where it could be measured
 


### PR DESCRIPTION
Closes #451.

Section 6 of `docs/AMD-VALIDATION.md` named four facts a reporter must send beside the output, and the intake form that landed under #246 asks for exactly those and nothing else - that issue's third Done-when refuses a field the runbook never told somebody to capture. Two facts a recorded AMD result needs were in neither.

## The commit built

Step 1 clones the default branch and nothing told the reporter to write down where it landed, so a result arrives pinned to the day it was run rather than to a tree. A row in `docs/BENCHMARKS.md` nobody can reproduce is not a row, and the cost to the reporter is one command:

```sh
git rev-parse HEAD
```

Required on the form.

## The driver, decided rather than left open

This issue held the driver question open as a real question rather than an oversight. It is taken here, in the direction the rest of the project already goes: the ROCm version is the userspace stack and the kernel module ships separately, so the two can differ; and every CUDA number this project records carries its driver beside its runtime, which is what makes those rows comparable across machines. The reason is written beside the field so nobody re-argues it from scratch.

It is **optional** on the form, and that is the one place this departs from a strict reading. It is the single fact of the six a reporter may genuinely be unable to read on their host - a container without `/sys/module/amdgpu`, a distribution that does not ship `modinfo` - and a required field somebody cannot answer turns a complete result away. The runbook says so in as many words: "not readable on this host" is a complete answer and better than a guess.

## The ordering

The runbook moves first and the form follows it, which is #246's Constraint section: that one is the instruction, this one is the intake. The form's header comment stops recording the two as a gap and records instead that they arrived through the runbook rather than being invented in the form.

## The means

Two files that already exist, edited in the order the rule sets. No mechanism is added and none is claimed: nothing refuses a form field that the runbook does not name, so the ordering is carried by these two documents and by the review, exactly as it was before.

## Gate

```
$ npx --yes prettier@3 --check .github/ISSUE_TEMPLATE/4-amd-validation-result.yml docs/AMD-VALIDATION.md
All matched files use Prettier code style!

$ sh scripts/check-doc-paths.sh
PASS: every path a tense-present document names resolves, and every declared forward reference names an open issue
```

and the form's shape, checked against what GitHub's schema requires rather than by eye - every non-markdown element with a unique lowercase id and a label, the dropdown with its options:

```
  markdown - required= None
  input gpu required= True
  dropdown wave-width required= True
  input rocm required= True
  textarea invocation required= True
  input driver required= False
  input commit required= True
  textarea ctest required= True
  textarea bench required= False
  textarea anything-else required= False
OK
```

Nothing under `src/`, `tests/` or `bench/` changes, so `build`, `hip` and `sanitize` on this pull request are re-runs of the mainline's own state; `format` is the one that reads these two files.

## What is not covered

Still nothing reads a form field against the runbook, so the one-for-one rule these two documents follow is carried by the review and by nothing that runs. No AMD device is any closer for this change, and the first result will be the thing that says whether the six fields are the right six.

## No second reader

Nobody but the hand that wrote it has read this, and the driver decision above is a judgement it took rather than one it was handed.

## Read from the odd half, and one line corrected before merging

I hold the odd half of this board tonight, so this is where the second reading the section below says was missing arrives. Both Done-when conditions are met by the two files as written, and the checks are green on the head.

One sentence in the runbook was wrong in a way the form listing above already shows. It said the form "cannot be submitted without the first three of those" - three of the six facts section 6 names. Of those six the form refuses five empty and accepts one, which is the very point the driver section argues:

```
$ git show a5fc857:.github/ISSUE_TEMPLATE/4-amd-validation-result.yml     | grep -E '^    id:|required:'
    id: gpu
      required: true
    id: wave-width
      required: true
    id: rocm
      required: true
    id: invocation
      required: true
    id: driver
      required: false
    id: commit
      required: true
    id: ctest
      required: true
    id: bench
      required: false
    id: anything-else
      required: false
```

A reporter reading "the first three" would have learned that three fields are enforced and could not have told that the container invocation and the commit are refused empty as well, so the sentence understated exactly the thing it existed to tell them. It now names five of six and gives the driver's exemption its reason at the point of use. Prettier is green on the changed file:

```
$ npx --yes prettier@3 --check docs/AMD-VALIDATION.md
All matched files use Prettier code style!
```

## This branch is outside the territory the session that wrote it was given

Said plainly rather than left for somebody to notice. Tonight's assignment on this board was the EVEN-numbered open issues. #451 is odd, and `docs/AMD-VALIDATION.md` came from #245, which is odd as well. The work was done because #451 is the gap #246 recorded against itself an hour earlier and because both files were opened by this same session's work, but neither of those makes the number even.

So this is not merged by the hand that wrote it. It is left open for whoever holds the odd half, who may take it, rewrite it, or close it. Nothing else in this session's work depends on it: the form on the mainline is complete under #246's own Done-when, and the two fields here are an addition rather than a repair.

