### PR TITLE
Declare the partial-word rung a strictness departure [#453]

### DIFF
--- a/fuzz/fuzz_gdeflate_page.cpp
+++ b/fuzz/fuzz_gdeflate_page.cpp
@@ -41,7 +41,16 @@
  * refuses, or the two accepting and disagreeing on the bytes or on the size.
  * The reverse - the twin refusing a page the reference decodes - traps as
  * well, unless the rung the twin refused on is one src/gdeflate_schedule.h
- * declares a strictness departure, which today is three of the twenty-two.
+ * declares a strictness departure, which today is four of the twenty-two.
+ *
+ * ONE OF THOSE FOUR CANNOT ARISE HERE, AND SAYING SO IS THE POINT (issue
+ * #453). kGDeflateRejectPagePartialWord refuses a page whose length is not a
+ * whole number of 32-bit words, and this target masks every length it hands
+ * either decoder down to a multiple of four - `chunk` below, and the
+ * structured mutator's `room` above it - so no input this target can build
+ * reaches that exemption arm. Its population is the GPU gate's single-byte
+ * truncations, and reading the predicate here as the measure of what this
+ * target tolerates would overstate it by exactly that rung.
  *
  * THIS DIRECTION WAS UNTRAPPED UNTIL THE LADDER EXISTED, AND THE REASON IS
  * WORTH KEEPING. The decoder used to report only that it had refused, so a
@@ -59,12 +68,13 @@
  * anywhere in this format that failure reaches the caller as data the
  * reference decompresses and cudec calls corrupt, with nothing to appeal to.
  *
- * WHAT THE EXEMPTION COSTS, SAID RATHER THAN IMPLIED. Three rungs are silent
- * here, so an over-strictness that lands on one of those three is not
- * distinguishable by this target from the departure that rung was declared
- * for. What holds them is tests/gdeflate_departure_lock.cpp, which requires a
- * page the reference accepts for every declared rung, so a list grown to
- * silence a trap reds a test instead. The pages both sides accept are still
+ * WHAT THE EXEMPTION COSTS, SAID RATHER THAN IMPLIED. Three of the four rungs
+ * are silent here - the fourth is unreachable, per the paragraph above - so an
+ * over-strictness that lands on one of those three is not distinguishable by
+ * this target from the departure that rung was declared for. What holds them
+ * is tests/gdeflate_departure_lock.cpp, which requires a page the reference
+ * accepts for every declared rung, so a list grown to silence a trap reds a
+ * test instead. The pages both sides accept are still
  * watched by the byte parity below, and the sanitizers have no opinion about
  * which decoder is stricter.
  *

--- a/src/gdeflate_schedule.h
+++ b/src/gdeflate_schedule.h
@@ -182,7 +182,7 @@ static_assert(kGDeflateRejectBlockFirst == kGDeflateRejectTablesLast + 1,
 static_assert(kGDeflateRejectCount == kGDeflateRejectBlockLast + 1,
               "the block section must be the last one");
 
-/* THE DECLARED STRICTNESS DEPARTURES (issue #183). Three rungs refuse a page
+/* THE DECLARED STRICTNESS DEPARTURES (issue #183). Four rungs refuse a page
  * that libdeflate's GDeflate decompressor decodes, and each one is a decision
  * argued at its own refusal site rather than an accident:
  *
@@ -196,6 +196,28 @@ static_assert(kGDeflateRejectCount == kGDeflateRejectBlockLast + 1,
  *   - kGDeflateRejectRepeatRunPastAlphabet, in src/gdeflate_tables.h: the
  *     reference absorbs a code-length repeat run that overruns HLIT + HDIST
  *     into slack entries it then never reads.
+ *   - kGDeflateRejectPagePartialWord, at GDeflatePageShape below: a page whose
+ *     length is not a whole number of 32-bit words is not a page this schedule
+ *     can prime, and the argument for refusing it is at that function. The
+ *     reference decodes one anyway whenever the bytes that went missing are
+ *     bytes it never needed - it stops when the OUTPUT is full and this format
+ *     carries no checksum anywhere, so a real page with its last byte removed
+ *     still reproduces the original output there and is refused here.
+ *
+ * THE FOURTH ARRIVED FROM THE GPU GATE AND NOT FROM THE FUZZER, which is the
+ * reason it was undeclared for as long as it was (issue #453). The mutant
+ * parity in tests/gdeflate_gate_gpu.cu truncates real pages by single bytes
+ * and met it 48 times in one run; the differential target cannot meet it at
+ * all, because fuzz/fuzz_gdeflate_page.cpp masks every page length it hands
+ * either decoder down to a multiple of four:
+ *
+ *     const size_t chunk = (payload_size / npages) & ~static_cast<size_t>(3);
+ *
+ * and its structured mutator word-aligns its own page the same way. So this
+ * rung reaches the exemption below on the gate's route and on no other, and
+ * declaring it loosens that target's trap by nothing rather than by one rung -
+ * a measurement rather than a hope, and the reason this list could be extended
+ * without buying the silence the paragraph below is about.
  *
  * WHY THE LIST IS A PREDICATE AND NOT A SENTENCE IN A COMMENT. For a format
  * with no checksum anywhere, over-strictness is not a lesser cousin of
@@ -205,7 +227,7 @@ static_assert(kGDeflateRejectCount == kGDeflateRejectBlockLast + 1,
  * never measured in this direction drifts stricter one refusal at a time, and
  * every step of that drift reads as a bug fix. So the differential target
  * traps the reverse direction and consults this predicate for the exemption,
- * which makes a fourth departure a thing somebody writes down rather than a
+ * which makes a further departure a thing somebody writes down rather than a
  * thing a later reader discovers by finding data that will not decompress.
  *
  * WHAT HOLDS THE LIST TO REALITY IS tests/gdeflate_departure_lock.cpp, which
@@ -216,6 +238,7 @@ static_assert(kGDeflateRejectCount == kGDeflateRejectBlockLast + 1,
 CUDEC_HOST_DEVICE inline bool GDeflateRejectIsDeclaredDeparture(
     GDeflateReject branch) {
     switch (branch) {
+        case kGDeflateRejectPagePartialWord:
         case kGDeflateRejectRefillPastEnd:
         case kGDeflateRejectEmptyTableUsed:
         case kGDeflateRejectRepeatRunPastAlphabet:
@@ -497,7 +520,26 @@ CUDEC_HOST_DEVICE inline void GDeflateReset(GDeflateSchedule& s) {
  * 5.3 says the first round always loads 32 consecutive words, so a stream
  * below 128 bytes cannot be valid and is refused here rather than discovered
  * part-way through the priming round. Both residencies prime through this, so
- * each rung has one site. */
+ * each rung has one site.
+ *
+ * THE FIRST OF THE TWO IS A DECLARED STRICTNESS DEPARTURE, and this is the
+ * refusal site the declaration above points at (issue #453). The reference
+ * decodes a page whose last byte was removed whenever that byte was one it
+ * never read - it stops at a full output rather than at the end of the page,
+ * and this format has no checksum to disagree with it - so the refusal here
+ * is a page libdeflate reproduces the original bytes for. Nothing in that
+ * argues for accepting it: the missing byte makes the page's own length a lie
+ * about what it carries, the priming round has no word to give a lane, and
+ * the caller who wanted those bytes back is better served by a defined
+ * refusal than by an output that happens to be right. What the declaration
+ * buys is that the strictness is written down and executed by
+ * tests/gdeflate_departure_lock.cpp rather than discovered by somebody whose
+ * data will not decompress.
+ *
+ * NOTHING HERE SAYS THE SECOND RUNG IS OR IS NOT ONE. Whether the reference
+ * also decodes a page below the priming round is a separate measurement, no
+ * run has produced a page on which it does, and an absence over one corpus is
+ * not a declaration either way. */
 CUDEC_HOST_DEVICE inline bool GDeflatePageShape(uint64_t page_bytes,
                                                 uint64_t* word_count,
                                                 GDeflateReject* why) {

--- a/tests/gdeflate_departure_lock.cpp
+++ b/tests/gdeflate_departure_lock.cpp
@@ -16,13 +16,33 @@
  * or because the refusal moved - fails its own case rather than sitting in the
  * exemption forever.
  *
- * THE FIXTURES ARE THE FUZZER'S AND NOT MINE, which is the point rather than a
- * convenience. Each page below is the shortest input a run of
- * fuzz_gdeflate_page reached its rung with, carried over as bytes; the same
- * inputs are committed as seeds under fuzz/corpus/fuzz_gdeflate_page, so the
- * CI replay leg drives the exemption path on every run. A hand-written page
- * would prove the departure I imagined; these prove the one the reference and
- * this decoder actually disagree about.
+ * THREE OF THE FOUR FIXTURES ARE THE FUZZER'S AND NOT MINE, which is the point
+ * rather than a convenience. Each page in gdeflate_departure_pages.h is the
+ * shortest input a run of fuzz_gdeflate_page reached its rung with, carried
+ * over as bytes; the same inputs are committed as seeds under
+ * fuzz/corpus/fuzz_gdeflate_page, so the CI replay leg drives the exemption
+ * path on every run. A hand-written page would prove the departure I imagined;
+ * these prove the one the reference and this decoder actually disagree about.
+ *
+ * THE FOURTH COULD NOT COME FROM THERE, AND THE REASON IS THE FINDING RATHER
+ * THAN AN EXCUSE (issue #453). kGDeflateRejectPagePartialWord refuses a page
+ * whose length is not a whole number of 32-bit words, and fuzz_gdeflate_page
+ * masks every length it hands either decoder down to a multiple of four, so
+ * that rung is unreachable in the target whose exemption this file exists to
+ * price. Its population is the GPU gate's single-byte truncations of real
+ * pages, and the fixture below is built the same way here: the reference's own
+ * compressor makes a page, one byte comes off the end, and both decoders are
+ * asked about what is left. It is generated rather than pinned because a
+ * pinned copy would fix the compressor's output of one day, and what the
+ * departure is about is any page of that shape rather than one page.
+ *
+ * IT ASSERTS THE ROUND TRIP AND NOT ONLY THE ACCEPTANCE, which the three
+ * pinned pages cannot: the reference reporting SUCCESS means its bits ran out
+ * cleanly and not that its answer is right (tests/oracle_gdeflate.cpp). For a
+ * truncation of a real page the original bytes are known, so this one holds
+ * the reference to reproducing them exactly - which is the same rule the GPU
+ * gate applies before it calls a refusal over-strict, and it is what separates
+ * a departure from a page neither decoder reproduced.
  *
  * THE REFERENCE GETS A ZERO TAIL AFTER ITS COPY AND THE TWIN DOES NOT, for the
  * reason fuzz/fuzz_gdeflate_page.cpp argues at its head: `ENSURE_BITS` in the
@@ -40,8 +60,10 @@
 
 #include <libdeflate.h>
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <string>
 #include <vector>
 
 namespace {
@@ -53,6 +75,7 @@ using cudec_detail::GDeflateRejectIsDeclaredDeparture;
 using cudec_detail::kGDeflateRejectCount;
 using cudec_detail::kGDeflateRejectEmptyTableUsed;
 using cudec_detail::kGDeflateRejectNone;
+using cudec_detail::kGDeflateRejectPagePartialWord;
 using cudec_detail::kGDeflateRejectRefillPastEnd;
 using cudec_detail::kGDeflateRejectRepeatRunPastAlphabet;
 
@@ -71,9 +94,16 @@ size_t OracleTailBytes(size_t capacity) {
 /* One declared departure, executed. Both halves are asserted rather than one:
  * that the reference decodes the page, and that this decoder refuses it on the
  * rung the predicate names. Asserting only the refusal would pass for a page
- * both sides reject, which is not a departure at all. */
+ * both sides reject, which is not a departure at all.
+ *
+ * `expect` is the third half where it can be had. A page found by the fuzzer
+ * has no known-good output - it is a mutation of nothing in particular - so
+ * those three pass a null pointer and the reference's SUCCESS is all there is.
+ * A page built by truncating a real one does have one, and there the
+ * reference is held to reproducing it rather than merely to finishing. */
 int Departure(const char* name, const unsigned char* page, size_t page_size,
-              size_t capacity, GDeflateReject expected) {
+              size_t capacity, GDeflateReject expected,
+              const std::vector<unsigned char>* expect) {
     REQUIRE_CTX(GDeflateRejectIsDeclaredDeparture(expected),
                 "%s: rung %d is not declared a departure, so this fixture "
                 "belongs in the ladder lock rather than here",
@@ -100,6 +130,17 @@ int Departure(const char* name, const unsigned char* page, size_t page_size,
                 "%s: the reference refused this page (status=%d), so it is not "
                 "a page the two decoders disagree about",
                 name, static_cast<int>(oracle_status));
+    if (expect != nullptr) {
+        REQUIRE_CTX(oracle_size == expect->size(),
+                    "%s: the reference produced %zu bytes and the unmutated "
+                    "page gives %zu, so it did not reproduce the original",
+                    name, oracle_size, expect->size());
+        REQUIRE_CTX(std::memcmp(oracle_out.data(), expect->data(),
+                                expect->size()) == 0,
+                    "%s: the reference produced other bytes than the "
+                    "unmutated page gives, so this is not a departure",
+                    name);
+    }
 
     /* The twin's copy is exactly its own size, so a read past the end lands in
      * an AddressSanitizer redzone rather than in slack - which is what makes
@@ -123,6 +164,133 @@ int Departure(const char* name, const unsigned char* page, size_t page_size,
     std::printf("  %-28s reference produced %zu byte(s), rung %d\n", name,
                 oracle_size, static_cast<int>(expected));
     g_shown[expected] = true;
+    return 0;
+}
+
+/* The reference's own compressor, one page. Real input rather than a literal,
+ * because the departure below is about what happens to a page a compressor
+ * actually emitted. */
+bool CompressOnePage(int level, const std::vector<unsigned char>& in,
+                     std::vector<unsigned char>* page) {
+    libdeflate_gdeflate_compressor* c =
+        libdeflate_alloc_gdeflate_compressor(level);
+    if (c == nullptr) {
+        return false;
+    }
+    size_t npages = 0;
+    const size_t bound =
+        libdeflate_gdeflate_compress_bound(c, in.size(), &npages);
+    if (bound == 0 || npages != 1) {
+        libdeflate_free_gdeflate_compressor(c);
+        return false;
+    }
+    std::vector<unsigned char> pool(bound, 0);
+    libdeflate_gdeflate_out_page out;
+    out.data = pool.data();
+    out.nbytes = bound;
+    const size_t total =
+        libdeflate_gdeflate_compress(c, in.data(), in.size(), &out, 1);
+    libdeflate_free_gdeflate_compressor(c);
+    if (total == 0) {
+        return false;
+    }
+    const unsigned char* p = static_cast<const unsigned char*>(out.data);
+    page->assign(p, p + out.nbytes);
+    return true;
+}
+
+/* Compressible without being trivial: a long stretch of one byte compresses to
+ * a page too short to have a byte worth losing, and incompressible input turns
+ * into stored blocks whose length fields the truncation would corrupt into a
+ * refusal on the reference's side too. */
+std::vector<unsigned char> DepartureSource(size_t n) {
+    std::vector<unsigned char> v;
+    v.reserve(n);
+    uint32_t x = 0x1234567u;
+    while (v.size() < n) {
+        x = x * 1664525u + 1013904223u;
+        const size_t run = 3u + (x >> 24) % 40u;
+        const unsigned char b =
+            static_cast<unsigned char>('a' + ((x >> 8) % 7u));
+        for (size_t i = 0; i < run && v.size() < n; i++) {
+            v.push_back(b);
+        }
+        x = x * 1664525u + 1013904223u;
+        const size_t noise = (x >> 16) % 6u;
+        for (size_t i = 0; i < noise && v.size() < n; i++) {
+            v.push_back(static_cast<unsigned char>((x >> i) & 0xFFu));
+        }
+    }
+    return v;
+}
+
+/* The partial-word departure, at every level the GPU gate's parity uses, so
+ * this does not rest on one compressor setting happening to leave a droppable
+ * byte. A level whose page truncates into something the reference will not
+ * reproduce is not a failure of the departure and is skipped with a line
+ * saying so; the sweep at the bottom is what requires at least one to have
+ * held. */
+int PartialWordDepartures() {
+    const int levels[] = {0, 1, 6, 12};
+    int shown = 0;
+    for (size_t l = 0; l < sizeof levels / sizeof levels[0]; l++) {
+        const std::vector<unsigned char> source = DepartureSource(20000);
+        std::vector<unsigned char> page;
+        REQUIRE_CTX(CompressOnePage(levels[l], source, &page),
+                    "level %d did not compress to a single page",
+                    levels[l]);
+        REQUIRE_CTX(page.size() % 4u == 0u,
+                    "level %d produced a %zu-byte page, which is not a whole "
+                    "number of words before anything was removed",
+                    levels[l], page.size());
+        REQUIRE(page.size() > 128u);
+
+        /* One byte off the end. The reference reads words it needs and stops
+         * at a full output, so where the last word was never reached this is
+         * still the same page to it and is no longer a page at all here. */
+        page.resize(page.size() - 1u);
+
+        const std::string name =
+            "partial word, level " + std::to_string(levels[l]);
+        const size_t capacity = source.size() + 64u;
+
+        /* Whether the reference still reproduces the source is what decides
+         * if this level's page is a departure, and it is asked here rather
+         * than asserted, because it is a property of that page and not of the
+         * rung. */
+        const size_t tail = OracleTailBytes(capacity);
+        std::vector<unsigned char> padded(page.size() + tail, 0);
+        std::memcpy(padded.data(), page.data(), page.size());
+        libdeflate_gdeflate_in_page probe;
+        probe.data = padded.data();
+        probe.nbytes = page.size();
+        std::vector<unsigned char> probe_out(capacity, 0);
+        libdeflate_gdeflate_decompressor* d =
+            libdeflate_alloc_gdeflate_decompressor();
+        REQUIRE(d != nullptr);
+        size_t probe_size = 0;
+        const libdeflate_result probe_status = libdeflate_gdeflate_decompress(
+            d, &probe, 1, probe_out.data(), capacity, &probe_size);
+        libdeflate_free_gdeflate_decompressor(d);
+        if (probe_status != LIBDEFLATE_SUCCESS || probe_size != source.size() ||
+            std::memcmp(probe_out.data(), source.data(), source.size()) != 0) {
+            std::printf("  %-28s the reference does not reproduce this "
+                        "truncation, so this level shows nothing\n",
+                        name.c_str());
+            continue;
+        }
+
+        if (Departure(name.c_str(), page.data(), page.size(), capacity,
+                      kGDeflateRejectPagePartialWord,
+                      &source) != 0) {
+            return 1;
+        }
+        shown++;
+    }
+    REQUIRE_CTX(shown > 0,
+                "no compression level produced a page whose last byte the "
+                "reference did not need, so this run showed the partial-word "
+                "departure nowhere (issue #453)");
     return 0;
 }
 
@@ -160,18 +328,21 @@ int Sweep() {
 int main() {
     if (Departure("refill past the end", kPageRefillPastEnd,
                   sizeof kPageRefillPastEnd, kCapacityRefillPastEnd,
-                  kGDeflateRejectRefillPastEnd) != 0) {
+                  kGDeflateRejectRefillPastEnd, nullptr) != 0) {
         return 1;
     }
     if (Departure("empty code used", kPageEmptyTableUsed,
                   sizeof kPageEmptyTableUsed, kCapacityEmptyTableUsed,
-                  kGDeflateRejectEmptyTableUsed) != 0) {
+                  kGDeflateRejectEmptyTableUsed, nullptr) != 0) {
         return 1;
     }
     if (Departure("repeat run past the alphabet", kPageRepeatRunPastAlphabet,
                   sizeof kPageRepeatRunPastAlphabet,
                   kCapacityRepeatRunPastAlphabet,
-                  kGDeflateRejectRepeatRunPastAlphabet) != 0) {
+                  kGDeflateRejectRepeatRunPastAlphabet, nullptr) != 0) {
+        return 1;
+    }
+    if (PartialWordDepartures() != 0) {
         return 1;
     }
     if (Sweep() != 0) {

--- a/tests/gdeflate_gate_gpu.cu
+++ b/tests/gdeflate_gate_gpu.cu
@@ -622,10 +622,10 @@ struct ParityCounts {
     size_t oracle_accepted_other_bytes;
     size_t fail_opens;
     size_t over_strict;
-    /* Refusals of a page the reference reproduces, on a rung already recorded
-     * as a strictness departure. Counted and printed per rung rather than
-     * ignored: an exemption whose population nobody prints is one nobody
-     * notices growing. */
+    /* Refusals of a page the reference reproduces, on a rung
+     * src/gdeflate_schedule.h declares a strictness departure. Counted and
+     * printed per rung rather than ignored: an exemption whose population
+     * nobody prints is one nobody notices growing. */
     size_t recorded_departures;
     size_t departure_hits[cudec_detail::kGDeflateRejectCount];
 };
@@ -641,24 +641,16 @@ bool IsDeclaredDeparture(GDeflateReject rung) {
     return cudec_detail::GDeflateRejectIsDeclaredDeparture(rung);
 }
 
-/* ONE RUNG BELONGS IN NEITHER PLACE YET, AND THIS IS THE WHOLE OF THE
- * CARVE-OUT. Removing one byte from the end of a real page makes its size stop
- * being a whole number of 32-bit words; this decoder refuses that on
+/* THE CARVE-OUT THAT STOOD HERE IS GONE, and this file names no rung of its
+ * own (issue #453). Removing one byte from the end of a real page makes its
+ * size stop being a whole number of 32-bit words; this decoder refuses that on
  * kGDeflateRejectPagePartialWord and the reference decodes it to the original
- * bytes, because the words it never needed are the ones that went missing. So
- * it is a strictness departure the two decoders genuinely have, and
- * GDeflateRejectIsDeclaredDeparture does not name it. Whether the predicate
- * should - which loosens the differential fuzz target's trap and is a change
- * to src/ rather than to a test - is issue #453, and it is not decided here.
- *
- * IT IS WRITTEN AS ONE NAMED RUNG RATHER THAN AS A SET, and the count it
- * absorbs is printed on every run, so it cannot grow into the allowlist the
- * departure lock exists against. Any other rung refusing a page the reference
- * reproduces still fails this gate. */
-bool IsRecordedDeparture(GDeflateReject rung) {
-    return IsDeclaredDeparture(rung) ||
-           rung == cudec_detail::kGDeflateRejectPagePartialWord;
-}
+ * bytes. That is a strictness departure the two decoders genuinely have, so it
+ * is declared in src/gdeflate_schedule.h with the rest and paid for by a page
+ * in tests/gdeflate_departure_lock.cpp, rather than exempted by a second list
+ * living in the gate that measures it. Every rung this gate absorbs is now a
+ * rung the predicate declares, and any other one refusing a page the reference
+ * reproduces still fails here. */
 
 int MutantParity(ParityCounts* counts) {
     counts->mutants = 0;
@@ -809,13 +801,14 @@ int MutantParity(ParityCounts* counts) {
                         chunks[i].name.c_str(),
                         static_cast<int>(results[i].status),
                         static_cast<int>(twin.status));
-            if (!IsRecordedDeparture(twin.rung)) {
+            if (!IsDeclaredDeparture(twin.rung)) {
                 counts->over_strict++;
                 REQUIRE_CTX(false,
                             "%s: OVER-STRICT - the reference decoded it to the "
                             "bytes the unmutated page gives, and this decoder "
-                            "refused on rung %d, which is neither declared in "
-                            "src/gdeflate_schedule.h nor recorded on #453",
+                            "refused on rung %d, which "
+                            "src/gdeflate_schedule.h does not declare a "
+                            "strictness departure",
                             chunks[i].name.c_str(),
                             static_cast<int>(twin.rung));
             }
@@ -846,7 +839,7 @@ int MutantParity(ParityCounts* counts) {
     std::printf("gdeflate_gate_gpu: mutant parity: %zu pages, %zu the "
                 "reference rejects and the kernel rejects too, %zu both accept "
                 "with identical bytes, %zu the reference accepts as other "
-                "bytes, %zu the kernel refuses on a rung already recorded as a "
+                "bytes, %zu the kernel refuses on a rung declared a "
                 "strictness departure; 0 fail-opens, 0 undeclared over-strict "
                 "rejects\n",
                 counts->mutants, counts->oracle_rejects,
@@ -855,18 +848,16 @@ int MutantParity(ParityCounts* counts) {
     /* Printed per rung rather than as one total, because the exemption's
      * population is the thing a reader has to be able to watch: a rung that
      * starts absorbing hundreds of mutants is an exemption that has quietly
-     * become the rule. */
+     * become the rule. Every rung reaching this loop is declared - an
+     * undeclared one fails the REQUIRE above and never gets here - so the line
+     * says where the declaration is and what pays for it. */
     for (uint32_t r = 0; r < cudec_detail::kGDeflateRejectCount; r++) {
         if (counts->departure_hits[r] != 0) {
+            REQUIRE(IsDeclaredDeparture(static_cast<GDeflateReject>(r)));
             std::printf("gdeflate_gate_gpu:   rung %u absorbed %zu of them, "
-                        "%s\n",
-                        r, counts->departure_hits[r],
-                        IsDeclaredDeparture(
-                            static_cast<GDeflateReject>(r))
-                            ? "declared in src/gdeflate_schedule.h and executed "
-                              "by tests/gdeflate_departure_lock.cpp"
-                            : "recorded on issue #453 and declared nowhere in "
-                              "src/");
+                        "declared in src/gdeflate_schedule.h and executed by "
+                        "tests/gdeflate_departure_lock.cpp\n",
+                        r, counts->departure_hits[r]);
         }
     }
     return 0;


### PR DESCRIPTION
Closes #453.

`kGDeflateRejectPagePartialWord` is a strictness departure the two decoders genuinely have, and `GDeflateRejectIsDeclaredDeparture` did not name it. The GPU gate absorbed it through a second allowlist written by hand in `tests/gdeflate_gate_gpu.cu` - inside the file whose job is to measure exactly that class. This declares the rung where the other three live, pays for the declaration with a page that executes it, and takes the hand-written carve-out out.

## The reading the issue asked for first

The first Done-when is whether a sub-word-length page reaches the exemption path in `fuzz/fuzz_gdeflate_page.cpp` at all. **It does not, and it cannot.** Every page length that target hands either decoder is masked down to a multiple of four before either sees it:

```
$ git grep -n 'size_t chunk = \|size_t room = ' cf4f39a -- fuzz/fuzz_gdeflate_page.cpp
cf4f39a:fuzz/fuzz_gdeflate_page.cpp:168:        size_t room = (max_size - 3u) & ~static_cast<size_t>(3);
cf4f39a:fuzz/fuzz_gdeflate_page.cpp:212:    const size_t chunk = (payload_size / npages) & ~static_cast<size_t>(3);
```

`chunk` is the length in the main entry point and `room` is the structured mutator's, so both routes into the target produce whole words only. `GDeflatePageShape` refuses on this rung when `page_bytes % 4u != 0u`, which no input the target can build satisfies. The exemption arm for this rung is dead code there.

That answers the objection the issue held the decision on. Declaring the rung loosens the differential target's trap **by nothing**, not by one rung - a reading rather than a hope. Its population is the GPU gate's single-byte truncations of real pages, on that route and on no other.

## What is executed

- `GDeflateRejectIsDeclaredDeparture` names `kGDeflateRejectPagePartialWord`; four of the twenty-two rungs are declared.
- `GDeflatePageShape` carries the argument at the refusal site, as the other three do. Nothing there argues for accepting the page: the missing byte makes the page's own length a lie about what it carries, and a caller is better served by a defined refusal than by an output that happens to be right. What the declaration buys is that the strictness is written down and executed rather than met by somebody whose data will not decompress.
- The fuzz target's header records that it cannot reach the rung, so a reader does not take its declared-departure count for the measure of what that target tolerates.
- `IsRecordedDeparture` is gone from `tests/gdeflate_gate_gpu.cu`. The gate consults the predicate alone, and the per-rung print now `REQUIRE`s every rung it reports to be one the predicate declares - the ternary that used to have a "declared nowhere in src/" arm had become unreachable, and an unreachable arm describing a state that can no longer exist is worse than no arm.

## The page that pays for the declaration

`tests/gdeflate_departure_lock.cpp` requires, for every declared rung, a page the reference decodes and this decoder refuses on exactly that rung. The three existing fixtures are pinned bytes the fuzzer found. **This one cannot be**, for the reason above, and the file says so rather than quietly departing from its own convention: the reference's own compressor makes a page at each of the four levels the gate's parity uses, one byte comes off the end, and both decoders are asked about what is left.

It asserts the **round trip** and not only the reference's `SUCCESS`. For a fuzzer-found page there is no known-good output, so those three can only assert that the reference finished; `SUCCESS` there means its bits ran out cleanly and not that its answer is right (`tests/oracle_gdeflate.cpp`). A truncation of a real page does have a known-good output, so the reference is held to reproducing it exactly - the same rule the GPU gate applies before it calls a refusal over-strict.

A level whose truncated page the reference does not reproduce is skipped with a line saying so, and the run requires at least one level to have held. All four held:

```
$ ./build-wsl/tests/gdeflate_departure_lock
  refill past the end          reference produced 2 byte(s), rung 3
  empty code used              reference produced 10 byte(s), rung 11
  repeat run past the alphabet reference produced 6 byte(s), rung 14
  partial word, level 0        reference produced 20000 byte(s), rung 1
  partial word, level 1        reference produced 20000 byte(s), rung 1
  partial word, level 6        reference produced 20000 byte(s), rung 1
  partial word, level 12       reference produced 20000 byte(s), rung 1
gdeflate_departure_lock: 4 declared departure(s), each shown against the reference
```

## The guard bites, in both directions

Deleting the declaration and rebuilding:

```
$ sed -i 's/^        case kGDeflateRejectPagePartialWord:$/        \/\/ removed/' src/gdeflate_schedule.h
$ ./build-wsl/tests/gdeflate_departure_lock; echo "EXIT=$?"
  refill past the end          reference produced 2 byte(s), rung 3
  empty code used              reference produced 10 byte(s), rung 11
  repeat run past the alphabet reference produced 6 byte(s), rung 14
FAIL ...: partial word, level 0: rung 1 is not declared a departure, so this fixture belongs in the ladder lock rather than here
EXIT=1
```

and the other way, the declaration kept and the fixture not run:

```
$ sed -i 's/if (PartialWordDepartures/if (false \&\& PartialWordDepartures/' tests/gdeflate_departure_lock.cpp
$ ./build-wsl/tests/gdeflate_departure_lock; echo "EXIT=$?"
FAIL ...:314: g_shown[i] | rung 1 is declared a strictness departure and no page here shows the reference decoding it (issue #183)
EXIT=1
```

So a rung added to the predicate to silence a trap still costs a page, and a page whose rung stops being a departure still reds.

## The device gate

Run on the RTX 3080 through the WSL CUDA route, not the pinned `nvidia/cuda:12.6.2` container CLAUDE.md names as the canonical gate - CUDA 13.3, driver 610.88, `sm_86`. This change touches no arithmetic, so nothing here depends on the compiler; a number that did would not be interchangeable between the two.

```
$ wsl.exe -d Ubuntu-24.04 -- sh -c 'uname -r; ls /dev/dxg; nvidia-smi --query-gpu=name,driver_version --format=csv,noheader'
6.6.87.2-microsoft-standard-WSL2
/dev/dxg
NVIDIA GeForce RTX 3080, 610.88

$ cmake -B build-wsl -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
$ cmake --build build-wsl -j8
$ ctest --test-dir build-wsl --no-tests=error --output-on-failure
100% tests passed, 0 tests failed out of 67

Label Time Summary:
gpu    =  12.80 sec*proc (11 tests)
```

The eleven `gpu`-labelled entries executed on the device rather than being deferred. The mutant parity's per-rung counts:

```
gdeflate_gate_gpu: mutant parity: 1216 pages, 579 the reference rejects and the kernel rejects too, 571 both accept with identical bytes, 2 the reference accepts as other bytes, 64 the kernel refuses on a rung declared a strictness departure; 0 fail-opens, 0 undeclared over-strict rejects
gdeflate_gate_gpu:   rung 1 absorbed 48 of them, declared in src/gdeflate_schedule.h and executed by tests/gdeflate_departure_lock.cpp
gdeflate_gate_gpu:   rung 3 absorbed 16 of them, declared in src/gdeflate_schedule.h and executed by tests/gdeflate_departure_lock.cpp
gdeflate_gate_gpu: crafted ladder: 13 hostile pages, each refused on the device with the status the host twin's rung maps to, bytes_written 0
```

Both rungs now report the same sentence, which is the carve-out being gone rather than a wording change: nothing is "declared nowhere in `src/`" any more.

**TWO SUBTOTALS MOVED AGAINST THE RUN QUOTED ON THE ISSUE AND THIS CHANGE DID NOT MOVE THEM.** That run read 550 refused by both and 31 the reference accepts as other bytes; this one reads 579 and 2. The four figures this issue is about - 1216 mutants, 64 departures, 48 on rung 1 and 16 on rung 3 - are identical. The classification that moved is decided by the reference's verdict, before the predicate is consulted at all, and nothing in this diff reaches the oracle, the corpus or the mutation. The environment is what differs, and the counts are stable within it: two consecutive runs of the gate binary on this host printed the same line byte for byte. Which of the two environments the difference belongs to is not measured here and is not claimed either way.

## The means

Four files that already exist, in the languages they are already in. The one new construction is a generated fixture in a test that until now held pinned bytes, and it is generated because the property is about a shape of page rather than about one page - a pinned copy would freeze one compressor's output of one day and would still not have come from the fuzzer.

## What is not covered

- **The fuzz target's blindness to this rung is recorded, not repaired.** Making `chunk` capable of a non-multiple of four would widen the differential coverage by one rung and change what every existing corpus entry means; whether it is worth that is a separate question and no issue is opened for it here, because nothing has measured what it would buy.
- **Whether `kGDeflateRejectPageBelowPrimingRound` is also a departure is not settled.** No run has produced a page below the priming round that the reference decodes, and an absence over one corpus is not a declaration either way. The refusal site says exactly that rather than implying the negative.
- **The `sanitize` and `fuzz` legs of CI have not run locally.** The changes to `fuzz/fuzz_gdeflate_page.cpp` are comment-only, so the corpus replay's behaviour is unchanged; the checks on this pull request are what says so rather than this sentence.
- The canonical container gate has not been run; the WSL route above is what was available, and its differences are disclosed with it.

## No second reader

Nobody but the hand that wrote it has read this change. The choice between the issue's two states was taken here rather than handed over, on the reading of `fuzz_gdeflate_page.cpp` quoted at the top - which is the fact that makes the two states not equally weighted, and which the issue asked for before the choice for that reason.
