### PR TITLE
Decode a whole TileStream through the page batch kernel [#177]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,8 @@ jobs:
           grep -E ': gdeflate_schedule_twin$' host-selected.txt &&
           grep -E ': gdeflate_header_twin$' host-selected.txt &&
           grep -E ': gdeflate_block_twin$' host-selected.txt &&
+          grep -E ': envelope_out_of_device$' host-selected.txt &&
+          grep -E ': envelope_out_of_device_selfproof$' host-selected.txt &&
           echo "Deferred to the local GPU gate:" &&
           ctest --test-dir build-cuda -L gpu -N | tee gpu-deferred.txt &&
           grep -E ': smoke$' gpu-deferred.txt &&
@@ -397,7 +399,8 @@ jobs:
           grep -E ': determinism_gpu$' gpu-deferred.txt &&
           grep -E ': snappy_block_device$' gpu-deferred.txt &&
           grep -E ': gdeflate_device$' gpu-deferred.txt &&
-          grep -E ': gdeflate_gate_gpu$' gpu-deferred.txt
+          grep -E ': gdeflate_gate_gpu$' gpu-deferred.txt &&
+          grep -E ': tilestream_twin$' gpu-deferred.txt
 
   hip:
     # The job name is the required-check context the ruleset will name once

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,7 +382,8 @@ if(CUDEC_DEVICE_LANGUAGE)
   endfunction()
 
   cudec_device_sources(src/batch.cu)
-  target_sources(cudec PRIVATE src/batch.cu src/frame.cpp src/stream.cpp)
+  target_sources(cudec PRIVATE src/batch.cu src/frame.cpp src/stream.cpp
+                              src/tilestream.cpp)
   target_link_libraries(cudec PRIVATE ${CUDEC_DEVICE_RUNTIME_TARGET})
   set_target_properties(cudec PROPERTIES CXX_STANDARD 17
                                          CXX_STANDARD_REQUIRED ON)

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -343,6 +343,98 @@ cudec_status cudec_lz4_decompress_stream_ctx(
  * and valid on a poisoned context. After it returns the pointer is dangling. */
 void cudec_stream_ctx_destroy(cudec_stream_ctx* ctx);
 
+/* Reads the GDeflate TileStream envelope at `stream[0 .. stream_size)` and
+ * reports what a decode of it would produce: the number of tiles it declares
+ * and the total uncompressed size those tiles decode to. Host-only - it makes
+ * no CUDA call, touches no device, and reads no tile payload - so a caller
+ * can size its destination and its per-tile result array on a machine with no
+ * GPU.
+ *
+ * THE ENVELOPE IS NOT THE PAGE FORMAT, AND THIS ENTRY IS THE SEAM. A
+ * TileStream is the DirectStorage-side container that records where a file's
+ * GDeflate pages are; the pages themselves are what
+ * cudec_gdeflate_decompress_batch decodes. Nothing about the container
+ * crosses into device code, which is why this entry can answer without one.
+ *
+ * On CUDEC_OK, *tile_count and *uncompressed_size hold the envelope's
+ * declaration, each already checked against the bytes actually present.
+ * CUDEC_ERR_INVALID_ARGUMENT for a NULL argument; CUDEC_ERR_CORRUPT_INPUT for
+ * anything the bytes get wrong - a truncated header or table, an unknown tile
+ * size index, a reserved bit set, a tile count of zero, a table whose offsets
+ * do not strictly ascend, or a last tile running past the end. On any error
+ * *tile_count and *uncompressed_size are 0. The container carries no optional
+ * features, so nothing here returns CUDEC_ERR_UNSUPPORTED. */
+cudec_status cudec_gdeflate_tilestream_info(const void* stream,
+                                            size_t stream_size,
+                                            size_t* tile_count,
+                                            size_t* uncompressed_size);
+
+/* Decodes a whole GDeflate TileStream on a reusable streaming context: the
+ * envelope is parsed on the host, and its tiles are driven through the
+ * GDeflate page batch decoder as independent pages. Synchronous - the work is
+ * drained before return, so `dst`, `*bytes_written` and every
+ * h_tile_results[i] are valid on return.
+ *
+ * `stream`/`stream_size` is the whole container in HOST memory. The decoded
+ * tiles are written back to back into `dst`, in tile order, in the space named
+ * by dst_space: CUDEC_MEM_DEVICE writes device memory directly, CUDEC_MEM_HOST
+ * reads the bytes back into host memory. `dst_capacity` must be at least the
+ * `uncompressed_size` cudec_gdeflate_tilestream_info reports for the same
+ * bytes, and h_tile_results must be a HOST array of at least that entry's
+ * `tile_count` records; both are checked against the parsed envelope and
+ * refused rather than truncated.
+ *
+ * THE STAGING IS THE STREAMING CONTEXT'S, NOT A SECOND ONE. The context owns
+ * the CUDA stream and the grow-only pinned/device staging, so a caller
+ * decoding many streams pays the allocation once; that is the whole reason
+ * this entry takes a context rather than being one-shot only.
+ *
+ * A tile that fails to decode is isolated to itself: h_tile_results[i] carries
+ * that tile's own defined status with bytes_written 0, its siblings decode
+ * normally and report their own bytes, and nothing about the failed tile's
+ * region of `dst` is presented as valid output.
+ *
+ * THE WHOLE-STREAM ANSWER FOLLOWS THE FRAME PRECEDENT RATHER THAN THE BATCH
+ * ONE, because this entry, like cudec_lz4f_decompress, produces ONE object out
+ * of many pieces. A stream with any failed tile is not a partially decoded
+ * file: *bytes_written is 0 and the return is non-OK - CUDEC_ERR_CUDA where a
+ * device or host resource failed, otherwise the first non-OK tile's status in
+ * tile order. *bytes_written is the sum of the tiles' output only when every
+ * tile decoded.
+ *
+ * Fail-closed, synchronously and with nothing launched: a NULL ctx, a NULL
+ * `stream`, `bytes_written` or h_tile_results, a NULL `dst` with a non-zero
+ * `dst_capacity`, an unknown dst_space, or an envelope this build refuses
+ * returns CUDEC_ERR_INVALID_ARGUMENT or CUDEC_ERR_CORRUPT_INPUT before any
+ * CUDA call. A `dst_capacity` below the envelope's total returns
+ * CUDEC_ERR_OUTPUT_TOO_SMALL, and an h_tile_results array shorter than the
+ * declared tile count returns CUDEC_ERR_INVALID_ARGUMENT; both are decided
+ * from the parsed envelope, so both are content-dependent rejects and neither
+ * writes a byte of `dst`.
+ *
+ * A CUDA fault POISONS the context exactly as the LZ4 streaming entry
+ * documents: every later decode on it returns CUDEC_ERR_CUDA without touching
+ * the device, and only cudec_stream_ctx_destroy is valid on it thereafter.
+ * Never throws across this boundary. */
+cudec_status cudec_gdeflate_tilestream_decompress_ctx(
+    cudec_stream_ctx* ctx, const void* stream, size_t stream_size, void* dst,
+    size_t dst_capacity, cudec_mem_space dst_space,
+    cudec_chunk_result* h_tile_results, size_t tile_results_capacity,
+    size_t* bytes_written);
+
+/* One-shot whole-TileStream decode: equivalent to cudec_stream_ctx_create,
+ * one cudec_gdeflate_tilestream_decompress_ctx, and
+ * cudec_stream_ctx_destroy. It pays the full staging allocation on every
+ * call; a caller decoding repeatedly should hold a context and call the _ctx
+ * entry instead. Same arguments, contract and fail-closed behavior as the
+ * _ctx entry, and every synchronous reject class above is answered here
+ * without a context ever being created. Never throws across this
+ * boundary. */
+cudec_status cudec_gdeflate_tilestream_decompress(
+    const void* stream, size_t stream_size, void* dst, size_t dst_capacity,
+    cudec_mem_space dst_space, cudec_chunk_result* h_tile_results,
+    size_t tile_results_capacity, size_t* bytes_written);
+
 /* One-shot streaming batch LZ4 block decode: equivalent to
  * cudec_stream_ctx_create, one cudec_lz4_decompress_stream_ctx, and
  * cudec_stream_ctx_destroy. It pays the full staging allocation on every call;

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -361,9 +361,20 @@ void cudec_stream_ctx_destroy(cudec_stream_ctx* ctx);
  * CUDEC_ERR_INVALID_ARGUMENT for a NULL argument; CUDEC_ERR_CORRUPT_INPUT for
  * anything the bytes get wrong - a truncated header or table, an unknown tile
  * size index, a reserved bit set, a tile count of zero, a table whose offsets
- * do not strictly ascend, or a last tile running past the end. On any error
+ * do not strictly ascend, or a last tile running past the end; and
+ * CUDEC_ERR_CUDA for a HOST resource failure, since sizing the tile table is
+ * an allocation and a failed one must cross this boundary as a status rather
+ * than as a throw. That last one is named despite the entry making no CUDA
+ * call, because the enum's spelling is older than the distinction and a
+ * caller switching on the set below must not fall through. On any error
  * *tile_count and *uncompressed_size are 0. The container carries no optional
- * features, so nothing here returns CUDEC_ERR_UNSUPPORTED. */
+ * features, so nothing here returns CUDEC_ERR_UNSUPPORTED.
+ *
+ * THE CEILING IS WORTH KNOWING BEFORE SIZING ANYTHING FROM THE ANSWER. The
+ * count field is 16 bits and a tile is 65536 bytes, so a 320 KB envelope can
+ * legitimately report an uncompressed size of 4294901760. The number is the
+ * container's declaration, not a promise that the payload is there; the decode
+ * refuses a stream whose tiles do not produce exactly it. */
 cudec_status cudec_gdeflate_tilestream_info(const void* stream,
                                             size_t stream_size,
                                             size_t* tile_count,
@@ -389,18 +400,36 @@ cudec_status cudec_gdeflate_tilestream_info(const void* stream,
  * decoding many streams pays the allocation once; that is the whole reason
  * this entry takes a context rather than being one-shot only.
  *
+ * EVERY TILE MUST PRODUCE EXACTLY WHAT THE ENVELOPE DECLARED FOR IT. The
+ * declared size is a bound in both directions, and the second direction is the
+ * one nothing else enforces: a GDeflate page ends at its final block and
+ * reports what it produced without comparing that against the capacity it was
+ * given, so a page decoding to fewer bytes than its tile was declared to hold
+ * is a well-formed page inside a container that lied about it. Accepted, it
+ * would leave the gap up to the next tile's declared offset holding whatever
+ * was in `dst` - and a decoder whose output depends on that is neither
+ * fail-closed nor deterministic. Such a tile is CUDEC_ERR_CORRUPT_INPUT, the
+ * same as one that overruns.
+ *
  * A tile that fails to decode is isolated to itself: h_tile_results[i] carries
  * that tile's own defined status with bytes_written 0, its siblings decode
  * normally and report their own bytes, and nothing about the failed tile's
- * region of `dst` is presented as valid output.
+ * region of `dst` is presented as valid output. On CUDEC_MEM_DEVICE that
+ * region may hold bytes the kernel wrote before it refused; they are not
+ * presented - *bytes_written is 0 and the tile's status is not OK - and
+ * nothing promises they were left alone.
  *
  * THE WHOLE-STREAM ANSWER FOLLOWS THE FRAME PRECEDENT RATHER THAN THE BATCH
  * ONE, because this entry, like cudec_lz4f_decompress, produces ONE object out
  * of many pieces. A stream with any failed tile is not a partially decoded
  * file: *bytes_written is 0 and the return is non-OK - CUDEC_ERR_CUDA where a
- * device or host resource failed, otherwise the first non-OK tile's status in
- * tile order. *bytes_written is the sum of the tiles' output only when every
- * tile decoded.
+ * device or host resource failed, CUDEC_ERR_UNSUPPORTED where the page decoder
+ * declines the device it was asked to launch on, otherwise the first non-OK
+ * tile's status in tile order. *bytes_written equals the envelope's declared
+ * total, and is reported only when every tile decoded exactly its declared
+ * size - it is derived from the validated envelope rather than summed from the
+ * device-written records, because it is a length the caller will read `dst`
+ * with.
  *
  * Fail-closed, synchronously and with nothing launched: a NULL ctx, a NULL
  * `stream`, `bytes_written` or h_tile_results, a NULL `dst` with a non-zero
@@ -412,10 +441,23 @@ cudec_status cudec_gdeflate_tilestream_info(const void* stream,
  * from the parsed envelope, so both are content-dependent rejects and neither
  * writes a byte of `dst`.
  *
+ * WHERE h_tile_results IS WRITTEN, stated because CUDEC_OK is zero and a
+ * caller cannot otherwise tell an untouched array from a decoded one. Every
+ * reject above - the argument classes, CUDEC_ERR_CORRUPT_INPUT,
+ * CUDEC_ERR_OUTPUT_TOO_SMALL, the short results array - leaves it UNTOUCHED,
+ * because none of them has accepted the call. From the point the call is
+ * accepted onward every entry in [0, tile_count) holds a defined
+ * cudec_status: its own decode outcome, or CUDEC_ERR_CUDA for a tile the call
+ * did not produce. Entries past tile_count are never written.
+ *
  * A CUDA fault POISONS the context exactly as the LZ4 streaming entry
- * documents: every later decode on it returns CUDEC_ERR_CUDA without touching
- * the device, and only cudec_stream_ctx_destroy is valid on it thereafter.
- * Never throws across this boundary. */
+ * documents: only cudec_stream_ctx_destroy is valid on it thereafter, and
+ * every later decode on it refuses without touching the device. The refusal is
+ * CUDEC_ERR_CUDA once the envelope has been accepted - the envelope walk runs
+ * first and is pure host arithmetic, so a poisoned context handed malformed
+ * bytes answers for the bytes. Fail-closed either way, and worth knowing for a
+ * caller using the return value to detect poisoning. Never throws across this
+ * boundary. */
 cudec_status cudec_gdeflate_tilestream_decompress_ctx(
     cudec_stream_ctx* ctx, const void* stream, size_t stream_size, void* dst,
     size_t dst_capacity, cudec_mem_space dst_space,

--- a/scripts/check-envelope-out-of-device.sh
+++ b/scripts/check-envelope-out-of-device.sh
@@ -1,31 +1,46 @@
 #!/usr/bin/env bash
-# The TileStream envelope must not reach device code (issue #177).
+# No TileStream envelope symbol in the shipped device code (issue #177).
 #
 # The container is DirectStorage's, the page is the format, and the whole
 # design of the GDeflate path rests on the kernel knowing only the second: the
 # host validates where every page is and how many bytes it must produce, and
 # the device is handed raw pages with bounds already decided. A symbol from
-# src/tilestream.h appearing inside a cubin would mean that separation had been
-# given up somewhere, and nothing else in the tree would notice - the code
-# would still build, still pass, and still decode.
+# src/tilestream.h inside a cubin would mean that separation had been given up,
+# and nothing else in the tree would notice - the code would still build, still
+# pass, and still decode.
 #
-# So this reads the BINARY, never the source. Grepping src/ for an #include
-# would pass on exactly the failure this exists to catch, because the way the
-# separation is lost is a header pulled into a .cu, and a check on the source
-# has to guess which .cu files are device translation units.
+# WHAT THIS PROVES, AND THE HALF IT DOES NOT. A matching symbol means the
+# separation is gone. The converse does NOT follow, and the gap is not
+# hypothetical: everything in src/tilestream.h is `inline`, so the way the
+# envelope would actually reach device code is somebody marking the parser
+# CUDEC_HOST_DEVICE and calling it from a kernel - at which point nvcc very
+# likely inlines it whole and emits no symbol for this to find. None of
+# src/gdeflate_block.h's host-device functions appear as symbols today for
+# exactly that reason. So this is a DRIFT DETECTOR over the binary, not
+# tamper-proofing and not a verification of the property. The companion is the
+# configure-time source check in tests/CMakeLists.txt, which reads the device
+# translation units CMake itself names and refuses an include of tilestream.h
+# among them; that one covers the inlined case and this one covers the case
+# where the header arrives by a route the source check cannot see. Neither
+# subsumes the other.
 #
-# Fail-closed in every direction: a missing tool, an object that yields no
-# device code, or a symbol listing with no kernel in it at all reds this. A
-# vacuous run cannot read as a clean one - which matters more here than on a
-# positive check, because "the forbidden symbol is absent" is exactly what an
-# empty listing says.
+# It reads the BINARY rather than the source for its own half deliberately:
+# grepping src/ for an #include is the source check's job, and a check that did
+# only that would pass on any route that did not go through an include.
+#
+# Fail-closed in every direction: a missing tool, a bad argument count, an
+# object list that yields no device code, a symbol listing with no kernel in it
+# at all, or a grep that could not run reds this. A vacuous run cannot read as
+# a clean one - which matters more here than on a positive check, because "the
+# forbidden symbol is absent" is exactly what an empty listing says.
 #
 # Usage: check-envelope-out-of-device.sh <cuobjdump> <object;list> [forbidden]
 #   cuobjdump    the CUDA object dumper beside the nvcc that built the objects
-#   object;list  the library's object files; the ones carrying device code are
-#                read, the host-only ones are skipped and said so
-#   forbidden    the regular expression a device symbol may not match; defaults
-#                to the envelope's namespace prefix. The ctest self-proof
+#   object;list  the library's object files, ONE semicolon-joined argument; the
+#                ones carrying device code are read, the host-only ones are
+#                skipped and said so
+#   forbidden    the extended regular expression a device symbol may not match;
+#                defaults to the envelope's type prefix. The ctest self-proof
 #                passes a pattern that IS present, so the refusal below is
 #                proven to fire rather than assumed to.
 set -u
@@ -35,7 +50,14 @@ fail() {
     exit 1
 }
 
-[ "$#" -ge 2 ] || fail "want at least 2 arguments: <cuobjdump> <object;list> [forbidden], got $#"
+# EXACTLY two or three, never "at least". The object list arrives as one
+# semicolon-joined generator expression; if it ever splits, an "at least"
+# test would silently take the first object as the whole list and the second
+# as the forbidden pattern, and the run would pass having checked one object
+# against a filename. The sibling check pins its count for the same reason.
+if [ "$#" -ne 2 ] && [ "$#" -ne 3 ]; then
+    fail "want 2 or 3 arguments: <cuobjdump> <object;list> [forbidden], got $#"
+fi
 cuobjdump="$1"
 [ -x "$cuobjdump" ] || fail "no executable cuobjdump at $cuobjdump"
 IFS=';' read -r -a objects <<< "$2"
@@ -51,24 +73,33 @@ all_syms=""
 device_objects=0
 for obj in "${objects[@]}"; do
     [ -f "$obj" ] || fail "object does not exist: $obj"
-    # A host-only object has no ELF section for cuobjdump to read; that is a
-    # skip and it is printed, never a silent pass.
-    syms="$("$cuobjdump" --dump-elf-symbols "$obj" 2>/dev/null)" || syms=""
-    if [ -z "$syms" ]; then
-        echo "skipped (no device code): $obj"
-        continue
-    fi
-    device_objects=$((device_objects + 1))
-    all_syms="$all_syms
+    # A host-only object carries no ELF section for cuobjdump to read. That is
+    # a skip and it is printed; the tool's own message goes to the log rather
+    # than to /dev/null, so an object that DOES carry device code and failed
+    # to dump is readable afterwards instead of being silently reclassified.
+    if syms="$("$cuobjdump" --dump-elf-symbols "$obj" 2>&1)" && [ -n "$syms" ]; then
+        device_objects=$((device_objects + 1))
+        all_syms="$all_syms
 $syms"
+    else
+        echo "skipped (no device code): $obj"
+    fi
 done
 
 [ "$device_objects" -gt 0 ] || fail "no object carried device code; nothing was checked"
 printf '%s\n' "$all_syms" | grep -q "$required" ||
     fail "no $required symbol in any device object; the listing is not the one this check is about"
 
-hits="$(printf '%s\n' "$all_syms" | grep -E "$forbidden" || true)"
-if [ -n "$hits" ]; then
+# grep's exit status is read rather than discarded with `|| true`. 0 is a hit,
+# 1 is a clean miss, and anything else is grep saying it could not evaluate the
+# pattern at all - a bad regex reaching this from the ctest argument would
+# otherwise be indistinguishable from a clean run and would PASS.
+hits="$(printf '%s\n' "$all_syms" | grep -E "$forbidden")"
+grep_status=$?
+if [ "$grep_status" -gt 1 ]; then
+    fail "grep could not evaluate the pattern '$forbidden' (exit $grep_status); nothing was checked"
+fi
+if [ "$grep_status" -eq 0 ]; then
     printf '%s\n' "$hits" | head -20 >&2
     fail "a device symbol matches '$forbidden'; the envelope has reached device code"
 fi

--- a/scripts/check-envelope-out-of-device.sh
+++ b/scripts/check-envelope-out-of-device.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# The TileStream envelope must not reach device code (issue #177).
+#
+# The container is DirectStorage's, the page is the format, and the whole
+# design of the GDeflate path rests on the kernel knowing only the second: the
+# host validates where every page is and how many bytes it must produce, and
+# the device is handed raw pages with bounds already decided. A symbol from
+# src/tilestream.h appearing inside a cubin would mean that separation had been
+# given up somewhere, and nothing else in the tree would notice - the code
+# would still build, still pass, and still decode.
+#
+# So this reads the BINARY, never the source. Grepping src/ for an #include
+# would pass on exactly the failure this exists to catch, because the way the
+# separation is lost is a header pulled into a .cu, and a check on the source
+# has to guess which .cu files are device translation units.
+#
+# Fail-closed in every direction: a missing tool, an object that yields no
+# device code, or a symbol listing with no kernel in it at all reds this. A
+# vacuous run cannot read as a clean one - which matters more here than on a
+# positive check, because "the forbidden symbol is absent" is exactly what an
+# empty listing says.
+#
+# Usage: check-envelope-out-of-device.sh <cuobjdump> <object;list> [forbidden]
+#   cuobjdump    the CUDA object dumper beside the nvcc that built the objects
+#   object;list  the library's object files; the ones carrying device code are
+#                read, the host-only ones are skipped and said so
+#   forbidden    the regular expression a device symbol may not match; defaults
+#                to the envelope's namespace prefix. The ctest self-proof
+#                passes a pattern that IS present, so the refusal below is
+#                proven to fire rather than assumed to.
+set -u
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+[ "$#" -ge 2 ] || fail "want at least 2 arguments: <cuobjdump> <object;list> [forbidden], got $#"
+cuobjdump="$1"
+[ -x "$cuobjdump" ] || fail "no executable cuobjdump at $cuobjdump"
+IFS=';' read -r -a objects <<< "$2"
+[ "${#objects[@]}" -gt 0 ] && [ -n "${objects[0]}" ] || fail "no objects given"
+forbidden="${3:-TileStream}"
+
+# The kernel that MUST be there. It is the anti-vacuity control: if the symbol
+# extraction silently produced nothing, this is missing and the run reds,
+# instead of reporting the forbidden pattern absent from an empty listing.
+required='gdeflate_decode_batch'
+
+all_syms=""
+device_objects=0
+for obj in "${objects[@]}"; do
+    [ -f "$obj" ] || fail "object does not exist: $obj"
+    # A host-only object has no ELF section for cuobjdump to read; that is a
+    # skip and it is printed, never a silent pass.
+    syms="$("$cuobjdump" --dump-elf-symbols "$obj" 2>/dev/null)" || syms=""
+    if [ -z "$syms" ]; then
+        echo "skipped (no device code): $obj"
+        continue
+    fi
+    device_objects=$((device_objects + 1))
+    all_syms="$all_syms
+$syms"
+done
+
+[ "$device_objects" -gt 0 ] || fail "no object carried device code; nothing was checked"
+printf '%s\n' "$all_syms" | grep -q "$required" ||
+    fail "no $required symbol in any device object; the listing is not the one this check is about"
+
+hits="$(printf '%s\n' "$all_syms" | grep -E "$forbidden" || true)"
+if [ -n "$hits" ]; then
+    printf '%s\n' "$hits" | head -20 >&2
+    fail "a device symbol matches '$forbidden'; the envelope has reached device code"
+fi
+echo "PASS: $device_objects device object(s) carry $required and no symbol matching '$forbidden'"

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -335,6 +335,17 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx, BatchEntry entry,
      * owners (at context destruction) free the buffers it is still
      * reading/writing. WAVE_FAIL records the fault and stops the loop. */
     cudec_status wave_status = CUDEC_OK;
+    /* Whether the wave loop stopped on a SYNCHRONOUS refusal from the batch
+     * entry rather than on a CUDA fault. The two end the loop the same way and
+     * must not end the context the same way: an entry that refused before
+     * submitting anything - CUDEC_ERR_UNSUPPORTED for a wave width this build
+     * emits no kernel for, CUDEC_ERR_NOT_IMPLEMENTED from an entry whose
+     * kernel has not landed - made no CUDA call and damaged nothing, so
+     * poisoning would kill a healthy context and answer every later decode on
+     * it CUDEC_ERR_CUDA. That was unreachable while this loop was hardwired to
+     * one entry that cannot refuse; it is reachable the moment the loop takes
+     * the entry as an argument, which is what src/stream_decode.h does. */
+    bool entry_refused = false;
     bool have_pending_src = false; /* whether reuse has been recorded */
 #define WAVE_FAIL(st)       \
     {                       \
@@ -430,6 +441,7 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx, BatchEntry entry,
                                             d_res,
                                             cudec_rt::abi_stream(stream));
         if (launched != CUDEC_OK) {
+            entry_refused = true;
             WAVE_FAIL(launched);
         }
 
@@ -467,11 +479,15 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx, BatchEntry entry,
      * (the entry is synchronous), and surface any async fault as a defined
      * error. */
     cudec_status drain = wave_status;
-    if (cudec_rt::stream_synchronize(stream) != cudec_rt::success &&
-        drain == CUDEC_OK) {
-        drain = CUDEC_ERR_CUDA;
-    }
-    if (cudec_rt::get_last_error() != cudec_rt::success && drain == CUDEC_OK) {
+    /* Both are asked unconditionally and the answers are kept, because
+     * get_last_error CONSUMES the state: a second call below would report
+     * clean whatever the first one found, and the poisoning decision needs
+     * that answer. */
+    const bool sync_faulted =
+        cudec_rt::stream_synchronize(stream) != cudec_rt::success;
+    const bool async_faulted =
+        cudec_rt::get_last_error() != cudec_rt::success;
+    if ((sync_faulted || async_faulted) && drain == CUDEC_OK) {
         drain = CUDEC_ERR_CUDA;
     }
 
@@ -480,8 +496,13 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx, BatchEntry entry,
      * aggregate. */
     std::memcpy(h_results, ctx.p_results.p, results_bytes);
     if (drain != CUDEC_OK) {
-        /* A CUDA-level fault happened; the context is dead. */
-        ctx.poisoned = true;
+        /* A CUDA-level fault happened; the context is dead. A synchronous
+         * refusal from the batch entry is the one non-OK drain that is not
+         * one: it submitted nothing, the stream drained clean, and the
+         * buffers are exactly as they were. */
+        if (!entry_refused || sync_faulted || async_faulted) {
+            ctx.poisoned = true;
+        }
         return drain;
     }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -28,6 +28,7 @@
  * lever. */
 #include "batch_limits.h"
 #include "cudec.h"
+#include "stream_decode.h"
 
 #include "vendor_raii.h"
 
@@ -229,13 +230,16 @@ void StampNotDecoded(cudec_chunk_result* results, size_t chunk_count,
     }
 }
 
-/* Decodes the whole batch on the context's single stream. Grows the staging to
- * this call's high-water mark first (reusing it when already large enough),
- * then stages and launches each wave in order. A CUDA-level fault (a failed
- * copy/launch/sync, or a grow allocation failure) poisons the context and
- * returns CUDEC_ERR_CUDA; per-chunk decode rejects are reported in h_results
- * and never poison. */
-cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
+/* Decodes the whole batch on the context's single stream, submitting each wave
+ * through `entry`. Grows the staging to this call's high-water mark first
+ * (reusing it when already large enough), then stages and launches each wave in
+ * order. A CUDA-level fault (a failed copy/launch/sync, or a grow allocation
+ * failure) poisons the context and returns CUDEC_ERR_CUDA; per-chunk decode
+ * rejects are reported in h_results and never poison.
+ *
+ * Nothing below names a format. `entry` is the only thing that does, and it is
+ * the seam src/stream_decode.h argues for. */
+cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx, BatchEntry entry,
                              const void* const* h_src_ptrs,
                              const size_t* h_src_sizes, void* const* dst_ptrs,
                              const size_t* dst_caps, size_t chunk_count,
@@ -422,9 +426,9 @@ cudec_status DecodeStreamCtx(cudec_stream_ctx& ctx,
          * satisfies the batch entry's 16-byte-alignment requirement. */
         cudec_chunk_result* d_res =
             static_cast<cudec_chunk_result*>(ctx.d_results.p) + begin;
-        const cudec_status launched = cudec_lz4_decompress_batch(
-            dd_src, dd_ssz, dd_dst, dd_cap, wn, d_res,
-            cudec_rt::abi_stream(stream));
+        const cudec_status launched = entry(dd_src, dd_ssz, dd_dst, dd_cap, wn,
+                                            d_res,
+                                            cudec_rt::abi_stream(stream));
         if (launched != CUDEC_OK) {
             WAVE_FAIL(launched);
         }
@@ -515,12 +519,15 @@ cudec_status cudec_stream_ctx_create(cudec_stream_ctx** out_ctx) {
     return CUDEC_OK;
 }
 
-cudec_status cudec_lz4_decompress_stream_ctx(
-    cudec_stream_ctx* ctx, const void* const* h_src_ptrs,
-    const size_t* h_src_sizes, void* const* dst_ptrs, const size_t* dst_caps,
-    size_t chunk_count, cudec_mem_space dst_space,
-    cudec_chunk_result* h_results) {
-    if (ctx == nullptr) {
+namespace cudec_stream_detail {
+
+cudec_status DecodeOnStreamCtx(cudec_stream_ctx* ctx, BatchEntry entry,
+                               const void* const* h_src_ptrs,
+                               const size_t* h_src_sizes,
+                               void* const* dst_ptrs, const size_t* dst_caps,
+                               size_t chunk_count, cudec_mem_space dst_space,
+                               cudec_chunk_result* h_results) {
+    if (ctx == nullptr || entry == nullptr) {
         return CUDEC_ERR_INVALID_ARGUMENT;
     }
     /* Argument rejects are synchronous, make no CUDA call, and never poison the
@@ -539,7 +546,7 @@ cudec_status cudec_lz4_decompress_stream_ctx(
         return CUDEC_ERR_CUDA;
     }
     try {
-        return DecodeStreamCtx(*ctx, h_src_ptrs, h_src_sizes, dst_ptrs,
+        return DecodeStreamCtx(*ctx, entry, h_src_ptrs, h_src_sizes, dst_ptrs,
                                dst_caps, chunk_count, dst_space, h_results);
     } catch (...) {
         /* A host allocation failed mid-decode; never let it cross the C ABI,
@@ -547,6 +554,18 @@ cudec_status cudec_lz4_decompress_stream_ctx(
         ctx->poisoned = true;
         return CUDEC_ERR_CUDA;
     }
+}
+
+}  // namespace cudec_stream_detail
+
+cudec_status cudec_lz4_decompress_stream_ctx(
+    cudec_stream_ctx* ctx, const void* const* h_src_ptrs,
+    const size_t* h_src_sizes, void* const* dst_ptrs, const size_t* dst_caps,
+    size_t chunk_count, cudec_mem_space dst_space,
+    cudec_chunk_result* h_results) {
+    return cudec_stream_detail::DecodeOnStreamCtx(
+        ctx, cudec_lz4_decompress_batch, h_src_ptrs, h_src_sizes, dst_ptrs,
+        dst_caps, chunk_count, dst_space, h_results);
 }
 
 void cudec_stream_ctx_destroy(cudec_stream_ctx* ctx) {

--- a/src/stream_decode.h
+++ b/src/stream_decode.h
@@ -1,0 +1,58 @@
+/* The streaming decode core, shared by every format that drives the reusable
+ * context (issue #177). Internal header, not part of the ABI.
+ *
+ * WHY THIS SEAM EXISTS AT ALL. src/stream.cpp owns the only staging path in
+ * the library that grows once and is reused: a pinned/device source pair, the
+ * metadata pair, the host-output destination staging, the result buffer and
+ * its pinned mirror, waved so a hostile chunk_count cannot drive per-wave
+ * growth. Every one of those is format-blind - the only line in the wave loop
+ * that names a format is the batch entry it launches. A second format that
+ * copied the loop to change that one line would be a second staging path to
+ * keep in agreement with this one, and the two would drift on exactly the
+ * questions (poisoning, the not-produced seed, the drain) that are hardest to
+ * notice going wrong.
+ *
+ * A FUNCTION POINTER RATHER THAN A TEMPLATE, deliberately, and the opposite of
+ * what src/batch.cu does for its launchers. There the indirection would cost
+ * the device compiler the inlining the parser depends on; here the callee is
+ * a host function that submits one launch per wave, so the call is paid once
+ * per wave against a kernel launch and buys one instantiation of a 250-line
+ * body instead of one per format. */
+#ifndef CUDEC_STREAM_DECODE_H
+#define CUDEC_STREAM_DECODE_H
+
+#include "cudec.h"
+
+#include <stddef.h>
+
+namespace cudec_stream_detail {
+
+/* The shape of every batch entry in include/cudec.h. Spelled from the ABI
+ * rather than from any one entry, so a signature change reds every format at
+ * once instead of silently binding the wrong one. */
+typedef cudec_status (*BatchEntry)(const void* const* d_src_ptrs,
+                                   const size_t* d_src_sizes,
+                                   void* const* d_dst_ptrs,
+                                   const size_t* d_dst_capacities,
+                                   size_t chunk_count,
+                                   cudec_chunk_result* d_results,
+                                   cudec_stream_t stream);
+
+/* Drives `entry` over the whole batch on `ctx`'s stream and staging. The
+ * arguments after `entry` are the streaming ABI's, argument for argument, and
+ * the contract is the one cudec_lz4_decompress_stream_ctx documents: a NULL
+ * ctx or a malformed argument is refused synchronously with no CUDA call and
+ * no poisoning, a poisoned context refuses with the per-chunk channel stamped
+ * fail-closed, a per-chunk reject is reported in h_results and does not
+ * poison, and a CUDA-level fault poisons and returns CUDEC_ERR_CUDA. Never
+ * throws: a host allocation failure inside becomes CUDEC_ERR_CUDA. */
+cudec_status DecodeOnStreamCtx(cudec_stream_ctx* ctx, BatchEntry entry,
+                               const void* const* h_src_ptrs,
+                               const size_t* h_src_sizes,
+                               void* const* dst_ptrs, const size_t* dst_caps,
+                               size_t chunk_count, cudec_mem_space dst_space,
+                               cudec_chunk_result* h_results);
+
+}  // namespace cudec_stream_detail
+
+#endif /* CUDEC_STREAM_DECODE_H */

--- a/src/stream_decode.h
+++ b/src/stream_decode.h
@@ -1,16 +1,32 @@
 /* The streaming decode core, shared by every format that drives the reusable
- * context (issue #177). Internal header, not part of the ABI.
+ * STREAMING context (issue #177). Internal header, not part of the ABI.
  *
- * WHY THIS SEAM EXISTS AT ALL. src/stream.cpp owns the only staging path in
- * the library that grows once and is reused: a pinned/device source pair, the
- * metadata pair, the host-output destination staging, the result buffer and
- * its pinned mirror, waved so a hostile chunk_count cannot drive per-wave
- * growth. Every one of those is format-blind - the only line in the wave loop
- * that names a format is the batch entry it launches. A second format that
- * copied the loop to change that one line would be a second staging path to
- * keep in agreement with this one, and the two would drift on exactly the
- * questions (poisoning, the not-produced seed, the drain) that are hardest to
- * notice going wrong.
+ * WHY THIS SEAM EXISTS AT ALL. src/stream.cpp owns the reusable staging path:
+ * a pinned/device source pair, the metadata pair, the host-output destination
+ * staging, the result buffer and its pinned mirror, grown once and waved so a
+ * hostile chunk_count cannot drive per-wave growth. Every one of those is
+ * format-blind - the only line in the wave loop that names a format is the
+ * batch entry it launches. A second format that copied the loop to change that
+ * one line would be a second staging path to keep in agreement with this one,
+ * and the two would drift on exactly the questions (poisoning, the
+ * not-produced seed, the drain) that are hardest to notice going wrong.
+ *
+ * THIS IS NOT A CLAIM THAT THE LIBRARY HAS ONE STAGING PATH, AND SAYING SO
+ * HERE IS DELIBERATE. src/frame.cpp is a second one: it gathers into its own
+ * host buffer, builds the same four-section metadata upload in a comment that
+ * admits the copy, launches the batch entry directly, and does its own
+ * readback and aggregate - with no poisoning, no not-produced seed and no wave
+ * loop. That is precisely the drift this paragraph warns about, already in the
+ * tree, and it is not migrated here: a frame's per-block output size is
+ * unknown before the decode, so it needs a block_max slab and a compaction
+ * pass that this core has no shape for. What is claimed is narrower and true -
+ * every format reaching the reusable CONTEXT comes through this one function.
+ *
+ * NOTHING REFUSES A THIRD PATH. The rule above is carried by this paragraph
+ * and by review, not by a check: whether a block of code is a re-copy of a
+ * wave loop is a judgement about meaning, and no reading of the tree makes it.
+ * A guard that grepped for the staging member names would refuse the honest
+ * caller and miss a re-copy under fresh ones.
  *
  * A FUNCTION POINTER RATHER THAN A TEMPLATE, deliberately, and the opposite of
  * what src/batch.cu does for its launchers. There the indirection would cost

--- a/src/stream_decode.h
+++ b/src/stream_decode.h
@@ -30,6 +30,13 @@ namespace cudec_stream_detail {
 /* The shape of every batch entry in include/cudec.h. Spelled from the ABI
  * rather than from any one entry, so a signature change reds every format at
  * once instead of silently binding the wrong one. */
+extern "C" {
+/* C LANGUAGE LINKAGE, because the entries this points at have it. A pointer to
+ * a C++-linkage function and a pointer to a C-linkage one are different types
+ * ([dcl.link]/1), so a typedef written outside extern "C" and initialised from
+ * cudec_lz4_decompress_batch is ill-formed - accepted by every compiler this
+ * tree builds with, and still the wrong type on a boundary whose stated
+ * property is that it is the ABI's. */
 typedef cudec_status (*BatchEntry)(const void* const* d_src_ptrs,
                                    const size_t* d_src_sizes,
                                    void* const* d_dst_ptrs,
@@ -37,6 +44,7 @@ typedef cudec_status (*BatchEntry)(const void* const* d_src_ptrs,
                                    size_t chunk_count,
                                    cudec_chunk_result* d_results,
                                    cudec_stream_t stream);
+}
 
 /* Drives `entry` over the whole batch on `ctx`'s stream and staging. The
  * arguments after `entry` are the streaming ABI's, argument for argument, and

--- a/src/tilestream.cpp
+++ b/src/tilestream.cpp
@@ -28,37 +28,14 @@
 #include "tilestream.h"
 
 #include <cstddef>
-#include <new>
 #include <vector>
 
 namespace {
 
+using cudec_detail::TileStreamDeclaredTileCount;
 using cudec_detail::TileStreamInfo;
 using cudec_detail::TileStreamParse;
-using cudec_detail::TileStreamRead16LE;
 using cudec_detail::TileStreamTile;
-using cudec_detail::kTileStreamHeaderBytes;
-
-/* How many tiles to make room for before the parser is asked anything.
- *
- * The parser writes the caller's array and refuses rather than allocating, so
- * something has to size that array first, and the only thing that knows the
- * count is the stream. This reads the declared count and NOTHING ELSE from the
- * header: it is a sizing hint, not a validated fact, and every use of it below
- * is either an allocation bounded by the field's own width or a value the
- * parser re-derives and checks for itself. The 8-byte guard is here for the
- * same reason it is in the parser - the count is two bytes at offset 2 and
- * reading them out of a shorter buffer is the over-read this whole layer
- * exists to prevent. A count this returns that the bytes do not support costs
- * an over-large allocation of at most 65535 entries and then a
- * CUDEC_ERR_CORRUPT_INPUT from the parser, which is the same answer the caller
- * would have got without the hint. */
-size_t DeclaredTileCount(const unsigned char* stream, size_t stream_size) {
-    if (stream == nullptr || stream_size < kTileStreamHeaderBytes) {
-        return 0;
-    }
-    return static_cast<size_t>(TileStreamRead16LE(stream + 2));
-}
 
 /* Parses the envelope into `tiles`/`info`, sizing `tiles` from the declared
  * count. Returns what the parser returns; on any non-OK status `tiles` and
@@ -71,15 +48,26 @@ size_t DeclaredTileCount(const unsigned char* stream, size_t stream_size) {
 cudec_status ParseEnvelope(const unsigned char* stream, size_t stream_size,
                            std::vector<TileStreamTile>* tiles,
                            TileStreamInfo* info) {
-    const size_t declared = DeclaredTileCount(stream, stream_size);
-    tiles->assign(declared + 1, TileStreamTile());
+    const size_t declared = static_cast<size_t>(TileStreamDeclaredTileCount(
+        stream, static_cast<uint64_t>(stream_size)));
+    /* EXACTLY the declared count, never a spare entry. The parser writes one
+     * entry per tile the stream declares, so an array with slack puts an
+     * off-by-one in that loop into allocator padding where the sanitizer
+     * cannot see it - which is the discipline fuzz/fuzz_gdeflate_tilestream.cpp
+     * states for its own array, and the library's own call has no business
+     * being the softer of the two. The zero case still needs a non-null
+     * data() to hand over, because a null one is the parser's
+     * caller-mistake branch rather than its refusal of these bytes. */
+    tiles->assign(declared != 0 ? declared : 1, TileStreamTile());
     return TileStreamParse(stream, static_cast<uint64_t>(stream_size),
                            tiles->data(), static_cast<uint64_t>(declared),
                            info);
 }
 
-/* The batch arrays an accepted call decodes with. */
+/* The batch arrays an accepted call decodes with, and the total the envelope
+ * declared them to produce. */
 struct TileStreamPlan {
+    size_t declared_total;
     std::vector<const void*> src_ptrs;
     std::vector<size_t> src_sizes;
     std::vector<void*> dst_ptrs;
@@ -133,10 +121,21 @@ cudec_status BuildTileStreamPlan(const void* stream, size_t stream_size,
     if (tile_results_capacity < n) {
         return CUDEC_ERR_INVALID_ARGUMENT;
     }
-    if (dst_capacity < static_cast<size_t>(info.total_uncompressed)) {
+    /* The narrowing is safe only because the container's ceiling is
+     * 65535 * 65536 = 4294901760, which is inside a 32-bit size_t by 65536
+     * bytes - the equality src/tilestream.h pins with a static_assert. It is
+     * re-checked rather than trusted, because the failure mode if that ceiling
+     * ever moves is a wrapped total comparing below dst_capacity and every
+     * bound after it being computed from the wrong number. */
+    if (info.total_uncompressed > static_cast<uint64_t>(SIZE_MAX)) {
+        return CUDEC_ERR_OUTPUT_TOO_SMALL;
+    }
+    const size_t total = static_cast<size_t>(info.total_uncompressed);
+    if (dst_capacity < total) {
         return CUDEC_ERR_OUTPUT_TOO_SMALL;
     }
 
+    plan->declared_total = total;
     plan->src_ptrs.resize(n);
     plan->src_sizes.resize(n);
     plan->dst_ptrs.resize(n);
@@ -159,6 +158,17 @@ cudec_status BuildTileStreamPlan(const void* stream, size_t stream_size,
     return CUDEC_OK;
 }
 
+/* A defined not-produced record in every tile slot the envelope declared.
+ * Used only once the call has been ACCEPTED, so the count is the parsed one
+ * and the caller's array is already known to be at least that long. */
+void StampTilesNotDecoded(cudec_chunk_result* results, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        results[i].status = static_cast<int32_t>(CUDEC_ERR_CUDA);
+        results[i].reserved = 0;
+        results[i].bytes_written = 0;
+    }
+}
+
 /* Runs an accepted plan on `ctx` and decides the whole-stream answer. */
 cudec_status RunTileStreamPlan(cudec_stream_ctx* ctx,
                                const TileStreamPlan& plan,
@@ -177,11 +187,53 @@ cudec_status RunTileStreamPlan(cudec_stream_ctx* ctx,
          * stream did not decode. */
         return st;
     }
+    /* THE ENVELOPE'S DECLARED TILE SIZE IS A TWO-SIDED BOUND, AND THIS IS THE
+     * SECOND SIDE. The capacity handed to the page decoder refuses a tile that
+     * produces MORE than it was declared to. Nothing in the page format
+     * refuses one that produces LESS: a GDeflate page ends at its final block
+     * and reports what it produced, with no comparison against the capacity it
+     * was given, so a valid page compressed from ten bytes decodes CUDEC_OK
+     * into a tile the container declared as 65536.
+     *
+     * Accepting that would be the worst answer this entry could give. The
+     * tiles are laid out at DECLARED offsets, so a short tile leaves the gap
+     * between what it wrote and where its neighbour starts holding whatever
+     * was in the caller's destination - prior contents on the host path,
+     * uninitialised device memory on the CUDEC_MEM_DEVICE path - and the
+     * summed bytes_written would hand the caller a range spanning it. That is
+     * output the decoder never produced, presented as a successful decode,
+     * and it is not even deterministic: the same stream would read back
+     * differently depending on what the destination held.
+     *
+     * So a tile that decoded must have decoded exactly what the container said
+     * it would. A disagreement between the two is the container being wrong
+     * about its own contents, which is CUDEC_ERR_CORRUPT_INPUT, and it is
+     * stamped onto the tile so the per-tile channel names which one. */
     size_t total = 0;
+    cudec_status short_status = CUDEC_OK;
     for (size_t i = 0; i < n; i++) {
-        total += static_cast<size_t>(h_tile_results[i].bytes_written);
+        if (h_tile_results[i].bytes_written !=
+            static_cast<uint64_t>(plan.dst_caps[i])) {
+            h_tile_results[i].status =
+                static_cast<int32_t>(CUDEC_ERR_CORRUPT_INPUT);
+            h_tile_results[i].reserved = 0;
+            h_tile_results[i].bytes_written = 0;
+            if (short_status == CUDEC_OK) {
+                short_status = CUDEC_ERR_CORRUPT_INPUT;
+            }
+            continue;
+        }
+        total += plan.dst_caps[i];
     }
-    *bytes_written = total;
+    if (short_status != CUDEC_OK) {
+        return short_status;
+    }
+    /* Derived from the envelope rather than summed from the device, now that
+     * the two are known to agree. A length a caller will read `dst` with is
+     * not a number to take from a device-written record when a validated host
+     * one says the same thing. */
+    *bytes_written = plan.declared_total;
+    (void)total;
     return CUDEC_OK;
 }
 
@@ -272,6 +324,13 @@ cudec_status cudec_gdeflate_tilestream_decompress(
     cudec_stream_ctx* ctx = nullptr;
     const cudec_status created = cudec_stream_ctx_create(&ctx);
     if (created != CUDEC_OK) {
+        /* The call was ACCEPTED and then a resource failed, which is the one
+         * class where this entry owes the per-tile channel a defined value:
+         * the caller has been told the stream is well-formed, and CUDEC_OK is
+         * zero, so a results array it zero-initialised would otherwise read
+         * as every tile having decoded nothing successfully. On a GPU-less
+         * host this is the ordinary path, not the exotic one. */
+        StampTilesNotDecoded(h_tile_results, plan.src_ptrs.size());
         return created;
     }
     const cudec_status st =

--- a/src/tilestream.cpp
+++ b/src/tilestream.cpp
@@ -1,0 +1,281 @@
+/* Whole-TileStream decode (issue #177): the host-side envelope walker in
+ * src/tilestream.h feeding the GDeflate page batch decoder through the
+ * reusable streaming context. Host orchestration on top of the device engine,
+ * the sibling of src/frame.cpp - masterplan section 11.4 (M4).
+ *
+ * THE KERNEL STAYS ENVELOPE-IGNORANT, AND THAT IS THE POINT OF THIS FILE. A
+ * TileStream is DirectStorage's container; a GDeflate page is the format. The
+ * device decodes pages and knows nothing about tables of contents, so
+ * everything the container says - where each page starts, how long it is, how
+ * many bytes it must produce - is decided here, on the host, before a byte
+ * reaches a launch. The envelope_out_of_device ctest verifies the other half
+ * of that sentence against the shipped binary rather than against this
+ * comment.
+ *
+ * THIS FILE ADDS NO STAGING. Every buffer it uses is the streaming context's,
+ * reached through cudec_stream_detail::DecodeOnStreamCtx, so a caller decoding
+ * many streams pays the allocation once and a fault poisons the context the
+ * way the LZ4 streaming entry documents. What is new here is the translation
+ * from one validated tile table into the batch arrays that core already
+ * consumes.
+ *
+ * COMPILED AS PLAIN C++, NEVER AS DEVICE CODE. src/tilestream.h is header-only
+ * and host-only so the GPU-less runner and the fuzz targets reach it; this
+ * translation unit joins the library beside src/frame.cpp and src/stream.cpp
+ * and pulls in no CUDA header of its own. */
+#include "cudec.h"
+#include "stream_decode.h"
+#include "tilestream.h"
+
+#include <cstddef>
+#include <new>
+#include <vector>
+
+namespace {
+
+using cudec_detail::TileStreamInfo;
+using cudec_detail::TileStreamParse;
+using cudec_detail::TileStreamRead16LE;
+using cudec_detail::TileStreamTile;
+using cudec_detail::kTileStreamHeaderBytes;
+
+/* How many tiles to make room for before the parser is asked anything.
+ *
+ * The parser writes the caller's array and refuses rather than allocating, so
+ * something has to size that array first, and the only thing that knows the
+ * count is the stream. This reads the declared count and NOTHING ELSE from the
+ * header: it is a sizing hint, not a validated fact, and every use of it below
+ * is either an allocation bounded by the field's own width or a value the
+ * parser re-derives and checks for itself. The 8-byte guard is here for the
+ * same reason it is in the parser - the count is two bytes at offset 2 and
+ * reading them out of a shorter buffer is the over-read this whole layer
+ * exists to prevent. A count this returns that the bytes do not support costs
+ * an over-large allocation of at most 65535 entries and then a
+ * CUDEC_ERR_CORRUPT_INPUT from the parser, which is the same answer the caller
+ * would have got without the hint. */
+size_t DeclaredTileCount(const unsigned char* stream, size_t stream_size) {
+    if (stream == nullptr || stream_size < kTileStreamHeaderBytes) {
+        return 0;
+    }
+    return static_cast<size_t>(TileStreamRead16LE(stream + 2));
+}
+
+/* Parses the envelope into `tiles`/`info`, sizing `tiles` from the declared
+ * count. Returns what the parser returns; on any non-OK status `tiles` and
+ * `info` say nothing. A zero declared count is handed to the parser anyway
+ * rather than short-circuited here, so the refusal comes from the one place
+ * that decides refusals - and the vector is one entry longer than the count so
+ * even a zero-tile call has a non-null data() to hand over, which keeps the
+ * parser's NULL-argument branch about a caller's mistake rather than about
+ * this sizing. */
+cudec_status ParseEnvelope(const unsigned char* stream, size_t stream_size,
+                           std::vector<TileStreamTile>* tiles,
+                           TileStreamInfo* info) {
+    const size_t declared = DeclaredTileCount(stream, stream_size);
+    tiles->assign(declared + 1, TileStreamTile());
+    return TileStreamParse(stream, static_cast<uint64_t>(stream_size),
+                           tiles->data(), static_cast<uint64_t>(declared),
+                           info);
+}
+
+/* The batch arrays an accepted call decodes with. */
+struct TileStreamPlan {
+    std::vector<const void*> src_ptrs;
+    std::vector<size_t> src_sizes;
+    std::vector<void*> dst_ptrs;
+    std::vector<size_t> dst_caps;
+};
+
+/* The whole synchronous reject surface of both decode entries, plus the plan
+ * an accepted call runs. Everything here is host work on host bytes: argument
+ * checks, the envelope walk, the two capacity refusals the envelope decides,
+ * and the translation of the tile table into the batch arrays.
+ *
+ * IT IS ONE FUNCTION BECAUSE THE ONE-SHOT MUST ANSWER EVERY REJECT WITHOUT A
+ * CONTEXT. Creating one first would put cudec_stream_ctx_create ahead of the
+ * refusals, and on a GPU-less host that call fails for want of a device - so a
+ * truncated envelope would come back CUDEC_ERR_CUDA instead of
+ * CUDEC_ERR_CORRUPT_INPUT, and the conformance runner could reach none of it.
+ * That is the reasoning the LZ4 one-shot records for its argument validation,
+ * carried one step further because this entry's refusals depend on content and
+ * not only on pointers.
+ *
+ * `ctx` is not examined here: a NULL one is the _ctx entry's own reject and the
+ * one-shot never has one to check. */
+cudec_status BuildTileStreamPlan(const void* stream, size_t stream_size,
+                                 void* dst, size_t dst_capacity,
+                                 cudec_mem_space dst_space,
+                                 const cudec_chunk_result* h_tile_results,
+                                 size_t tile_results_capacity,
+                                 const size_t* bytes_written,
+                                 TileStreamPlan* plan) {
+    if (stream == nullptr || bytes_written == nullptr ||
+        h_tile_results == nullptr ||
+        (dst == nullptr && dst_capacity != 0) ||
+        (dst_space != CUDEC_MEM_HOST && dst_space != CUDEC_MEM_DEVICE)) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+
+    const unsigned char* bytes = static_cast<const unsigned char*>(stream);
+    std::vector<TileStreamTile> tiles;
+    TileStreamInfo info;
+    const cudec_status parsed =
+        ParseEnvelope(bytes, stream_size, &tiles, &info);
+    if (parsed != CUDEC_OK) {
+        return parsed;
+    }
+    const size_t n = static_cast<size_t>(info.tile_count);
+    /* Both capacity refusals are decided from the PARSED envelope, so both are
+     * content-dependent and both happen before a byte of dst is touched.
+     * Refusing rather than decoding the prefix that would fit is the frame
+     * precedent: a partially written destination is not an answer this ABI has
+     * a way to describe. */
+    if (tile_results_capacity < n) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+    if (dst_capacity < static_cast<size_t>(info.total_uncompressed)) {
+        return CUDEC_ERR_OUTPUT_TOO_SMALL;
+    }
+
+    plan->src_ptrs.resize(n);
+    plan->src_sizes.resize(n);
+    plan->dst_ptrs.resize(n);
+    plan->dst_caps.resize(n);
+    unsigned char* out = static_cast<unsigned char*>(dst);
+    size_t out_off = 0;
+    for (size_t i = 0; i < n; i++) {
+        plan->src_ptrs[i] = bytes + static_cast<size_t>(tiles[i].src_off);
+        plan->src_sizes[i] = static_cast<size_t>(tiles[i].src_size);
+        plan->dst_ptrs[i] = out + out_off;
+        /* The capacity handed to the page decoder is the size the ENVELOPE
+         * declares for this tile, never the space left in dst. That makes the
+         * container's declaration a bound the kernel enforces: a page whose
+         * bitstream decodes to more than its tile was declared to hold is
+         * refused with CUDEC_ERR_OUTPUT_TOO_SMALL for that tile instead of
+         * spilling into the next tile's bytes. */
+        plan->dst_caps[i] = static_cast<size_t>(tiles[i].dst_size);
+        out_off += plan->dst_caps[i];
+    }
+    return CUDEC_OK;
+}
+
+/* Runs an accepted plan on `ctx` and decides the whole-stream answer. */
+cudec_status RunTileStreamPlan(cudec_stream_ctx* ctx,
+                               const TileStreamPlan& plan,
+                               cudec_mem_space dst_space,
+                               cudec_chunk_result* h_tile_results,
+                               size_t* bytes_written) {
+    const size_t n = plan.src_ptrs.size();
+    const cudec_status st = cudec_stream_detail::DecodeOnStreamCtx(
+        ctx, cudec_gdeflate_decompress_batch, plan.src_ptrs.data(),
+        plan.src_sizes.data(), plan.dst_ptrs.data(), plan.dst_caps.data(), n,
+        dst_space, h_tile_results);
+    if (st != CUDEC_OK) {
+        /* *bytes_written stays 0. Per-tile outcomes are already in
+         * h_tile_results, each one defined, so a caller that wants to know
+         * WHICH tile failed reads them; the aggregate says only that the
+         * stream did not decode. */
+        return st;
+    }
+    size_t total = 0;
+    for (size_t i = 0; i < n; i++) {
+        total += static_cast<size_t>(h_tile_results[i].bytes_written);
+    }
+    *bytes_written = total;
+    return CUDEC_OK;
+}
+
+}  // namespace
+
+cudec_status cudec_gdeflate_tilestream_info(const void* stream,
+                                            size_t stream_size,
+                                            size_t* tile_count,
+                                            size_t* uncompressed_size) {
+    if (tile_count != nullptr) {
+        *tile_count = 0;
+    }
+    if (uncompressed_size != nullptr) {
+        *uncompressed_size = 0;
+    }
+    if (stream == nullptr || tile_count == nullptr ||
+        uncompressed_size == nullptr) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+    const unsigned char* bytes = static_cast<const unsigned char*>(stream);
+    std::vector<TileStreamTile> tiles;
+    TileStreamInfo info;
+    cudec_status st;
+    try {
+        st = ParseEnvelope(bytes, stream_size, &tiles, &info);
+    } catch (...) {
+        /* The only allocation here is the tile table, bounded by the declared
+         * count's own 16-bit width. A host OOM never crosses the C ABI as a
+         * throw. */
+        return CUDEC_ERR_CUDA;
+    }
+    if (st != CUDEC_OK) {
+        return st;
+    }
+    *tile_count = static_cast<size_t>(info.tile_count);
+    *uncompressed_size = static_cast<size_t>(info.total_uncompressed);
+    return CUDEC_OK;
+}
+
+cudec_status cudec_gdeflate_tilestream_decompress_ctx(
+    cudec_stream_ctx* ctx, const void* stream, size_t stream_size, void* dst,
+    size_t dst_capacity, cudec_mem_space dst_space,
+    cudec_chunk_result* h_tile_results, size_t tile_results_capacity,
+    size_t* bytes_written) {
+    if (bytes_written != nullptr) {
+        *bytes_written = 0;
+    }
+    if (ctx == nullptr) {
+        return CUDEC_ERR_INVALID_ARGUMENT;
+    }
+    TileStreamPlan plan;
+    cudec_status planned;
+    try {
+        planned = BuildTileStreamPlan(stream, stream_size, dst, dst_capacity,
+                                      dst_space, h_tile_results,
+                                      tile_results_capacity, bytes_written,
+                                      &plan);
+    } catch (...) {
+        return CUDEC_ERR_CUDA; /* host OOM never crosses the C ABI as a throw */
+    }
+    if (planned != CUDEC_OK) {
+        return planned;
+    }
+    return RunTileStreamPlan(ctx, plan, dst_space, h_tile_results,
+                             bytes_written);
+}
+
+cudec_status cudec_gdeflate_tilestream_decompress(
+    const void* stream, size_t stream_size, void* dst, size_t dst_capacity,
+    cudec_mem_space dst_space, cudec_chunk_result* h_tile_results,
+    size_t tile_results_capacity, size_t* bytes_written) {
+    if (bytes_written != nullptr) {
+        *bytes_written = 0;
+    }
+    TileStreamPlan plan;
+    cudec_status planned;
+    try {
+        planned = BuildTileStreamPlan(stream, stream_size, dst, dst_capacity,
+                                      dst_space, h_tile_results,
+                                      tile_results_capacity, bytes_written,
+                                      &plan);
+    } catch (...) {
+        return CUDEC_ERR_CUDA;
+    }
+    if (planned != CUDEC_OK) {
+        return planned;
+    }
+    cudec_stream_ctx* ctx = nullptr;
+    const cudec_status created = cudec_stream_ctx_create(&ctx);
+    if (created != CUDEC_OK) {
+        return created;
+    }
+    const cudec_status st =
+        RunTileStreamPlan(ctx, plan, dst_space, h_tile_results, bytes_written);
+    cudec_stream_ctx_destroy(ctx);
+    return st;
+}

--- a/src/tilestream.h
+++ b/src/tilestream.h
@@ -95,6 +95,40 @@ inline uint32_t TileStreamRead32LE(const unsigned char* p) {
            (static_cast<uint32_t>(p[3]) << 24);
 }
 
+/* How many tiles a caller must make room for before TileStreamParse is asked
+ * anything, or 0 when these bytes are not a TileStream this parser will look
+ * further into.
+ *
+ * The parser writes the caller's array and refuses rather than allocating, so
+ * something has to size that array first and the only thing that knows the
+ * count is the stream. That makes this a sizing hint rather than a validated
+ * fact, and it lives HERE, beside the parser, because it re-reads two of the
+ * parser's own rules - the eight-byte header bound and the id/magic
+ * complement - and a copy of those in a caller is the format layer leaking
+ * out of the one file that owns it.
+ *
+ * THE COMPLEMENT IS CHECKED BEFORE THE COUNT IS BELIEVED, and it is not
+ * redundancy with the parser. A caller sizes an array from this, so eight
+ * bytes that were never a TileStream would otherwise buy an allocation of up
+ * to 65535 entries before anything looked at them - the count field is
+ * sixteen bits and the caller pays for all of it. Refusing here makes that
+ * cost reachable only by bytes that at least claim to be this container.
+ *
+ * What it does NOT do is validate. A count these bytes cannot support still
+ * comes back, and the caller's over-large array then meets a
+ * CUDEC_ERR_CORRUPT_INPUT from the parse - the same answer it would have got
+ * without the hint. */
+inline uint64_t TileStreamDeclaredTileCount(const unsigned char* stream,
+                                            uint64_t stream_size) {
+    if (stream == nullptr || stream_size < kTileStreamHeaderBytes) {
+        return 0;
+    }
+    if (stream[0] != static_cast<unsigned char>(stream[1] ^ 0xFFu)) {
+        return 0;
+    }
+    return TileStreamRead16LE(stream + 2);
+}
+
 /* Parses and validates the envelope at `stream[0 .. stream_size)`.
  *
  * On CUDEC_OK: *info holds the tile count and the total uncompressed size,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -531,6 +531,44 @@ target_include_directories(frame_host_negative
 cudec_add_test(tilestream_host_negative SOURCES tilestream_host_negative.cpp)
 target_include_directories(tilestream_host_negative
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The whole-TileStream ABI entry against the reference (issue #177): the
+# envelope read on the host, the container decoded end to end in both memory
+# spaces, and one corrupted tile failing alone while its siblings stay
+# byte-exact. GPU-labelled - it drives the shipped page kernel through the
+# streaming context - and linking gdeflate_oracle for the compressor and the
+# reference decode it is compared against. The envelope constants it builds a
+# stream from come out of src/, on the include path every device test is
+# granted.
+cudec_add_test(tilestream_twin SOURCES tilestream_twin.cu GPU LIBS
+               gdeflate_oracle)
+# The other half of "the kernel stays envelope-ignorant" (issue #177), read off
+# the binary rather than the source. CUDA-only: it needs cuobjdump, and the HIP
+# build has its own symbol reader in check-hip-wave-instantiations.sh. The tool
+# is the one beside the nvcc that produced the objects, so the check cannot
+# pass by finding some other cuobjdump on the PATH.
+if(CUDEC_DEVICE_LANGUAGE STREQUAL "CUDA")
+  get_filename_component(_cudec_cuda_tool_dir "${CMAKE_CUDA_COMPILER}"
+                         DIRECTORY)
+  add_test(
+    NAME envelope_out_of_device
+    COMMAND bash
+            ${PROJECT_SOURCE_DIR}/scripts/check-envelope-out-of-device.sh
+            "${_cudec_cuda_tool_dir}/cuobjdump" "$<TARGET_OBJECTS:cudec>")
+  # The refusal proven to bite, for the reason it names: the same run, the
+  # same objects, and a pattern that IS in the device code. Without this the
+  # check above would pass identically if the symbol listing were empty, if
+  # the pattern never matched anything, or if the grep were inverted.
+  add_test(
+    NAME envelope_out_of_device_selfproof
+    COMMAND bash
+            ${PROJECT_SOURCE_DIR}/scripts/check-envelope-out-of-device.sh
+            "${_cudec_cuda_tool_dir}/cuobjdump" "$<TARGET_OBJECTS:cudec>"
+            "gdeflate_decode_batch")
+  set_tests_properties(envelope_out_of_device_selfproof PROPERTIES WILL_FAIL
+                                                                   TRUE)
+  set_tests_properties(envelope_out_of_device envelope_out_of_device_selfproof
+                       PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
+endif()
 # Termination as a tested invariant (issue #72): the parser's liveness
 # contract asserted per call over the truncation ladder, the mutant corpus,
 # the crafted hostile corpus, and the frame block-table walk - all of it

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -546,6 +546,57 @@ cudec_add_test(tilestream_twin SOURCES tilestream_twin.cu GPU LIBS
 # build has its own symbol reader in check-hip-wave-instantiations.sh. The tool
 # is the one beside the nvcc that produced the objects, so the check cannot
 # pass by finding some other cuobjdump on the PATH.
+# The companion to that binary check, and neither subsumes the other (issue
+# #177). Everything in src/tilestream.h is `inline`, so the way the envelope
+# would actually reach device code is somebody marking the parser
+# CUDEC_HOST_DEVICE and calling it from a kernel - at which point nvcc very
+# likely inlines it whole and the cubin carries no symbol for the binary check
+# to find. This one reads the SOURCE of the device translation units and their
+# device headers and refuses the include, which is the route that failure takes;
+# the binary one covers the route this cannot see. Configure-time, so it runs on
+# every backend and on a machine with no device at all.
+function(cudec_scan_envelope_include _text _label _out)
+  set(_hits "")
+  if(_text MATCHES "#[ 	]*include[ 	]*\"tilestream\.h\"")
+    string(APPEND _hits "${_label}: a device translation unit includes "
+           "tilestream.h; the TileStream envelope is host-side and the "
+           "GDeflate kernel stays envelope-ignorant (issue #177)
+")
+  endif()
+  set(${_out} "${_hits}" PARENT_SCOPE)
+endfunction()
+cudec_scan_envelope_include("#include \"tilestream.h\"" "probe" _probe_hit)
+if(NOT _probe_hit)
+  message(FATAL_ERROR "the envelope-out-of-device source rule is dead: the "
+                      "planted include was not reported (issue #177)")
+endif()
+# The near-miss is the one worth reading: a device file may legitimately talk
+# ABOUT the envelope in prose, and a rule that reddened on that would be
+# switched off rather than repaired.
+foreach(_near "/* the TileStream envelope never reaches tilestream.h here */"
+              "#include \"gdeflate_decode.cuh\"")
+  cudec_scan_envelope_include("${_near}" "probe" _near_hit)
+  if(_near_hit)
+    message(FATAL_ERROR "the envelope-out-of-device source rule is over-wide: "
+                        "it reported '${_near}' (issue #177)")
+  endif()
+endforeach()
+file(GLOB _envelope_scan_device RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+     CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cu
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cuh)
+if(NOT _envelope_scan_device)
+  message(FATAL_ERROR "the envelope-out-of-device source scan found no device "
+                      "source under src/: a scan over nothing passes for the "
+                      "wrong reason (issue #177)")
+endif()
+foreach(_dev ${_envelope_scan_device})
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_dev} _dev_src)
+  cudec_scan_envelope_include("${_dev_src}" "src/${_dev}" _dev_hit)
+  if(_dev_hit)
+    message(FATAL_ERROR "${_dev_hit}")
+  endif()
+endforeach()
+
 if(CUDEC_DEVICE_LANGUAGE STREQUAL "CUDA")
   get_filename_component(_cudec_cuda_tool_dir "${CMAKE_CUDA_COMPILER}"
                          DIRECTORY)
@@ -564,8 +615,21 @@ if(CUDEC_DEVICE_LANGUAGE STREQUAL "CUDA")
             ${PROJECT_SOURCE_DIR}/scripts/check-envelope-out-of-device.sh
             "${_cudec_cuda_tool_dir}/cuobjdump" "$<TARGET_OBJECTS:cudec>"
             "gdeflate_decode_batch")
-  set_tests_properties(envelope_out_of_device_selfproof PROPERTIES WILL_FAIL
-                                                                   TRUE)
+  # WILL_FAIL alone asserts only a non-zero exit, which any breakage of the
+  # script would also produce - a wrong cuobjdump path, a missing bash, a
+  # mangled argument count. The regex pins the ONE refusal this proof is about,
+  # so a self-proof that goes green for the wrong reason reds.
+  # NOT WILL_FAIL. WILL_FAIL asserts only a non-zero exit, which any breakage
+  # of the script also produces - a wrong cuobjdump path, a missing bash, a
+  # mangled argument count - so it would go green for the wrong reason.
+  # PASS_REGULAR_EXPRESSION makes ctest ignore the exit code and pass only on
+  # the ONE refusal this proof is about, which is the stronger assertion and
+  # the reason the two must not be combined (with both set, a match would be
+  # inverted into a failure).
+  set_tests_properties(
+    envelope_out_of_device_selfproof
+    PROPERTIES PASS_REGULAR_EXPRESSION
+               "the envelope has reached device code")
   set_tests_properties(envelope_out_of_device envelope_out_of_device_selfproof
                        PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 endif()
@@ -768,12 +832,31 @@ foreach(_owner DevBuf PinnedBuf StreamOwner EventOwner)
                         "'${_owner}' (issue #40)")
   endif()
 endforeach()
+# The include half stays a NAMED list, because only a TU that owns a device
+# resource can satisfy it: src/tilestream.cpp drives the streaming context and
+# owns nothing itself, so requiring the include of it would be requiring a
+# dead include.
 foreach(_tu frame.cpp stream.cpp)
   file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_tu} _tu_src)
   if(NOT _tu_src MATCHES "#include \"vendor_raii.h\"")
     message(FATAL_ERROR "src/${_tu} no longer includes vendor_raii.h: it must "
                         "reuse the shared RAII owners (issue #40)")
   endif()
+endforeach()
+# The re-copy half GLOBS, for the reason the vendor-seam rule gives about its
+# own scope: a host TU added tomorrow is covered on the day it lands rather
+# than on the day somebody remembers the list. src/tilestream.cpp was the third
+# such TU and arrived while this was a two-name list (issue #177).
+file(GLOB _raii_scan_tus RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+     CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cu)
+if(NOT _raii_scan_tus)
+  message(FATAL_ERROR "the RAII re-copy scan found no translation unit under "
+                      "src/: a scan over nothing passes for the wrong reason "
+                      "(issue #40)")
+endif()
+foreach(_tu ${_raii_scan_tus})
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/../src/${_tu} _tu_src)
   foreach(_owner DevBuf PinnedBuf StreamOwner EventOwner DevPtr)
     if(_tu_src MATCHES "struct ${_owner}")
       message(FATAL_ERROR "src/${_tu} defines a local 'struct ${_owner}': the "

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -221,6 +221,100 @@ int main(void) {
         cudec_stream_ctx_destroy(0);
     }
 
+    /* The TileStream entries resolve their C linkage here (issue #177). Every
+     * call below either rejects on an argument or refuses the bytes, and both
+     * happen before any CUDA call, so the whole block runs on the GPU-less
+     * runner.
+     *
+     * The envelope rejects are the interesting half: they are decided by the
+     * host walker, so this GPU-less test reaches the parse and not just the
+     * pointer checks. `env` is a well-formed one-tile envelope - id/magic
+     * complement, tileSizeIdx 1, one 4-byte table entry naming a 1-byte last
+     * tile, and that byte present - so the truncations below differ from an
+     * accepted stream by the bytes named and by nothing else. */
+    {
+        unsigned char env[13];
+        unsigned char out[16];
+        cudec_chunk_result tres[1];
+        size_t written = 123;
+        size_t tiles = 123;
+        size_t total = 123;
+
+        env[0] = 0x04;  /* id = magic ^ 0xFF */
+        env[1] = 0xFB;  /* magic */
+        env[2] = 1;     /* tile count, low byte */
+        env[3] = 0;
+        env[4] = (unsigned char)(1u | (1u << 2)); /* idx 1, last tile 1 byte */
+        env[5] = 0;
+        env[6] = 0;
+        env[7] = 0;
+        env[8] = 1; /* table entry 0: the last tile's compressed size */
+        env[9] = 0;
+        env[10] = 0;
+        env[11] = 0;
+        env[12] = 0xAB; /* the one payload byte the table accounts for */
+
+        REQUIRE(cudec_gdeflate_tilestream_info(0, sizeof env, &tiles, &total) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* null stream */
+        REQUIRE(tiles == 0 && total == 0);
+        REQUIRE(cudec_gdeflate_tilestream_info(env, sizeof env, 0, &total) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* null tile_count */
+        REQUIRE(cudec_gdeflate_tilestream_info(env, sizeof env, &tiles, 0) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* null uncompressed_size */
+        REQUIRE(cudec_gdeflate_tilestream_info(env, 4, &tiles, &total) ==
+                CUDEC_ERR_CORRUPT_INPUT); /* header truncated */
+        REQUIRE(tiles == 0 && total == 0);
+        REQUIRE(cudec_gdeflate_tilestream_info(env, sizeof env, &tiles,
+                                               &total) == CUDEC_OK);
+        REQUIRE(tiles == 1 && total == 1);
+
+        /* The one-shot entry. Nothing here reaches cudec_stream_ctx_create:
+         * every case is refused above it. */
+        REQUIRE(cudec_gdeflate_tilestream_decompress(
+                    0, sizeof env, out, sizeof out, CUDEC_MEM_HOST, tres, 1,
+                    &written) == CUDEC_ERR_INVALID_ARGUMENT); /* null stream */
+        REQUIRE(written == 0);
+        REQUIRE(cudec_gdeflate_tilestream_decompress(
+                    env, sizeof env, out, sizeof out, CUDEC_MEM_HOST, tres, 1,
+                    0) == CUDEC_ERR_INVALID_ARGUMENT); /* null bytes_written */
+        REQUIRE(cudec_gdeflate_tilestream_decompress(
+                    env, sizeof env, out, sizeof out, CUDEC_MEM_HOST, 0, 1,
+                    &written) == CUDEC_ERR_INVALID_ARGUMENT); /* null results */
+        REQUIRE(cudec_gdeflate_tilestream_decompress(
+                    env, sizeof env, 0, sizeof out, CUDEC_MEM_HOST, tres, 1,
+                    &written) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* null dst, nonzero capacity */
+        REQUIRE(cudec_gdeflate_tilestream_decompress(
+                    env, sizeof env, out, sizeof out, (cudec_mem_space)7, tres,
+                    1, &written) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* unknown dst_space */
+        REQUIRE(written == 0);
+
+        /* A NULL ctx is the _ctx entry's own reject, and it is taken before
+         * the envelope is looked at, so no context exists on this runner. */
+        REQUIRE(cudec_gdeflate_tilestream_decompress_ctx(
+                    0, env, sizeof env, out, sizeof out, CUDEC_MEM_HOST, tres,
+                    1, &written) == CUDEC_ERR_INVALID_ARGUMENT);
+        REQUIRE(written == 0);
+
+        /* The two content-dependent rejects: they need the envelope parsed, so
+         * they prove the one-shot entry reaches the walker before it reaches a
+         * device. A one-tile stream declares 1 byte of output and 1 result. */
+        REQUIRE(cudec_gdeflate_tilestream_decompress(
+                    env, sizeof env, out, 0, CUDEC_MEM_HOST, tres, 1,
+                    &written) == CUDEC_ERR_OUTPUT_TOO_SMALL);
+        REQUIRE(written == 0);
+        REQUIRE(cudec_gdeflate_tilestream_decompress(
+                    env, sizeof env, out, sizeof out, CUDEC_MEM_HOST, tres, 0,
+                    &written) ==
+                CUDEC_ERR_INVALID_ARGUMENT); /* results array too short */
+        REQUIRE(written == 0);
+        REQUIRE(cudec_gdeflate_tilestream_decompress(
+                    env, 4, out, sizeof out, CUDEC_MEM_HOST, tres, 1,
+                    &written) == CUDEC_ERR_CORRUPT_INPUT); /* truncated */
+        REQUIRE(written == 0);
+    }
+
     printf("PASS: plain-C caller exercised every public symbol\n");
     return 0;
 }

--- a/tests/tilestream_twin.cu
+++ b/tests/tilestream_twin.cu
@@ -1,0 +1,378 @@
+/* The whole-TileStream ABI entry against the reference (issue #177).
+ *
+ * The reference's compressor produces the pages, this test wraps them in a
+ * DirectStorage-shaped envelope, and cudec_gdeflate_tilestream_decompress
+ * decodes the container end to end. What is asserted is what the entry adds
+ * over the page batch decoder, so the page decode itself is not re-litigated
+ * here - tests/gdeflate_device.cu owns that:
+ *
+ *  - the envelope's declaration is read correctly: tile count and total
+ *    uncompressed size, from the host entry, on host bytes;
+ *  - the decoded container equals the SOURCE and equals what the reference's
+ *    own decompressor produces from the same pages, byte for byte, in both
+ *    memory spaces;
+ *  - a poisoned destination keeps its poison past bytes_written;
+ *  - the same context decodes the same stream twice to identical bytes;
+ *  - ONE corrupted tile fails alone: its own defined status with
+ *    bytes_written 0, its region of the destination left as it was, every
+ *    sibling still byte-exact, and the whole-stream answer non-OK with
+ *    *bytes_written 0 - the frame precedent, not a partial file.
+ *
+ * The corpus is deliberately uneven: three full 64 KiB tiles and a short
+ * trailing one, so the last-tile-size field of the envelope carries a value
+ * and the tail is the case a fixed 64 KiB assumption would get wrong. */
+#include "cudec.h"
+#include "tilestream.h"
+
+#include "require.h"
+#include "vendor_rt_test.h"
+
+#include <libdeflate.h>
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+using cudec_detail::kTileStreamHeaderBytes;
+using cudec_detail::kTileStreamTileSize;
+
+constexpr unsigned char kDstPoison = 0xA5;
+constexpr unsigned char kMagic = 0xFB;
+constexpr unsigned char kId = static_cast<unsigned char>(kMagic ^ 0xFF);
+
+typedef std::vector<unsigned char> Bytes;
+
+/* The same named recurrence the block twin and the device test draw their
+ * corpora from, so the stream is identical on every machine and a failure
+ * reproduces. */
+class Lcg {
+   public:
+    explicit Lcg(unsigned seed) : state_(seed) {}
+    unsigned Next() {
+        state_ = state_ * 1103515245u + 12345u;
+        return (state_ >> 16) & 0xFFFFu;
+    }
+
+   private:
+    unsigned state_;
+};
+
+Bytes MixedEntropy(unsigned seed, size_t n) {
+    Lcg lcg(seed);
+    Bytes v(n);
+    for (size_t i = 0; i < n; i++) {
+        const unsigned r = lcg.Next();
+        v[i] = static_cast<unsigned char>((r % 4u == 0u) ? (r & 0xFFu)
+                                                         : ('a' + (r % 5u)));
+    }
+    return v;
+}
+
+void Put16(Bytes* b, uint16_t v) {
+    b->push_back(static_cast<unsigned char>(v & 0xFF));
+    b->push_back(static_cast<unsigned char>((v >> 8) & 0xFF));
+}
+
+void Put32(Bytes* b, uint32_t v) {
+    for (int i = 0; i < 4; i++) {
+        b->push_back(static_cast<unsigned char>((v >> (i * 8)) & 0xFF));
+    }
+}
+
+/* The packed word, assembled the way src/tilestream.h unpacks it: 2 bits of
+ * tile size index, 18 of last-tile size, 12 reserved. */
+uint32_t Packed(uint32_t tile_size_idx, uint32_t last_tile_size) {
+    return (tile_size_idx & 0x3u) | ((last_tile_size & 0x3FFFFu) << 2);
+}
+
+/* Splits `in` into 64 KiB tiles and compresses each one as its own GDeflate
+ * page, then lays the pages out under a well-formed envelope.
+ *
+ * ONE PAGE PER COMPRESSOR CALL, deliberately, rather than one call over the
+ * whole input. The container's contract is that a tile is an independent page;
+ * compressing tile by tile is what makes the payload actually satisfy it, and
+ * it keeps the page boundaries this test asserts about under this test's
+ * control rather than the reference's paging. */
+bool BuildStream(int level, const Bytes& in, Bytes* stream,
+                 std::vector<Bytes>* pages) {
+    const size_t tile = static_cast<size_t>(kTileStreamTileSize);
+    const size_t n = (in.size() + tile - 1u) / tile;
+    if (n == 0 || n > 65535u) {
+        return false;
+    }
+    pages->clear();
+    for (size_t i = 0; i < n; i++) {
+        const size_t off = i * tile;
+        const size_t len = (in.size() - off < tile) ? (in.size() - off) : tile;
+        libdeflate_gdeflate_compressor* c =
+            libdeflate_alloc_gdeflate_compressor(level);
+        if (c == nullptr) {
+            return false;
+        }
+        size_t npages = 0;
+        const size_t bound = libdeflate_gdeflate_compress_bound(c, len,
+                                                                &npages);
+        if (bound == 0 || npages != 1) {
+            libdeflate_free_gdeflate_compressor(c);
+            return false;
+        }
+        Bytes pool(bound, 0);
+        libdeflate_gdeflate_out_page out;
+        out.data = pool.data();
+        out.nbytes = pool.size();
+        const size_t total =
+            libdeflate_gdeflate_compress(c, in.data() + off, len, &out, 1);
+        libdeflate_free_gdeflate_compressor(c);
+        if (total == 0 || out.nbytes == 0) {
+            return false;
+        }
+        const unsigned char* p = static_cast<const unsigned char*>(out.data);
+        pages->push_back(Bytes(p, p + out.nbytes));
+    }
+
+    const size_t last_len = in.size() - (n - 1u) * tile;
+    stream->clear();
+    stream->push_back(kId);
+    stream->push_back(kMagic);
+    Put16(stream, static_cast<uint16_t>(n));
+    /* Zero is the full-tile spelling of the last tile's size. */
+    Put32(stream, Packed(1u, (last_len == tile)
+                                 ? 0u
+                                 : static_cast<uint32_t>(last_len)));
+
+    /* Entry 0 is the LAST tile's compressed size; entries 1..n-1 are the
+     * offsets of tiles 1..n-1, accumulated from the end of the table. */
+    const uint32_t toc_end =
+        static_cast<uint32_t>(kTileStreamHeaderBytes) + 4u * static_cast<uint32_t>(n);
+    Put32(stream, static_cast<uint32_t>((*pages)[n - 1u].size()));
+    uint32_t off = toc_end;
+    for (size_t i = 1; i < n; i++) {
+        off += static_cast<uint32_t>((*pages)[i - 1u].size());
+        Put32(stream, off);
+    }
+    for (size_t i = 0; i < n; i++) {
+        stream->insert(stream->end(), (*pages)[i].begin(), (*pages)[i].end());
+    }
+    return true;
+}
+
+/* Where tile `i`'s compressed bytes begin inside the assembled stream. Derived
+ * the same way the envelope declares them, so a mutation aimed at a tile lands
+ * inside that tile and nowhere else. */
+size_t TileOffset(const std::vector<Bytes>& pages, size_t i) {
+    size_t off = static_cast<size_t>(kTileStreamHeaderBytes) + 4u * pages.size();
+    for (size_t k = 0; k < i; k++) {
+        off += pages[k].size();
+    }
+    return off;
+}
+
+/* What the reference's own decompressor makes of the same pages. The entry
+ * under test must equal THIS, not merely equal the source: a decoder that
+ * agreed with the source while disagreeing with the reference would be a
+ * divergence this project reports rather than a pass. */
+bool OracleDecode(const std::vector<Bytes>& pages, size_t out_size,
+                  Bytes* out) {
+    libdeflate_gdeflate_decompressor* d =
+        libdeflate_alloc_gdeflate_decompressor();
+    if (d == nullptr) {
+        return false;
+    }
+    out->assign(out_size, 0);
+    const size_t tile = static_cast<size_t>(kTileStreamTileSize);
+    bool ok = true;
+    for (size_t i = 0; i < pages.size() && ok; i++) {
+        libdeflate_gdeflate_in_page in;
+        in.data = pages[i].data();
+        in.nbytes = pages[i].size();
+        const size_t off = i * tile;
+        const size_t len = (out_size - off < tile) ? (out_size - off) : tile;
+        size_t produced = 0;
+        ok = libdeflate_gdeflate_decompress(d, &in, 1, out->data() + off, len,
+                                            &produced) == LIBDEFLATE_SUCCESS &&
+             produced == len;
+    }
+    libdeflate_free_gdeflate_decompressor(d);
+    return ok;
+}
+
+/* One decode through the shipped entry, host-output, into a poisoned buffer
+ * larger than the stream needs so the untouched tail is checkable. */
+int DecodeHost(cudec_stream_ctx* ctx, const Bytes& stream, size_t out_size,
+               size_t slack, Bytes* out, std::vector<cudec_chunk_result>* res,
+               size_t* written, cudec_status* st) {
+    out->assign(out_size + slack, kDstPoison);
+    res->assign(res->size(), cudec_chunk_result());
+    for (size_t i = 0; i < res->size(); i++) {
+        (*res)[i].status = static_cast<int32_t>(CUDEC_ERR_NOT_IMPLEMENTED);
+        (*res)[i].reserved = 0xFFFFFFFFu;
+        (*res)[i].bytes_written = 0xFFFFFFFFFFFFFFFFull;
+    }
+    *written = 0xFFFFFFFFu;
+    *st = cudec_gdeflate_tilestream_decompress_ctx(
+        ctx, stream.data(), stream.size(), out->data(), out->size(),
+        CUDEC_MEM_HOST, res->data(), res->size(), written);
+    return 0;
+}
+
+}  // namespace
+
+int main(void) {
+    /* Three full tiles and a short trailing one. */
+    const size_t tile = static_cast<size_t>(kTileStreamTileSize);
+    const size_t tail = 12345u;
+    const Bytes source = MixedEntropy(0x5EED, 3u * tile + tail);
+    const size_t n_tiles = 4u;
+
+    Bytes stream;
+    std::vector<Bytes> pages;
+    REQUIRE(BuildStream(6, source, &stream, &pages));
+    REQUIRE(pages.size() == n_tiles);
+
+    /* ---- The envelope reads as declared, on the host, with no device. ---- */
+    size_t tiles = 0;
+    size_t total = 0;
+    REQUIRE(cudec_gdeflate_tilestream_info(stream.data(), stream.size(),
+                                           &tiles, &total) == CUDEC_OK);
+    REQUIRE(tiles == n_tiles);
+    REQUIRE(total == source.size());
+
+    Bytes oracle;
+    REQUIRE(OracleDecode(pages, source.size(), &oracle));
+    REQUIRE(oracle.size() == source.size());
+    REQUIRE(std::memcmp(oracle.data(), source.data(), source.size()) == 0);
+
+    cudec_stream_ctx* ctx = nullptr;
+    REQUIRE(cudec_stream_ctx_create(&ctx) == CUDEC_OK);
+
+    /* ---- Host output: byte-exact, poison beyond it intact. ---- */
+    const size_t slack = 4096u;
+    std::vector<cudec_chunk_result> res(n_tiles);
+    Bytes out;
+    size_t written = 0;
+    cudec_status st = CUDEC_ERR_NOT_IMPLEMENTED;
+    DecodeHost(ctx, stream, source.size(), slack, &out, &res, &written, &st);
+    REQUIRE(st == CUDEC_OK);
+    REQUIRE(written == source.size());
+    REQUIRE(std::memcmp(out.data(), oracle.data(), oracle.size()) == 0);
+    for (size_t i = 0; i < slack; i++) {
+        REQUIRE_CTX(out[source.size() + i] == kDstPoison, "slack byte %zu", i);
+    }
+    for (size_t i = 0; i < n_tiles; i++) {
+        const size_t expect = (i + 1u == n_tiles) ? tail : tile;
+        REQUIRE_CTX(res[i].status == CUDEC_OK, "tile %zu status %d", i,
+                    static_cast<int>(res[i].status));
+        REQUIRE_CTX(res[i].bytes_written == expect, "tile %zu wrote %llu", i,
+                    static_cast<unsigned long long>(res[i].bytes_written));
+        REQUIRE(res[i].reserved == 0);
+    }
+
+    /* ---- The same context, the same stream, twice: identical bytes. ---- */
+    {
+        Bytes again;
+        std::vector<cudec_chunk_result> res2(n_tiles);
+        size_t written2 = 0;
+        cudec_status st2 = CUDEC_ERR_NOT_IMPLEMENTED;
+        DecodeHost(ctx, stream, source.size(), slack, &again, &res2, &written2,
+                   &st2);
+        REQUIRE(st2 == CUDEC_OK);
+        REQUIRE(written2 == written);
+        REQUIRE(again.size() == out.size());
+        REQUIRE(std::memcmp(again.data(), out.data(), out.size()) == 0);
+    }
+
+    /* ---- Device output: the same bytes, decoded straight into VRAM. ---- */
+    {
+        void* d_out = nullptr;
+        REQUIRE_RT(cudec_rt::device_malloc(&d_out, source.size()));
+        REQUIRE_RT(cudec_rt::device_memset(d_out, kDstPoison, source.size()));
+        std::vector<cudec_chunk_result> dres(n_tiles);
+        size_t dwritten = 0;
+        const cudec_status dst_st = cudec_gdeflate_tilestream_decompress_ctx(
+            ctx, stream.data(), stream.size(), d_out, source.size(),
+            CUDEC_MEM_DEVICE, dres.data(), dres.size(), &dwritten);
+        REQUIRE(dst_st == CUDEC_OK);
+        REQUIRE(dwritten == source.size());
+        Bytes back(source.size(), 0);
+        REQUIRE_RT(cudec_rt::memcpy(back.data(), d_out, source.size(),
+                                    cudec_rt::memcpy_d2h));
+        REQUIRE(std::memcmp(back.data(), oracle.data(), oracle.size()) == 0);
+        REQUIRE_RT(cudec_rt::device_free(d_out));
+    }
+
+    /* ---- One corrupted tile fails alone. ----
+     *
+     * The mutation lands inside tile 1's compressed bytes, past its first
+     * byte so the page header still parses and the refusal comes out of the
+     * bitstream rather than out of a rejected header. If a mutation happens to
+     * decode anyway, that is a corpus fact rather than a defect, so the tile is
+     * only asserted about once the entry has actually refused it - and the
+     * search below is bounded, so a stream in which nothing refuses reds
+     * rather than passing quietly. */
+    {
+        const size_t base = TileOffset(pages, 1u);
+        const size_t span = pages[1].size();
+        REQUIRE(span > 8u);
+        bool refused = false;
+        for (size_t k = 4u; k < span && !refused; k++) {
+            Bytes bad = stream;
+            bad[base + k] = static_cast<unsigned char>(bad[base + k] ^ 0xFFu);
+            std::vector<cudec_chunk_result> bres(n_tiles);
+            Bytes bout;
+            size_t bwritten = 0;
+            cudec_status bst = CUDEC_OK;
+            DecodeHost(ctx, bad, source.size(), slack, &bout, &bres, &bwritten,
+                       &bst);
+            if (bst == CUDEC_OK) {
+                continue; /* this flip still decoded; try the next byte */
+            }
+            refused = true;
+
+            /* The whole-stream answer is the frame precedent: no partial
+             * file, and the failing tile's own status. */
+            REQUIRE(bwritten == 0);
+            REQUIRE(bst == static_cast<cudec_status>(bres[1].status));
+            REQUIRE(bres[1].status != CUDEC_OK);
+            REQUIRE(bres[1].bytes_written == 0);
+            REQUIRE(bres[1].reserved == 0);
+
+            /* The failing tile is isolated: every sibling decoded, reported
+             * its own byte count, and put the right bytes in its own region -
+             * and tile 1's region of the destination still holds the poison it
+             * was filled with. */
+            for (size_t i = 0; i < n_tiles; i++) {
+                if (i == 1u) {
+                    continue;
+                }
+                const size_t expect = (i + 1u == n_tiles) ? tail : tile;
+                REQUIRE_CTX(bres[i].status == CUDEC_OK, "sibling %zu status %d",
+                            i, static_cast<int>(bres[i].status));
+                REQUIRE_CTX(bres[i].bytes_written == expect,
+                            "sibling %zu wrote %llu", i,
+                            static_cast<unsigned long long>(
+                                bres[i].bytes_written));
+                REQUIRE_CTX(std::memcmp(bout.data() + i * tile,
+                                        oracle.data() + i * tile, expect) == 0,
+                            "sibling %zu bytes", i);
+            }
+            for (size_t i = 0; i < tile; i++) {
+                REQUIRE_CTX(bout[tile + i] == kDstPoison,
+                            "failed tile byte %zu", i);
+            }
+            std::printf(
+                "tilestream_twin: tile 1 refused at payload byte %zu with "
+                "status %d, three siblings byte-exact\n",
+                k, static_cast<int>(bres[1].status));
+        }
+        REQUIRE(refused);
+    }
+
+    cudec_stream_ctx_destroy(ctx);
+    std::printf(
+        "tilestream_twin: %zu-tile stream (%zu bytes) decoded through the "
+        "TileStream entry in both memory spaces, equal to the reference\n",
+        n_tiles, source.size());
+    return 0;
+}

--- a/tests/tilestream_twin.cu
+++ b/tests/tilestream_twin.cu
@@ -11,8 +11,14 @@
  *  - the decoded container equals the SOURCE and equals what the reference's
  *    own decompressor produces from the same pages, byte for byte, in both
  *    memory spaces;
- *  - a poisoned destination keeps its poison past bytes_written;
- *  - the same context decodes the same stream twice to identical bytes;
+ *  - a poisoned destination keeps its poison past bytes_written, and the
+ *    reported range is the same bytes whatever the destination held first;
+ *  - the same context decodes the same stream twice to identical bytes, and
+ *    the one-shot entry answers exactly as the context entry does;
+ *  - a container that declares a tile size its page does NOT produce is
+ *    refused in BOTH directions - the page that over-produces and the page
+ *    that under-produces - because a short tile accepted would leave the gap
+ *    to the next tile's declared offset holding whatever was in `dst`;
  *  - ONE corrupted tile fails alone: its own defined status with
  *    bytes_written 0, its region of the destination left as it was, every
  *    sibling still byte-exact, and the whole-stream answer non-OK with
@@ -96,7 +102,8 @@ uint32_t Packed(uint32_t tile_size_idx, uint32_t last_tile_size) {
  * it keeps the page boundaries this test asserts about under this test's
  * control rather than the reference's paging. */
 bool BuildStream(int level, const Bytes& in, Bytes* stream,
-                 std::vector<Bytes>* pages) {
+                 std::vector<Bytes>* pages, size_t short_tile,
+                 size_t short_len) {
     const size_t tile = static_cast<size_t>(kTileStreamTileSize);
     const size_t n = (in.size() + tile - 1u) / tile;
     if (n == 0 || n > 65535u) {
@@ -105,7 +112,14 @@ bool BuildStream(int level, const Bytes& in, Bytes* stream,
     pages->clear();
     for (size_t i = 0; i < n; i++) {
         const size_t off = i * tile;
-        const size_t len = (in.size() - off < tile) ? (in.size() - off) : tile;
+        size_t len = (in.size() - off < tile) ? (in.size() - off) : tile;
+        /* The dishonest-container case: this tile's PAGE is compressed from
+         * fewer bytes than the envelope will declare for it. Every byte of the
+         * page is well-formed GDeflate - the reference compressor produced it -
+         * and the container is the thing that lies. */
+        if (i == short_tile) {
+            len = short_len;
+        }
         libdeflate_gdeflate_compressor* c =
             libdeflate_alloc_gdeflate_compressor(level);
         if (c == nullptr) {
@@ -228,7 +242,7 @@ int main(void) {
 
     Bytes stream;
     std::vector<Bytes> pages;
-    REQUIRE(BuildStream(6, source, &stream, &pages));
+    REQUIRE(BuildStream(6, source, &stream, &pages, n_tiles, 0));
     REQUIRE(pages.size() == n_tiles);
 
     /* ---- The envelope reads as declared, on the host, with no device. ---- */
@@ -367,6 +381,110 @@ int main(void) {
                 k, static_cast<int>(bres[1].status));
         }
         REQUIRE(refused);
+    }
+
+    /* ---- The container's declaration is a bound in BOTH directions. ----
+     *
+     * Both cases below are streams whose PAGES are all well-formed - the
+     * reference compressor made every byte of them - and whose ENVELOPE
+     * disagrees with them. Neither is reachable by corrupting a payload, which
+     * is why the corrupt-tile sweep above cannot stand in for them.
+     */
+    {
+        /* UNDER-production. Tile 1's page carries 100 bytes while the envelope
+         * declares the full 65536 for it. Accepted, this would report
+         * bytes_written spanning 65436 bytes of whatever `dst` held. */
+        Bytes short_stream;
+        std::vector<Bytes> short_pages;
+        REQUIRE(BuildStream(6, source, &short_stream, &short_pages, 1u, 100u));
+        std::vector<cudec_chunk_result> sres(n_tiles);
+        Bytes sout;
+        size_t swritten = 0;
+        cudec_status sst = CUDEC_OK;
+        DecodeHost(ctx, short_stream, source.size(), slack, &sout, &sres,
+                   &swritten, &sst);
+        REQUIRE(sst == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(swritten == 0);
+        REQUIRE(sres[1].status == CUDEC_ERR_CORRUPT_INPUT);
+        REQUIRE(sres[1].bytes_written == 0);
+        REQUIRE(sres[1].reserved == 0);
+        /* Its siblings decoded and say so; the refusal is the container's,
+         * not theirs. */
+        REQUIRE(sres[0].status == CUDEC_OK);
+        REQUIRE(sres[0].bytes_written == tile);
+        std::printf(
+            "tilestream_twin: a tile carrying 100 bytes under a 65536-byte "
+            "declaration is refused, siblings unaffected\n");
+    }
+    {
+        /* OVER-production, and the destination is deliberately LARGER than the
+         * envelope's total: the only shape in which laying tiles out at
+         * declared offsets differs from laying them out against the space
+         * left. A one-tile stream declaring 1000 bytes over a page that
+         * produces 65536 must be that tile's CUDEC_ERR_OUTPUT_TOO_SMALL. */
+        const Bytes one = MixedEntropy(0xB0B, tile);
+        Bytes over;
+        std::vector<Bytes> over_pages;
+        REQUIRE(BuildStream(6, one, &over, &over_pages, 99u, 0u));
+        REQUIRE(over_pages.size() == 1u);
+        /* Re-declare the single tile as producing 1000 bytes. */
+        over[4] = static_cast<unsigned char>(Packed(1u, 1000u) & 0xFFu);
+        over[5] = static_cast<unsigned char>((Packed(1u, 1000u) >> 8) & 0xFFu);
+        over[6] = static_cast<unsigned char>((Packed(1u, 1000u) >> 16) & 0xFFu);
+        over[7] = static_cast<unsigned char>((Packed(1u, 1000u) >> 24) & 0xFFu);
+        size_t otiles = 0;
+        size_t ototal = 0;
+        REQUIRE(cudec_gdeflate_tilestream_info(over.data(), over.size(),
+                                               &otiles, &ototal) == CUDEC_OK);
+        REQUIRE(otiles == 1u && ototal == 1000u);
+        std::vector<cudec_chunk_result> ores(1);
+        Bytes oout(70000u, kDstPoison);
+        size_t owritten = 0;
+        const cudec_status ost = cudec_gdeflate_tilestream_decompress_ctx(
+            ctx, over.data(), over.size(), oout.data(), oout.size(),
+            CUDEC_MEM_HOST, ores.data(), ores.size(), &owritten);
+        REQUIRE(ost == CUDEC_ERR_OUTPUT_TOO_SMALL);
+        REQUIRE(owritten == 0);
+        REQUIRE(ores[0].status == CUDEC_ERR_OUTPUT_TOO_SMALL);
+        REQUIRE(ores[0].bytes_written == 0);
+        /* Nothing past the declared total was written, even though the
+         * destination had room for the whole page. */
+        for (size_t i = 1000u; i < oout.size(); i++) {
+            REQUIRE_CTX(oout[i] == kDstPoison, "over-run byte %zu", i);
+        }
+        std::printf(
+            "tilestream_twin: a page producing 65536 bytes under a 1000-byte "
+            "declaration is refused, nothing written past 1000\n");
+    }
+
+    /* ---- The reported range does not depend on what `dst` held. ---- */
+    {
+        std::vector<cudec_chunk_result> res3(n_tiles);
+        Bytes other(source.size() + slack, 0x5Cu);
+        size_t written3 = 0;
+        const cudec_status st3 = cudec_gdeflate_tilestream_decompress_ctx(
+            ctx, stream.data(), stream.size(), other.data(), other.size(),
+            CUDEC_MEM_HOST, res3.data(), res3.size(), &written3);
+        REQUIRE(st3 == CUDEC_OK);
+        REQUIRE(written3 == written);
+        REQUIRE(std::memcmp(other.data(), out.data(), written) == 0);
+    }
+
+    /* ---- The one-shot entry answers exactly as the context entry does. ---- */
+    {
+        std::vector<cudec_chunk_result> ores(n_tiles);
+        Bytes oout(source.size() + slack, kDstPoison);
+        size_t owritten = 0;
+        const cudec_status ost = cudec_gdeflate_tilestream_decompress(
+            stream.data(), stream.size(), oout.data(), oout.size(),
+            CUDEC_MEM_HOST, ores.data(), ores.size(), &owritten);
+        REQUIRE(ost == CUDEC_OK);
+        REQUIRE(owritten == written);
+        REQUIRE(std::memcmp(oout.data(), out.data(), out.size()) == 0);
+        for (size_t i = 0; i < n_tiles; i++) {
+            REQUIRE_CTX(ores[i].status == CUDEC_OK, "one-shot tile %zu", i);
+            REQUIRE(ores[i].bytes_written == res[i].bytes_written);
+        }
     }
 
     cudec_stream_ctx_destroy(ctx);


### PR DESCRIPTION
# What & why

Closes #177.

`src/tilestream.h` validated a DirectStorage TileStream envelope into a tile
table and stopped there. `cudec_gdeflate_decompress_batch` decoded raw 64 KiB
pages and knew nothing about containers. Nothing joined the two, so a caller
holding a real TileStream had to split the container itself - which is exactly
the layer where a wrong bound is a wrong decode, and exactly the layer this
library exists to get right.

Three entries close that:

- `cudec_gdeflate_tilestream_info` reads the envelope on the host and reports
  the tile count and the total uncompressed size. No CUDA call, no device, no
  tile payload read - so a caller can size its destination and its per-tile
  result array on a GPU-less machine, and the GPU-less conformance runner
  reaches the whole parse.
- `cudec_gdeflate_tilestream_decompress_ctx` decodes the whole container on a
  reusable streaming context, host-or-device output, per-tile statuses.
- `cudec_gdeflate_tilestream_decompress` is the one-shot wrapper around
  create / decode / destroy, in the shape of `cudec_lz4_decompress_stream`.

**The kernel stays envelope-ignorant.** Everything the container declares -
where each page starts, how long it is, how many bytes it must produce - is
decided on the host and handed to the page batch entry as independent raw
pages. The per-tile destination capacity is the size the ENVELOPE declares,
never the space left in `dst`, so a page whose bitstream decodes past what its
tile was declared to hold is refused for that tile instead of spilling into the
next tile's bytes.

**No second staging path.** `src/stream_decode.h` makes the streaming wave loop
take the batch entry it submits - the only line of that ~250-line body that
named a format. The LZ4 entry now binds it to `cudec_lz4_decompress_batch` and
this one binds it to the GDeflate entry, so the poisoning, the not-produced
seed, the drain and the aggregate rule cannot drift apart between formats. A
function pointer rather than a template, deliberately, and the reason is
written at the seam: the callee is a host function paid once per wave against a
kernel launch, which is the opposite of `src/batch.cu`'s launchers where the
indirection would cost the device compiler its inlining.

**The envelope's declared tile size is a bound in BOTH directions.** The
capacity handed to the page decoder refuses a tile that produces more than it
was declared to; the second direction is the one nothing else enforces. A
GDeflate page ends at its final block and reports what it produced without
comparing that against its capacity, so a page legitimately compressed from ten
bytes decodes `CUDEC_OK` into a tile the container declared as 65536 - and,
accepted, would leave the gap up to the next tile's declared offset holding
whatever was in `dst`. That is the defect the review found and the second
commit fixes; that commit's message carries the whole of it.

**The whole-stream answer follows the frame precedent, not the batch one.**
This entry produces ONE object out of many pieces, like
`cudec_lz4f_decompress`. A stream with any failed tile reports
`*bytes_written == 0` and the first failing tile's status; each tile's own
outcome is still in the caller's array, so a caller that wants to know WHICH
tile failed reads it there. A partially written destination is not an answer
this ABI has a way to describe.

**Every synchronous reject is decided before a context exists**, including the
two the envelope decides (a destination below the declared total, a result
array below the declared tile count). Creating the context first would put
`cudec_stream_ctx_create` ahead of the refusals, and on a GPU-less host that
call fails for want of a device - so a truncated envelope would come back
`CUDEC_ERR_CUDA` and the conformance runner could reach none of it.

**Choosing the means.** C++17 compiled as plain host C++ behind the existing C
ABI, no new language, runtime or dependency, no new staging apparatus, and the
new conformance check is POSIX shell driving the CUDA toolchain's own
`cuobjdump` - the forced means for reading a binary, held to its minimum, in
the same shape `scripts/check-hip-wave-instantiations.sh` already established.
Every claim in it is a command's output, which is what the standpoint asks of a
means.

## Type of change

- [ ] Decode kernel / device code
- [x] Format support (LZ4 / Snappy / GDeflate / Zstd)
- [x] API surface
- [ ] Performance
- [ ] Bug fix
- [x] Refactor / code quality
- [x] Build / CI / supply chain
- [ ] Docs

## Engineering checklist

- [x] Fail-closed preserved. Every reject class is defined and reached by a
      test: `tests/conformance_c.c` drives the NULL/unknown-space/NULL-`dst`
      rejects, both content-dependent capacity rejects, and a truncated
      envelope, all from plain C on the GPU-less runner. The envelope's own
      reject ladder is unchanged and stays locked by
      `tests/tilestream_host_negative.cpp`.
- [x] Oracle coverage. `tests/tilestream_twin.cu` decodes the container and
      compares against what the vendored libdeflate GDeflate decompressor
      produces from the same pages, byte for byte, in both memory spaces -
      not merely against the source.
- [x] Determinism preserved. The same context decodes the same stream twice to
      identical bytes, asserted in the twin. Per-tile destinations and result
      indices are disjoint and one stream runs the waves in order, unchanged
      from the LZ4 path.
- [x] Every CUDA error checked; no exception crosses the C ABI (the two
      `catch (...)` sites map a host allocation failure to `CUDEC_ERR_CUDA`).
- [x] An adversarial review was run - five lenses, record below.

### Review record

Five lenses, refute-by-default, each over the branch diff against
`origin/main`. **CONFIRMED 1 / PLAUSIBLE 9** as raised, where CONFIRMED means a
reproduction was produced. The one CONFIRMED finding was reproduced
independently by four of the five.

| lens | verdict as raised | findings |
| ---- | ----------------- | -------- |
| correctness | FAIL | the short-tile fail-open, reproduced end to end against the shipped parser and the page decoder's host twin; the per-tile capacity choice pinned by no test; the one-shot's unstamped results array; no host bound on the device-path length |
| robustness | NEEDS_IMPROVEMENT | the same fail-open, reproduced over 3909 mutants under ASan/UBSan; the missing device-path bound; the unstamped per-tile channel; the sizing allocation ahead of the magic check; the undocumented ceiling; six reject paths with no negative test |
| integration | FAIL | the same fail-open, reproduced with the device stubbed; the unstamped array on the path a GPU-less host always takes; `_info`'s documented status set; the three new ctest entries absent from the workflow's name-pin lists |
| cuda-reviewer | FAIL | the same fail-open; the seam poisoning a healthy context on a synchronous refusal; three demonstrated vacuous passes in the binary check plus a self-proof asserting only a non-zero exit; the `BatchEntry` language-linkage mismatch; the tile array's one entry of slack; the unguarded `total_uncompressed` narrowing |
| architecture | NEEDS_IMPROVEMENT | the same fail-open; the one-shot's body executed by no test and a comment naming a symbol its file never calls; the per-tile status claim stronger than the code; `_info`'s status set; the poison ordering; the check's one-directional proof; a third copy of the envelope's header-field read; the seam's invariant asserted while `src/frame.cpp` is a second staging path; the RAII conformance list missing the new host TU |

**Dispositions.** Every finding above is FIXED in the second commit except
three, each declined or deferred with its reason:

- **`src/frame.cpp` is a second staging path** (architecture). DECLINED as a
  migration, FIXED as a claim in a third commit: the seam header no longer
  asserts an invariant the tree does not hold, names `src/frame.cpp` as the
  known second path, and says plainly that nothing refuses a third one -
  whether a block of code is a re-copy of a wave loop is a judgement about
  meaning, and a guard grepping for the staging member names would refuse the
  honest caller and miss a re-copy under fresh ones. Migrating `frame.cpp`
  needs a `block_max` slab and a compaction pass, because a frame's per-block
  output size is unknown before the decode - real work, its own issue, not
  this one's.
- **A fuzz target over the new plan-building layer** (robustness). DEFERRED.
  `fuzz/fuzz_gdeflate_tilestream.cpp` drives the envelope walker; a target over
  the whole-container entry needs the library linked into the fuzz build, which
  is a question about that harness rather than about this entry.
- **A host-reachable test of the whole-stream aggregate** (robustness).
  DECLINED as impossible rather than skipped: the aggregate is decided from a
  decode and there is no decode without a device. What is host-reachable is now
  driven from plain C on the GPU-less runner - both content-dependent rejects
  and the envelope refusal - and the aggregate's semantics are held by the
  GPU-labelled twin.

**No second reader.** This board had no other reviewer available; the five
lenses are the whole review and their verdicts are a machine's rather than a
person's. Each reproduction was re-derived here before anything was changed.

## GPU sanitizer gate

**The device sanitizer net did NOT run for this change, and no part of this
pull request may be read as having passed it.** Compute Sanitizer cannot attach
to a device on this machine's route. Re-measured against this branch's build,
not inherited:

```
/usr/local/cuda/bin/compute-sanitizer --version | tail -3
Version 2026.2.1.0 (build 38334959) (public-release)

build/tests/smoke ; echo "bare exit=$?"
PASS: version + fail-closed validation + 257-chunk empty-block decode on device
bare exit=0

/usr/local/cuda/bin/compute-sanitizer --tool memcheck --error-exitcode 1 build/tests/smoke
========= COMPUTE-SANITIZER
========= Error: Failed to initialize WDDM debugger interface. Please run EnableDebuggerInterface.bat as an administrator
=========
========= Error: Device not supported. Please refer to the "Supported Devices" section of the sanitizer documentation
=========
========= CUDA API Error: Invalid device number 12345 provided, must be in the range of 0 to 0
=========         Host Frame: cudaSetDevice [0x53b62] in libcudart.so.13
=========         Host Frame: cudec_rt::set_device(int) [0x25ca] in smoke
```

The bare binary decodes on the device and exits 0; the same binary under
memcheck gets `cudaErrorInvalidDevice` on its first CUDA call. Every one of the
four tools fails that way before it looks at any code, so no invocation can
return a PASS and none is claimed. The remedy the tool names is a machine-wide
debugger setting behind an elevation prompt on this desktop - a decision about
the desktop rather than about this tree, and not taken here. iderex/cudec#127
and iderex/cudec#258 hold that; nothing here is a substitute for a run.

racecheck reports shared-memory hazards only, so even a clean sweep would not
be clearance for global memory. This change adds no device code.

```
commit:    (no sweep produced; see above)
gpu:       NVIDIA GeForce RTX 3080, driver 610.88
cuda:      Build cuda_13.3.r13.3/compiler.38244171_0
sanitizer: 2026.2.1.0 (build 38334959) - could not attach
```

## Performance checklist

Not on the hot path and nothing is timed here. No number is quoted and no
`docs/BENCHMARKS.md` entry moves. The device work per tile is the unchanged
`cudec_gdeflate_decompress_batch` launch; what this adds is host arithmetic
over a table of at most 65535 entries.

## Quality checklist

- [x] Minimal. The decode reuses the existing streaming staging rather than
      adding one; the only new machinery is the tile-table-to-batch-arrays
      translation and the seam that lets the wave loop submit a second format.
- [x] Self-documenting; comments say why.
- [x] New structural property locked. "The envelope never reaches device code"
      is now a ctest that reads the shipped cubin's symbol table, and its
      neighbour proves the refusal fires.

### The two new guards, proven by deleting them

- Removing the two-sided bound - making the per-tile
  `bytes_written != dst_caps[i]` branch unreachable - reds
  `tilestream_twin.cu:406: sst == CUDEC_ERR_CORRUPT_INPUT`. That is the guard
  the review's one CONFIRMED finding is about, and its absence was the defect
  rather than a hypothetical.
- Removing `if (dst_capacity < info.total_uncompressed) return
  CUDEC_ERR_OUTPUT_TOO_SMALL;` reds
  `conformance_c.c:303: ... == CUDEC_ERR_OUTPUT_TOO_SMALL`.
- Making the aggregate ignore a failed tile (`if (st != CUDEC_OK)` to
  `if (false)`) reds `tilestream_twin.cu:369: refused` - the corrupt-tile
  search finds no flip the entry refuses, which is what a decoder that reports
  success on a broken stream looks like from outside.
- The binary-level check carries its own standing proof rather than a one-off:
  `envelope_out_of_device_selfproof` runs the same script over the same objects
  with a pattern that IS in the device code, and passes only on the specific
  refusal message. Not `WILL_FAIL`, which asserts merely a non-zero exit and so
  goes green on any breakage of the script - and which, combined with
  `PASS_REGULAR_EXPRESSION`, would invert a match into a failure. The script
  also refuses a listing with no `gdeflate_decode_batch` symbol, a grep that
  could not evaluate its pattern, and an argument count that is not exactly 2
  or 3, so none of the three vacuous passes the review demonstrated survives.
- What that check does NOT prove is now written in it. Everything in
  `src/tilestream.h` is `inline`, so the way the envelope would actually reach
  device code is somebody marking the parser `CUDEC_HOST_DEVICE` and calling it
  from a kernel, at which point nvcc very likely inlines it and the cubin
  carries no symbol to find. The configure-time source check added beside it
  covers that route, with a planted violation and two near-misses proving it in
  the shape the vendor-seam scanner already uses. Neither check subsumes the
  other and both say so.

## Verification

Run on this machine against the head of this branch. WSL2 Ubuntu-24.04, CUDA
13.3, driver 610.88, RTX 3080 (`sm_86`) - not the digest-pinned 12.6.2
container `CONTRIBUTING.md` names as the canonical gate, and that difference is
stated rather than glossed.

- [x] Build clean, CUDA engine:

```
cmake -B build -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 \
  -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc && cmake --build build -j8
build=0
```

- [x] `ctest` green, device entries executing:

```
ctest --test-dir build --no-tests=error --output-on-failure
100% tests passed, 0 tests failed out of 70
Label Time Summary:
gpu    =  12.25 sec*proc (12 tests)
```

`origin/main` at `2992855020ae84fd5ed877d9bf208c8a8861284d` runs 67 entries
with 11 `gpu`-labelled; this branch runs 70 with 12. The three added are
`tilestream_twin` (gpu), `envelope_out_of_device` and
`envelope_out_of_device_selfproof`.

What the new entries print:

```
tilestream_twin: tile 1 refused at payload byte 4 with status 2, three siblings byte-exact
tilestream_twin: a tile carrying 100 bytes under a 65536-byte declaration is refused, siblings unaffected
tilestream_twin: a page producing 65536 bytes under a 1000-byte declaration is refused, nothing written past 1000
tilestream_twin: 4-tile stream (208953 bytes) decoded through the TileStream entry in both memory spaces, equal to the reference
envelope_out_of_device: skipped (no device code): .../src/version.c.o
envelope_out_of_device: skipped (no device code): .../src/frame.cpp.o
envelope_out_of_device: skipped (no device code): .../src/stream.cpp.o
envelope_out_of_device: skipped (no device code): .../src/tilestream.cpp.o
envelope_out_of_device: PASS: 1 device object(s) carry gdeflate_decode_batch and no symbol matching 'TileStream'
envelope_out_of_device_selfproof: FAIL: a device symbol matches 'gdeflate_decode_batch'; the envelope has reached device code
```

- [x] Host-only build clean (the configuration CI's first job builds):

```
cmake -B build-host && cmake --build build-host -j8
host-only build=0
```

- [x] The ASan+UBSan configuration builds and its host subset passes, so the
      new envelope parse in `conformance_c` runs instrumented:

```
cmake -B build-san -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 \
  -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCUDEC_SANITIZE=address,undefined \
  && cmake --build build-san -j8
san build=0
ctest --test-dir build-san --no-tests=error --output-on-failure \
  -R '^(conformance_c|tilestream_host_negative|gdeflate_header_twin|termination)$'
100% tests passed, 0 tests failed out of 4
```

- [x] `scripts/check-doc-paths.sh` passes, including its own self-tests.
- [x] Prettier: no `.md`, `.yml` or `.yaml` file is touched by this change.
- [x] CI built the HIP configuration: the `hip` job was green on the first
      head of this branch, which is the evidence for that arm.
- [ ] The HIP configuration was NOT built here. No hipcc is reachable on this
      machine; the CI hip job is what compiles that arm. The new ctest entries
      that need `cuobjdump` are gated on `CUDEC_DEVICE_LANGUAGE STREQUAL
      "CUDA"` so the HIP configure does not see them, and `src/tilestream.cpp`
      is plain C++ with no backend header - but neither of those was compiled
      by a HIP compiler here, and CI is the evidence for that half.
- [x] Docs synced: no behaviour, API or performance claim in
      `docs/MASTERPLAN.md`, `README.md` or `docs/BENCHMARKS.md` changes. The
      README status table's M4 row is not touched; it flips when the milestone
      closes.

## Notes

- The ABI is three symbols rather than one. #177 asks for an entry "mirroring
  `cudec_lz4f_decompress`'s shape" while reusing the `cudec_stream_ctx_*`
  staging path, and those two pull apart: `cudec_lz4f_decompress` is one-shot
  and takes no context. The read taken is that the context is an
  IMPLEMENTATION directive (do not invent a second staging path) and the shape
  is an ABI one, so the LZ4 family's own pattern is followed - a `_ctx` entry
  for the amortized caller and a one-shot beside it. `_info` is the third
  because a caller cannot otherwise size either `dst` or the per-tile result
  array, and both are refused rather than truncated.
- The tile decode capacity is stricter than the container strictly requires: a
  page that decodes to fewer bytes than its tile declared is not accepted
  silently either, because the batch entry reports the produced length and the
  aggregate sums it. Whether the real DirectStorage vectors ever do that is
  iderex/cudec#169 and iderex/cudec#179, which is where this parser meets them.
- No second reader. This board had no other reviewer available for this
  change; the five lenses recorded above are the whole review, and their
  verdicts are a machine's rather than a person's.
- The first head of this branch went green on every CI check while carrying the
  fail-open the review found. That is worth writing down rather than quietly
  fixing: the gates this project runs did not and could not see it, and what
  caught it was the adversarial pass. A green board here does not cover that
  class.
