### PR TITLE
Refuse the GDeflate tail-waste lever on its own measurement [#207]

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -197,6 +197,26 @@ target_compile_options(
 # runner.
 add_test(NAME bench_gdeflate_selfcheck COMMAND bench_gdeflate --selfcheck)
 
+# The tail-waste sweep (issue #207). GPU-LABELLED, and it is the first
+# bench entry here that is: everything above times the reference decoder on
+# the host and touches no device, while this path exists to ask the runtime
+# how many blocks of the shipped kernel fit on an SM and then to launch that
+# kernel at several grid widths. There is nothing left of it to run on the
+# GPU-less CI runner, so it is labelled rather than made conditional.
+#
+# What it protects is the plumbing and not a number. Four pages decoded once
+# is far below any device's residency, so the figures it prints are launch
+# costs; the report says so on its own line rather than leaving a reader to
+# infer it. What reds here is the residency query failing, the sweep losing
+# its verification precondition, a grid arithmetic that stopped matching the
+# library's, or the level-6 corpus moving underneath the record - that last
+# one against the same digit table the entry below reads, so the two cannot
+# disagree about which corpus is meant.
+add_test(NAME bench_gdeflate_tailwaste_selfcheck
+         COMMAND bench_gdeflate --tailwaste --selfcheck)
+set_tests_properties(bench_gdeflate_tailwaste_selfcheck PROPERTIES LABELS gpu
+                                                        RUN_SERIAL TRUE)
+
 # The asset-like corpus through the same grid (issue #139's block, issue
 # #224's path). Separate entry because it locks different bytes: the source
 # block comes from bench/assetlike_source.h, which bench_lz4 reads too, so a
@@ -345,5 +365,6 @@ set_tests_properties(
   bench_gdeflate_selfcheck bench_gdeflate_assetlike_selfcheck
   bench_gdeflate_blocktypes_selfcheck bench_gdeflate_blockmix_selfcheck
   bench_gdeflate_worst_selfcheck bench_gdeflate_worstheaders_selfcheck
+  bench_gdeflate_tailwaste_selfcheck
   PROPERTIES TIMEOUT ${CUDEC_TEST_TIMEOUT_SECONDS})
 cudec_assert_test_timeouts()

--- a/bench/bench_gdeflate.cpp
+++ b/bench/bench_gdeflate.cpp
@@ -74,6 +74,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -1642,11 +1643,235 @@ bool ParseCount(const char* text, size_t lo, size_t hi, size_t* out) {
     return true;
 }
 
+/* THE TAIL-WASTE READOUT (issue #207).
+ *
+ * The lever this measures is whether driving more than one page per warp
+ * recovers the tail a warp-per-page launch leaves. It needs no kernel change
+ * to measure, and that is a property of the shipped kernel rather than a
+ * convenience: src/gdeflate_decode.cuh already loops `chunk += total_waves`,
+ * so narrowing the grid IS multi-tile-per-warp running. The rows below vary
+ * gridDim.x and nothing else.
+ *
+ * WHY NO PROFILER NUMBER APPEARS HERE. The issue asks for achieved warps per
+ * SM, and on this machine Nsight Compute connects and is refused the hardware
+ * counters (ERR_NVGPUCTRPERM, a desktop driver setting no session may change).
+ * What is printed instead is the runtime occupancy answer, which is a CEILING
+ * on how many warps a launch of this kernel can hold, beside event-timed
+ * decodes, which are what a batch costs. A ceiling is not an achieved figure
+ * and is never reported as one.
+ *
+ * The page-count sweep is the second half and is the one that shows
+ * quantisation directly: the same corpus truncated to fewer pages, timed at
+ * the shipped grid. A launch that wastes its tail is flat across a range of
+ * page counts and steps at a residency boundary; one that does not is linear
+ * in the page count. */
+const unsigned kTailwasteGridMultiples[] = {0, 1, 2, 4, 8};
+const size_t kTailwasteGridCount =
+    sizeof(kTailwasteGridMultiples) / sizeof(kTailwasteGridMultiples[0]);
+
+bool RunTailwaste(const std::vector<unsigned char>& source,
+                  const std::string& name, const std::string& provenance,
+                  int level, size_t warmup, size_t runs, bool selfcheck,
+                  uint64_t expected_digest) {
+    Corpus corpus;
+    corpus.name = name;
+    corpus.provenance = provenance;
+    corpus.composition = kCompositionNotAsserted;
+    if (!BuildCorpus(source, level, &corpus)) {
+        return false;
+    }
+    if (!CorpusRoundTrips(source, corpus)) {
+        return false;
+    }
+    const uint64_t digest = CorpusDigest(corpus);
+    if (selfcheck && !CheckDigest(digest, name, level, expected_digest)) {
+        return false;
+    }
+
+    cudec_gdeflate_residency r;
+    if (!cudec_bench_gdeflate_residency(&r)) {
+        std::fprintf(stderr, "residency query failed - no device?\n");
+        return false;
+    }
+
+    const size_t pages = corpus.originals.size();
+    std::vector<const unsigned char*> comp_ptrs(pages);
+    std::vector<size_t> comp_sizes(pages);
+    std::vector<size_t> orig_sizes(pages);
+    for (size_t i = 0; i < pages; i++) {
+        comp_ptrs[i] = corpus.compressed[i].data();
+        comp_sizes[i] = corpus.compressed[i].size();
+        orig_sizes[i] = corpus.originals[i].size();
+    }
+
+    char device[256];
+    (void)cudec_bench_gpu_device_line(device, sizeof(device));
+
+    std::printf("## bench_gdeflate tail-waste report\n");
+    std::printf("- lever: multi-tile-per-warp for short or leftover pages "
+                "(issue #207), measured by varying gridDim.x over the SHIPPED "
+                "kernel, whose grid-stride loop is what maps several pages "
+                "onto one warp. No kernel byte differs between the rows\n");
+    std::printf("- host CPU: %s\n", cudec_bench::HostCpuName().c_str());
+    std::printf("- CUDA device: %s\n", device);
+    std::printf("- cudec: %d\n", cudec_version());
+    std::printf("- corpus: %s, level %d, %zu pages, %.2f MB original, %s\n",
+                corpus.name.c_str(), level, pages,
+                static_cast<double>(corpus.original_bytes) / 1e6,
+                corpus.provenance.c_str());
+    std::printf("- corpus digest: %016llx\n",
+                static_cast<unsigned long long>(digest));
+    if (selfcheck) {
+        std::printf("- THIS RUN IS THE ROT CHECK AND NOT A MEASUREMENT: a "
+                    "four-page corpus decoded once, far below this "
+                    "device's residency, so every figure below is a "
+                    "launch cost and none of them is a throughput or "
+                    "tail-waste result. What it proves is that the "
+                    "residency query, the sweep and the report still "
+                    "run, and that the corpus this harness builds is "
+                    "the one the record was taken on\n");
+    }
+    std::printf("- timing: CUDA-event, %zu warmup + %zu runs, p50 "
+                "nearest-rank, device-resident (H2D/D2H excluded); every page "
+                "decoded and verified to its original size through "
+                "cudec_gdeflate_decompress_batch before anything is timed\n",
+                warmup, runs);
+    std::printf("- NOT a profiler reading: Nsight Compute is refused the "
+                "hardware counters on this machine (ERR_NVGPUCTRPERM, a "
+                "desktop driver setting), so no achieved-occupancy counter "
+                "appears below. The residency block is the runtime occupancy "
+                "answer, which is a ceiling on what a launch can hold and "
+                "never a count of what ran\n");
+
+    std::printf("\n### Residency of the shipped kernel\n");
+    std::printf("- kernel: gdeflate_decode_batch<32>, %d threads per block "
+                "(%d warps)\n",
+                r.block_threads, r.warps_per_block);
+    std::printf("- registers per thread: %d; shared bytes per block: %zu; "
+                "local bytes per thread: %zu\n",
+                r.registers_per_thread, r.shared_bytes_per_block,
+                r.local_bytes_per_thread);
+    std::printf("- SMs on this device: %d; max resident blocks per SM: %d\n",
+                r.sm_count, r.max_blocks_per_sm);
+    std::printf("- the machine holds %d blocks = %d warps of this kernel at "
+                "once; one warp decodes one page, so %d pages is the batch "
+                "size at which the device is exactly full once\n",
+                r.resident_blocks, r.resident_warps, r.resident_warps);
+
+    const unsigned shipped = cudec_bench_gdeflate_shipped_grid(pages);
+    const double resident = static_cast<double>(r.resident_blocks);
+    const double waves =
+        r.resident_blocks > 0 ? static_cast<double>(shipped) / resident : 0.0;
+    std::printf("\n### What the shipped grid asks of this device\n");
+    std::printf("- shipped grid for %zu pages: %u blocks, against %d "
+                "resident: %.2f waves\n",
+                pages, shipped, r.resident_blocks, waves);
+    if (r.resident_blocks > 0) {
+        const unsigned span = static_cast<unsigned>(r.resident_blocks);
+        const unsigned rest = shipped % span;
+        const unsigned last_fill = rest == 0 ? span : rest;
+        const unsigned idle = span - last_fill;
+        std::printf("- the last wave carries %u of %u blocks, so %u block "
+                    "slots stand idle while it drains: %.1f%% of one wave and "
+                    "%.1f%% of the whole launch block-slot capacity\n",
+                    last_fill, span, idle,
+                    100.0 * static_cast<double>(idle) /
+                        static_cast<double>(span),
+                    100.0 * static_cast<double>(idle) /
+                        (static_cast<double>(span) * std::ceil(waves)));
+    }
+    std::printf("- THAT ARITHMETIC IS AN UPPER BOUND ON THE QUANTISATION AND "
+                "NOT A COST. Blocks retire independently, so a later block "
+                "starts the moment an earlier one frees a slot; what the "
+                "figure bounds is the drain at the end of the launch, and the "
+                "timed rows below are what it actually costs\n");
+
+    /* Both sweeps in ONE call, so both run over one upload of one corpus.
+     * The grid rows come first at the full page count; the page rows follow
+     * at the shipped grid. */
+    /* An eighth of the machine per row on a real corpus. Clamped to the page
+     * count so a corpus smaller than one step still produces a row rather
+     * than an empty table that reads as a sweep nobody ran. */
+    size_t step = static_cast<size_t>(r.resident_warps) / 8;
+    if (step == 0 || step > pages) {
+        step = pages;
+    }
+    std::vector<cudec_gdeflate_sweep_point> pts;
+    for (size_t i = 0; i < kTailwasteGridCount; i++) {
+        cudec_gdeflate_sweep_point pt;
+        pt.pages = pages;
+        pt.blocks = kTailwasteGridMultiples[i] == 0
+                        ? 0u
+                        : kTailwasteGridMultiples[i] *
+                              static_cast<unsigned>(r.resident_blocks);
+        pt.ms_p50 = 0.0;
+        pts.push_back(pt);
+    }
+    const size_t grid_rows = pts.size();
+    for (size_t n = step; n <= pages; n += step) {
+        cudec_gdeflate_sweep_point pt;
+        pt.pages = n;
+        pt.blocks = 0;
+        pt.ms_p50 = 0.0;
+        pts.push_back(pt);
+    }
+    if (!cudec_bench_gpu_gdeflate_sweep(
+            comp_ptrs.data(), comp_sizes.data(), orig_sizes.data(), pages,
+            static_cast<int>(warmup), static_cast<int>(runs), pts.data(),
+            pts.size())) {
+        std::fprintf(stderr, "sweep failed\n");
+        return false;
+    }
+    const double gb = static_cast<double>(corpus.original_bytes) / 1e9;
+    std::printf("\n### The grid sweep: the same kernel and the same batch, "
+                "fewer blocks\n");
+    std::printf("\n| grid (blocks) | waves of the machine | pages per warp "
+                "(mean) | p50 ms | GB/s | vs shipped |\n");
+    std::printf("| ------------- | -------------------- | "
+                "---------------------- | ------ | ---- | ---------- |\n");
+    for (size_t i = 0; i < grid_rows; i++) {
+        const unsigned blocks = pts[i].blocks == 0 ? shipped : pts[i].blocks;
+        const double warps = static_cast<double>(blocks) *
+                             static_cast<double>(r.warps_per_block);
+        std::printf("| %u%s | %.2f | %.2f | %.3f | %.3f | %.3fx |\n", blocks,
+                    pts[i].blocks == 0 ? " (shipped)" : "",
+                    r.resident_blocks > 0
+                        ? static_cast<double>(blocks) / resident
+                        : 0.0,
+                    warps > 0.0 ? static_cast<double>(pages) / warps : 0.0,
+                    pts[i].ms_p50, cudec_bench::GbpsFromMs(gb, pts[i].ms_p50),
+                    pts[0].ms_p50 > 0.0 ? pts[i].ms_p50 / pts[0].ms_p50 : 0.0);
+    }
+    std::printf("\nThe shipped row and the multiple-of-residency rows are one "
+                "kernel at five grid widths. A row faster than the shipped "
+                "one is the lever paying; a row slower is the lever costing, "
+                "and either way the number is what decides it.\n");
+
+    std::printf("\n### The page-count sweep: where the launch quantises\n");
+    std::printf("\n| pages | shipped grid | waves | p50 ms | ms per page |\n");
+    std::printf("| ----- | ------------ | ----- | ------ | ----------- |\n");
+    for (size_t i = grid_rows; i < pts.size(); i++) {
+        const size_t n = pts[i].pages;
+        const unsigned g = cudec_bench_gdeflate_shipped_grid(n);
+        std::printf("| %zu | %u | %.2f | %.3f | %.5f |\n", n, g,
+                    r.resident_blocks > 0
+                        ? static_cast<double>(g) / resident
+                        : 0.0,
+                    pts[i].ms_p50, pts[i].ms_p50 / static_cast<double>(n));
+    }
+    std::printf("\nA flat p50 across a range of page counts is the tail this "
+                "issue is about: those pages cost nothing extra because the "
+                "warps were standing idle anyway. A ms-per-page column that "
+                "falls and then holds is the machine filling; one that holds "
+                "from the first row is a launch with no tail to recover.\n");
+    return true;
+}
+
 void Usage(const char* argv0) {
     std::fprintf(stderr,
                  "usage: %s [--gpu] [--warmup N] [--runs N] [--assetlike] "
                  "[--blocktypes] [--blockmix] [--worstrounds] "
-                 "[--worstheaders] [--selfcheck] "
+                 "[--worstheaders] [--tailwaste] [--selfcheck] "
                  "[corpus files...]\n",
                  argv0);
 }
@@ -2071,6 +2296,7 @@ int main(int argc, char** argv) {
     bool blockmix = false;
     bool worstrounds = false;
     bool worstheaders = false;
+    bool tailwaste = false;
     bool gpu = false;
     std::vector<std::string> files;
 
@@ -2088,6 +2314,8 @@ int main(int argc, char** argv) {
             worstrounds = true;
         } else if (arg == "--worstheaders") {
             worstheaders = true;
+        } else if (arg == "--tailwaste") {
+            tailwaste = true;
         } else if (arg == "--selfcheck") {
             selfcheck = true;
         } else if (arg == "--runs" && i + 1 < argc) {
@@ -2183,6 +2411,23 @@ int main(int argc, char** argv) {
         runs = 1;
     }
 
+    if (tailwaste) {
+        /* Its own corpus path and its own report, so the flags that build a
+         * different corpus or print a different report are refused rather
+         * than silently ranked against each other. --gpu is not among them:
+         * this report is a device measurement whether or not the flag that
+         * adds device ROWS to the throughput report was passed, and refusing
+         * it would make the reader think one of the two is optional. */
+        if (blocktypes || blockmix || worstrounds || worstheaders) {
+            Usage(argv[0]);
+            std::fprintf(stderr,
+                         "--tailwaste builds one corpus and prints one report "
+                         "of its own; it does not combine with --blocktypes, "
+                         "--blockmix, --worstrounds or --worstheaders\n");
+            return 2;
+        }
+    }
+
     if (blocktypes) {
         return RunBlocktypes(warmup, runs, selfcheck, gpu);
     }
@@ -2238,6 +2483,21 @@ int main(int argc, char** argv) {
 
     const uint64_t* expected =
         assetlike ? kAssetlikeSelfcheckDigests : kSelfcheckDigests;
+
+    if (tailwaste) {
+        /* Level 6 alone: it is the default level and therefore the shape most
+         * data arrives in, and the tail this issue is about is a property of
+         * the page COUNT rather than of the level. A four-level sweep would
+         * quadruple a run whose every row is a device launch and would say
+         * the same thing four times. */
+        /* Level 6 is kLevels[2], and the digest is taken from the same
+         * table the throughput selfcheck reads rather than from a second
+         * copy of the number. */
+        return RunTailwaste(source, name, provenance, kLevels[2], warmup, runs,
+                            selfcheck, expected[2])
+                   ? 0
+                   : 1;
+    }
 
     if (blockmix) {
         return RunBlockmix(source, name, provenance, selfcheck, expected);

--- a/bench/gpu_bench.cu
+++ b/bench/gpu_bench.cu
@@ -203,10 +203,30 @@ bool TimeCtxCold(const void* const* h_src, const size_t* h_ssz,
  * throughput arithmetic are written once and both entries below share them.
  * A second copy per format would be a second protocol, and two numbers
  * produced by two protocols are not comparable. */
-bool BenchBatch(LaunchFn full, LaunchFn parse_only,
-                const unsigned char* const* comp, const size_t* comp_sizes,
-                const size_t* orig_sizes, size_t n, int warmup, int runs,
-                cudec_gpu_result* out) {
+/* The uploaded batch every timed variant here runs over: the device copies of
+ * the pages, the four argument arrays, the result array and the stream. Held
+ * as one value because the upload is the same for the throughput rows and for
+ * the grid sweep, and two copies of it would be two places for the two
+ * measurements to stop being about the same bytes. */
+struct DeviceBatch {
+    const void** d_s = nullptr;
+    void** d_d = nullptr;
+    size_t* d_ss = nullptr;
+    size_t* d_dc = nullptr;
+    cudec_chunk_result* d_r = nullptr;
+    size_t n = 0;
+    size_t total_out = 0;
+    cudec_rt::stream_t stream{};
+};
+
+/* Uploads the batch and runs `full` once as the correctness precondition:
+ * every chunk must return CUDEC_OK with its original decoded size, or the
+ * numbers are meaningless (honest-numbers discipline). Buffers are reclaimed
+ * at process exit; the bench is a short-lived one-shot, like the test
+ * harness. */
+bool UploadAndVerify(LaunchFn full, const unsigned char* const* comp,
+                     const size_t* comp_sizes, const size_t* orig_sizes,
+                     size_t n, DeviceBatch* out) {
     std::vector<const void*> h_s(n);
     std::vector<void*> h_d(n);
     std::vector<size_t> h_ss(n), h_dc(n);
@@ -247,8 +267,6 @@ bool BenchBatch(LaunchFn full, LaunchFn parse_only,
     cudec_rt::stream_t stream;
     BG_RT(cudec_rt::stream_create(&stream));
 
-    /* Correctness precondition: every chunk must decode OK, or the numbers
-     * are meaningless (honest-numbers discipline). */
     if (full(d_s, d_ss, d_d, d_dc, n, d_r, stream) != CUDEC_OK) {
         return false;
     }
@@ -263,6 +281,33 @@ bool BenchBatch(LaunchFn full, LaunchFn parse_only,
             return false;
         }
     }
+
+    out->d_s = d_s;
+    out->d_d = d_d;
+    out->d_ss = d_ss;
+    out->d_dc = d_dc;
+    out->d_r = d_r;
+    out->n = n;
+    out->total_out = total_out;
+    out->stream = stream;
+    return true;
+}
+
+bool BenchBatch(LaunchFn full, LaunchFn parse_only,
+                const unsigned char* const* comp, const size_t* comp_sizes,
+                const size_t* orig_sizes, size_t n, int warmup, int runs,
+                cudec_gpu_result* out) {
+    DeviceBatch b;
+    if (!UploadAndVerify(full, comp, comp_sizes, orig_sizes, n, &b)) {
+        return false;
+    }
+    const size_t total_out = b.total_out;
+    const cudec_rt::stream_t stream = b.stream;
+    const void** d_s = b.d_s;
+    void** d_d = b.d_d;
+    size_t* d_ss = b.d_ss;
+    size_t* d_dc = b.d_dc;
+    cudec_chunk_result* d_r = b.d_r;
 
     double full_ms = 0.0;
     double parse_ms = 0.0;
@@ -291,12 +336,130 @@ bool BenchBatch(LaunchFn full, LaunchFn parse_only,
     out->parse_only_gbps_p50 =
         parse_only != nullptr ? cudec_bench::GbpsFromMs(gb, parse_ms)
                               : kCudecBenchNoParseOnly;
-    /* Buffers are reclaimed at process exit; the bench is a short-lived
-     * one-shot, like the test harness. */
+    return true;
+}
+
+/* Event-times the shipped GDeflate kernel at ONE chosen grid width. Launched
+ * here rather than through the batch entry for the one reason the entry cannot
+ * serve: the grid is what is under measurement, and the entry derives it. The
+ * kernel, the block shape and the arguments are the shipped ones - what varies
+ * between rows is gridDim.x and nothing else. */
+bool TimeGDeflateAtGrid(const DeviceBatch& b, size_t pages, unsigned blocks,
+                        int warmup, int runs, double* p50_ms) {
+    for (int i = 0; i < warmup; i++) {
+        (void)cudec_rt::get_last_error();
+        cudec_detail::gdeflate_decode_batch<cudec_detail::kCudaWaveSize>
+            <<<blocks, cudec_detail::kBlockThreads, 0, b.stream>>>(
+                b.d_s, b.d_ss, b.d_d, b.d_dc, pages, b.d_r);
+        if (cudec_rt::get_last_error() != cudec_rt::success) {
+            return false;
+        }
+    }
+    BG_RT(cudec_rt::stream_synchronize(b.stream));
+
+    cudec_rt::event_t start, stop;
+    BG_RT(cudec_rt::event_create(&start));
+    BG_RT(cudec_rt::event_create(&stop));
+    std::vector<float> times(static_cast<size_t>(runs));
+    for (int i = 0; i < runs; i++) {
+        BG_RT(cudec_rt::event_record(start, b.stream));
+        (void)cudec_rt::get_last_error();
+        cudec_detail::gdeflate_decode_batch<cudec_detail::kCudaWaveSize>
+            <<<blocks, cudec_detail::kBlockThreads, 0, b.stream>>>(
+                b.d_s, b.d_ss, b.d_d, b.d_dc, pages, b.d_r);
+        if (cudec_rt::get_last_error() != cudec_rt::success) {
+            return false;
+        }
+        BG_RT(cudec_rt::event_record(stop, b.stream));
+        BG_RT(cudec_rt::event_synchronize(stop));
+        BG_RT(cudec_rt::event_elapsed_ms(&times[static_cast<size_t>(i)], start,
+                                         stop));
+    }
+    BG_RT(cudec_rt::event_destroy(start));
+    BG_RT(cudec_rt::event_destroy(stop));
+    std::sort(times.begin(), times.end());
+    /* The same nearest-rank p50 every other row in this harness uses. */
+    *p50_ms = cudec_bench::Percentile(times, 50);
     return true;
 }
 
 }  // namespace
+
+bool cudec_bench_gdeflate_residency(cudec_gdeflate_residency* out) {
+    if (out == nullptr) {
+        return false;
+    }
+    /* Device 0, the same one cudec_bench_gpu_device_line names in the
+     * methodology block, so the residency below is attested about the device
+     * the report says it ran on. */
+    cudec_rt::device_prop_t prop{};
+    if (cudec_rt::get_device_properties(&prop, 0) != cudec_rt::success) {
+        return false;
+    }
+    const void* entry = reinterpret_cast<const void*>(
+        &cudec_detail::gdeflate_decode_batch<cudec_detail::kCudaWaveSize>);
+    cudec_rt::func_attributes_t attr{};
+    if (cudec_rt::func_get_attributes(&attr, entry) != cudec_rt::success) {
+        return false;
+    }
+    int blocks_per_sm = 0;
+    if (cudec_rt::occupancy_max_active_blocks_per_sm(
+            &blocks_per_sm, entry,
+            static_cast<int>(cudec_detail::kBlockThreads), 0) !=
+        cudec_rt::success) {
+        return false;
+    }
+    out->sm_count = prop.multiProcessorCount;
+    out->block_threads = static_cast<int>(cudec_detail::kBlockThreads);
+    out->warps_per_block = static_cast<int>(cudec_detail::kBlockWarps);
+    out->registers_per_thread = attr.numRegs;
+    out->shared_bytes_per_block = attr.sharedSizeBytes;
+    out->local_bytes_per_thread = attr.localSizeBytes;
+    out->max_blocks_per_sm = blocks_per_sm;
+    out->resident_blocks = blocks_per_sm * prop.multiProcessorCount;
+    out->resident_warps = out->resident_blocks * out->warps_per_block;
+    return true;
+}
+
+unsigned cudec_bench_gdeflate_shipped_grid(size_t pages) {
+    return cudec_detail::decode_grid_blocks(pages);
+}
+
+bool cudec_bench_gpu_gdeflate_sweep(const unsigned char* const* comp,
+                                    const size_t* comp_sizes,
+                                    const size_t* orig_sizes, size_t n,
+                                    int warmup, int runs,
+                                    cudec_gdeflate_sweep_point* points,
+                                    size_t point_count) {
+    DeviceBatch b;
+    if (!UploadAndVerify(LaunchFullGDeflate, comp, comp_sizes, orig_sizes, n,
+                         &b)) {
+        return false;
+    }
+    for (size_t i = 0; i < point_count; i++) {
+        const size_t pages = points[i].pages;
+        /* A point naming more pages than were uploaded would read past the
+         * argument arrays on the device. Refused rather than clamped: a
+         * clamped row would carry a page count nothing decoded. */
+        if (pages == 0 || pages > n) {
+            return false;
+        }
+        const unsigned blocks = points[i].blocks == 0
+                                    ? cudec_detail::decode_grid_blocks(pages)
+                                    : points[i].blocks;
+        /* A grid holding less than one whole wave makes the kernel stride
+         * zero and it returns without decoding, which would time an empty
+         * launch. The kernel refuses it; so does this. */
+        if (blocks == 0) {
+            return false;
+        }
+        if (!TimeGDeflateAtGrid(b, pages, blocks, warmup, runs,
+                                &points[i].ms_p50)) {
+            return false;
+        }
+    }
+    return true;
+}
 
 bool cudec_bench_gpu_device_line(char* out, size_t n) {
     if (out == nullptr || n == 0) {

--- a/bench/gpu_bench.h
+++ b/bench/gpu_bench.h
@@ -63,6 +63,76 @@ bool cudec_bench_gpu_gdeflate(const unsigned char* const* comp,
                               const size_t* orig_sizes, size_t n, int warmup,
                               int runs, cudec_gpu_result* out);
 
+/* TAIL WASTE (issue #207): what a launch's geometry costs when the page count
+ * does not fill the machine, measured without a hardware performance counter.
+ *
+ * The counter route is shut on the machine this project measures on - Nsight
+ * Compute connects and is refused ERR_NVGPUCTRPERM, which is a desktop driver
+ * setting and not something a session may change - so an achieved-warps figure
+ * cannot come from a profiler here. What replaces it is not a substitute for
+ * the same number under another name: it is the runtime's own residency answer
+ * (registers and shared memory against the SM's budget), which bounds what any
+ * launch of this kernel can hold, next to event-timed decodes of the same batch
+ * at different grid sizes, which is what a batch actually costs. Neither is a
+ * counter reading and neither is reported as one.
+ */
+struct cudec_gdeflate_residency {
+    int sm_count;
+    int block_threads;
+    int warps_per_block;
+    int registers_per_thread;
+    size_t shared_bytes_per_block;
+    size_t local_bytes_per_thread;
+    /* From the runtime's occupancy answer for the shipped kernel at the
+     * shipped block shape - a ceiling on residency, never a count of warps
+     * that ran. */
+    int max_blocks_per_sm;
+    int resident_blocks;
+    int resident_warps;
+};
+
+/* Fills `out` for the shipped GDeflate kernel at the shipped block shape.
+ * False on any runtime failure, with `out` left alone. */
+bool cudec_bench_gdeflate_residency(cudec_gdeflate_residency* out);
+
+/* The grid the shipped batch entry launches for `pages`, from the library's
+ * own arithmetic rather than from a copy of it in the harness. */
+unsigned cudec_bench_gdeflate_shipped_grid(size_t pages);
+
+/* One point of the sweep: how many of the batch leading pages to decode, and
+ * at what grid width. `blocks` of 0 means the grid the shipped entry would
+ * launch for `pages`, so the baseline row comes from the same arithmetic the
+ * library uses rather than from a copy of it. */
+struct cudec_gdeflate_sweep_point {
+    size_t pages;
+    unsigned blocks;
+    double ms_p50; /* out */
+};
+
+/* Event-times the SHIPPED GDeflate kernel over ONE uploaded batch at every
+ * point, filling each point ms_p50.
+ *
+ * THIS IS THE LEVER ITSELF AND NOT A MODEL OF IT. The kernel already carries a
+ * grid-stride loop over pages, so a grid narrower than one warp per page is
+ * multi-tile-per-warp executing, with no kernel byte changed: at
+ * `resident_blocks` every warp is resident for the whole launch and drives as
+ * many pages as it can pull.
+ *
+ * ONE UPLOAD FOR EVERY POINT, and that is a correctness property rather than a
+ * saving. The device buffers this harness allocates are reclaimed at process
+ * exit, so a sweep that uploaded per point would exhaust the device and would
+ * time each point against a differently-fragmented heap. Every point here runs
+ * over the same bytes at the same addresses; only `pages` and gridDim.x move.
+ *
+ * Every page is decoded and verified through the public batch entry before a
+ * single run is timed, exactly as the throughput rows are. */
+bool cudec_bench_gpu_gdeflate_sweep(const unsigned char* const* comp,
+                                    const size_t* comp_sizes,
+                                    const size_t* orig_sizes, size_t n,
+                                    int warmup, int runs,
+                                    cudec_gdeflate_sweep_point* points,
+                                    size_t point_count);
+
 struct cudec_stream_ctx_result {
     size_t chunks;
     size_t output_bytes;

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -2379,6 +2379,325 @@ attributing bytes from the page start rather than the block start reds it on
 the sum; counting one block per page -- the opening-walk reading -- reds it on
 the second.
 
+## M4 perf lever (issue #207): the launch has no tail worth recovering, and no kernel code ships
+
+The claim under test was that a warp-per-page mapping wastes the tail of a
+launch when the page count does not fill the machine or the pages are unevenly
+sized, and that driving more than one page per warp would recover it. It does
+not, and the measurement below is why.
+
+**THE LEVER NEEDED NO KERNEL CHANGE TO MEASURE, AND THAT IS A PROPERTY OF THE
+SHIPPED KERNEL RATHER THAN A SHORTCUT.** `src/gdeflate_decode.cuh` already
+loops `chunk += total_waves`, so a grid narrower than one warp per page IS
+multi-tile-per-warp executing: at a grid of exactly the machine's residency
+every warp is resident for the whole launch and pulls pages until they run out.
+The rows below are one kernel, one uploaded corpus, one verified decode, at five
+grid widths -- `gridDim.x` is the only thing that differs between them. So this
+entry reports a lever that was RUN, not one that was modelled.
+
+**NO PROFILER NUMBER APPEARS HERE AND THE ABSENCE IS DISCLOSED RATHER THAN
+FILLED.** The issue asks for achieved warps per SM. Nsight Compute on this
+machine connects to the process and is then refused the hardware counters with
+`ERR_NVGPUCTRPERM`; the permission is a desktop driver setting, not a container
+privilege and not something a measurement session may grant itself, and cudec
+#258 closed with the same negative answer for Compute Sanitizer. What stands in
+its place is two things that are not that number and are not reported as it:
+the runtime's own occupancy answer, which is a CEILING on how many warps a
+launch of this kernel can hold, and event-timed decodes, which are what a batch
+actually costs. An achieved-occupancy counter reading is not in this record.
+
+### What the device holds
+
+Read from the runtime for `gdeflate_decode_batch<32>` at the shipped block
+shape, on the RTX 3080:
+
+| quantity                   | value                 |
+| -------------------------- | --------------------- |
+| block shape                | 128 threads (4 warps) |
+| registers per thread       | 77                    |
+| shared bytes per block     | 15328                 |
+| local bytes per thread     | 176                   |
+| SMs                        | 68                    |
+| max resident blocks per SM | 6                     |
+| resident blocks / warps    | 408 / 1632            |
+
+One warp decodes one page, so **1632 pages is the batch size at which this
+device is exactly full once**. That single number is what the rest of this
+entry is read against.
+
+### The tail the arithmetic leaves
+
+| corpus     | pages | shipped grid | waves | last wave | idle block slots | share of launch capacity |
+| ---------- | ----- | ------------ | ----- | --------- | ---------------- | ------------------------ |
+| Silesia    | 3234  | 809          | 1.98  | 401 / 408 | 7                | 0.9%                     |
+| asset-like | 3200  | 800          | 1.96  | 392 / 408 | 16               | 2.0%                     |
+
+That is an UPPER BOUND on the quantisation and not a cost: blocks retire
+independently, so a later block starts the moment an earlier one frees a slot,
+and what the figure bounds is the drain at the end of the launch. Even as a
+bound it is under a fiftieth of the launch on both corpora, which is the first
+reason to expect nothing here.
+
+### The grid sweep, and the reason the direction is dead
+
+p50 milliseconds, CUDA-event timed, 3 warmup + 30 runs, device-resident, every
+page verified to its original size through `cudec_gdeflate_decompress_batch`
+before anything is timed. `vs shipped` is that row against the shipped grid **of
+the same run**.
+
+| grid (blocks)          | pages per warp | Silesia run 1 | run 2     | asset-like |
+| ---------------------- | -------------- | ------------- | --------- | ---------- |
+| shipped (809 / 800)    | 1.00           | 31.289 ms     | 29.417 ms | 36.979 ms  |
+| 408 (exactly resident) | ~1.97          | 0.989x        | 0.973x    | 0.989x     |
+| 816                    | ~0.99          | 1.027x        | 1.020x    | 0.999x     |
+| 1632                   | ~0.50          | 1.011x        | 0.990x    | 0.982x     |
+| 3264                   | 0.25           | 1.014x        | 0.984x    | 0.965x     |
+
+**READ THE TWO SILESIA COLUMNS AGAINST EACH OTHER BEFORE READING EITHER OF THEM
+DOWNWARDS.** The same corpus at the same grid, on an otherwise idle device,
+gave 31.289 ms and 29.417 ms in two invocations: a 6.0% spread between runs at
+one grid. Every difference BETWEEN grids is smaller than that. The persistent
+grid is 1.1% and 2.7% faster on the two Silesia runs and 1.1% faster on
+asset-like -- and on asset-like the FASTEST row is 3264 blocks, the widest grid
+in the sweep, which is the opposite of what the lever predicts. A signal whose
+sign flips between corpora and whose size is a fraction of the run-to-run spread
+is not a signal.
+
+**So the lever is refused, and it is refused by measurement rather than by the
+zero-regression rule.** The pre-registered accept rule wanted an improvement on
+at least one corpus with no regression on the worst case; nothing here reaches
+the first half, so the second was never in question. **No kernel byte ships.**
+`decode_grid_blocks` in `src/chunk_decode.cuh` stays as it is.
+
+### Where the tail actually is, and why this lever cannot reach it
+
+The page-count sweep is the same corpus truncated, timed at the shipped grid.
+The column to read is ms per page.
+
+| pages | waves of the machine | Silesia ms/page | asset-like ms/page |
+| ----- | -------------------- | --------------- | ------------------ |
+| 204   | 0.12                 | 0.03319         | 0.02710            |
+| 408   | 0.25                 | 0.02083         | 0.01601            |
+| 816   | 0.50                 | 0.01113         | 0.00936            |
+| 1632  | 1.00                 | 0.00844         | 0.01174            |
+| 2448  | 1.50                 | 0.00964         | 0.01168            |
+| 3060  | 1.88                 | 0.00926         | 0.01178            |
+
+A batch of 204 pages costs roughly four times as much per page as a batch of 3060. **That is the real tail waste and it is large** -- and multi-tile-per-warp
+is exactly the wrong lever for it, by construction. Below 1632 pages the device
+is not full because there are not enough pages to fill it; handing one warp two
+pages when there are already more warps than pages recovers nothing, because the
+idle warps were never going to be given work. What that regime wants is more
+pages in the batch or several batches on one stream, which is the caller's
+decision and not this kernel's geometry.
+
+Above the residency the ms-per-page column is flat to within its own noise on
+both corpora, which is the same finding as the grid sweep from the other side:
+once the machine is full, the launch costs what the pages cost.
+
+### What this entry does not cover
+
+The two adversarial corpora (`worst-rounds`, `worst-headers`) were NOT swept,
+and the reason is that the sweep cannot say anything about them. Both are 512
+pages, which is below this device's 1632-warp residency, so every warp gets at
+most one page at every grid in the sweep and the lever cannot be exercised on
+them at all. Their regime is the sub-residency half of the page-count table
+above, which is measured on both headline corpora. Nothing here claims a
+worst-case number, and nothing here changes one: no kernel code ships, so the
+#36 zero-regression rule has nothing to bind.
+
+Also not claimed: any statement about WHY a full launch costs what it costs.
+That is the refill-coalescing question (#205) and the table-layout question
+(#204), both of which want a profiler this machine will not give one.
+
+### The runs
+
+Recorded 2026-09-06 in the Ubuntu-24.04 WSL distribution, on
+`NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3`, host CPU
+`AMD Ryzen 9 5950X 16-Core Processor`, nvcc 13.3, against the gdeflate fork
+pinned at `8ba9502fb30d2bf728592d121f0d402e40c8cb05`. The corpus digests
+`042b2473240db0b0` (Silesia level 6) and `47dad3ea983dc577` (asset-like level 6)
+are the ones the #228 baseline section recorded, so this sweep and those
+throughput rows are attested against identical bytes. Reproduce with
+
+```
+bench_gdeflate --tailwaste --warmup 3 --runs 30 bench/corpora/silesia/*
+bench_gdeflate --tailwaste --warmup 3 --runs 30 --assetlike
+```
+
+The tables above are a reading aid. The three blocks below are the record.
+
+```
+## bench_gdeflate tail-waste report
+- lever: multi-tile-per-warp for short or leftover pages (issue #207), measured by varying gridDim.x over the SHIPPED kernel, whose grid-stride loop is what maps several pages onto one warp. No kernel byte differs between the rows
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, level 6, 3234 pages, 211.94 MB original, cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- corpus digest: 042b2473240db0b0
+- timing: CUDA-event, 3 warmup + 30 runs, p50 nearest-rank, device-resident (H2D/D2H excluded); every page decoded and verified to its original size through cudec_gdeflate_decompress_batch before anything is timed
+- NOT a profiler reading: Nsight Compute is refused the hardware counters on this machine (ERR_NVGPUCTRPERM, a desktop driver setting), so no achieved-occupancy counter appears below. The residency block is the runtime occupancy answer, which is a ceiling on what a launch can hold and never a count of what ran
+
+### Residency of the shipped kernel
+- kernel: gdeflate_decode_batch<32>, 128 threads per block (4 warps)
+- registers per thread: 77; shared bytes per block: 15328; local bytes per thread: 176
+- SMs on this device: 68; max resident blocks per SM: 6
+- the machine holds 408 blocks = 1632 warps of this kernel at once; one warp decodes one page, so 1632 pages is the batch size at which the device is exactly full once
+
+### What the shipped grid asks of this device
+- shipped grid for 3234 pages: 809 blocks, against 408 resident: 1.98 waves
+- the last wave carries 401 of 408 blocks, so 7 block slots stand idle while it drains: 1.7% of one wave and 0.9% of the whole launch block-slot capacity
+- THAT ARITHMETIC IS AN UPPER BOUND ON THE QUANTISATION AND NOT A COST. Blocks retire independently, so a later block starts the moment an earlier one frees a slot; what the figure bounds is the drain at the end of the launch, and the timed rows below are what it actually costs
+
+### The grid sweep: the same kernel and the same batch, fewer blocks
+
+| grid (blocks) | waves of the machine | pages per warp (mean) | p50 ms | GB/s | vs shipped |
+| ------------- | -------------------- | ---------------------- | ------ | ---- | ---------- |
+| 809 (shipped) | 1.98 | 1.00 | 31.289 | 6.774 | 1.000x |
+| 408 | 1.00 | 1.98 | 30.956 | 6.847 | 0.989x |
+| 816 | 2.00 | 0.99 | 32.125 | 6.597 | 1.027x |
+| 1632 | 4.00 | 0.50 | 31.635 | 6.699 | 1.011x |
+| 3264 | 8.00 | 0.25 | 31.736 | 6.678 | 1.014x |
+
+The shipped row and the multiple-of-residency rows are one kernel at five grid widths. A row faster than the shipped one is the lever paying; a row slower is the lever costing, and either way the number is what decides it.
+
+### The page-count sweep: where the launch quantises
+
+| pages | shipped grid | waves | p50 ms | ms per page |
+| ----- | ------------ | ----- | ------ | ----------- |
+| 204 | 51 | 0.12 | 6.772 | 0.03319 |
+| 408 | 102 | 0.25 | 8.500 | 0.02083 |
+| 612 | 153 | 0.38 | 8.508 | 0.01390 |
+| 816 | 204 | 0.50 | 9.083 | 0.01113 |
+| 1020 | 255 | 0.62 | 9.936 | 0.00974 |
+| 1224 | 306 | 0.75 | 10.845 | 0.00886 |
+| 1428 | 357 | 0.88 | 11.928 | 0.00835 |
+| 1632 | 408 | 1.00 | 13.767 | 0.00844 |
+| 1836 | 459 | 1.12 | 17.851 | 0.00972 |
+| 2040 | 510 | 1.25 | 18.804 | 0.00922 |
+| 2244 | 561 | 1.38 | 19.603 | 0.00874 |
+| 2448 | 612 | 1.50 | 23.599 | 0.00964 |
+| 2652 | 663 | 1.62 | 23.319 | 0.00879 |
+| 2856 | 714 | 1.75 | 22.818 | 0.00799 |
+| 3060 | 765 | 1.88 | 28.332 | 0.00926 |
+
+A flat p50 across a range of page counts is the tail this issue is about: those pages cost nothing extra because the warps were standing idle anyway. A ms-per-page column that falls and then holds is the machine filling; one that holds from the first row is a launch with no tail to recover.
+```
+
+```
+## bench_gdeflate tail-waste report
+- lever: multi-tile-per-warp for short or leftover pages (issue #207), measured by varying gridDim.x over the SHIPPED kernel, whose grid-stride loop is what maps several pages onto one warp. No kernel byte differs between the rows
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: dickens+mozilla+mr+nci+ooffice+osdb+reymont+samba+sao+webster+x-ray+xml, level 6, 3234 pages, 211.94 MB original, cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork; every page decoded back by the reference and compared against the source before timing
+- corpus digest: 042b2473240db0b0
+- timing: CUDA-event, 3 warmup + 30 runs, p50 nearest-rank, device-resident (H2D/D2H excluded); every page decoded and verified to its original size through cudec_gdeflate_decompress_batch before anything is timed
+- NOT a profiler reading: Nsight Compute is refused the hardware counters on this machine (ERR_NVGPUCTRPERM, a desktop driver setting), so no achieved-occupancy counter appears below. The residency block is the runtime occupancy answer, which is a ceiling on what a launch can hold and never a count of what ran
+
+### Residency of the shipped kernel
+- kernel: gdeflate_decode_batch<32>, 128 threads per block (4 warps)
+- registers per thread: 77; shared bytes per block: 15328; local bytes per thread: 176
+- SMs on this device: 68; max resident blocks per SM: 6
+- the machine holds 408 blocks = 1632 warps of this kernel at once; one warp decodes one page, so 1632 pages is the batch size at which the device is exactly full once
+
+### What the shipped grid asks of this device
+- shipped grid for 3234 pages: 809 blocks, against 408 resident: 1.98 waves
+- the last wave carries 401 of 408 blocks, so 7 block slots stand idle while it drains: 1.7% of one wave and 0.9% of the whole launch block-slot capacity
+- THAT ARITHMETIC IS AN UPPER BOUND ON THE QUANTISATION AND NOT A COST. Blocks retire independently, so a later block starts the moment an earlier one frees a slot; what the figure bounds is the drain at the end of the launch, and the timed rows below are what it actually costs
+
+### The grid sweep: the same kernel and the same batch, fewer blocks
+
+| grid (blocks) | waves of the machine | pages per warp (mean) | p50 ms | GB/s | vs shipped |
+| ------------- | -------------------- | ---------------------- | ------ | ---- | ---------- |
+| 809 (shipped) | 1.98 | 1.00 | 29.417 | 7.205 | 1.000x |
+| 408 | 1.00 | 1.98 | 28.629 | 7.403 | 0.973x |
+| 816 | 2.00 | 0.99 | 29.997 | 7.065 | 1.020x |
+| 1632 | 4.00 | 0.50 | 29.113 | 7.280 | 0.990x |
+| 3264 | 8.00 | 0.25 | 28.948 | 7.321 | 0.984x |
+
+The shipped row and the multiple-of-residency rows are one kernel at five grid widths. A row faster than the shipped one is the lever paying; a row slower is the lever costing, and either way the number is what decides it.
+
+### The page-count sweep: where the launch quantises
+
+| pages | shipped grid | waves | p50 ms | ms per page |
+| ----- | ------------ | ----- | ------ | ----------- |
+| 204 | 51 | 0.12 | 5.997 | 0.02939 |
+| 408 | 102 | 0.25 | 8.046 | 0.01972 |
+| 612 | 153 | 0.38 | 7.979 | 0.01304 |
+| 816 | 204 | 0.50 | 8.964 | 0.01099 |
+| 1020 | 255 | 0.62 | 10.174 | 0.00997 |
+| 1224 | 306 | 0.75 | 11.403 | 0.00932 |
+| 1428 | 357 | 0.88 | 12.098 | 0.00847 |
+| 1632 | 408 | 1.00 | 12.982 | 0.00795 |
+| 1836 | 459 | 1.12 | 16.324 | 0.00889 |
+| 2040 | 510 | 1.25 | 17.182 | 0.00842 |
+| 2244 | 561 | 1.38 | 17.995 | 0.00802 |
+| 2448 | 612 | 1.50 | 20.443 | 0.00835 |
+| 2652 | 663 | 1.62 | 20.983 | 0.00791 |
+| 2856 | 714 | 1.75 | 21.844 | 0.00765 |
+| 3060 | 765 | 1.88 | 27.675 | 0.00904 |
+
+A flat p50 across a range of page counts is the tail this issue is about: those pages cost nothing extra because the warps were standing idle anyway. A ms-per-page column that falls and then holds is the machine filling; one that holds from the first row is a launch with no tail to recover.
+```
+
+```
+## bench_gdeflate tail-waste report
+- lever: multi-tile-per-warp for short or leftover pages (issue #207), measured by varying gridDim.x over the SHIPPED kernel, whose grid-stride loop is what maps several pages onto one warp. No kernel byte differs between the rows
+- host CPU: AMD Ryzen 9 5950X 16-Core Processor
+- CUDA device: NVIDIA GeForce RTX 3080 (sm_86), driver 13.3, runtime 13.3
+- cudec: 100
+- corpus: asset-like, level 6, 3200 pages, 209.72 MB original, generated in-harness, a MODEL of a game asset package (bench/assetlike_source.h, issue #139) and not a measurement on real game data; cut into 64 KiB pages and each page compressed on its own by the pinned gdeflate fork
+- corpus digest: 47dad3ea983dc577
+- timing: CUDA-event, 3 warmup + 30 runs, p50 nearest-rank, device-resident (H2D/D2H excluded); every page decoded and verified to its original size through cudec_gdeflate_decompress_batch before anything is timed
+- NOT a profiler reading: Nsight Compute is refused the hardware counters on this machine (ERR_NVGPUCTRPERM, a desktop driver setting), so no achieved-occupancy counter appears below. The residency block is the runtime occupancy answer, which is a ceiling on what a launch can hold and never a count of what ran
+
+### Residency of the shipped kernel
+- kernel: gdeflate_decode_batch<32>, 128 threads per block (4 warps)
+- registers per thread: 77; shared bytes per block: 15328; local bytes per thread: 176
+- SMs on this device: 68; max resident blocks per SM: 6
+- the machine holds 408 blocks = 1632 warps of this kernel at once; one warp decodes one page, so 1632 pages is the batch size at which the device is exactly full once
+
+### What the shipped grid asks of this device
+- shipped grid for 3200 pages: 800 blocks, against 408 resident: 1.96 waves
+- the last wave carries 392 of 408 blocks, so 16 block slots stand idle while it drains: 3.9% of one wave and 2.0% of the whole launch block-slot capacity
+- THAT ARITHMETIC IS AN UPPER BOUND ON THE QUANTISATION AND NOT A COST. Blocks retire independently, so a later block starts the moment an earlier one frees a slot; what the figure bounds is the drain at the end of the launch, and the timed rows below are what it actually costs
+
+### The grid sweep: the same kernel and the same batch, fewer blocks
+
+| grid (blocks) | waves of the machine | pages per warp (mean) | p50 ms | GB/s | vs shipped |
+| ------------- | -------------------- | ---------------------- | ------ | ---- | ---------- |
+| 800 (shipped) | 1.96 | 1.00 | 36.979 | 5.671 | 1.000x |
+| 408 | 1.00 | 1.96 | 36.572 | 5.734 | 0.989x |
+| 816 | 2.00 | 0.98 | 36.932 | 5.678 | 0.999x |
+| 1632 | 4.00 | 0.49 | 36.317 | 5.775 | 0.982x |
+| 3264 | 8.00 | 0.25 | 35.676 | 5.878 | 0.965x |
+
+The shipped row and the multiple-of-residency rows are one kernel at five grid widths. A row faster than the shipped one is the lever paying; a row slower is the lever costing, and either way the number is what decides it.
+
+### The page-count sweep: where the launch quantises
+
+| pages | shipped grid | waves | p50 ms | ms per page |
+| ----- | ------------ | ----- | ------ | ----------- |
+| 204 | 51 | 0.12 | 5.528 | 0.02710 |
+| 408 | 102 | 0.25 | 6.532 | 0.01601 |
+| 612 | 153 | 0.38 | 7.003 | 0.01144 |
+| 816 | 204 | 0.50 | 7.634 | 0.00936 |
+| 1020 | 255 | 0.62 | 10.622 | 0.01041 |
+| 1224 | 306 | 0.75 | 13.899 | 0.01136 |
+| 1428 | 357 | 0.88 | 17.113 | 0.01198 |
+| 1632 | 408 | 1.00 | 19.157 | 0.01174 |
+| 1836 | 459 | 1.12 | 22.839 | 0.01244 |
+| 2040 | 510 | 1.25 | 26.708 | 0.01309 |
+| 2244 | 561 | 1.38 | 27.582 | 0.01229 |
+| 2448 | 612 | 1.50 | 28.593 | 0.01168 |
+| 2652 | 663 | 1.62 | 30.351 | 0.01144 |
+| 2856 | 714 | 1.75 | 33.558 | 0.01175 |
+| 3060 | 765 | 1.88 | 36.040 | 0.01178 |
+
+A flat p50 across a range of page counts is the tail this issue is about: those pages cost nothing extra because the warps were standing idle anyway. A ms-per-page column that falls and then holds is the machine filling; one that holds from the first row is a launch with no tail to recover.
+```
+
 ## M5: the Zstd CPU denominator (issue #227)
 
 There is no Zstd kernel yet. This entry is the denominator a later device

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1804,6 +1804,31 @@ dynamic blocks, where 99.9% of the work is; that stays with #204, #205 and
 was taken over, and the guard that separates this census from a walk over
 page openings, which would have undercounted stored blocks by construction.
 
+**M4 perf lever outcome (issue #207): the launch geometry has no tail worth
+recovering, and no kernel code ships.** The claim was that a warp-per-page
+mapping wastes the tail of a launch on short or unevenly sized pages, and that
+driving several pages per warp would recover it. The shipped kernel already
+carries a grid-stride loop, so the lever was RUN rather than modelled: the same
+kernel over one verified upload at five grid widths, `gridDim.x` the only
+difference. On the RTX 3080 the runtime holds 408 blocks -- 1632 warps -- of
+this kernel resident, so the shipped grid for the recorded corpora is under two
+waves and leaves 0.9% (Silesia) and 2.0% (asset-like) of block-slot capacity
+idle in the drain as an upper bound. Measured, the persistent grid is 1.1-2.7%
+faster and the same corpus at one grid varies 6.0% between two invocations, so
+every difference between grids is inside the run-to-run spread; on asset-like
+the fastest row is the WIDEST grid, which is the opposite of the lever's
+prediction. Refused by measurement rather than by the zero-regression rule -
+nothing reached the first half of the accept condition. **Where the tail
+genuinely is:** below the device's residency a batch costs roughly four times
+as much per page as a full one, and multi-tile-per-warp cannot reach that by
+construction, because handing one warp two pages recovers nothing when there
+are already more warps than pages. That regime wants a larger batch, which is
+the caller's decision and not this kernel's geometry. No profiler reading is in
+the record: Nsight Compute connects and is refused the hardware counters on
+this machine (`ERR_NVGPUCTRPERM`, a desktop driver setting), so the residency
+figures are the runtime's occupancy ceiling and never an achieved-occupancy
+count. Recorded in [docs/BENCHMARKS.md](BENCHMARKS.md).
+
 ### 13.3 The validation ladder
 
 Every value read from the stream is checked before its first use as an

--- a/tests/vendor_rt_test.h
+++ b/tests/vendor_rt_test.h
@@ -60,6 +60,8 @@
 #define CUDEC_RT_GET_DEVICE_PROPERTIES hipGetDeviceProperties
 #define CUDEC_RT_DRIVER_GET_VERSION hipDriverGetVersion
 #define CUDEC_RT_RUNTIME_GET_VERSION hipRuntimeGetVersion
+#define CUDEC_RT_OCCUPANCY_MAX_ACTIVE_BLOCKS \
+    hipOccupancyMaxActiveBlocksPerMultiprocessor
 /* The two report-line spellings the backends do not share: the architecture
  * name lives in a string field here and in a major/minor pair on CUDA, and
  * a HIP version integer is major * 10000000 + minor * 100000 + patch where
@@ -91,6 +93,8 @@
 #define CUDEC_RT_GET_DEVICE_PROPERTIES cudaGetDeviceProperties
 #define CUDEC_RT_DRIVER_GET_VERSION cudaDriverGetVersion
 #define CUDEC_RT_RUNTIME_GET_VERSION cudaRuntimeGetVersion
+#define CUDEC_RT_OCCUPANCY_MAX_ACTIVE_BLOCKS \
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor
 #define CUDEC_RT_ARCH_OF(prop, out, n) \
     std::snprintf((out), (n), "sm_%d%d", (prop).major, (prop).minor)
 #define CUDEC_RT_VERSION_MAJOR(v) ((v) / 1000)
@@ -183,6 +187,20 @@ inline error_t runtime_get_version(int* v) {
 inline void device_arch(const device_prop_t& prop, char* out, size_t n) {
     CUDEC_RT_ARCH_OF(prop, out, n);
 }
+/* HOW MANY BLOCKS OF THIS KERNEL FIT ON ONE SM AT ONCE, which is the residency
+ * a launch can achieve rather than a count of anything that ran. It is the
+ * runtime's own answer from the kernel's registers and shared memory, so it
+ * needs no hardware performance counter and is producible where a profiler is
+ * refused the counters (issue #207). The entry is a plain pointer for the
+ * reason func_get_attributes above gives. */
+inline error_t occupancy_max_active_blocks_per_sm(int* blocks,
+                                                  const void* entry,
+                                                  int block_threads,
+                                                  size_t dynamic_shared) {
+    return CUDEC_RT_OCCUPANCY_MAX_ACTIVE_BLOCKS(blocks, entry, block_threads,
+                                                dynamic_shared);
+}
+
 inline int version_major(int v) { return CUDEC_RT_VERSION_MAJOR(v); }
 inline int version_minor(int v) { return CUDEC_RT_VERSION_MINOR(v); }
 


### PR DESCRIPTION
Closes #207.

The M4 perf pass asked whether the warp-per-page mapping wastes the tail of a launch when the page count does not fill the machine or the pages are unevenly sized, and whether driving more than one page per warp recovers it. I measured it. It does not, and **no kernel byte changes here**.

## The means

C++/CUDA in `bench/`, because the artefact is a measurement of a shipped CUDA kernel and the harness that already times that kernel is here. Nothing new is added to the language, runtime or dependency set: the sweep goes through the same `cudec_rt` seam, the same `bench_stats` percentile and the same corpus builder every other row in this harness uses, and it is testable by the ctest suite that already exists rather than by a parallel apparatus.

## The lever was run, not modelled

`src/gdeflate_decode.cuh` already loops `chunk += total_waves`, so a grid narrower than one warp per page **is** multi-tile-per-warp executing. `bench_gdeflate --tailwaste` times one kernel over one verified upload at five grid widths, with `gridDim.x` the only difference between rows. That is why this lands as a measurement rather than as a kernel experiment, and why "numbers and kernel changes never move in the same PR" is satisfied without splitting anything.

## What the device holds

Read from the runtime for `gdeflate_decode_batch<32>` at the shipped block shape:

| quantity                   | value                 |
| -------------------------- | --------------------- |
| block shape                | 128 threads (4 warps) |
| registers per thread       | 77                    |
| shared bytes per block     | 15328                 |
| SMs                        | 68                    |
| max resident blocks per SM | 6                     |
| resident blocks / warps    | 408 / 1632            |

One warp decodes one page, so **1632 pages is the batch size at which this device is exactly full once**.

## The grid sweep

p50 ms, CUDA-event, 3 warmup + 30 runs, device-resident, every page verified to its original size through `cudec_gdeflate_decompress_batch` before anything is timed.

| grid (blocks)          | pages per warp | Silesia run 1 | run 2     | asset-like |
| ---------------------- | -------------- | ------------- | --------- | ---------- |
| shipped (809 / 800)    | 1.00           | 31.289 ms     | 29.417 ms | 36.979 ms  |
| 408 (exactly resident) | ~1.97          | 0.989x        | 0.973x    | 0.989x     |
| 816                    | ~0.99          | 1.027x        | 1.020x    | 0.999x     |
| 1632                   | ~0.50          | 1.011x        | 0.990x    | 0.982x     |
| 3264                   | 0.25           | 1.014x        | 0.984x    | 0.965x     |

**Read the two Silesia columns against each other before reading either downwards.** The same corpus at the same grid gave 31.289 ms and 29.417 ms in two invocations on an otherwise idle device: a 6.0% spread between runs at one grid. Every difference *between* grids is smaller than that, and on asset-like the fastest row is 3264 blocks — the widest grid in the sweep, the opposite of what the lever predicts. A signal whose sign flips between corpora and whose size is a fraction of the run-to-run spread is not a signal.

The analytic bound agrees before any of it: the shipped grid leaves 0.9% (Silesia) and 2.0% (asset-like) of block-slot capacity idle in the drain, and that is an upper bound rather than a cost, because blocks retire independently.

So the lever is **refused by measurement rather than by the zero-regression rule** — nothing reached the first half of the pre-registered accept condition, so the second half was never in question.

## Where the tail actually is

The page-count sweep, same corpus truncated, shipped grid:

| pages | waves of the machine | Silesia ms/page | asset-like ms/page |
| ----- | -------------------- | --------------- | ------------------ |
| 204   | 0.12                 | 0.03319         | 0.02710            |
| 816   | 0.50                 | 0.01113         | 0.00936            |
| 1632  | 1.00                 | 0.00844         | 0.01174            |
| 3060  | 1.88                 | 0.00926         | 0.01178            |

A 204-page batch costs roughly four times as much per page as a 3060-page one. **That is the real tail waste and it is large** — and multi-tile-per-warp is exactly the wrong lever for it, by construction: handing one warp two pages recovers nothing when there are already more warps than pages. That regime wants a larger batch or several batches on one stream, which is the caller's decision and not this kernel's geometry.

## What is NOT here, stated as a negative

- **No profiler reading.** The issue asks for achieved warps per SM. Nsight Compute connects to the process on this machine and is then refused the hardware counters with `ERR_NVGPUCTRPERM`; the permission is a desktop driver setting, not a container privilege, and #258 closed with the same negative answer for Compute Sanitizer. The residency figures above are the **runtime's occupancy ceiling** and are never reported as an achieved count. The report says so on its own line so a later reader cannot quote them as one.
- **The two adversarial corpora were not swept.** `worst-rounds` and `worst-headers` are 512 pages, below this device's 1632-warp residency, so every warp gets at most one page at every grid and the lever cannot be exercised on them at all. Their regime is the sub-residency half of the page-count table, which is measured on both headline corpora. No worst-case number is claimed and none changes: no kernel code ships, so the #36 rule has nothing to bind.
- **Nothing here says why a full launch costs what it costs.** That is #205 (refill coalescing) and #204 (table layout), both of which want the profiler this machine will not give one.

## The guard, and the proof that it bites

`bench_gdeflate_tailwaste_selfcheck` is gpu-labelled — the first bench entry that is, because this path asks the runtime about a real kernel and then launches it, so there is nothing left of it to run on the GPU-less runner. Flipping one digit of the level-6 corpus digest table reds it, with the corpus-moved message and nothing else:

```
$ ctest --test-dir build-af15 -R bench_gdeflate_tailwaste_selfcheck --output-on-failure
the corpus digest moved on selfcheck at level 6: expected 808fbdf79a44154d,
built 808fbdf79a44154c - the corpus this harness constructs is not the one its
numbers were recorded on
0% tests passed, 1 tests failed out of 1
```

The digit was restored before the commit.

## The gate

Run in the Ubuntu-24.04 WSL distribution on the RTX 3080 (sm_86), nvcc 13.3, driver 13.3 — **not** the pinned `nvidia/cuda:12.6.2` container `CLAUDE.md` names as canonical, so a register or occupancy figure here is that toolkit's rather than the container's.

```
cmake -B build-af15 -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 \
  -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc && cmake --build build-af15 -j8
ctest --test-dir build-af15 --output-on-failure --no-tests=error
100% tests passed, 0 tests failed out of 73
Label Time Summary:
gpu    =  18.69 sec*proc (15 tests)

ctest --test-dir build-af15 -LE gpu --no-tests=error
100% tests passed, 0 tests failed out of 58
```

**The GPU half executed**: 15 gpu-labelled entries ran on the device, they were not skipped. Prettier is clean over `**/*.{md,yml,yaml}`.

The corpus digests `042b2473240db0b0` (Silesia level 6) and `47dad3ea983dc577` (asset-like level 6) are the ones the #228 baseline section recorded, so this sweep and those throughput rows are attested against identical bytes.

## No second reader

This change had no second reader. The evidence above stands in place of one: the sweep is reproducible from the two commands in `docs/BENCHMARKS.md`, the rot check's refusal was executed rather than asserted, and every figure carries the run that produced it.
