### PR TITLE
Decode a Zstd frame on the device behind the batch entry [#203]

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -2213,9 +2213,22 @@ them by naming where the literals live.
   warps against the 32 the budget is derived from, and nothing in this
   landing tries to argue that down: what would move it is a register
   measurement per stage, which is #235 to #239's business rather than the
-  kernel's own pull request. Nothing spilled - local memory is zero - so
-  this is the allocation the busy lane needs and not a shape leaking into
-  local storage.
+  kernel's own pull request.
+
+  **It does spill, by a little, and that is stated rather than rounded to
+  none.** `-Xptxas -v` over the same translation unit:
+
+  ```
+  176 bytes stack frame, 8 bytes spill stores, 4 bytes spill loads
+  Used 80 registers, used 1 barriers, 12064 bytes smem
+  ```
+
+  Twelve bytes of traffic against a 176-byte frame is not what holds this
+  kernel back at 80 registers, and no claim here says the allocation is
+  spill-free. What the frame itself costs is the serial lane's working set -
+  a bit reader, three FSE states and the repeat history at once, which 14.10
+  predicted would set the whole block's allocation - and moving it is the
+  same per-stage measurement named above.
 
 - **An extension that widens a table.** 12.5's extension ladder is where a
   wider window or a larger table log would arrive, and the 9472 bytes moves

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -2195,6 +2195,28 @@ them by naming where the literals live.
   from 32 resident warps at 64 registers. Above it the block count falls
   and the shared-memory headroom the four-warp block relies on stops being
   headroom.
+
+  **Measured outcome (issue #203, 2026-09-06): this trigger has fired, and
+  the shared-memory half of 14.2 held.** Read off the shipped kernel on the
+  RTX 3080 through `cudaFuncGetAttributes` and
+  `cudaOccupancyMaxActiveBlocksPerMultiprocessor`, at 128 threads:
+
+  ```
+  kernel: 80 registers/thread, 12064 bytes static smem, 176 bytes local
+  occupancy: 6 resident blocks/SM at 128 threads = 24 warps/SM
+  ```
+
+  So registers bind rather than shared memory: 12064 bytes is inside the
+  12292 bytes 14.10 budgeted, and eight blocks of it would still fit the
+  roughly 100 KiB an sm_86 SM offers - what stops the eighth block is 80
+  registers a thread, not the table set. The consequence is 24 resident
+  warps against the 32 the budget is derived from, and nothing in this
+  landing tries to argue that down: what would move it is a register
+  measurement per stage, which is #235 to #239's business rather than the
+  kernel's own pull request. Nothing spilled - local memory is zero - so
+  this is the allocation the busy lane needs and not a shape leaking into
+  local storage.
+
 - **An extension that widens a table.** 12.5's extension ladder is where a
   wider window or a larger table log would arrive, and the 9472 bytes moves
   with it. A literals tree of depth twelve alone would take the table set

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -231,15 +231,17 @@ cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
  * capacity, bytes_written == 0 on any of them, and the destination contents
  * then unspecified but never presented as a valid decode.
  *
- * THIS BUILD CARRIES NO ZSTD KERNEL, AND THAT IS A DEFINED STATUS RATHER
- * THAN AN ABSENT SYMBOL. A batch that passes the validation above returns
- * CUDEC_ERR_NOT_IMPLEMENTED, having made no CUDA call at all - so this
- * entry, like the GDeflate one above, also leaves the thread's pending CUDA
- * error state untouched on a call it accepts. The symbol, the signature and
- * every reject class above are frozen now and do not move when the kernel
- * lands; only the answer to an accepted batch does. A symbol that was absent
- * instead would make the freeze conditional on a build configuration, which
- * is two contracts wearing one name. */
+ * A frame is decoded by one BLOCK rather than by one warp, and that is the
+ * format rather than a tuning choice: a Zstd frame's entropy decode is
+ * serial per stream, so what a frame is given is a block whose shared memory
+ * holds its entropy table set. Nothing a caller can observe moves with it.
+ *
+ * The contract was frozen before the kernel stood behind it, and the freeze
+ * held: the symbol, the signature and every reject class above did not move
+ * when the kernel landed; only the answer to an accepted batch did, from
+ * CUDEC_ERR_NOT_IMPLEMENTED to the launch. A symbol that had been absent
+ * instead would have made the freeze conditional on a build configuration,
+ * which is two contracts wearing one name. */
 cudec_status cudec_zstd_decompress_batch(const void* const* d_src_ptrs,
                                          const size_t* d_src_sizes,
                                          void* const* d_dst_ptrs,

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -34,11 +34,15 @@ typedef enum cudec_status {
     /* An API entry point or decode path declared here but not implemented
      * in this build. It is what a declared-but-unbuilt entry answers a
      * batch it has already accepted, so the freeze on that entry's symbol
-     * and signature never depends on a build configuration:
-     * cudec_zstd_decompress_batch returns it today, and the value is fixed
-     * so a caller's switch stays exhaustive across the build that stops
-     * returning it - which cudec_gdeflate_decompress_batch did when its
-     * kernel landed, with the symbol and every reject class unmoved. */
+     * and signature never depends on a build configuration.
+     *
+     * NO ENTRY RETURNS IT TODAY, and the value stays where it is rather than
+     * being reclaimed. Both entries that ever answered it -
+     * cudec_gdeflate_decompress_batch and then cudec_zstd_decompress_batch -
+     * stopped when their kernels landed, with the symbol and every reject
+     * class unmoved, which is what the freeze was for. A caller's switch
+     * stays exhaustive across that change only because the value is
+     * fixed. */
     CUDEC_ERR_NOT_IMPLEMENTED = 5,
     /* A well-formed frame that uses a feature cudec does not decode, or a
      * legal frame type it declines (block-linked mode, a dictionary id, a

--- a/src/batch.cu
+++ b/src/batch.cu
@@ -4,6 +4,7 @@
 #include "gdeflate_decode.cuh"
 #include "lz4_block.h"
 #include "snappy_block.h"
+#include "zstd_decode.cuh"
 
 #include "vendor_rt.h"
 
@@ -44,6 +45,29 @@ struct GDeflateLaunch {
         cudec_detail::gdeflate_decode_batch<WaveSize>
             <<<cudec_detail::decode_grid_blocks(chunk_count),
                cudec_detail::kBlockThreadsFor<WaveSize>, 0,
+               cudec_rt::stream_from_abi(stream)>>>(
+                d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities,
+                chunk_count, d_results);
+    }
+};
+
+/* One BLOCK per frame rather than one wave, and the grid is one block per
+ * frame: a Zstd frame's entropy decode is serial per stream, so what a frame
+ * gets is a block whose shared memory holds its table set
+ * (docs/MASTERPLAN.md section 14.2). The width is the kernel's own constant
+ * rather than the wave-derived one the two launchers above use, because 14.2
+ * derives it from the table set against an SM's shared memory and not from a
+ * wave count - it is 128 threads at either wave width, which is four waves on
+ * one and two on the other. */
+struct ZstdLaunch {
+    template <int WaveSize>
+    static void Run(const void* const* d_src_ptrs, const size_t* d_src_sizes,
+                    void* const* d_dst_ptrs, const size_t* d_dst_capacities,
+                    size_t chunk_count, cudec_chunk_result* d_results,
+                    cudec_stream_t stream) {
+        cudec_detail::zstd_decode_batch<WaveSize>
+            <<<cudec_detail::zstd_grid_blocks(chunk_count),
+               cudec_detail::kZstdBlockThreads, 0,
                cudec_rt::stream_from_abi(stream)>>>(
                 d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities,
                 chunk_count, d_results);
@@ -154,21 +178,18 @@ cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
                                         d_results, stream);
 }
 
-/* The Zstd entry is the frozen contract without its kernel behind it yet
- * (issue #427). It shares the validator with the three above rather than
- * growing its own, so the reject classes cannot drift apart while it is being
- * frozen, and then stops: no launch, and deliberately no
- * cudec_rt::get_last_error() drain either. Draining is how the entries above
- * buy a post-launch check that reports their own submission; with nothing
- * submitted there is nothing to report, and consuming a caller's pending
- * error on the way to answering "not built here" would be this entry
- * altering CUDA state it never used.
+/* The Zstd entry with its kernel behind it (issues #427, #203). It shares the
+ * validator, the width query and the post-launch check with the three above,
+ * so the reject classes and the launch discipline cannot drift apart between
+ * the families; what it does not share is the launch geometry, which is
+ * ZstdLaunch's and is a block per frame.
  *
- * That absence is what tests/launch_fail.cpp reads: with no visible device
- * an entry that made any CUDA call would answer CUDEC_ERR_CUDA, so the
- * not-implemented answer there is the evidence that this path touches the
- * runtime at all only through the validator, which touches it not at
- * all. */
+ * tests/launch_fail.cpp read the not-implemented answer this entry used to
+ * give as the evidence that it touched the runtime only through a validator
+ * that touches it not at all. That evidence is spent: with a kernel behind it
+ * the entry queries the width and launches, so with no visible device it
+ * answers CUDEC_ERR_CUDA exactly as the three entries beside it do, and that
+ * is the line in that test which changes meaning today. */
 cudec_status cudec_zstd_decompress_batch(const void* const* d_src_ptrs,
                                          const size_t* d_src_sizes,
                                          void* const* d_dst_ptrs,
@@ -176,12 +197,7 @@ cudec_status cudec_zstd_decompress_batch(const void* const* d_src_ptrs,
                                          size_t chunk_count,
                                          cudec_chunk_result* d_results,
                                          cudec_stream_t stream) {
-    (void)stream;
-    const cudec_status valid = cudec_detail::validate_batch_args(
-        d_src_ptrs, d_src_sizes, d_dst_ptrs, d_dst_capacities, chunk_count,
-        d_results);
-    if (valid != CUDEC_OK) {
-        return valid;
-    }
-    return CUDEC_ERR_NOT_IMPLEMENTED;
+    return submit_batch<ZstdLaunch>(d_src_ptrs, d_src_sizes, d_dst_ptrs,
+                                    d_dst_capacities, chunk_count, d_results,
+                                    stream);
 }

--- a/src/zstd_decode.cuh
+++ b/src/zstd_decode.cuh
@@ -1,0 +1,603 @@
+/* The block-per-frame Zstd decoder (issue #203): one 128-thread block per
+ * frame over a grid-stride loop, one entropy table set per frame in shared
+ * memory, the literals staged in the tail of the frame's own remaining
+ * destination, and the sequences produced and consumed a tile at a time so
+ * the frame needs no workspace beyond the caller's buffer
+ * (docs/MASTERPLAN.md sections 14.1 to 14.4). Internal header, not part of
+ * the ABI; src/batch.cu instantiates it.
+ *
+ * NOTHING IN THIS FILE DECODES A BIT. Every value is produced by a unit under
+ * src/zstd_*.h that the CPU twins already run, compiled __device__ unchanged:
+ * the frame and block headers, the literals section, the Huffman and FSE
+ * machinery, the resumable sequence cursor, the tiled prefix sum, the
+ * per-sequence execution and the content checksum. What this file owns is the
+ * placement - which memory each unit is handed - and the order they run in,
+ * which is the order src/zstd_blocks.h runs them in on the host. So a frame
+ * that decodes to different bytes on the two residencies is a defect here,
+ * and the units cannot be that defect: they are the same code.
+ *
+ * WHERE THE LITERALS LIVE, AND WHY THAT IS THE WHOLE REASON THERE IS NO
+ * WORKSPACE. Section 14.3: with R bytes of declared output left at the start
+ * of a block and L literal bytes regenerated, the literals are decoded into
+ * [P + R - L, P + R) and every sequence's literal run then copies toward
+ * LOWER addresses, so run i ends at or before run i+1's source begins. The
+ * host twin decodes the same literals into a buffer of its own; the bytes are
+ * identical and only the address differs.
+ *
+ * WHAT THIS LANDING DOES NOT TAKE FROM THE LANE MAP. Sections 14.7 to 14.11
+ * assign the literal streams to four lanes of warp 0 and one sequence of a
+ * tile to each of the 128 threads. Neither is taken here and both are
+ * recorded rather than silently dropped:
+ *
+ *   - The four literal streams are one call of ZstdDecodeLiterals, because
+ *     the four spans are derived inside that unit. Splitting them across
+ *     lanes needs the span derivation extracted into a function the host twin
+ *     still runs, which is 14.9's own pattern and is not this rung's work.
+ *   - The sequences of a tile execute IN ORDER on one lane. The ruling of
+ *     2026-09-04 on #203 forbids fanning a tile's match copies across lanes -
+ *     over the #185 corpus 60616 of 124212 matches read bytes a lower-numbered
+ *     sequence of their own tile writes, the nearest at an offset of two. What
+ *     the ruling permits, a parallel literal phase ahead of a serial match
+ *     phase, would need ZstdExecuteSequence split in two, and the split
+ *     reorders the reject ladder: all the literal rungs of a tile would fire
+ *     ahead of the match rung of a lower-numbered sequence, so the device
+ *     would report a different refusal from the host twin on the same bytes.
+ *
+ * So the parallelism this kernel takes is the copies that are copies rather
+ * than format units: a Raw or RLE block's body and a block's leftover literal
+ * tail move across all 128 threads. The rest of a frame runs on thread 0, and
+ * what that costs is a measurement rather than a claim - #231 records the
+ * first baselines and #235 to #239 are the levers that would widen it.
+ *
+ * FAIL-CLOSED, WITH THE BOUNDS THE UNITS ALREADY CARRY. Every write is
+ * bounded before it happens by the frame's declared content size, which is
+ * bounded by the caller's capacity before the first block runs. On any
+ * refusal the frame's result is a non-OK status with bytes_written zero, and
+ * the destination is unspecified and never presented as a decode. */
+#ifndef CUDEC_ZSTD_DECODE_CUH
+#define CUDEC_ZSTD_DECODE_CUH
+
+#include "cudec.h"
+#include "xxhash64.h"
+#include "zstd_blocks.h"
+
+#include "vendor_rt.h"
+
+namespace cudec_detail {
+
+/* Section 14.2: the smallest block at which the table set stops being the
+ * resource that decides how many frames an SM holds. It is a thread count and
+ * not a wave count, so it does not move with the wave width; what the width
+ * decides is how many waves that is, which the static assertion in the kernel
+ * holds to a whole number. */
+constexpr unsigned kZstdBlockThreads = 128;
+
+/* The table set of 14.1, sized by the format's own ceilings and by nothing a
+ * frame says. */
+constexpr uint32_t kZstdLitLenCells = 1u << kZstdLitLenAccuracyLogMax;
+constexpr uint32_t kZstdMatchLenCells = 1u << kZstdMatchLenAccuracyLogMax;
+constexpr uint32_t kZstdOffsetCells = 1u << kZstdOffsetAccuracyLogMax;
+constexpr uint32_t kZstdHufTableCells = 1u << kZstdLiteralsMaxTableLog;
+
+/* Sequences per tile.
+ *
+ * SECTION 14.10 BUDGETS 128 AND THIS LANDING TAKES THE HALVING THAT SECTION
+ * ITSELF NAMES AS THE FIRST MOVE. Its arithmetic costs a tile record at five
+ * 32-bit fields, twenty bytes; the record here is what the units actually
+ * read and write - a ZstdSequence, a uint64 destination, a uint64 literal
+ * cursor and a uint64 resolved offset - which is forty. Packing them to the
+ * budgeted twenty would mean a narrowed copy live beside the arrays the units
+ * fill, which costs more than it saves rather than less. At sixty-four
+ * records the shared footprint is under 12.4 KiB, so the eight resident
+ * blocks 14.2 derives still fit inside the roughly 100 KiB an sm_86 SM
+ * offers, with room left for whatever the driver reserves. */
+constexpr uint32_t kZstdTileSequences = 64;
+
+/* The per-block working memory of a table description. The literals section
+ * finishes before the first sequence table is read - that is the order
+ * src/zstd_blocks.h runs them in - so one region serves both and the union
+ * says so rather than two regions sitting idle in turn. */
+union ZstdBuildScratch {
+    ZstdLiteralsScratch literals;
+    ZstdSeqScratch seq;
+};
+
+/* One tile of sequences and everything the execution needs per sequence.
+ * `offsets` holds the resolved distance the repeat-offset chain produced,
+ * which is what lets each copy be independent of the chain that made it. */
+struct ZstdTile {
+    ZstdSequence sequences[kZstdTileSequences];
+    uint64_t destinations[kZstdTileSequences];
+    uint64_t literal_cursors[kZstdTileSequences];
+    uint64_t offsets[kZstdTileSequences];
+};
+
+/* Everything one block holds for the frame it is decoding.
+ *
+ * The scratch and the tile overlay each other for the reason 14.10 gives: the
+ * tile holds nothing until the sequences of a block start arriving, and by
+ * then every description that needed scratch has been read. */
+struct ZstdFrameShared {
+    ZstdFseCell litlen_cells[kZstdLitLenCells];
+    ZstdFseCell matchlen_cells[kZstdMatchLenCells];
+    ZstdFseCell offset_cells[kZstdOffsetCells];
+    ZstdHufCell huf_cells[kZstdHufTableCells];
+    union {
+        ZstdBuildScratch build;
+        ZstdTile tile;
+    } work;
+
+    ZstdFrameState state;
+    ZstdFrameHeader header;
+
+    /* The walk, kept where every thread reads it: the barriers below are what
+     * make thread 0's writes visible to the rest, and a value recomputed per
+     * thread instead would be a second spelling of the walk. */
+    cudec_status status;
+    uint64_t produced;
+    uint64_t pos;
+    /* What the block header declared, which is how the walk steps over the
+     * block; never the count of the copy below, which is a different
+     * quantity and once shared this field. */
+    uint64_t body_size;
+    /* The one copy the whole block makes for the block being decoded: a Raw
+     * or RLE body, or the leftover literal tail of a Compressed one. */
+    uint64_t copy_count;
+    const unsigned char* copy_src;
+    unsigned char* copy_dst;
+    bool copy_is_rle;
+    bool compressed;
+    bool last_block;
+};
+
+/* One block per frame, capped where the chunk decoder caps its own grid and
+ * for the same reason: a grid larger than the device will ever run resident
+ * buys nothing, and the loop inside the kernel is what covers the rest. */
+inline unsigned zstd_grid_blocks(size_t chunk_count) {
+    constexpr size_t kMaxBlocks = 8192;
+    const size_t blocks = chunk_count == 0 ? 1 : chunk_count;
+    return static_cast<unsigned>(blocks > kMaxBlocks ? kMaxBlocks : blocks);
+}
+
+/* A forward copy of `count` bytes whose destination is at or below its
+ * source, spread over the whole block.
+ *
+ * WHY THE BARRIER IS INSIDE THE LOOP. With the destination below the source
+ * the regions may overlap, and a thread writing dst[i] can be clobbering the
+ * byte another thread has not read yet. Reading a chunk into registers,
+ * meeting at a barrier and only then writing it is what removes that race:
+ * inside a chunk every read precedes every write, and across chunks the
+ * writes of chunk k end at or below the reads of chunk k+1 because the
+ * destination is at or below the source. Serial byte order would also be
+ * safe and is what the host twin does; this is the same move, held to the
+ * same rule, at 128 bytes a step. */
+__device__ inline void ZstdMoveDown(unsigned char* dst,
+                                    const unsigned char* src, uint64_t count) {
+    const uint64_t stride = static_cast<uint64_t>(kZstdBlockThreads);
+    const uint64_t steps = (count + stride - 1) / stride;
+    for (uint64_t step = 0; step < steps; step++) {
+        const uint64_t at = step * stride + threadIdx.x;
+        unsigned char byte = 0;
+        const bool live = at < count;
+        if (live) {
+            byte = src[at];
+        }
+        __syncthreads();
+        if (live) {
+            dst[at] = byte;
+        }
+        __syncthreads();
+    }
+}
+
+/* A Raw or RLE block's body, spread over the whole block. No overlap is
+ * possible here - the source is the compressed frame and the destination is
+ * the caller's output - so this needs no barrier of its own. */
+__device__ inline void ZstdFillBlock(unsigned char* dst,
+                                     const unsigned char* src, uint64_t count,
+                                     bool rle) {
+    const uint64_t stride = static_cast<uint64_t>(kZstdBlockThreads);
+    for (uint64_t at = threadIdx.x; at < count; at += stride) {
+        dst[at] = rle ? src[0] : src[at];
+    }
+}
+
+/* One Compressed block, on thread 0, in the order src/zstd_blocks.h runs the
+ * same units in: the literals section, the sequences section header, the
+ * three table descriptions, then the sequences a tile at a time.
+ *
+ * `remaining` is what the frame has left to declare, so every bound below is
+ * the caller's capacity narrowed by what earlier blocks produced.
+ *
+ * THE EXECUTION IS HANDED `remaining` WHERE THE HOST HANDS IT THE BLOCK'S OWN
+ * SIZE, AND THE DIFFERENCE IS VISIBLE ONLY ON A REFUSAL. A block's size is
+ * the running total plus the literals its sequences do not consume, so it is
+ * known only once the last tile has been summed - and the tiles have to
+ * execute as they are produced, because holding them all is the workspace
+ * 14.3 refuses. `remaining` is the larger of the two and is what the caller's
+ * buffer actually allows, so every write stays inside the declared region
+ * either way; on a block that decodes, the two bounds admit exactly the same
+ * sequences, because such a block's size is at most `remaining`. The check
+ * that says so runs after the last tile and refuses with the rung the host
+ * gives. */
+__device__ inline cudec_status ZstdDecodeCompressedBlockDevice(
+    ZstdFrameShared* frame, const unsigned char* body, uint64_t body_size,
+    unsigned char* dst, uint64_t remaining) {
+    ZstdFrameState* state = &frame->state;
+    const uint64_t block_max = ZstdLiteralsBlockMaximum(
+        frame->header.window_size);
+
+    /* Where the literals go, which is what the whole no-workspace shape rests
+     * on. The regenerated size is read from the header before the section is
+     * decoded so the tail address is known before a byte is written; the
+     * header is then read a second time by the decode itself, which is a pure
+     * function of the same bytes and cannot disagree with the first reading. */
+    ZstdLiteralsHeader literals_header;
+    ZstdLiteralsReject literals_rung = kZstdLiteralsRejectNone;
+    cudec_status status = ZstdParseLiteralsHeader(body, body_size,
+                                                  &literals_header,
+                                                  &literals_rung);
+    if (status != CUDEC_OK) {
+        return status;
+    }
+    const uint64_t literals_size = literals_header.regenerated_size;
+    if (literals_size > remaining) {
+        /* A block regenerates at least its own literals, so a literals
+         * section larger than the frame has left to declare is a frame that
+         * cannot be describing this output. Refused before the address below
+         * is formed, which is what keeps the subtraction from wrapping. */
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+    unsigned char* literals = dst + frame->produced + remaining - literals_size;
+
+    uint64_t consumed = 0;
+    uint64_t produced_literals = 0;
+    status = ZstdDecodeLiterals(body, body_size, frame->header.window_size,
+                                &state->literals_table,
+                                &frame->work.build.literals, literals,
+                                literals_size, &produced_literals, &consumed,
+                                &literals_rung);
+    if (status != CUDEC_OK) {
+        return status;
+    }
+
+    const unsigned char* section = body + consumed;
+    uint64_t section_size = body_size - consumed;
+    ZstdSeqSectionHeader seq_header;
+    uint64_t seq_consumed = 0;
+    ZstdSeqReject seq_rung = kZstdSeqRejectNone;
+    status = ZstdParseSeqSectionHeader(section, section_size, block_max,
+                                       &seq_header, &seq_consumed, &seq_rung);
+    if (status != CUDEC_OK) {
+        return status;
+    }
+    section += seq_consumed;
+    section_size -= seq_consumed;
+
+    /* The sequence count is NOT compared against a capacity here, and its
+     * absence is the tile. The host loop refuses a count larger than the
+     * array it materialises; this one holds sixty-four sequences whatever the
+     * block declares, so the only bound the count needs is the one
+     * ZstdParseSeqSectionHeader already applied against the block maximum. */
+    if (seq_header.sequence_count != 0) {
+        const unsigned fields[3] = {kZstdSeqFieldLitLen, kZstdSeqFieldOffset,
+                                    kZstdSeqFieldMatchLen};
+        const unsigned modes[3] = {seq_header.litlen_mode,
+                                   seq_header.offset_mode,
+                                   seq_header.matchlen_mode};
+        ZstdSeqTable* targets[3] = {&state->litlen, &state->offset,
+                                    &state->matchlen};
+        for (unsigned index = 0; index < 3; index++) {
+            uint64_t table_consumed = 0;
+            status = ZstdSeqLoadTable(fields[index], modes[index], section,
+                                      section_size, &frame->work.build.seq,
+                                      targets[index], &table_consumed,
+                                      &seq_rung);
+            if (status != CUDEC_OK) {
+                return status;
+            }
+            section += table_consumed;
+            section_size -= table_consumed;
+        }
+    }
+
+    ZstdExecCarry carry;
+    carry.at = 0;
+    carry.literals_used = 0;
+    ZstdTile* tile = &frame->work.tile;
+
+    if (seq_header.sequence_count != 0) {
+        ZstdSeqCursor cursor;
+        status = ZstdSeqBegin(section, section_size, seq_header.sequence_count,
+                              &state->litlen, &state->offset, &state->matchlen,
+                              &cursor, &seq_rung);
+        if (status != CUDEC_OK) {
+            return status;
+        }
+        /* The trip count is derived from the declared sequence count before
+         * the first tile runs, so the walk cannot be extended by anything the
+         * bitstream says. */
+        const uint32_t tiles =
+            (seq_header.sequence_count + kZstdTileSequences - 1) /
+            kZstdTileSequences;
+        uint32_t done = 0;
+        for (uint32_t tile_index = 0; tile_index < tiles; tile_index++) {
+            uint32_t want = seq_header.sequence_count - done;
+            if (want > kZstdTileSequences) {
+                want = kZstdTileSequences;
+            }
+            uint32_t got = 0;
+            status = ZstdSeqDecodeTile(&cursor, tile->sequences,
+                                       kZstdTileSequences, want, &got,
+                                       &seq_rung);
+            if (status != CUDEC_OK) {
+                return status;
+            }
+
+            /* The repeat-offset chain is serial over the whole frame and is
+             * resolved for the tile before any of its bytes move, which is
+             * what makes each copy below independent of the chain. */
+            for (uint32_t index = 0; index < got; index++) {
+                ZstdRepcodeReject repcode_rung = kZstdRepcodeRejectNone;
+                status = ZstdRepcodeResolve(&state->repcodes,
+                                            tile->sequences[index].offset_value,
+                                            tile->sequences[index].literals_length,
+                                            &tile->offsets[index],
+                                            &repcode_rung);
+                if (status != CUDEC_OK) {
+                    return status;
+                }
+            }
+
+            ZstdExecReject exec_rung = kZstdExecRejectNone;
+            status = ZstdExecPrefixSumTile(tile->sequences, got, literals_size,
+                                           block_max, &carry,
+                                           tile->destinations,
+                                           tile->literal_cursors,
+                                           kZstdTileSequences, &exec_rung);
+            if (status != CUDEC_OK) {
+                return status;
+            }
+
+            for (uint32_t index = 0; index < got; index++) {
+                /* The successor of the tile's last sequence is where the sum
+                 * has got to, which is the destination the next tile's first
+                 * sequence will be given. */
+                const uint64_t next = index + 1 < got
+                                          ? tile->destinations[index + 1]
+                                          : carry.at;
+                status = ZstdExecuteSequence(
+                    &tile->sequences[index], tile->destinations[index], next,
+                    tile->offsets[index], literals, literals_size,
+                    tile->literal_cursors[index], remaining,
+                    frame->header.window_size, dst, frame->produced,
+                    &exec_rung);
+                if (status != CUDEC_OK) {
+                    return status;
+                }
+            }
+            done += got;
+        }
+    }
+
+    ZstdExecPlan plan;
+    ZstdExecReject exec_rung = kZstdExecRejectNone;
+    uint64_t tail_at = 0;
+    status = ZstdExecPrefixSumFinish(&carry, literals_size, block_max,
+                                     &tail_at, &plan, &exec_rung);
+    if (status != CUDEC_OK) {
+        return status;
+    }
+    /* The bound the execution above was given loosely, applied exactly. The
+     * host's own rung for a block that regenerates past what the frame
+     * declared is OUTPUT_TOO_SMALL, and it is the same statement made in the
+     * same place: after the plan exists and before the block is reported. */
+    if (plan.block_size > remaining) {
+        return CUDEC_ERR_OUTPUT_TOO_SMALL;
+    }
+    frame->copy_count = literals_size - plan.literals_used;
+    frame->copy_src = literals + plan.literals_used;
+    frame->copy_dst = dst + frame->produced + tail_at;
+    frame->produced += plan.block_size;
+    return CUDEC_OK;
+}
+
+/* One frame, by the whole block. Thread 0 walks it and the rest meet it at
+ * the barriers; every value the walk produces that another thread reads goes
+ * through shared memory, so there is one walk and not 128 of them. */
+__device__ inline void ZstdDecodeFrameDevice(ZstdFrameShared* frame,
+                                             const unsigned char* src,
+                                             uint64_t size, unsigned char* dst,
+                                             uint64_t capacity) {
+    if (threadIdx.x == 0) {
+        ZstdFrameReject frame_rung = kZstdFrameRejectNone;
+        frame->produced = 0;
+        frame->pos = 0;
+        frame->last_block = false;
+        frame->status = ZstdParseFrameHeader(src, size, &frame->header,
+                                             &frame_rung);
+        if (frame->status == CUDEC_OK &&
+            frame->header.frame_content_size > capacity) {
+            /* THE DECLARED SIZE IS CHECKED AGAINST THE CAPACITY, NEVER USED
+             * AS ONE - src/zstd_blocks.h's rule, applied here because this
+             * kernel runs the block loop itself. */
+            frame->status = CUDEC_ERR_OUTPUT_TOO_SMALL;
+        }
+        if (frame->status == CUDEC_OK) {
+            frame->pos = frame->header.header_size;
+            ZstdFrameStateInit(&frame->state);
+        }
+    }
+    __syncthreads();
+    if (frame->status != CUDEC_OK) {
+        return;
+    }
+
+    const uint64_t declared = frame->header.frame_content_size;
+    /* The termination fuel of src/zstd_blocks.h, for the reason it gives:
+     * every block consumes at least its three header bytes, so a frame of
+     * `size` bytes admits at most that many steps and the step after the last
+     * one a legal frame could take finds no three bytes to read. A bounds
+     * defect becomes a rejected frame rather than a block that never
+     * retires. */
+    const uint64_t fuel = size / 3 + 1;
+    for (uint64_t step = 0; step < fuel; step++) {
+        if (threadIdx.x == 0) {
+            ZstdBlockHeader block;
+            ZstdFrameReject frame_rung = kZstdFrameRejectNone;
+            frame->status = ZstdParseBlockHeader(src + frame->pos,
+                                                 size - frame->pos,
+                                                 frame->header.window_size,
+                                                 &block, &frame_rung);
+            frame->copy_count = 0;
+            frame->copy_is_rle = false;
+            frame->copy_src = src;
+            frame->copy_dst = dst;
+            frame->compressed = false;
+            if (frame->status == CUDEC_OK) {
+                frame->body_size = block.body_size;
+                frame->last_block = block.last_block;
+                frame->compressed =
+                    block.block_type == kZstdBlockTypeCompressed;
+                if (!frame->compressed) {
+                    /* Raw and RLE both regenerate their declared size and
+                     * differ only in where the bytes come from. Bounded in
+                     * the subtraction direction against what the declaration
+                     * leaves, so nothing can wrap. */
+                    const uint64_t regenerated = block.block_size;
+                    if (regenerated > declared - frame->produced) {
+                        frame->status = CUDEC_ERR_OUTPUT_TOO_SMALL;
+                    } else {
+                        frame->copy_count = regenerated;
+                        frame->copy_is_rle =
+                            block.block_type == kZstdBlockTypeRle;
+                        frame->copy_src = src + frame->pos + 3;
+                        frame->copy_dst = dst + frame->produced;
+                        frame->produced += regenerated;
+                    }
+                }
+            }
+        }
+        __syncthreads();
+        if (frame->status != CUDEC_OK) {
+            return;
+        }
+
+        if (frame->compressed) {
+            if (threadIdx.x == 0) {
+                frame->status = ZstdDecodeCompressedBlockDevice(
+                    frame, src + frame->pos + 3, frame->body_size, dst,
+                    declared - frame->produced);
+            }
+            __syncthreads();
+            if (frame->status != CUDEC_OK) {
+                return;
+            }
+            /* The leftover literals: the bytes after the final sequence's
+             * literal run, moved down out of the staging tail into the place
+             * the plan located. */
+            ZstdMoveDown(frame->copy_dst, frame->copy_src, frame->copy_count);
+        } else {
+            ZstdFillBlock(frame->copy_dst, frame->copy_src, frame->copy_count,
+                          frame->copy_is_rle);
+        }
+        __syncthreads();
+
+        if (threadIdx.x == 0) {
+            frame->pos += static_cast<uint64_t>(3) + frame->body_size;
+        }
+        __syncthreads();
+        if (frame->last_block) {
+            break;
+        }
+    }
+
+    if (threadIdx.x == 0) {
+        if (!frame->last_block) {
+            /* The fuel ran out, which the bound above puts beyond every
+             * input: the block header refuses for want of its three bytes
+             * first, and that is the refusal reported here. */
+            frame->status = CUDEC_ERR_CORRUPT_INPUT;
+        } else if (frame->produced != declared) {
+            /* Every path that would have produced MORE than the declaration
+             * was refused where it happened; what is left is the frame that
+             * produced less. */
+            frame->status = CUDEC_ERR_CORRUPT_INPUT;
+        } else if (frame->header.content_checksum) {
+            const uint64_t digest = Xxh64(dst, frame->produced);
+            ZstdFrameReject frame_rung = kZstdFrameRejectNone;
+            frame->status = ZstdVerifyContentChecksum(src + frame->pos,
+                                                      size - frame->pos,
+                                                      digest, &frame_rung);
+            frame->pos += 4;
+        }
+        if (frame->status == CUDEC_OK && frame->pos != size) {
+            /* A chunk holding more than one frame is outside the subset
+             * (section 12.4), so bytes after the frame are refused rather
+             * than ignored. */
+            frame->status = CUDEC_ERR_CORRUPT_INPUT;
+        }
+    }
+    __syncthreads();
+}
+
+/* One block per frame over a grid-stride loop. A grid with no blocks in it
+ * cannot arise from the launcher, which derives the grid from the chunk
+ * count; a block of the wrong width can only arise from a launch this file
+ * did not shape, and it is refused rather than decoded, because the shared
+ * region below is sized for that shape. */
+template <int WaveSize>
+__global__ void __launch_bounds__(kZstdBlockThreads)
+    zstd_decode_batch(const void* const* src_ptrs, const size_t* src_sizes,
+                      void* const* dst_ptrs, const size_t* dst_caps,
+                      size_t chunk_count, cudec_chunk_result* results) {
+    /* The block is a whole number of waves at either width, which is what
+     * lets every collective in this file be a block barrier rather than a
+     * wave one. */
+    static_assert(kZstdBlockThreads % static_cast<unsigned>(WaveSize) == 0,
+                  "the Zstd block must be a whole number of waves");
+    __shared__ ZstdFrameShared frame;
+
+    if (blockDim.x != kZstdBlockThreads || gridDim.x == 0) {
+        return;
+    }
+    for (size_t chunk = blockIdx.x; chunk < chunk_count; chunk += gridDim.x) {
+        const unsigned char* src =
+            static_cast<const unsigned char*>(src_ptrs[chunk]);
+        unsigned char* dst = static_cast<unsigned char*>(dst_ptrs[chunk]);
+        if (threadIdx.x == 0) {
+            frame.state.literals_table.cells = frame.huf_cells;
+            frame.state.literals_table.capacity = kZstdHufTableCells;
+            frame.state.litlen.cells = frame.litlen_cells;
+            frame.state.litlen.capacity = kZstdLitLenCells;
+            frame.state.offset.cells = frame.offset_cells;
+            frame.state.offset.capacity = kZstdOffsetCells;
+            frame.state.matchlen.cells = frame.matchlen_cells;
+            frame.state.matchlen.capacity = kZstdMatchLenCells;
+            frame.body_size = 0;
+            frame.copy_count = 0;
+            frame.copy_is_rle = false;
+            frame.compressed = false;
+            frame.copy_src = src;
+            frame.copy_dst = dst;
+        }
+        __syncthreads();
+
+        ZstdDecodeFrameDevice(&frame, src, src_sizes[chunk], dst,
+                              dst_caps[chunk]);
+
+        if (threadIdx.x == 0) {
+            results[chunk].status = frame.status;
+            results[chunk].reserved = 0;
+            results[chunk].bytes_written =
+                frame.status == CUDEC_OK ? frame.produced : 0;
+        }
+        /* The next frame's table build must not overtake a thread still
+         * reading this one's tables. */
+        __syncthreads();
+    }
+}
+
+}  // namespace cudec_detail
+
+#endif /* CUDEC_ZSTD_DECODE_CUH */

--- a/src/zstd_decode.cuh
+++ b/src/zstd_decode.cuh
@@ -226,16 +226,17 @@ __device__ inline void ZstdFillBlock(unsigned char* dst,
  * the caller's capacity narrowed by what earlier blocks produced.
  *
  * THE EXECUTION IS HANDED `remaining` WHERE THE HOST HANDS IT THE BLOCK'S OWN
- * SIZE, AND THE DIFFERENCE IS VISIBLE ONLY ON A REFUSAL. A block's size is
- * the running total plus the literals its sequences do not consume, so it is
- * known only once the last tile has been summed - and the tiles have to
- * execute as they are produced, because holding them all is the workspace
- * 14.3 refuses. `remaining` is the larger of the two and is what the caller's
- * buffer actually allows, so every write stays inside the declared region
- * either way; on a block that decodes, the two bounds admit exactly the same
- * sequences, because such a block's size is at most `remaining`. The check
- * that says so runs after the last tile and refuses with the rung the host
- * gives. */
+ * SIZE, AND WHAT MAKES THAT SOUND IS THE CHECK IN THE TILE LOOP. A block's
+ * size is the running total plus the literals its sequences do not consume,
+ * so it is known only once the last tile has been summed - and the tiles have
+ * to execute as they are produced, because holding them all is the workspace
+ * 14.3 refuses. What the loop does instead is hold the size-so-far to
+ * `remaining` after each tile's prefix sum and BEFORE that tile's copies, so
+ * by the time a sequence runs, the bound the host would have given it is
+ * already known to be at least as tight as `remaining`. On a block that
+ * decodes the two are the same number; on one that does not, the refusal
+ * comes from that comparison with the class the host gives, rather than from
+ * a rung inside the execution unit that no stream is supposed to reach. */
 __device__ inline cudec_status ZstdDecodeCompressedBlockDevice(
     ZstdFrameShared* frame, const unsigned char* body, uint64_t body_size,
     unsigned char* dst, uint64_t remaining) {
@@ -257,12 +258,32 @@ __device__ inline cudec_status ZstdDecodeCompressedBlockDevice(
         return status;
     }
     const uint64_t literals_size = literals_header.regenerated_size;
+    /* THE BLOCK MAXIMUM IS COMPARED HERE AND NOT ONLY INSIDE THE UNIT THAT
+     * OWNS IT, AND THE REASON IS THE ORDER RATHER THAN DOUBT. ZstdDecodeLiterals
+     * makes this same comparison against the same ZstdLiteralsBlockMaximum
+     * value and refuses CORRUPT_INPUT, which is the class the host reports for
+     * such a block - but it cannot be asked until it has an address to decode
+     * into, and the address below only exists once the section fits in what
+     * the frame has left. So the two comparisons run in the host's order:
+     * a section larger than the format allows is malformed, and only a section
+     * the format allows but the declaration does not is the capacity answer
+     * below. The bound is derived once, at block_max, and compared twice. */
+    if (literals_size > block_max) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
     if (literals_size > remaining) {
         /* A block regenerates at least its own literals, so a literals
-         * section larger than the frame has left to declare is a frame that
-         * cannot be describing this output. Refused before the address below
-         * is formed, which is what keeps the subtraction from wrapping. */
-        return CUDEC_ERR_CORRUPT_INPUT;
+         * section larger than the frame has left to declare is a block whose
+         * size passes the declaration. Refused before the address below is
+         * formed, which is what keeps the subtraction from wrapping.
+         *
+         * THE STATUS IS THE HOST'S, NOT THE ONE THE CONDITION SUGGESTS. The
+         * host reaches the same bytes through ZstdExecuteBlock's
+         * destination-too-small rung, which answers OUTPUT_TOO_SMALL, and
+         * `plan.block_size >= literals_size` is what makes the two rungs the
+         * same statement. Answering CORRUPT_INPUT here would be the device
+         * and the twin giving different classes for one frame. */
+        return CUDEC_ERR_OUTPUT_TOO_SMALL;
     }
     unsigned char* literals = dst + frame->produced + remaining - literals_size;
 
@@ -375,6 +396,43 @@ __device__ inline cudec_status ZstdDecodeCompressedBlockDevice(
                 return status;
             }
 
+            /* THE ONE CHECK THAT MAKES THE WHOLE NO-WORKSPACE SHAPE SAFE,
+             * AND IT RUNS BEFORE THE COPIES RATHER THAN AFTER THEM.
+             *
+             * `carry.at + (literals_size - carry.literals_used)` is the
+             * block's size as far as the sum has got: the bytes the
+             * sequences so far produce, plus every literal they have not
+             * consumed. It is the same quantity ZstdExecPrefixSumFinish
+             * returns as `block_size`, taken at a tile boundary, and it only
+             * grows - each further sequence adds its match bytes and moves
+             * literals from the tail into the runs.
+             *
+             * Held to `remaining`, it establishes 14.3's placement invariant
+             * for every sequence of this tile before one byte moves. The
+             * literals sit at [P + R - L, P + R) and sequence i's run copies
+             * from `literals + literal_at_i` to `base + at_i`, so the copy
+             * moves toward lower addresses exactly when the match bytes
+             * before it fit in `R - L` - which is what this comparison says.
+             * Checked after the tile's copies instead, a block that violated
+             * it would overwrite literals it has not read yet, and only the
+             * refusal at the end of the block would stop that garbage being
+             * reported. It stays inside the caller's buffer either way, but
+             * "inside the buffer and refused afterwards" is not the property
+             * this shape claims.
+             *
+             * It is also what keeps ZstdExecuteSequence's plan-consistency
+             * rung out of reach of a stream. That rung is the unit's
+             * caller-bug rung, documented as reachable by a wrong scan and
+             * never by a stream, and handing the execution `remaining`
+             * instead of the block's own size would otherwise let a hostile
+             * frame fire it - answering CORRUPT_INPUT where the host answers
+             * OUTPUT_TOO_SMALL, and mis-filing a stream rejection as a
+             * decoder bug in anything that triages by rung. */
+            if (carry.at > remaining ||
+                literals_size - carry.literals_used > remaining - carry.at) {
+                return CUDEC_ERR_OUTPUT_TOO_SMALL;
+            }
+
             for (uint32_t index = 0; index < got; index++) {
                 /* The successor of the tile's last sequence is where the sum
                  * has got to, which is the destination the next tile's first
@@ -404,10 +462,10 @@ __device__ inline cudec_status ZstdDecodeCompressedBlockDevice(
     if (status != CUDEC_OK) {
         return status;
     }
-    /* The bound the execution above was given loosely, applied exactly. The
-     * host's own rung for a block that regenerates past what the frame
-     * declared is OUTPUT_TOO_SMALL, and it is the same statement made in the
-     * same place: after the plan exists and before the block is reported. */
+    /* The same comparison the tile loop makes, at the close. It is not a
+     * second guard for the tiles - each of those was already held to it - it
+     * is the one for a block with no sequences at all, whose whole size is
+     * its literals and which never enters the loop above. */
     if (plan.block_size > remaining) {
         return CUDEC_ERR_OUTPUT_TOO_SMALL;
     }

--- a/src/zstd_decode.cuh
+++ b/src/zstd_decode.cuh
@@ -49,6 +49,22 @@
  * what that costs is a measurement rather than a claim - #231 records the
  * first baselines and #235 to #239 are the levers that would widen it.
  *
+ * EVERY THREAD-0 SECTION IS PRECEDED BY A BARRIER, AND THAT IS A RULE RATHER
+ * THAN A HABIT. The block's control flow is decided on flags in shared memory
+ * that thread 0 writes and all 128 threads read, so a flag read after the
+ * barrier that published it is still racing the NEXT write of it: thread 0 is
+ * free to run ahead the moment a barrier releases, and a lagging warp then
+ * reads the following block's `last_block` or the following call's `status`.
+ * What that produces is not a wrong byte but a SPLIT BLOCK - some warps break
+ * out of the loop or return while the others go on - and from there the
+ * barriers below are reached by a subset of the block. Measured on this
+ * kernel before the rule was applied: a legal two-block frame answered
+ * CUDEC_OK with bytes_written set and 380 of its 1024 bytes never written by
+ * anybody, because three of four warps had left. The barrier in front of each
+ * thread-0 section is what stops the writer from moving until every reader is
+ * done with the previous value, and tests/CMakeLists.txt refuses a section in
+ * this file that does not have one.
+ *
  * FAIL-CLOSED, WITH THE BOUNDS THE UNITS ALREADY CARRY. Every write is
  * bounded before it happens by the frame's declared content size, which is
  * bounded by the caller's capacity before the first block runs. On any
@@ -409,6 +425,7 @@ __device__ inline void ZstdDecodeFrameDevice(ZstdFrameShared* frame,
                                              const unsigned char* src,
                                              uint64_t size, unsigned char* dst,
                                              uint64_t capacity) {
+    __syncthreads();
     if (threadIdx.x == 0) {
         ZstdFrameReject frame_rung = kZstdFrameRejectNone;
         frame->produced = 0;
@@ -442,6 +459,7 @@ __device__ inline void ZstdDecodeFrameDevice(ZstdFrameShared* frame,
      * retires. */
     const uint64_t fuel = size / 3 + 1;
     for (uint64_t step = 0; step < fuel; step++) {
+        __syncthreads();
         if (threadIdx.x == 0) {
             ZstdBlockHeader block;
             ZstdFrameReject frame_rung = kZstdFrameRejectNone;
@@ -484,6 +502,7 @@ __device__ inline void ZstdDecodeFrameDevice(ZstdFrameShared* frame,
         }
 
         if (frame->compressed) {
+            __syncthreads();
             if (threadIdx.x == 0) {
                 frame->status = ZstdDecodeCompressedBlockDevice(
                     frame, src + frame->pos + 3, frame->body_size, dst,
@@ -502,7 +521,6 @@ __device__ inline void ZstdDecodeFrameDevice(ZstdFrameShared* frame,
                           frame->copy_is_rle);
         }
         __syncthreads();
-
         if (threadIdx.x == 0) {
             frame->pos += static_cast<uint64_t>(3) + frame->body_size;
         }
@@ -512,6 +530,7 @@ __device__ inline void ZstdDecodeFrameDevice(ZstdFrameShared* frame,
         }
     }
 
+    __syncthreads();
     if (threadIdx.x == 0) {
         if (!frame->last_block) {
             /* The fuel ran out, which the bound above puts beyond every
@@ -565,6 +584,7 @@ __global__ void __launch_bounds__(kZstdBlockThreads)
         const unsigned char* src =
             static_cast<const unsigned char*>(src_ptrs[chunk]);
         unsigned char* dst = static_cast<unsigned char*>(dst_ptrs[chunk]);
+        __syncthreads();
         if (threadIdx.x == 0) {
             frame.state.literals_table.cells = frame.huf_cells;
             frame.state.literals_table.capacity = kZstdHufTableCells;
@@ -586,6 +606,7 @@ __global__ void __launch_bounds__(kZstdBlockThreads)
         ZstdDecodeFrameDevice(&frame, src, src_sizes[chunk], dst,
                               dst_caps[chunk]);
 
+        __syncthreads();
         if (threadIdx.x == 0) {
             results[chunk].status = frame.status;
             results[chunk].reserved = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3123,6 +3123,156 @@ foreach(_exempt IN LISTS _loop_rule_exempt)
   endif()
 endforeach()
 
+# Every thread-0 section in the Zstd kernel is preceded by a block barrier
+# (issue #203).
+#
+# WHAT IT REFUSES AND WHY IT IS A RULE RATHER THAN A HABIT. src/zstd_decode.cuh
+# decides the whole block's control flow on flags in shared memory that thread 0
+# writes and all 128 threads read - the block's status, whether it is a
+# Compressed block, whether it was the last one. A flag read after the barrier
+# that published it is STILL racing the next write of it: a barrier releases
+# every thread at once, thread 0 is free to run ahead into the following
+# section, and a lagging warp then reads the following block's value. What that
+# produces is not a wrong byte, it is a SPLIT BLOCK - some warps break out of
+# the loop or return while the others carry on - and every barrier after that
+# is reached by a subset of the block.
+#
+# It was measured on this kernel before the rule existed: a legal two-block
+# frame came back CUDEC_OK with bytes_written set and 380 of its 1024 bytes
+# never written by anybody, because three of four warps had left the loop an
+# iteration early. A second instance leaked across chunks, so a hostile frame
+# corrupted an honest one sharing its block and the honest one was still
+# reported as a success.
+#
+# THE ORACLE DIFF CANNOT SEE THIS AND NEITHER CAN A SECOND RUN OF IT. The test
+# in tests/zstd_device.cu asserts on the schedule the hardware happened to give,
+# and the schedule that exposes the race is legal but rare; racecheck, which
+# would see it directly, cannot attach to a device on this host (#127, #258).
+# So the guard is over the SOURCE - the barrier in front of each thread-0
+# section is what stops the writer moving until every reader is done with the
+# previous value, and its absence is decidable by reading the file.
+#
+# WHAT IT DOES NOT CATCH, said rather than left to be discovered. It is a
+# textual rule over one file: it counts thread-0 sections and counts the ones
+# whose immediately preceding line is a barrier, and a mismatch is the refusal.
+# It says nothing about a shared flag read and rewritten inside a single
+# section, nothing about the other kernels, and nothing about whether the
+# barriers that ARE there are the right ones. It is a floor under one defect
+# class, not a proof of barrier discipline.
+function(cudec_check_thread_zero_barriers path out_violations)
+  set(_violations "")
+  if(NOT EXISTS "${path}")
+    string(APPEND _violations
+           "  ${path}: the file this rule is written against does not exist\n")
+    set(${out_violations} "${_violations}" PARENT_SCOPE)
+    return()
+  endif()
+  file(READ "${path}" _text)
+  # The semicolon is protected for the reason cudec_scan_source protects it:
+  # it separates list elements, so a match carrying one would be counted twice
+  # by list(LENGTH) and the two counts below would stop meaning what they say.
+  # The placeholder is a control byte, which no source in this tree carries.
+  string(ASCII 2 _tok_semi)
+  if(_text MATCHES "${_tok_semi}")
+    string(APPEND _violations
+           "  ${path}: a control byte (0x02) in a source read as text - this "
+           "check cannot tell one from its own line markers, so the file is "
+           "refused rather than scanned\n")
+    set(${out_violations} "${_violations}" PARENT_SCOPE)
+    return()
+  endif()
+  string(REPLACE "\r\n" "\n" _text "${_text}")
+  string(REPLACE ";" "${_tok_semi}" _text "${_text}")
+  set(_section "if[ \t]*\\([ \t]*threadIdx\\.x[ \t]*==[ \t]*0[ \t]*\\)[ \t]*{")
+  set(_barrier "__syncthreads\\([ \t]*\\)[ \t]*${_tok_semi}[ \t]*\n[ \t]*")
+  string(REGEX MATCHALL "${_section}" _all "${_text}")
+  string(REGEX MATCHALL "${_barrier}${_section}" _guarded "${_text}")
+  list(LENGTH _all _n_all)
+  list(LENGTH _guarded _n_guarded)
+  if(_n_all EQUAL 0)
+    # A rule that matched nothing reports the same silence as a rule that
+    # matched everything and was satisfied, which is the failure this whole
+    # file's probes exist against.
+    string(APPEND _violations
+           "  ${path}: no `if (threadIdx.x == 0) {` section found at all - "
+           "this rule cannot be vacuously satisfied, so it refuses rather "
+           "than passing over a file it did not understand\n")
+  elseif(NOT _n_all EQUAL _n_guarded)
+    math(EXPR _missing "${_n_all} - ${_n_guarded}")
+    string(APPEND _violations
+           "  ${path}: ${_missing} of ${_n_all} `if (threadIdx.x == 0) {` "
+           "sections are not immediately preceded by `__syncthreads();` - "
+           "thread 0 may reach the write before every thread has read the "
+           "previous value, which splits the block (issue #203)\n")
+  endif()
+  set(${out_violations} "${_violations}" PARENT_SCOPE)
+endfunction()
+
+# The refusal proven to bite, in both directions, on files this file writes:
+# one section with its barrier must come back silent, the same section without
+# it must be refused by name, and a file with no section at all must be refused
+# rather than passed.
+set(_barrier_probe_dir ${CMAKE_CURRENT_BINARY_DIR}/probes/zstd_barriers)
+file(MAKE_DIRECTORY ${_barrier_probe_dir})
+file(
+  WRITE ${_barrier_probe_dir}/guarded.cu
+  "__global__ void probe(int* p) {\n"
+  "    __shared__ int flag;\n"
+  "    __syncthreads();\n"
+  "    if (threadIdx.x == 0) {\n"
+  "        flag = p[0];\n"
+  "    }\n"
+  "    __syncthreads();\n"
+  "    p[1] = flag;\n"
+  "}\n")
+file(
+  WRITE ${_barrier_probe_dir}/unguarded.cu
+  "__global__ void probe(int* p) {\n"
+  "    __shared__ int flag;\n"
+  "    if (threadIdx.x == 0) {\n"
+  "        flag = p[0];\n"
+  "    }\n"
+  "    __syncthreads();\n"
+  "    p[1] = flag;\n"
+  "}\n")
+file(WRITE ${_barrier_probe_dir}/empty.cu
+     "__global__ void probe(int* p) { p[0] = 0; }\n")
+cudec_check_thread_zero_barriers(${_barrier_probe_dir}/guarded.cu
+                                 _barrier_probe_guarded)
+if(_barrier_probe_guarded)
+  message(
+    FATAL_ERROR
+      "the thread-0 barrier rule rejects a compliant probe (issue #203). It "
+      "reported:\n${_barrier_probe_guarded}")
+endif()
+cudec_check_thread_zero_barriers(${_barrier_probe_dir}/unguarded.cu
+                                 _barrier_probe_unguarded)
+string(FIND "${_barrier_probe_unguarded}" "1 of 1" _barrier_probe_found)
+if(_barrier_probe_found LESS 0)
+  message(
+    FATAL_ERROR
+      "the thread-0 barrier rule does not refuse a section with no barrier in "
+      "front of it, so it proves nothing about src/zstd_decode.cuh (issue "
+      "#203). It reported:\n${_barrier_probe_unguarded}")
+endif()
+cudec_check_thread_zero_barriers(${_barrier_probe_dir}/empty.cu
+                                 _barrier_probe_empty)
+string(FIND "${_barrier_probe_empty}" "vacuously" _barrier_probe_vacuous)
+if(_barrier_probe_vacuous LESS 0)
+  message(
+    FATAL_ERROR
+      "the thread-0 barrier rule passes a file carrying no section at all, so "
+      "a rename would silently retire it (issue #203). It reported:\n"
+      "${_barrier_probe_empty}")
+endif()
+
+cudec_check_thread_zero_barriers(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src/zstd_decode.cuh _zstd_barrier_violations)
+if(_zstd_barrier_violations)
+  message(FATAL_ERROR "thread-0 sections without a barrier in front of them "
+                      "(issue #203):\n${_zstd_barrier_violations}")
+endif()
+
 set(_structural_violations "")
 foreach(_source IN LISTS _all_sources)
   set(_check_loops TRUE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -482,6 +482,27 @@ cudec_add_test(zstd_tile_dependency SOURCES zstd_tile_dependency.cpp
                zstd_corpus.cpp LIBS zstd_full)
 target_include_directories(zstd_tile_dependency
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The Zstd kernel on the device (issue #203): the pinned compressor makes the
+# frames, every frame goes through the batch entry into a poisoned
+# destination, and the answer is held to what the pinned decompressor says the
+# frame means. GPU-labelled: it drives the shipped kernel.
+#
+# The corpus reaches it through a static library rather than through a source
+# listed beside the .cu, and that is the rule at the top of this file rather
+# than a preference: zstd_full carries the reference's include directory
+# PUBLIC, so naming it on a target holding a .cu would put <zstd.h> on nvcc's
+# command line. The library takes that link PRIVATE and hands the test the
+# corpus header alone, which is the shape cudec_test_fixtures already uses for
+# the same reason.
+if(NOT CUDEC_SANITIZE)
+  add_library(cudec_zstd_corpus STATIC zstd_corpus.cpp)
+  target_link_libraries(cudec_zstd_corpus PRIVATE zstd_full)
+  target_include_directories(cudec_zstd_corpus PUBLIC .)
+  set_target_properties(cudec_zstd_corpus PROPERTIES CXX_STANDARD 17
+                                                     CXX_STANDARD_REQUIRED ON)
+  target_compile_options(cudec_zstd_corpus PRIVATE -O2)
+endif()
+cudec_add_test(zstd_device SOURCES zstd_device.cu GPU LIBS cudec_zstd_corpus)
 cudec_add_test(parser_twin SOURCES parser_twin.cpp LIBS cudec_test_fixtures)
 # The twin compiles the decoder core from src/ on the host - the
 # fail-closed ladder runs on the GPU-less CI runner (masterplan section 9,

--- a/tests/conformance_c.c
+++ b/tests/conformance_c.c
@@ -5,11 +5,10 @@
  * fallback, which no other translation unit compiles.
  *
  * Every path exercised here returns synchronously without making a CUDA
- * call (see cudec.h): the documented argument rejects, and the one
- * documented ACCEPT that answers CUDEC_ERR_NOT_IMPLEMENTED because this
- * build carries no GDeflate kernel. So this test runs green on the
- * GPU-less CI runner - the pointers below are host memory and are never
- * dereferenced. */
+ * call (see cudec.h): the documented argument rejects, and nothing else.
+ * Every batch entry now has a kernel behind it, so no accepted batch is
+ * called here at all. So this test runs green on the GPU-less CI runner -
+ * the pointers below are host memory and are never dereferenced. */
 #include "cudec.h"
 
 #include <stdint.h>
@@ -138,10 +137,10 @@ int main(void) {
      * symbol and the eight reject classes above did not move, and
      * tests/launch_fail.cpp holds the launch half on a GPU-less process. */
 
-    /* The same nine classes on the Zstd entry (issue #427), written out call
-     * for call for the reason the two blocks above are: a future entry wired
-     * to its own validator, or to none, would pass a test that only counted
-     * on the sharing. */
+    /* The same eight classes on the Zstd entry (issues #427, #203), written
+     * out call for call for the reason the two blocks above are: a future
+     * entry wired to its own validator, or to none, would pass a test that
+     * only counted on the sharing. */
     REQUIRE(cudec_zstd_decompress_batch(0, sizes, dsts, caps, 1, aligned,
                                         0) == CUDEC_ERR_INVALID_ARGUMENT);
     REQUIRE(cudec_zstd_decompress_batch(srcs, 0, dsts, caps, 1, aligned,
@@ -159,8 +158,12 @@ int main(void) {
     REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, SIZE_MAX,
                                         aligned,
                                         0) == CUDEC_ERR_INVALID_ARGUMENT);
-    REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, aligned,
-                                        0) == CUDEC_ERR_NOT_IMPLEMENTED);
+
+    /* The ninth class this entry carried while it had no kernel is gone with
+     * the kernel (issue #203), and no call replaces it here for the reason
+     * the GDeflate block above gives: an accepted batch now reaches a launch,
+     * and these are host pointers this GPU-less test must never hand to one.
+     */
 
     /* The frame entry point resolves its own C linkage here. Every call
      * below is a documented argument reject that returns before any CUDA

--- a/tests/launch_fail.cpp
+++ b/tests/launch_fail.cpp
@@ -65,20 +65,19 @@ int main() {
     REQUIRE(cudec_gdeflate_decompress_batch(srcs, sizes, dsts, caps, 1,
                                             results, nullptr) == CUDEC_ERR_CUDA);
 
-    /* The Zstd entry, the same opposite assertion and for the same reason
-     * (issue #427). Written out rather than folded into a loop over the two
-     * not-implemented entries: what this file is for is the point where two
-     * entries stop being the same code, and a loop would assume they are. */
+    /* The Zstd entry, which flipped the same way on the day its own kernel
+     * landed (issues #427, #203). Written out rather than folded into a loop
+     * over the four: what this file is for is the point where two entries
+     * stop being the same code, and a loop would assume they are. */
     REQUIRE(cudec_zstd_decompress_batch(nullptr, sizes, dsts, caps, 1, results,
                                         nullptr) ==
             CUDEC_ERR_INVALID_ARGUMENT);
     REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, results,
-                                        nullptr) == CUDEC_ERR_NOT_IMPLEMENTED);
+                                        nullptr) == CUDEC_ERR_CUDA);
     REQUIRE(cudec_zstd_decompress_batch(srcs, sizes, dsts, caps, 1, results,
-                                        nullptr) == CUDEC_ERR_NOT_IMPLEMENTED);
+                                        nullptr) == CUDEC_ERR_CUDA);
 
-    std::printf("PASS: with zero visible devices the three kernel-backed batch "
-                "entries report CUDEC_ERR_CUDA and the Zstd entry reports "
-                "CUDEC_ERR_NOT_IMPLEMENTED\n");
+    std::printf("PASS: with zero visible devices all four batch entries "
+                "report CUDEC_ERR_CUDA on a batch that passes validation\n");
     return 0;
 }

--- a/tests/zstd_device.cu
+++ b/tests/zstd_device.cu
@@ -1,0 +1,464 @@
+/* The Zstd block-per-frame kernel against the oracle (issue #203). The
+ * pinned compressor produces the frames, the pinned decompressor says what
+ * they mean, and every frame goes through cudec_zstd_decompress_batch on the
+ * device into a poisoned destination: the bytes must equal what libzstd
+ * decodes, bytes_written must equal that length, and the poison past
+ * bytes_written must survive.
+ *
+ * WHAT IS AND IS NOT HERE. The #185 corpus, which is built to reach every
+ * decode surface the subset admits, plus the batch geometry the entry
+ * actually consumes - one source cut into many independent frames, all of
+ * them in one launch. The census below is REQUIRED rather than reported: a
+ * corpus that decodes byte-identically proves nothing about a surface it
+ * never reached, so a generator that stops emitting Treeless literals or a
+ * Repeat table mode reds here instead of costing that arm its coverage in
+ * silence.
+ *
+ * The standing device gate set - same-batch-twice determinism, the
+ * two-directional mutant reject parity against libzstd, and the capacity and
+ * window adversarials - is #399 and is deliberately not restated here.
+ * Nothing here is timed. */
+#include "cudec.h"
+#include "require.h"
+#include "zstd_corpus.h"
+
+#include "vendor_rt_test.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Bytes = std::vector<unsigned char>;
+
+constexpr unsigned char kDstPoison = 0xA5;
+/* Slack past the declared content size, so the poison beyond bytes_written
+ * has somewhere to survive. */
+constexpr size_t kCapacitySlack = 96;
+
+struct Chunk {
+    const Bytes* src;
+    size_t dst_capacity;
+};
+
+/* One batch through the real plumbing: device pointer tables, per-frame sizes
+ * and capacities, poisoned destinations, and the results primed with a non-OK
+ * sentinel so an entry the kernel never wrote reads as a failure. */
+int RunBatch(const std::vector<Chunk>& chunks,
+             std::vector<cudec_chunk_result>* results,
+             std::vector<Bytes>* dst_bytes) {
+    const size_t n = chunks.size();
+    std::vector<const void*> h_srcs(n);
+    std::vector<void*> h_dsts(n);
+    std::vector<size_t> h_sizes(n);
+    std::vector<size_t> h_caps(n);
+    for (size_t i = 0; i < n; i++) {
+        void* d_src = nullptr;
+        void* d_dst = nullptr;
+        const size_t src_size = chunks[i].src->size();
+        REQUIRE_RT(cudec_rt::device_malloc(&d_src, src_size ? src_size : 1));
+        if (src_size) {
+            REQUIRE_RT(cudec_rt::memcpy(d_src, chunks[i].src->data(), src_size,
+                                        cudec_rt::memcpy_h2d));
+        }
+        const size_t cap = chunks[i].dst_capacity;
+        REQUIRE_RT(cudec_rt::device_malloc(&d_dst, cap ? cap : 1));
+        if (cap) {
+            REQUIRE_RT(cudec_rt::device_memset(d_dst, kDstPoison, cap));
+        }
+        h_srcs[i] = d_src;
+        h_dsts[i] = d_dst;
+        h_sizes[i] = src_size;
+        h_caps[i] = cap;
+    }
+    const void** d_srcs;
+    void** d_dsts;
+    size_t* d_sizes;
+    size_t* d_caps;
+    cudec_chunk_result* d_results;
+    REQUIRE_RT(cudec_rt::device_malloc(&d_srcs, n * sizeof(*d_srcs)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_dsts, n * sizeof(*d_dsts)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_sizes, n * sizeof(*d_sizes)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_caps, n * sizeof(*d_caps)));
+    REQUIRE_RT(cudec_rt::device_malloc(&d_results, n * sizeof(*d_results)));
+    REQUIRE_RT(cudec_rt::memcpy(d_srcs, h_srcs.data(), n * sizeof(*d_srcs),
+                                cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_dsts, h_dsts.data(), n * sizeof(*d_dsts),
+                                cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_sizes, h_sizes.data(), n * sizeof(*d_sizes),
+                                cudec_rt::memcpy_h2d));
+    REQUIRE_RT(cudec_rt::memcpy(d_caps, h_caps.data(), n * sizeof(*d_caps),
+                                cudec_rt::memcpy_h2d));
+    REQUIRE_RT(
+        cudec_rt::device_memset(d_results, 0xFF, n * sizeof(*d_results)));
+
+    cudec_rt::stream_t stream;
+    REQUIRE_RT(cudec_rt::stream_create(&stream));
+    REQUIRE(cudec_zstd_decompress_batch(d_srcs, d_sizes, d_dsts, d_caps, n,
+                                        d_results,
+                                        cudec_rt::abi_stream(stream)) ==
+            CUDEC_OK);
+    REQUIRE_RT(cudec_rt::stream_synchronize(stream));
+    REQUIRE_RT(cudec_rt::stream_destroy(stream));
+
+    results->assign(n, cudec_chunk_result{});
+    REQUIRE_RT(cudec_rt::memcpy(results->data(), d_results,
+                                n * sizeof(*d_results), cudec_rt::memcpy_d2h));
+    dst_bytes->assign(n, Bytes());
+    for (size_t i = 0; i < n; i++) {
+        (*dst_bytes)[i].assign(h_caps[i], 0);
+        if (h_caps[i]) {
+            REQUIRE_RT(cudec_rt::memcpy((*dst_bytes)[i].data(), h_dsts[i],
+                                        h_caps[i], cudec_rt::memcpy_d2h));
+        }
+        REQUIRE_RT(cudec_rt::device_free(h_dsts[i]));
+        REQUIRE_RT(cudec_rt::device_free(const_cast<void*>(h_srcs[i])));
+    }
+    REQUIRE_RT(cudec_rt::device_free(d_srcs));
+    REQUIRE_RT(cudec_rt::device_free(d_dsts));
+    REQUIRE_RT(cudec_rt::device_free(d_sizes));
+    REQUIRE_RT(cudec_rt::device_free(d_caps));
+    REQUIRE_RT(cudec_rt::device_free(d_results));
+    return 0;
+}
+
+/* One frame's decode held to the oracle's: the length, the bytes, and the
+ * poison the kernel had no business touching. */
+int CheckDecode(const char* name, const cudec_chunk_result& result,
+                const Bytes& produced, const Bytes& expected) {
+    REQUIRE_CTX(result.status == CUDEC_OK, "%s: status %d", name,
+                static_cast<int>(result.status));
+    REQUIRE_CTX(result.bytes_written == expected.size(),
+                "%s: wrote %llu bytes, the oracle produced %llu", name,
+                static_cast<unsigned long long>(result.bytes_written),
+                static_cast<unsigned long long>(expected.size()));
+    REQUIRE_CTX(produced.size() >= expected.size() + kCapacitySlack,
+                "%s: destination readback is short", name);
+    for (size_t i = 0; i < expected.size(); i++) {
+        REQUIRE_CTX(produced[i] == expected[i],
+                    "%s: byte %llu is 0x%02X, the oracle says 0x%02X", name,
+                    static_cast<unsigned long long>(i),
+                    static_cast<unsigned>(produced[i]),
+                    static_cast<unsigned>(expected[i]));
+    }
+    for (size_t i = expected.size(); i < produced.size(); i++) {
+        REQUIRE_CTX(produced[i] == kDstPoison,
+                    "%s: byte %llu past bytes_written is 0x%02X, not the "
+                    "poison",
+                    name, static_cast<unsigned long long>(i),
+                    static_cast<unsigned>(produced[i]));
+    }
+    return 0;
+}
+
+/* What the corpus actually reached, counted off the frame walker rather than
+ * off what the generator was asked for. */
+struct Census {
+    unsigned literals[4];
+    unsigned modes[4];
+    unsigned block_types[3];
+    unsigned four_stream;
+    unsigned single_stream;
+    unsigned checksummed;
+    unsigned multi_block;
+};
+
+void CountFrame(const ZstdFrameShape& shape, Census* census) {
+    if (shape.checksum_present) {
+        census->checksummed++;
+    }
+    if (shape.blocks.size() > 1) {
+        census->multi_block++;
+    }
+    for (size_t i = 0; i < shape.blocks.size(); i++) {
+        const ZstdBlockShape& block = shape.blocks[i];
+        if (block.block_type < 3) {
+            census->block_types[block.block_type]++;
+        }
+        if (block.block_type != kZstdBlockCompressed) {
+            continue;
+        }
+        if (block.literals_type < 4) {
+            census->literals[block.literals_type]++;
+        }
+        if (block.literals_streams == 4) {
+            census->four_stream++;
+        } else if (block.literals_streams == 1) {
+            census->single_stream++;
+        }
+        if (block.sequence_count == 0) {
+            continue;
+        }
+        const unsigned modes[3] = {block.ll_mode, block.of_mode,
+                                   block.ml_mode};
+        for (unsigned m = 0; m < 3; m++) {
+            if (modes[m] < 4) {
+                census->modes[modes[m]]++;
+            }
+        }
+    }
+}
+
+/* ---- The corpus rung ---------------------------------------------------- */
+
+int RunCorpus(Census* census) {
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    REQUIRE(!fixtures.empty());
+
+    std::vector<Chunk> chunks;
+    std::vector<Bytes> frames;
+    std::vector<Bytes> expected;
+    std::vector<std::string> names;
+    frames.reserve(fixtures.size());
+    expected.reserve(fixtures.size());
+    for (size_t i = 0; i < fixtures.size(); i++) {
+        Bytes reference;
+        const Bytes frame(fixtures[i].compressed.begin(),
+                          fixtures[i].compressed.end());
+        REQUIRE_CTX(ZstdOracleDecodes(frame, &reference),
+                    "%s: the oracle refused a fixture it produced",
+                    fixtures[i].name.c_str());
+        frames.push_back(frame);
+        expected.push_back(reference);
+        names.push_back(fixtures[i].name);
+    }
+    for (size_t i = 0; i < frames.size(); i++) {
+        Chunk chunk;
+        chunk.src = &frames[i];
+        chunk.dst_capacity = expected[i].size() + kCapacitySlack;
+        chunks.push_back(chunk);
+    }
+
+    std::vector<cudec_chunk_result> results;
+    std::vector<Bytes> produced;
+    if (RunBatch(chunks, &results, &produced) != 0) {
+        return 1;
+    }
+
+    unsigned decoded = 0;
+    unsigned declined = 0;
+    for (size_t i = 0; i < frames.size(); i++) {
+        if (results[i].status == CUDEC_ERR_UNSUPPORTED) {
+            /* A fixture outside the v1 subset is declined rather than
+             * refused, and declining is not this file's subject. */
+            REQUIRE_CTX(results[i].bytes_written == 0,
+                        "%s: declined and still reported bytes",
+                        names[i].c_str());
+            std::printf("corpus: declined %s\n", names[i].c_str());
+            declined++;
+            continue;
+        }
+        if (CheckDecode(names[i].c_str(), results[i], produced[i],
+                        expected[i]) != 0) {
+            return 1;
+        }
+        decoded++;
+        ZstdFrameShape shape;
+        std::string why;
+        REQUIRE_CTX(ParseZstdFrameShape(frames[i], &shape, &why),
+                    "%s: the frame walker could not account for a frame the "
+                    "kernel decoded: %s",
+                    names[i].c_str(), why.c_str());
+        CountFrame(shape, census);
+    }
+    std::printf("corpus: %u frames decoded byte-identically, %u declined\n",
+                decoded, declined);
+    REQUIRE(decoded > 0);
+    return 0;
+}
+
+/* ---- The surfaces the pinned compressor will not emit ------------------- */
+
+/* An RLE literals section inside the accepted envelope.
+ *
+ * WHY IT IS BUILT HERE AND NOT TAKEN FROM THE CORPUS. The corpus already
+ * carries one, and it is declined rather than decoded: its frame header
+ * declares no content size, which section 12.2 puts outside the subset, so
+ * the fixture proves the section legal and leaves the kernel's RLE arm
+ * unrun. tests/zstd_corpus.cpp records why no compressor emits this section
+ * at all - the sources that make every literal identical also make the run
+ * matchable - so a compressed corpus cannot supply one at any level.
+ *
+ * The frame: magic, a descriptor with Single_Segment set (which is what
+ * makes Frame_Content_Size present and the window the content size), the
+ * one-byte content size, then one last Compressed block of three bytes - the
+ * Literals_Section_Header for RLE with Size_Format 00 and Regenerated_Size
+ * 20, the repeated byte, and Number_Of_Sequences 0.
+ *
+ * The oracle round-trip below is what says this is a legal frame rather than
+ * a plausible one; the kernel is never held to bytes only this file
+ * believes. */
+int RunHandBuilt(Census* census) {
+    const unsigned char kRegenerated = 20;
+    Bytes frame;
+    frame.push_back(0x28);
+    frame.push_back(0xB5);
+    frame.push_back(0x2F);
+    frame.push_back(0xFD);
+    frame.push_back(0x20);
+    frame.push_back(kRegenerated);
+    /* Block_Header: Last_Block, Block_Type Compressed, Block_Size 3. */
+    frame.push_back(0x1D);
+    frame.push_back(0x00);
+    frame.push_back(0x00);
+    frame.push_back(
+        static_cast<unsigned char>(kZstdLiteralsRle | (kRegenerated << 3)));
+    frame.push_back('z');
+    frame.push_back(0x00);
+
+    Bytes expected;
+    REQUIRE_CTX(ZstdOracleDecodes(frame, &expected),
+                "literals-rle-in-subset: the reference refused the frame this "
+                "test hand-built, so it is not a legal frame to hold the "
+                "kernel to");
+    REQUIRE(expected.size() == kRegenerated);
+
+    std::vector<Chunk> chunks;
+    Chunk chunk;
+    chunk.src = &frame;
+    chunk.dst_capacity = expected.size() + kCapacitySlack;
+    chunks.push_back(chunk);
+
+    std::vector<cudec_chunk_result> results;
+    std::vector<Bytes> produced;
+    if (RunBatch(chunks, &results, &produced) != 0) {
+        return 1;
+    }
+    if (CheckDecode("literals-rle-in-subset", results[0], produced[0],
+                    expected) != 0) {
+        return 1;
+    }
+    ZstdFrameShape shape;
+    std::string why;
+    REQUIRE_CTX(ParseZstdFrameShape(frame, &shape, &why),
+                "literals-rle-in-subset: the frame walker could not account "
+                "for it: %s",
+                why.c_str());
+    CountFrame(shape, census);
+    std::printf("hand-built: one RLE literals section in the subset\n");
+    return 0;
+}
+
+/* ---- The batch rung ----------------------------------------------------- */
+
+/* The geometry the entry actually consumes: one source cut at a fixed size,
+ * every chunk its own independent frame, all of them in ONE launch. It is a
+ * different question from the corpus above - that one asks whether a frame
+ * decodes, this one asks whether many frames decode side by side without
+ * reading each other's shared memory or each other's destination. */
+int RunBatchGeometry(size_t chunk_size, int level) {
+    Bytes source;
+    /* A deterministic mixed-entropy source: literal runs the compressor can
+     * match, punctuated by bytes it cannot, so the frames carry both
+     * sequences and incompressible literals rather than one shape. */
+    unsigned state = 0x1234567u;
+    for (size_t i = 0; i < 512u * 1024u; i++) {
+        state = state * 1103515245u + 12345u;
+        const unsigned r = (state >> 16) & 0xFFFFu;
+        source.push_back(static_cast<unsigned char>(
+            (r % 5u == 0u) ? (r & 0xFFu) : ('a' + (r % 7u))));
+    }
+    const std::vector<Bytes> frames =
+        MakeZstdBatchFrames(source, chunk_size, level);
+    REQUIRE(!frames.empty());
+
+    std::vector<Bytes> expected(frames.size());
+    std::vector<Chunk> chunks;
+    for (size_t i = 0; i < frames.size(); i++) {
+        REQUIRE(ZstdOracleDecodes(frames[i], &expected[i]));
+        Chunk chunk;
+        chunk.src = &frames[i];
+        chunk.dst_capacity = expected[i].size() + kCapacitySlack;
+        chunks.push_back(chunk);
+    }
+
+    std::vector<cudec_chunk_result> results;
+    std::vector<Bytes> produced;
+    if (RunBatch(chunks, &results, &produced) != 0) {
+        return 1;
+    }
+    Bytes rejoined;
+    for (size_t i = 0; i < frames.size(); i++) {
+        char name[64];
+        std::snprintf(name, sizeof(name), "batch %llu chunk %llu",
+                      static_cast<unsigned long long>(chunk_size),
+                      static_cast<unsigned long long>(i));
+        if (CheckDecode(name, results[i], produced[i], expected[i]) != 0) {
+            return 1;
+        }
+        rejoined.insert(rejoined.end(), expected[i].begin(), expected[i].end());
+    }
+    /* The cut and the rejoin are the caller's contract, so the batch is held
+     * to reproducing the source it was cut from rather than only to each
+     * frame's own oracle answer. */
+    REQUIRE(rejoined.size() == source.size());
+    REQUIRE(std::memcmp(rejoined.data(), source.data(), source.size()) == 0);
+    std::printf("batch: %llu frames at a chunk size of %llu, level %d\n",
+                static_cast<unsigned long long>(frames.size()),
+                static_cast<unsigned long long>(chunk_size), level);
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    Census census;
+    std::memset(&census, 0, sizeof(census));
+
+    if (RunCorpus(&census) != 0) {
+        return 1;
+    }
+    if (RunHandBuilt(&census) != 0) {
+        return 1;
+    }
+    if (RunBatchGeometry(64u * 1024u, 3) != 0) {
+        return 1;
+    }
+    if (RunBatchGeometry(200u * 1024u, 9) != 0) {
+        return 1;
+    }
+
+    std::printf(
+        "census: the Zstd kernel decoded a corpus carrying "
+        "libzstd - blocks raw/rle/compressed %u/%u/%u, literals "
+        "raw/rle/compressed/treeless %u/%u/%u/%u, table modes "
+        "basic/rle/compressed/repeat %u/%u/%u/%u, %u four-stream and %u "
+        "single-stream literals sections, %u checksummed frames, %u frames "
+        "of more than one block\n",
+        census.block_types[kZstdBlockRaw], census.block_types[kZstdBlockRle],
+        census.block_types[kZstdBlockCompressed],
+        census.literals[kZstdLiteralsRaw], census.literals[kZstdLiteralsRle],
+        census.literals[kZstdLiteralsCompressed],
+        census.literals[kZstdLiteralsTreeless],
+        census.modes[kZstdTableBasic], census.modes[kZstdTableRle],
+        census.modes[kZstdTableCompressed], census.modes[kZstdTableRepeat],
+        census.four_stream, census.single_stream, census.checksummed,
+        census.multi_block);
+
+    /* The surfaces the decoded corpus actually carried. Required, not
+     * reported: without this a generator that quietly stopped emitting one of
+     * them would leave this file green and that arm of the kernel unrun. */
+    REQUIRE(census.block_types[kZstdBlockRaw] > 0);
+    REQUIRE(census.block_types[kZstdBlockRle] > 0);
+    REQUIRE(census.block_types[kZstdBlockCompressed] > 0);
+    REQUIRE(census.literals[kZstdLiteralsRaw] > 0);
+    REQUIRE(census.literals[kZstdLiteralsRle] > 0);
+    REQUIRE(census.literals[kZstdLiteralsCompressed] > 0);
+    REQUIRE(census.literals[kZstdLiteralsTreeless] > 0);
+    REQUIRE(census.modes[kZstdTableBasic] > 0);
+    REQUIRE(census.modes[kZstdTableRle] > 0);
+    REQUIRE(census.modes[kZstdTableCompressed] > 0);
+    REQUIRE(census.modes[kZstdTableRepeat] > 0);
+    REQUIRE(census.four_stream > 0);
+    REQUIRE(census.single_stream > 0);
+    REQUIRE(census.checksummed > 0);
+    REQUIRE(census.multi_block > 0);
+
+    std::printf(
+        "PASS: every frame of the Zstd corpus and of the batch geometry "
+        "decodes on the device byte-identically to the pinned reference, "
+        "with the poison past bytes_written intact\n");
+    return 0;
+}

--- a/tests/zstd_device.cu
+++ b/tests/zstd_device.cu
@@ -20,6 +20,8 @@
  * Nothing here is timed. */
 #include "cudec.h"
 #include "require.h"
+#include "xxhash64.h"
+#include "zstd_blocks.h"
 #include "zstd_corpus.h"
 
 #include "vendor_rt_test.h"
@@ -37,6 +39,10 @@ constexpr unsigned char kDstPoison = 0xA5;
 /* Slack past the declared content size, so the poison beyond bytes_written
  * has somewhere to survive. */
 constexpr size_t kCapacitySlack = 96;
+/* The format's own ceiling on a block's sequence count - every sequence emits
+ * at least a three-byte match, so a 128 KiB block holds no more - given to the
+ * host harness below so its storage rung is never the one that fires. */
+constexpr uint32_t kHostSequenceCapacity = 43690;
 
 struct Chunk {
     const Bytes* src;
@@ -269,6 +275,306 @@ int RunCorpus(Census* census) {
     return 0;
 }
 
+/* ---- The reject rungs this kernel introduces, held to the host twin ----- */
+
+/* WHAT THIS IS AND WHAT IT IS NOT. The standing device gate set - determinism,
+ * the two-directional mutant reject parity over the whole corpus, and the
+ * capacity and window adversarials - is #399 and none of it is here. What is
+ * here is narrower and belongs to this landing: the kernel's own walk carries
+ * refusals the host loop makes somewhere else, because the literals are staged
+ * in the destination and the sequences are executed a tile at a time, and each
+ * of those refusals has to answer with the CLASS the twin answers on the same
+ * bytes. A class that diverges is not cosmetic - CUDEC_ERR_OUTPUT_TOO_SMALL
+ * invites a caller to retry with a bigger buffer and CUDEC_ERR_CORRUPT_INPUT
+ * does not - and it was a divergence in exactly these rungs that the review of
+ * this branch found.
+ *
+ * The verdict comes from src/zstd_blocks.h run on the host over the same
+ * bytes, never from a status written down here. */
+struct HostHarness {
+    std::vector<cudec_detail::ZstdHufCell> huf;
+    std::vector<cudec_detail::ZstdFseCell> litlen;
+    std::vector<cudec_detail::ZstdFseCell> matchlen;
+    std::vector<cudec_detail::ZstdFseCell> offset;
+    cudec_detail::ZstdLiteralsScratch literals_scratch;
+    cudec_detail::ZstdSeqScratch seq_scratch;
+    Bytes literals;
+    std::vector<cudec_detail::ZstdSequence> sequences;
+    std::vector<uint64_t> offsets;
+    std::vector<uint64_t> destinations;
+    cudec_detail::ZstdFrameState state;
+
+    HostHarness()
+        : huf(1u << cudec_detail::kZstdLiteralsMaxTableLog),
+          litlen(1u << cudec_detail::kZstdLitLenAccuracyLogMax),
+          matchlen(1u << cudec_detail::kZstdMatchLenAccuracyLogMax),
+          offset(1u << cudec_detail::kZstdOffsetAccuracyLogMax),
+          literals(cudec_detail::kZstdBlockSizeCeiling),
+          /* The format's own ceiling on a block's sequence count, so the
+           * loop's storage rung is never the one that fires and the classes
+           * being compared are the ones this test is about. */
+          sequences(kHostSequenceCapacity),
+          offsets(kHostSequenceCapacity),
+          destinations(kHostSequenceCapacity + 1) {
+        state.literals_table.cells = huf.data();
+        state.literals_table.capacity = static_cast<uint32_t>(huf.size());
+        state.litlen.cells = litlen.data();
+        state.litlen.capacity = static_cast<uint32_t>(litlen.size());
+        state.matchlen.cells = matchlen.data();
+        state.matchlen.capacity = static_cast<uint32_t>(matchlen.size());
+        state.offset.cells = offset.data();
+        state.offset.capacity = static_cast<uint32_t>(offset.size());
+        state.literals_scratch = &literals_scratch;
+        state.seq_scratch = &seq_scratch;
+        state.literals = literals.data();
+        state.literals_capacity = literals.size();
+        state.sequences = sequences.data();
+        state.sequences_capacity = kHostSequenceCapacity;
+        state.offsets = offsets.data();
+        state.offsets_capacity = kHostSequenceCapacity;
+        state.destinations = destinations.data();
+        state.destinations_capacity = kHostSequenceCapacity + 1;
+        cudec_detail::ZstdFrameStateInit(&state);
+    }
+};
+
+/* The whole-frame host path, the same three steps tests/zstd_twin_driver.h
+ * walks: the frame header, the block loop, and the content checksum. */
+cudec_status HostDecode(const Bytes& frame, size_t capacity, Bytes* out) {
+    HostHarness harness;
+    cudec_detail::ZstdFrameHeader header;
+    cudec_detail::ZstdFrameReject frame_rung =
+        cudec_detail::kZstdFrameRejectNone;
+    cudec_status status = cudec_detail::ZstdParseFrameHeader(
+        frame.data(), frame.size(), &header, &frame_rung);
+    if (status != CUDEC_OK) {
+        return status;
+    }
+    if (header.frame_content_size > capacity) {
+        return CUDEC_ERR_OUTPUT_TOO_SMALL;
+    }
+    out->assign(capacity, 0);
+    uint64_t produced = 0;
+    uint64_t consumed = 0;
+    cudec_detail::ZstdBlocksReport report;
+    cudec_detail::ZstdBlocksReject blocks_rung =
+        cudec_detail::kZstdBlocksRejectNone;
+    status = cudec_detail::ZstdDecodeBlocks(
+        frame.data() + header.header_size, frame.size() - header.header_size,
+        &header, &harness.state, out->data(), header.frame_content_size,
+        &produced, &consumed, &report, &blocks_rung);
+    if (status != CUDEC_OK) {
+        return status;
+    }
+    uint64_t pos = header.header_size + consumed;
+    if (header.content_checksum) {
+        const uint64_t digest =
+            cudec_detail::Xxh64(out->data(), static_cast<size_t>(produced));
+        if (cudec_detail::ZstdVerifyContentChecksum(frame.data() + pos,
+                                                    frame.size() - pos, digest,
+                                                    &frame_rung) != CUDEC_OK) {
+            return CUDEC_ERR_CORRUPT_INPUT;
+        }
+        pos += 4;
+    }
+    if (pos != frame.size()) {
+        return CUDEC_ERR_CORRUPT_INPUT;
+    }
+    out->resize(static_cast<size_t>(produced));
+    return CUDEC_OK;
+}
+
+/* A single-segment frame header: Frame_Content_Size present and one byte
+ * wide, which is what puts the frame inside the accepted envelope and makes
+ * the window the content size. */
+void AppendSingleSegmentHeader(Bytes* frame, unsigned char content_size) {
+    frame->push_back(0x28);
+    frame->push_back(0xB5);
+    frame->push_back(0x2F);
+    frame->push_back(0xFD);
+    frame->push_back(0x20);
+    frame->push_back(content_size);
+}
+
+/* Block_Header, RFC 8878 section 3.1.1.2: Last_Block in bit 0, Block_Type in
+ * bits 1 and 2, Block_Size in the remaining 21, little-endian. */
+void AppendBlockHeader(Bytes* frame, uint32_t size, unsigned type, bool last) {
+    const uint32_t raw = (last ? 1u : 0u) | (type << 1) | (size << 3);
+    frame->push_back(static_cast<unsigned char>(raw & 0xFFu));
+    frame->push_back(static_cast<unsigned char>((raw >> 8) & 0xFFu));
+    frame->push_back(static_cast<unsigned char>((raw >> 16) & 0xFFu));
+}
+
+int RunRejectParity() {
+    struct Case {
+        const char* name;
+        Bytes frame;
+        size_t capacity;
+    };
+    std::vector<Case> cases;
+
+    /* A block whose literals section alone regenerates more than the frame
+     * declared, with the section still inside the format's block maximum.
+     * The kernel meets this before it has an address to stage the literals
+     * at; the host meets it after the literals are decoded, at the
+     * execution's destination bound. */
+    {
+        Case c;
+        c.name = "literals past the declaration, inside the block maximum";
+        /* Two blocks, because a single-segment frame's window IS its content
+         * size: with one block the two bounds coincide and the case cannot be
+         * built. A first Raw block spends most of the declaration, and the
+         * second block's literals then exceed what is left while staying
+         * inside the block maximum the window implies. */
+        AppendSingleSegmentHeader(&c.frame, 40);
+        AppendBlockHeader(&c.frame, 35, kZstdBlockRaw, false);
+        for (unsigned i = 0; i < 35; i++) {
+            c.frame.push_back(static_cast<unsigned char>('a' + (i % 26u)));
+        }
+        AppendBlockHeader(&c.frame, 3, kZstdBlockCompressed, true);
+        c.frame.push_back(
+            static_cast<unsigned char>(kZstdLiteralsRle | (30u << 3)));
+        c.frame.push_back('q');
+        c.frame.push_back(0x00);
+        c.capacity = 40 + kCapacitySlack;
+        cases.push_back(c);
+    }
+    /* The same shape with the section ALSO past the block maximum the window
+     * implies, which is the malformed answer rather than the capacity one.
+     * The two cases are next to each other on purpose: they differ in one
+     * field and they must not answer the same. */
+    {
+        Case c;
+        c.name = "literals past the block maximum";
+        AppendSingleSegmentHeader(&c.frame, 20);
+        AppendBlockHeader(&c.frame, 3, kZstdBlockCompressed, true);
+        c.frame.push_back(static_cast<unsigned char>(kZstdLiteralsRle | (60u << 3)));
+        c.frame.push_back('q');
+        c.frame.push_back(0x00);
+        c.capacity = 20 + kCapacitySlack;
+        cases.push_back(c);
+    }
+    /* A Raw block declaring more than the frame has left. */
+    {
+        Case c;
+        c.name = "raw block past the declaration";
+        AppendSingleSegmentHeader(&c.frame, 4);
+        AppendBlockHeader(&c.frame, 10, kZstdBlockRaw, true);
+        for (unsigned i = 0; i < 10; i++) {
+            c.frame.push_back(static_cast<unsigned char>('a' + i));
+        }
+        c.capacity = 64;
+        cases.push_back(c);
+    }
+    /* A frame that declares fewer bytes than its blocks produce is refused;
+     * so is one that declares more. */
+    {
+        Case c;
+        c.name = "frame produces less than it declared";
+        AppendSingleSegmentHeader(&c.frame, 20);
+        AppendBlockHeader(&c.frame, 4, kZstdBlockRaw, true);
+        for (unsigned i = 0; i < 4; i++) {
+            c.frame.push_back('r');
+        }
+        c.capacity = 20 + kCapacitySlack;
+        cases.push_back(c);
+    }
+    /* The reserved block type, which no frame may carry. */
+    {
+        Case c;
+        c.name = "reserved block type";
+        AppendSingleSegmentHeader(&c.frame, 4);
+        AppendBlockHeader(&c.frame, 4, 3, true);
+        for (unsigned i = 0; i < 4; i++) {
+            c.frame.push_back('r');
+        }
+        c.capacity = 64;
+        cases.push_back(c);
+    }
+    /* Truncated at the block body. */
+    {
+        Case c;
+        c.name = "block body truncated";
+        AppendSingleSegmentHeader(&c.frame, 8);
+        AppendBlockHeader(&c.frame, 8, kZstdBlockRaw, true);
+        c.frame.push_back('t');
+        c.capacity = 64;
+        cases.push_back(c);
+    }
+    /* Bytes after the last block, which section 12.4 refuses rather than
+     * ignores. */
+    {
+        Case c;
+        c.name = "bytes follow the frame";
+        AppendSingleSegmentHeader(&c.frame, 4);
+        AppendBlockHeader(&c.frame, 4, kZstdBlockRaw, true);
+        for (unsigned i = 0; i < 4; i++) {
+            c.frame.push_back('r');
+        }
+        c.frame.push_back(0x00);
+        c.capacity = 64;
+        cases.push_back(c);
+    }
+    /* A capacity below what the frame declares, which is the one condition
+     * on this list a larger destination really does repair. */
+    {
+        Case c;
+        c.name = "capacity below the declaration";
+        AppendSingleSegmentHeader(&c.frame, 40);
+        AppendBlockHeader(&c.frame, 40, kZstdBlockRaw, true);
+        for (unsigned i = 0; i < 40; i++) {
+            c.frame.push_back(static_cast<unsigned char>('a' + (i % 26u)));
+        }
+        c.capacity = 8;
+        cases.push_back(c);
+    }
+
+    std::vector<Chunk> chunks;
+    for (size_t i = 0; i < cases.size(); i++) {
+        Chunk chunk;
+        chunk.src = &cases[i].frame;
+        chunk.dst_capacity = cases[i].capacity;
+        chunks.push_back(chunk);
+    }
+    std::vector<cudec_chunk_result> results;
+    std::vector<Bytes> produced;
+    if (RunBatch(chunks, &results, &produced) != 0) {
+        return 1;
+    }
+
+    for (size_t i = 0; i < cases.size(); i++) {
+        Bytes host_out;
+        const cudec_status want =
+            HostDecode(cases[i].frame, cases[i].capacity, &host_out);
+        REQUIRE_CTX(want != CUDEC_OK,
+                    "%s: the host twin ACCEPTED a frame this case is built to "
+                    "have refused, so the case proves nothing",
+                    cases[i].name);
+        REQUIRE_CTX(results[i].status == want,
+                    "%s: the device answers %d and the host twin answers %d "
+                    "on the same bytes",
+                    cases[i].name, static_cast<int>(results[i].status),
+                    static_cast<int>(want));
+        REQUIRE_CTX(results[i].bytes_written == 0,
+                    "%s: refused and still reported %llu bytes",
+                    cases[i].name,
+                    static_cast<unsigned long long>(results[i].bytes_written));
+        /* The destination of a refused frame is unspecified by the ABI and
+         * is deliberately not asserted on: the kernel stages literals into it
+         * and executes tiles into it before the refusal that stops the block,
+         * and the contract's promise is bytes_written zero rather than an
+         * untouched buffer. */
+    }
+    /* The two neighbouring literals cases must not have answered the same,
+     * which is the whole reason they are both here. */
+    REQUIRE(results[0].status != results[1].status);
+    std::printf(
+        "reject parity: %llu refusals, each in the class the host twin gives, "
+        "each reporting no bytes\n",
+        static_cast<unsigned long long>(cases.size()));
+    return 0;
+}
+
 /* ---- The surfaces the pinned compressor will not emit ------------------- */
 
 /* An RLE literals section inside the accepted envelope.
@@ -413,6 +719,9 @@ int main() {
     if (RunHandBuilt(&census) != 0) {
         return 1;
     }
+    if (RunRejectParity() != 0) {
+        return 1;
+    }
     if (RunBatchGeometry(64u * 1024u, 3) != 0) {
         return 1;
     }
@@ -421,8 +730,8 @@ int main() {
     }
 
     std::printf(
-        "census: the Zstd kernel decoded a corpus carrying "
-        "libzstd - blocks raw/rle/compressed %u/%u/%u, literals "
+        "census: the decoded frames carried "
+        "blocks raw/rle/compressed %u/%u/%u, literals "
         "raw/rle/compressed/treeless %u/%u/%u/%u, table modes "
         "basic/rle/compressed/repeat %u/%u/%u/%u, %u four-stream and %u "
         "single-stream literals sections, %u checksummed frames, %u frames "


### PR DESCRIPTION
Closes #203.

The M5 rung-2 landing: a device translation unit that compiles the eight Zstd
host headers `__device__` unchanged, and `cudec_zstd_decompress_batch` wired to
launch it. The frozen contract from #427 did not move; only the answer to an
accepted batch did, from `CUDEC_ERR_NOT_IMPLEMENTED` to the launch.

## The shape, and what it is taken from

`src/zstd_decode.cuh` is the shape `docs/MASTERPLAN.md` 14.1 to 14.4 settled and
nothing else: one 128-thread block per frame over a grid-stride loop, fused with
`__syncthreads()` phase barriers, one entropy table set per frame in shared
memory, the literals decoded into the tail of the frame's own remaining
destination, and the sequences produced and consumed a tile at a time so the
frame needs no workspace and the batch ABI grows no argument.

Nothing in the file decodes a bit. Every value comes from a unit under
`src/zstd_*.h` that the CPU twins already run - the frame and block headers, the
literals section, the Huffman and FSE machinery, `ZstdSeqBegin` and
`ZstdSeqDecodeTile`, `ZstdExecPrefixSumTile` and `ZstdExecPrefixSumFinish`,
`ZstdExecuteSequence`, the repeat-offset chain and the content checksum. What
the file owns is the placement and the order, and the order is the one
`src/zstd_blocks.h` runs the same units in on the host.

## What it does NOT take from the lane map, said plainly

14.7 to 14.11 assign the four literal streams to four lanes and one sequence of
a tile to each of the 128 threads. Neither is taken here.

- **The four literal streams are one call of `ZstdDecodeLiterals`.** The four
  spans are derived inside that unit; splitting them across lanes needs the
  derivation extracted into a function the host twin still runs, which is
  14.9's own pattern and is not this rung's work.
- **A tile's sequences execute in order on one lane.** The ruling of 2026-09-04
  on this issue forbids fanning a tile's match copies across lanes. What the
  ruling permits - a parallel literal phase ahead of a serial match phase -
  would need `ZstdExecuteSequence` split in two, and the split reorders the
  reject ladder: every literal rung of a tile would fire ahead of the match rung
  of a lower-numbered sequence, so the device would report a different refusal
  from the host twin on the same bytes. That is a parity cost paid for a
  throughput gain nobody has measured, and this rung is the minimal-correct one.

So the parallelism taken is the copies that are copies rather than format units:
a Raw or RLE block's body and a block's leftover literal tail move across all
128 threads. The rest of a frame runs on thread 0. What that costs is a
measurement rather than a claim - #231 is the first baselines and #235 to #239
are the levers that would widen it.

**The tile is 64 sequences and not 14.10's 128**, which is the halving that
section itself names as the first move. Its arithmetic costs a record at five
32-bit fields; the record here is what the units actually read and write - a
`ZstdSequence`, a `uint64` destination, a `uint64` literal cursor and a `uint64`
resolved offset - which is forty bytes. Packing to twenty would put a narrowed
copy live beside the arrays the units fill, which costs more than it saves.

**One bound is looser than the host's, and only on a refusal.**
`ZstdExecuteSequence` is handed the frame's remaining declared bytes where
`src/zstd_blocks.h` hands it the block's own size, because a block's size is the
running total plus the literals its sequences do not consume and is therefore
known only after the last tile - and holding every tile is the workspace 14.3
refuses. The remaining declared bytes is the larger of the two and is what the
caller's buffer actually allows, so every write stays inside the declared region
either way; on a block that decodes, the two admit exactly the same sequences,
because such a block's size is at most the remaining. `plan.block_size >
remaining` is refused after the last tile with the rung the host gives.

## Gates, all on this machine

Built and run in the WSL CUDA route at this branch's head, `sm_86`, nvcc
13.3.73, driver 610.88, on an RTX 3080:

```
cmake -B build-af21 -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 \
  -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
cmake --build build-af21 -j8
ctest --test-dir build-af21 --no-tests=error
100% tests passed, 0 tests failed out of 71
Label Time Summary:
gpu    =  13.63 sec*proc (13 tests)
```

**The whole-corpus GPU-vs-oracle byte diff**, which is the first bullet of the
Done-when. `tests/zstd_device.cu` puts every #185 fixture through
`cudec_zstd_decompress_batch` into a poisoned destination and holds the answer
to what the pinned libzstd says the frame means:

```
$ ./build-af21/tests/zstd_device
corpus: declined envelope-no-content-size-no-checksum
corpus: declined literals-rle-handbuilt
corpus: 17 frames decoded byte-identically, 2 declined
hand-built: one RLE literals section in the subset
batch: 8 frames at a chunk size of 65536, level 3
batch: 3 frames at a chunk size of 204800, level 9
census: the decoded frames carried blocks raw/rle/compressed 1/6/332, literals
raw/rle/compressed/treeless 21/1/13/297, table modes basic/rle/compressed/repeat
6/2/835/150, 4 four-stream and 306 single-stream literals sections, 1
checksummed frames, 8 frames of more than one block
PASS: every frame of the Zstd corpus and of the batch geometry decodes on the
device byte-identically to the pinned reference, with the poison past
bytes_written intact
```

Zero mismatched bytes across every forced-mode family, and the poison past
`bytes_written` survives on every frame. The two declines are correct and are
the subset rather than a refusal: both frames declare no content size, which
12.2 puts outside the envelope, and both are answered `CUDEC_ERR_UNSUPPORTED`
with `bytes_written == 0`.

**The census is REQUIRED, not reported**, because a corpus that decodes
byte-identically proves nothing about a surface it never reached. That guard
bit while this was being written: the RLE literals arm counted zero, because the
only fixture carrying one is out of the subset and is declined. It is closed by
a hand-built in-subset frame in the test itself, round-tripped through libzstd
first so the kernel is held to a legal frame rather than a plausible one.

**The byte diff is load-bearing rather than vacuous**, proven by breaking it:
shifting the literals staging address by one byte -

```
-    unsigned char* literals = dst + frame->produced + remaining - literals_size;
+    unsigned char* literals = dst + frame->produced + remaining - literals_size - 1;
```

reds the run at the first checksummed frame with `status 2`
(`CUDEC_ERR_CORRUPT_INPUT`). Reverted; green again.

## Registers and occupancy, which 14.5 rung 2 asks for at this pull request

Read off the shipped kernel on the device rather than derived:

```
$ cuobjdump -res-usage build-af21/libcudec.a | grep -A1 zstd_decode_batchILi32
 Function _ZN12cudec_detail17zstd_decode_batchILi32EEEvPKPKvPKmPKPvS6_mP18cudec_chunk_result:
  REG:80 STACK:176 SHARED:12064 LOCAL:0 CONSTANT[2]:24 CONSTANT[0]:400

$ ./occ                      # cudaFuncGetAttributes + cudaOccupancyMaxActiveBlocksPerMultiprocessor
device: NVIDIA GeForce RTX 3080, sm_86, 68 SMs
kernel: 80 registers/thread, 12064 bytes static smem, 176 bytes local, 0 bytes const
occupancy: 6 resident blocks/SM at 128 threads = 24 warps/SM (max 48)
smem/SM available to a block: 102400 bytes optin, 49152 bytes per block default
```

**14.6's register falsifier has fired, and the shared-memory half of 14.2
held.** 12064 bytes is inside the 12292 that 14.10 budgeted, and eight blocks of
it would still fit the roughly 100 KiB an sm_86 SM offers; what stops the eighth
block is 80 registers a thread, not the table set. So 24 resident warps against
the 32 the budget is derived from. Nothing spilled - local memory is zero - so
this is the allocation the busy lane needs rather than a shape leaking into
local storage. `docs/MASTERPLAN.md` 14.6 carries that measurement beside the
trigger it answers, which is where the #237 outcome sits for the same reason.
Nothing here argues the number down: what would move it is a register
measurement per stage, and that is #235 to #239's business.

## What changes meaning elsewhere

- `tests/launch_fail.cpp`: with no visible device the Zstd entry answered
  `CUDEC_ERR_NOT_IMPLEMENTED` as the evidence that an accepted batch reached the
  runtime not at all. That evidence is spent - it now answers
  `CUDEC_ERR_CUDA` like the three entries beside it, which is the cleanest
  record this file can hold of the landing.
- `tests/conformance_c.c`: the ninth class goes, exactly as it went for the
  GDeflate entry when its kernel landed, and no call replaces it - an accepted
  batch now reaches a launch and those are host pointers a GPU-less test must
  never hand to one. The eight reject classes are untouched.
- `include/cudec.h`: the "this build carries no Zstd kernel" paragraph is
  replaced by the same freeze-held sentence the GDeflate entry carries.

## Not in this landing

- `compute-sanitizer` per #73: still unavailable on this host. All four tools
  report `Failed to initialize WDDM debugger interface` and `Device not
  supported` before they look at any code, which #258 closed with and #127
  re-measured on 2026-09-05 against this same driver. **No claim is made here
  that this kernel is clean under memcheck, racecheck, initcheck or synccheck:
  that net has not run.**
- The device gate set - same-batch-twice determinism, two-directional mutant
  reject parity against libzstd, and the capacity and window adversarials - is
  #399 by the 2026-08-28 ruling and is deliberately not restated in
  `tests/zstd_device.cu`.
- No perf numbers. That is #231 and #233, and numbers and kernel never move in
  the same pull request.
- `__constant__` sequence baselines (14.10): not taken. It is a second spelling
  of a twinned function that has to carry its own lock, and it is a performance
  shape on a kernel whose per-stage cost nobody has measured yet.

## Second reader

There is no second reader on this board tonight, and the review that stood in
for one is recorded here rather than implied: the adversarial lenses were run
over this diff before it was pushed, and what they raised is answered above or
in the code.

## What the review found, and what it cost

The adversarial gate this repository requires on a kernel or ABI diff was run
over this branch before it was merged, and it came back FAIL on the first head
(`e70d774`). The finding is recorded here rather than quietly folded into the
diff, because it is the most useful thing on this page for whoever writes the
next kernel.

**Three block-wide control flags were read after a barrier and rewritten by
thread 0 with no barrier in between.** `frame->status`, `frame->compressed` and
`frame->last_block` are written by thread 0 and read by all 128 threads. A
barrier releases every thread at once, so thread 0 was free to run ahead into
the next section while a lagging warp was still reading the previous value - and
what that produces is not a wrong byte, it is a **split block**: some warps break
out of the loop or return while the others carry on, and every barrier after
that is reached by a subset of the block.

It was demonstrated on the device, not argued. With a legal post-barrier delay
on warps 1 to 3 and a hand-built two-Raw-block frame:

```
frame bytes = 1037, content = 1024 (two Raw blocks, second is last)
AS-IS    status=0 bytes_written=1024  untouched(poison)=0   wrong=0
DELAYED  status=0 bytes_written=1024  untouched(poison)=380 wrong=0
```

`CUDEC_OK`, `bytes_written == 1024`, and 380 of those bytes never written by
anybody. A second instance of the same shape leaked across chunks: a frame that
refused early left an honest neighbour sharing its block half-written and still
reported as a success.

**The repair is one rule rather than three patches** (`3759d56`): every `if
(threadIdx.x == 0) {` section is immediately preceded by `__syncthreads();`.

**And the rule is refused by a machine, not by this paragraph.**
`tests/CMakeLists.txt` reads `src/zstd_decode.cuh` and refuses a thread-0 section
without a barrier in front of it. The guard is over the SOURCE because nothing
else here can see the defect: the oracle diff asserts on whatever schedule the
hardware happened to give, and `racecheck` cannot attach to a device on this
host. It carries three probes - a guarded section must pass, an unguarded one
must be refused by name, and a file with no section at all must be refused
rather than passed, so a rename cannot retire the rule in silence. Proven to
bite on the real file by deleting one barrier:

```
thread-0 sections without a barrier in front of them (issue #203):
  src/zstd_decode.cuh: 1 of 7 `if (threadIdx.x == 0) {` sections are not
  immediately preceded by `__syncthreads();` ...
```

What it does NOT catch is stated at the rule: it is textual and over one file,
it says nothing about a flag read and rewritten inside a single section, nothing
about the other kernels, and nothing about whether the barriers that are there
are the right ones. It is a floor under one defect class.

**Two claims on this page were also wrong and are corrected in the same commit**,
both found by re-running the command they rested on:

- The register paragraph said nothing spilled. `-Xptxas -v` reports `176 bytes
  stack frame, 8 bytes spill stores, 4 bytes spill loads`. Twelve bytes of
  traffic is not what holds this kernel at 80 registers, but "nothing spilled"
  was not a reading and is gone.
- `include/cudec.h`'s `CUDEC_ERR_NOT_IMPLEMENTED` enumerator still said
  `cudec_zstd_decompress_batch` returns it today. No entry returns it any more.

**What the review could not refute**, tried and recorded rather than assumed:
the bounds on hostile input, the literals staging invariant, the down-move
chunking, the shared-memory union and the cross-frame reuse all held, including
under a 15360-mutant guarded fuzz against libzstd across four levels and three
sizes with 4 KiB guard bands - zero guard violations, zero oracle mismatches on
7717 accepted decodes, zero refusals reporting a non-zero `bytes_written`. That
fuzz is a review probe built outside the tree, not a shipped test; the shipped
mutant parity is #399.

All gates were re-run after the fix at `3759d56`: 71 of 71 on the device,
Prettier clean, and the register and occupancy numbers above are unchanged.

## The second lens, and the second fix

A robustness pass ran alongside the CUDA one and came back NEEDS_IMPROVEMENT
on the same first head. It compiled the shipped kernel bodies on the host at
one thread, byte-identical otherwise, and ran them against `src/zstd_blocks.h`
and libzstd under ASan and UBSan with `-fno-sanitize-recover=all`: 240 real
frames byte-identical with the poison intact, and 96,000 mutants with **0
out-of-bounds accesses, 0 UB reports, 0 streams accepted that libzstd rejects,
0 byte mismatches on accepted mutants, 0 rejections carrying a non-zero
`bytes_written`**. Every subtraction this PR's description claims is
non-wrapping was checked and named.

**What it did find was the status CLASS.** Two sites answered
`CUDEC_ERR_CORRUPT_INPUT` where the host twin answers `CUDEC_ERR_OUTPUT_TOO_SMALL`
on identical bytes - 79 divergences over those 96,000 mutants, all one
direction. The classes are not interchangeable: one invites a caller to retry
with a larger destination and the other does not.

- **The literals section.** The kernel meets an over-large section before it
  has an address to stage it at; the host meets it after the literals are
  decoded, at the execution's destination bound. The comparison stays where it
  is - the address cannot be formed without it - and the two bounds now run in
  the host's order, so a section past the format's block maximum is malformed
  and only a section the format allows but the declaration does not is the
  capacity answer.
- **The tile loop, and this repair is worth more than the status it fixes.**
  Handing `ZstdExecuteSequence` the remaining declaration let a hostile frame
  reach its plan-consistency rung - the unit's *caller-bug* rung, documented
  as reachable by a wrong scan and never by a stream. The loop now holds the
  block's size-so-far to the remaining declaration after each tile's prefix sum
  and **before** that tile's copies. That closes a second finding at the same
  time: section 14.3's placement invariant was true of every block that decoded
  but was only *established* by a check at the end of the block, after the
  copies it licenses had run. It is established before them now, and the
  load-bearing "why" is written where the check is.

**`tests/zstd_device.cu` gains the reject rungs this kernel introduces**, each
held to what `src/zstd_blocks.h` answers on the same bytes rather than to a
status written down in the test - eight hand-built frames covering the literals
sites in both directions, a Raw block past the declaration, a short frame, the
reserved block type, a truncated body, trailing bytes, and a capacity below the
declaration:

```
reject parity: 8 refusals, each in the class the host twin gives, each reporting no bytes
```

Proven to bite: deleting the block-maximum ordering flips one case from status
2 to status 3 and reds the run. This is **not** the device gate set -
determinism, the mutant parity over the corpus, and the capacity and window
adversarials are #399 by the ruling that cut them out, and none of them is
here.

**One finding is deliberately NOT fixed in this diff and went to the tracker
instead: #460.** `OUTPUT_TOO_SMALL` now names a frame that overruns its own
declared content size, which no larger destination repairs, while the Snappy
entry twelve lines away in `include/cudec.h` states the opposite rule for the
same situation. That condition is the host units' and predates this kernel;
changing it means moving a class the twins already lock, in a landing whose
whole claim is that the device agrees with the twin. It is a decision, it is
assigned, and it is labelled as waiting on one.

Re-run at `7cb8378`: 71 of 71 on the device, Prettier clean, and the register
and occupancy numbers above are unchanged by either fix (80 registers, 12064
bytes of shared memory, 6 resident blocks per SM).
