### PR TITLE
Decide the Huffman-description strictness from the bytes, not a name list [#461]

### DIFF
--- a/tests/zstd_gate_gpu.cu
+++ b/tests/zstd_gate_gpu.cu
@@ -525,35 +525,33 @@ int RunWidthRefusal() {
  *
  * An entry also carries the issue that holds its repair. A departure nobody is
  * holding is a permanent exemption wearing a temporary name. */
-struct DeclaredDeparture {
-    const char* name;
-    int stage;
-    int rung;
-    const char* issue;
-};
-
-/* One entry. The mutation moves a byte of a Compressed literals section's
- * Huffman tree description; the reference decodes the frame whole and this
- * decoder stops inside the literals section with a stream that runs out of
- * bits. The stage is src/zstd_blocks.h's Literals and the rung is
- * src/zstd_literals.h's StreamTruncated, and it is the FORMAT UNITS' verdict
- * rather than the kernel's - the device and the host twin give the same status
- * on the same bytes, which is what the lock below asserts rather than assumes. */
-const DeclaredDeparture kDeclaredDepartures[] = {
-    {"tables-compressed / block1-huffman-description-header-at-22032", 2, 13,
-     "#461"},
-};
-constexpr size_t kDeclaredDepartureCount =
-    sizeof(kDeclaredDepartures) / sizeof(kDeclaredDepartures[0]);
-
-const DeclaredDeparture* FindDeparture(const std::string& name) {
-    for (size_t i = 0; i < kDeclaredDepartureCount; i++) {
-        if (name == kDeclaredDepartures[i].name) {
-            return &kDeclaredDepartures[i];
-        }
-    }
-    return 0;
-}
+/* WHAT SEPARATES A REFERENCE THAT WAS RIGHT FROM ONE THAT WAS ONLY WILLING
+ * (issue #461).
+ *
+ * The rule this file applies is mechanical - a refusal against an accepting
+ * reference - and mechanical is the point, because a rule that asked which
+ * answer was better would be arguing with its own evidence. But an accepting
+ * reference is not by itself a legal frame: a mutation can leave a stream the
+ * reference reads to the end and gets wrong, and on a fixture with no content
+ * checksum nothing downstream has anything to check that against.
+ *
+ * So the classifier asks one more question before it calls a refusal
+ * over-strict: did the reference produce the bytes the UNMUTATED fixture
+ * produces? Where it did, the mutation was inert and a refusal is a departure
+ * to explain. Where it did not, the reference decoded a corrupt frame into
+ * wrong bytes without noticing, and this decoder refusing is the fail-closed
+ * contract rather than strictness - that row is counted as
+ * reference-permissive and named on the run's own output.
+ *
+ * THE DECLARED-DEPARTURE REGISTER IS GONE WITH IT AND THAT IS THE REPAIR
+ * RATHER THAN A LOOSENING. Its one entry was this class, declared per name
+ * because there was nothing that could tell the two apart; the comparison
+ * above tells them apart from the bytes, so a name-list would now be a second
+ * way of saying the same thing that could disagree with it. What the register
+ * used to lock - that the twin refuses too - is asserted on every
+ * reference-permissive row below rather than on the one that was written down,
+ * and the instance itself is held at the unit by the jump-table case in
+ * tests/zstd_literals_twin.cpp. An undeclared over-strict row still reds. */
 
 /* ---- section 3: two-directional mutant reject parity ---- */
 
@@ -563,8 +561,7 @@ struct ParityCounts {
     unsigned both_reject;
     unsigned declined;
     unsigned overstrict;
-    unsigned declared_departures;
-    bool departure_seen[kDeclaredDepartureCount];
+    unsigned reference_permissive;
 };
 
 int RunMutantParity(ParityCounts* counts) {
@@ -575,6 +572,7 @@ int RunMutantParity(ParityCounts* counts) {
     std::vector<Chunk> chunks;
     std::vector<Bytes> oracle_out;
     std::vector<bool> oracle_ok;
+    std::vector<bool> oracle_matches_base;
     for (size_t i = 0; i < fixtures.size(); i++) {
         const Bytes frame(fixtures[i].compressed.begin(),
                           fixtures[i].compressed.end());
@@ -587,6 +585,10 @@ int RunMutantParity(ParityCounts* counts) {
         for (size_t m = 0; m < mutants.size(); m++) {
             Bytes decoded;
             const bool ok = ZstdOracleDecodes(mutants[m].frame, &decoded);
+            /* Whether the reference's answer for this mutant is the frame's
+             * own bytes. Taken against `plain`, the unmutated fixture's
+             * decode, which this loop already has. */
+            oracle_matches_base.push_back(ok && decoded == plain);
             Chunk chunk;
             chunk.name = fixtures[i].name + " / " + mutants[m].description;
             chunk.src = mutants[m].frame;
@@ -665,53 +667,50 @@ int RunMutantParity(ParityCounts* counts) {
             int rung = -1;
             const cudec_status twin = cudec_test::HostDecodeFrame(
                 slice[i].src, slice[i].dst_capacity, &host_out, &stage, &rung);
-            const DeclaredDeparture* declared = FindDeparture(batch.names[i]);
-            if (declared == 0) {
-                counts->overstrict++;
-                REQUIRE_CTX(false,
-                            "%s: the kernel REFUSED with status %d a frame "
-                            "the reference decodes, and no departure is "
-                            "declared for it (host twin %d, stage %d, rung "
-                            "%d)",
-                            batch.names[i].c_str(), static_cast<int>(status),
-                            static_cast<int>(twin), stage, rung);
+            if (!oracle_matches_base[at]) {
+                /* The reference decoded a corrupt frame into bytes that are
+                 * not the frame's own and did not notice. Refusing is the
+                 * contract; the row is not over-strictness. The twin is still
+                 * held to the same answer, because a refusal only this kernel
+                 * makes is a different fault and must not hide here. */
+                REQUIRE_CTX(twin != CUDEC_OK,
+                            "%s: the reference decoded it to bytes the "
+                            "unmutated fixture does not produce, this kernel "
+                            "refused with status %d, and the host twin "
+                            "DECODED it - so the refusal is this kernel's own "
+                            "rather than the format units'",
+                            batch.names[i].c_str(), static_cast<int>(status));
+                counts->reference_permissive++;
+                continue;
             }
-            /* The lock: a declared departure has to still BE one. */
-            REQUIRE_CTX(twin != CUDEC_OK,
-                        "%s is declared a departure of the format units, and "
-                        "the host twin decodes it - so the refusal is this "
-                        "kernel's own and the declaration hides it (%s)",
-                        batch.names[i].c_str(), declared->issue);
-            REQUIRE_CTX(stage == declared->stage && rung == declared->rung,
-                        "%s is declared at stage %d rung %d and the twin now "
-                        "stops at stage %d rung %d - the declaration names a "
-                        "refusal that is no longer the one happening (%s)",
-                        batch.names[i].c_str(), declared->stage,
-                        declared->rung, stage, rung, declared->issue);
-            counts->declared_departures++;
-            counts->departure_seen[declared - kDeclaredDepartures] = true;
+            counts->overstrict++;
+            REQUIRE_CTX(false,
+                        "%s: the kernel REFUSED with status %d a frame the "
+                        "reference decodes to the unmutated fixture's own "
+                        "bytes, so the mutation was inert and this is a "
+                        "departure to explain (host twin %d, stage %d, rung "
+                        "%d)",
+                        batch.names[i].c_str(), static_cast<int>(status),
+                        static_cast<int>(twin), stage, rung);
         }
         FreeBatch(&batch);
     }
     REQUIRE(counts->overstrict == 0);
     REQUIRE(counts->both_reject > 0);
     REQUIRE(counts->both_accept > 0);
-    /* A declaration nothing reached is stale, and a stale one is an exemption
-     * that outlived its reason. It reds here rather than sitting. */
-    for (size_t i = 0; i < kDeclaredDepartureCount; i++) {
-        REQUIRE_CTX(counts->departure_seen[i],
-                    "the departure declared for %s was not reached by any "
-                    "mutant - either the corpus stopped producing it or it is "
-                    "repaired, and either way the declaration goes (%s)",
-                    kDeclaredDepartures[i].name, kDeclaredDepartures[i].issue);
-    }
+    /* The reference-permissive class is not required to be non-empty here.
+     * The corpus deciding to stop producing such a mutant is not a failure of
+     * this gate, and the instance #461 is about is held at the unit by
+     * tests/zstd_literals_twin.cpp, which DOES red if it stops being reached.
+     * The count is printed so a change in it is visible. */
     std::printf(
         "mutant parity: %u mutants - %u accepted by both with identical "
         "bytes, %u rejected by both, %u declined as outside the subset, %u "
-        "undeclared over-strict, %u declared departures still refusing at the "
-        "rung they are declared at\n",
+        "over-strict against a reference that decoded the frame's own bytes, "
+        "%u refused where the reference decoded a corrupt frame into bytes "
+        "the unmutated fixture does not produce\n",
         counts->mutants, counts->both_accept, counts->both_reject,
-        counts->declined, counts->overstrict, counts->declared_departures);
+        counts->declined, counts->overstrict, counts->reference_permissive);
     return 0;
 }
 
@@ -859,8 +858,9 @@ int main() {
     std::printf(
         "PASS: the Zstd device gate set - determinism across five grids, a "
         "three-stream split and a repeat of the shipped entry; two-directional "
-        "reject parity over %u mutants with %u undeclared over-strict and %u "
-        "declared departures; and the capacity and window bounds\n",
-        counts.mutants, counts.overstrict, counts.declared_departures);
+        "reject parity over %u mutants with %u over-strict and %u refused "
+        "where the reference decoded a corrupt frame; and the capacity "
+        "and window bounds\n",
+        counts.mutants, counts.overstrict, counts.reference_permissive);
     return 0;
 }

--- a/tests/zstd_huf_twin.cpp
+++ b/tests/zstd_huf_twin.cpp
@@ -591,6 +591,122 @@ int main() {
         CoverRung(rung);
     }
 
+    /* ---- Step 5: the spelling boundary, and the eight bytes that hang on one
+     * byte (issue #461).
+     *
+     * RFC 8878 section 4.2.1 splits the Huffman_Tree_Description's header byte
+     * at 128. At or above it the byte declares `header - 127` weights packed
+     * two to a byte, so the description is 1 + ceil((header - 127) / 2) bytes.
+     * Below it the byte IS the byte count of an FSE-compressed weight stream,
+     * so the description is 1 + header bytes. Nothing else in the description
+     * says how long it is.
+     *
+     * WHY THAT MATTERS ONE LAYER UP AND IS ASSERTED HERE. The description's
+     * consumed length is what fixes where a Compressed literals section's four
+     * streams begin. So a single flipped bit in this byte moves every stream,
+     * and a decoder that read the description generously would go on to decode
+     * out of bytes that are not streams. The two readings of one byte are
+     * asserted side by side rather than left as prose.
+     *
+     * WHAT THIS IS NOT, AND THE NAME THAT MISLEADS. The #461 mutation is called
+     * `huffman-description-header`, so this looks like the place that holds its
+     * instance, and it is not. That mutation is guarded in
+     * tests/zstd_corpus.cpp on `literals_payload_size != 0`, which is set for a
+     * Treeless section too, and on the fixture it fires on it lands on one - a
+     * Treeless section carries no tree description at all, and the byte it
+     * moves is the first size in the Jump_Table. The instance is held by the
+     * jump-table case in tests/zstd_literals_twin.cpp. What is held HERE is the
+     * neighbouring clause, unreached by any corpus mutation, which is why it is
+     * written by hand: the corpus emits only the FSE spelling at these sizes.
+     *
+     * The numbers are chosen to be the ones a reader of #461 will be carrying:
+     * 0x91 is the direct spelling of eighteen weights, ten bytes; 0x11 is an
+     * FSE spelling of seventeen compressed bytes, eighteen bytes. Eight apart,
+     * from one bit. */
+    {
+        /* Eighteen written weights: sixteen of one and two of three. They
+         * spend 16 * 2^0 + 2 * 2^2 = 24 of a 32-cell table, so the depth is
+         * five, the remainder is eight, and the implied nineteenth weight is
+         * four. Hand-computed, so the expectation is not the thing under
+         * test, and the deepest rank is populated because sixteen weights of
+         * one sit in it. */
+        Weights eighteen(16, 1);
+        eighteen.push_back(3);
+        eighteen.push_back(3);
+        REQUIRE(eighteen.size() == 18);
+
+        const Bytes direct = EncodeDirect(eighteen);
+        REQUIRE(direct.size() == 10);
+        REQUIRE(direct[0] == 0x91);
+        REQUIRE(ParityHolds(direct.data(), direct.size(), "spelling-direct"));
+
+        ZstdHufWeightScratch scratch;
+        Weights weights(kZstdHufMaxSymbolValue + 1, 0);
+        unsigned count = 0;
+        unsigned log = 0;
+        uint64_t consumed = 0;
+        ZstdHufReject rung = cudec_detail::kZstdHufRejectNone;
+        REQUIRE(ZstdHufReadWeights(direct.data(), direct.size(),
+                                   kZstdHufMaxSymbolValue + 1,
+                                   kZstdHufMaxTableLog, &scratch,
+                                   weights.data(), &count, &log, &consumed,
+                                   &rung) == CUDEC_OK);
+        REQUIRE(count == 19);
+        REQUIRE(log == 5);
+        REQUIRE(weights[18] == 4);
+        /* The whole point: ten, and it came from the header byte alone. */
+        REQUIRE(consumed == 10);
+
+        /* One bit down in that byte and the same ten bytes are an FSE spelling
+         * declaring seventeen compressed bytes behind it. The unit does not
+         * have them, so it refuses as truncated - and the refusal is the proof
+         * that it asked for eighteen bytes where the direct reading asked for
+         * ten. A decoder that had read this description as ten bytes long
+         * would have gone on to read four streams starting eight bytes too
+         * early. */
+        Bytes fse = direct;
+        fse[0] = 0x11;
+        REQUIRE(fse[0] == (direct[0] & 0x7Fu));
+        count = 0;
+        log = 0;
+        consumed = 0;
+        rung = cudec_detail::kZstdHufRejectNone;
+        REQUIRE(ZstdHufReadWeights(fse.data(), fse.size(),
+                                   kZstdHufMaxSymbolValue + 1,
+                                   kZstdHufMaxTableLog, &scratch,
+                                   weights.data(), &count, &log, &consumed,
+                                   &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectDescriptionTruncated);
+        REQUIRE(consumed == 0);
+        CoverRung(rung);
+
+        /* THE RUNG DOES NOT SEPARATE THE LENGTH FROM THE CONTENTS ON THE FSE
+         * ARM, AND THAT IS ASSERTED RATHER THAN LEFT TO BE ASSUMED. Padding
+         * the same bytes out to the eighteen the header asks for gets past the
+         * length check and then fails inside the FSE weight decode - which
+         * reports the SAME rung, because src/zstd_huf.h spends
+         * DescriptionTruncated on the table read, the table build and the bit
+         * reader as well. So the refusal above is evidence that the unit
+         * refused, and the CONSUMED LENGTH above it - ten against the
+         * eighteen this header asks for - is the evidence about where the
+         * streams would begin. A reader who took the rung for the length
+         * check alone would be reading more out of it than it carries. */
+        Bytes padded = fse;
+        padded.resize(18, 0);
+        count = 0;
+        log = 0;
+        consumed = 0;
+        rung = cudec_detail::kZstdHufRejectNone;
+        REQUIRE(ZstdHufReadWeights(padded.data(), padded.size(),
+                                   kZstdHufMaxSymbolValue + 1,
+                                   kZstdHufMaxTableLog, &scratch,
+                                   weights.data(), &count, &log, &consumed,
+                                   &rung) != CUDEC_OK);
+        REQUIRE(rung == cudec_detail::kZstdHufRejectDescriptionTruncated);
+        REQUIRE(consumed == 0);
+        CoverRung(rung);
+    }
+
     /* Every rung the unit can return has a negative written to reach it. A rung
      * added later with nothing behind it reds here rather than shipping as
      * untested refusal. */

--- a/tests/zstd_literals_twin.cpp
+++ b/tests/zstd_literals_twin.cpp
@@ -940,6 +940,175 @@ int Negatives() {
 
 }  // namespace
 
+/* THE JUMP TABLE THAT THE #461 INSTANCE ACTUALLY LANDS IN, HELD AT THE UNIT
+ * RATHER THAN ONLY THROUGH A WHOLE FRAME.
+ *
+ * WHAT THIS IS AND WHAT IT IS NOT, because the instance is named after
+ * something else. The mutation that raised #461 is called
+ * `block1-huffman-description-header`, and the name is the generator's
+ * intention rather than what it hits: tests/zstd_corpus.cpp guards that
+ * mutation on `literals_payload_size != 0`, which is set for a Treeless
+ * section as well as a Compressed one, and on the fixture in question it lands
+ * on a TREELESS section. A Treeless section carries no Huffman tree
+ * description at all - RFC 8878 section 4.2.2 says its payload opens with the
+ * Jump_Table - so the byte the mutation flips is the low byte of the first
+ * stream's compressed size, not a tree description header.
+ *
+ * WHAT THE FLIP DOES. The jump table is three 16-bit sizes and the fourth
+ * stream's size is what is left over, so moving the first size by 128 moves
+ * where streams two, three and four begin and shortens the fourth by the same
+ * amount. cudec reaches the streams and finds one that ends before its size
+ * says it does, which is kZstdLiteralsRejectStreamTruncated.
+ *
+ * WHAT THIS LOCKS IS A DELIBERATE STRICTNESS AND NOT A BUG, which is the #461
+ * decision. The pinned reference does not refuse this class: it returns the
+ * declared content size with some bytes wrong, on a fixture carrying no
+ * content checksum. So this case is asserted the other way round from every
+ * negative above - the twin refuses AND what the reference does is read and
+ * printed rather than required to be a refusal. If the reference ever starts
+ * refusing it, that is a change worth seeing rather than a failure. */
+int JumpTableStrictness() {
+    const std::vector<ZstdFixture> fixtures = MakeZstdFixtures();
+    REQUIRE(!fixtures.empty());
+    size_t instances = 0;
+    size_t reference_permissive = 0;
+
+    for (const ZstdFixture& fixture : fixtures) {
+        uint64_t window_size = 0;
+        std::vector<LiteralsSite> sites;
+        std::string why;
+        if (WalkLiteralsSites(fixture.compressed, &window_size, &sites,
+                              &why) != CUDEC_OK) {
+            continue;
+        }
+        /* The table a Treeless section reads is the one the last Compressed
+         * section in the same frame left behind, so the sections are decoded
+         * in frame order and the state is carried exactly as the sweep above
+         * carries it. A Treeless section decoded against a fresh state would
+         * be refused for the missing table and would prove nothing about the
+         * jump table. */
+        TwinState state;
+        for (const LiteralsSite& site : sites) {
+            const Bytes section(
+                fixture.compressed.begin() + static_cast<long>(site.offset),
+                fixture.compressed.begin() +
+                    static_cast<long>(site.offset + site.available));
+            ZstdLiteralsHeader header;
+            ZstdLiteralsReject rung = cudec_detail::kZstdLiteralsRejectNone;
+            REQUIRE_CTX(ZstdParseLiteralsHeader(section.data(), section.size(),
+                                                &header, &rung) == CUDEC_OK,
+                        "%s: a section the sweep parsed no longer parses",
+                        fixture.name.c_str());
+
+            /* The four-stream Treeless sections are the ones with a jump
+             * table AND a carried table to read it with. Everything else is
+             * decoded only to carry the state forward. */
+            const bool candidate = header.block_type == kZstdLiteralsTreeless &&
+                                   header.stream_count == 4 &&
+                                   state.table.present;
+            if (candidate) {
+                const size_t at = site.offset + header.header_size;
+                const unsigned char before = fixture.compressed[at];
+                const unsigned char after =
+                    static_cast<unsigned char>(before ^ 0x80u);
+
+                /* A COPY of the carried state, so the mutant cannot leave a
+                 * half-built table behind for the sections after it. */
+                TwinState mutant_state = state;
+                Bytes moved = section;
+                moved[header.header_size] = after;
+                Bytes dst(header.regenerated_size == 0
+                              ? 1
+                              : header.regenerated_size,
+                          0);
+                uint64_t produced = 0;
+                uint64_t consumed = 0;
+                ZstdLiteralsReject moved_rung =
+                    cudec_detail::kZstdLiteralsRejectNone;
+                const cudec_status status = ZstdDecodeLiterals(
+                    moved.data(), moved.size(), window_size,
+                    &mutant_state.table, &mutant_state.scratch, dst.data(),
+                    dst.size(), &produced, &consumed, &moved_rung);
+                if (status == CUDEC_OK) {
+                    /* A flip that happens to land on a legal jump table is
+                     * not this class and is skipped rather than counted. */
+                    continue;
+                }
+                REQUIRE_CTX(produced == 0,
+                            "%s block %zu: refused the moved jump table and "
+                            "still produced %llu bytes",
+                            fixture.name.c_str(), site.block_index,
+                            static_cast<unsigned long long>(produced));
+                CoverRung(moved_rung);
+                if (moved_rung !=
+                    cudec_detail::kZstdLiteralsRejectStreamTruncated) {
+                    continue;
+                }
+                instances++;
+
+                /* What the reference does with the same frame, read rather
+                 * than required. */
+                Bytes moved_frame = fixture.compressed;
+                moved_frame[at] = after;
+                Bytes reference_out(fixture.original.size() + 64, 0);
+                const size_t by_reference = ZSTD_decompress(
+                    reference_out.data(), reference_out.size(),
+                    moved_frame.data(), moved_frame.size());
+                const bool refuses = ZSTD_isError(by_reference) != 0;
+                if (!refuses) {
+                    reference_permissive++;
+                }
+                std::printf(
+                    "- %s block %zu: first jump-table size moved (0x%02X -> "
+                    "0x%02X), twin refuses at StreamTruncated, the reference "
+                    "%s\n",
+                    fixture.name.c_str(), site.block_index,
+                    static_cast<unsigned>(before), static_cast<unsigned>(after),
+                    refuses ? "refuses too"
+                            : "does NOT refuse - it returns bytes it cannot "
+                              "have read correctly, which is the "
+                              "permissiveness #461 records");
+            }
+
+            /* Carry the state forward on the unmutated bytes. */
+            Bytes dst(header.regenerated_size == 0 ? 1
+                                                   : header.regenerated_size,
+                      0);
+            uint64_t produced = 0;
+            uint64_t consumed = 0;
+            ZstdLiteralsReject clean_rung =
+                cudec_detail::kZstdLiteralsRejectNone;
+            REQUIRE_CTX(ZstdDecodeLiterals(section.data(), section.size(),
+                                           window_size, &state.table,
+                                           &state.scratch, dst.data(),
+                                           dst.size(), &produced, &consumed,
+                                           &clean_rung) == CUDEC_OK,
+                        "%s: an unmutated section the sweep decoded no longer "
+                        "decodes (rung %d)",
+                        fixture.name.c_str(), static_cast<int>(clean_rung));
+        }
+    }
+
+    /* A sweep that reached no instance would pass every assertion above,
+     * which is the shape this project has been bitten by. */
+    REQUIRE_CTX(instances > 0,
+                "no four-stream Treeless section in the corpus reaches "
+                "StreamTruncated on a moved jump table, so the #461 class is "
+                "unmeasured at this unit");
+    /* AND THE HALF THAT IS THE ISSUE ITSELF: at least one of them must be a
+     * case the reference does not refuse. If they all became refusals the
+     * strictness would no longer be a departure from the reference, and this
+     * test would be locking a distinction that had stopped existing. */
+    REQUIRE_CTX(reference_permissive > 0,
+                "the reference now refuses every moved jump table this twin "
+                "refuses, so the departure #461 records is gone and the "
+                "record needs re-reading rather than this test passing");
+    std::printf("- jump-table strictness: %zu instances, %zu of them the "
+                "reference does not refuse\n",
+                instances, reference_permissive);
+    return 0;
+}
+
 int main() {
     int rc = Sweep();
     if (rc != 0) {
@@ -954,6 +1123,10 @@ int main() {
         return rc;
     }
     rc = Negatives();
+    if (rc != 0) {
+        return rc;
+    }
+    rc = JumpTableStrictness();
     if (rc != 0) {
         return rc;
     }


### PR DESCRIPTION
Closes #461.

The decision recorded on #461 on 2026-09-06 is that cudec keeps the refusal: the reference returns the declared 262144 bytes with 5624 of them wrong on a fixture carrying no content checksum, so the mutant is a corrupt frame the reference fails to detect rather than a legal frame cudec refuses. This executes that decision — and corrects the characterisation it was taken on.

## The means

C++ in `tests/`, because what is owed is a lock on behaviour at the units that hold it, and the twins for those units already exist here with the pinned reference beside them. No new language, runtime or dependency; the new cases run under the ctest suite the tree already has, and the gate change is an edit to the file that already asks this question.

## The mutation is not where its name says it is

This is the correction, and it is the reason the record needed re-reading rather than only extending. `block1-huffman-description-header` is guarded in `tests/zstd_corpus.cpp` on `literals_payload_size != 0`, which is set for a **Treeless** literals section as well as a Compressed one. Read from the corpus walker on this machine:

```
tables-compressed block 0: literals type 2 (Compressed), payload at 16,    byte 0x17
tables-compressed block 1: literals type 3 (Treeless),   payload at 22032, byte 0x91
```

A Treeless section carries **no Huffman tree description at all** — RFC 8878 section 4.2.2 puts the `Jump_Table` at the start of its payload. So the byte at 22032 is the low byte of the first stream's compressed size, and flipping bit seven moves that size by 128: streams two, three and four begin 128 bytes late and the fourth is 128 bytes short. The decode reaches a stream that ends before its size says it does, which is `kZstdLiteralsRejectStreamTruncated` — the rung the issue already recorded, reached for a different reason than the one written down.

**The class and the decision are unchanged by this.** A length field the section's own bytes carry still decides where the streams begin, cudec still detects the corruption and the reference still does not. What changes is the clause the strictness is recorded against: RFC 8878 **4.2.2**, not 4.2.1. A record naming the wrong clause is what a later reader builds on, which is why this is corrected here rather than left standing.

## The classifier decides it from the bytes

An accepting reference is not by itself a legal frame. The parity check in `tests/zstd_gate_gpu.cu` now asks one more question before it calls a refusal over-strict: **did the reference produce what the unmutated fixture produces?**

- It did → the mutation was inert and a refusal is a departure to explain. Still reds, undeclared.
- It did not → the reference decoded a corrupt frame into wrong bytes without noticing, and refusing is the fail-closed contract. Counted as **reference-permissive** and named on the run's own output.

The declared-departure register goes with it. Its one entry was this class, declared per name because nothing could tell the two apart; a name list beside a comparison that *can* is a second way of saying the same thing that could disagree with it. What the register locked — that the host twin refuses too, so a refusal only the kernel makes cannot hide here — is asserted on **every** reference-permissive row instead of on the one that was written down.

The counts do not move, which is what says nothing was loosened:

```
mutant parity: 784 mutants - 115 accepted by both with identical bytes,
605 rejected by both, 63 declined as outside the subset, 0 over-strict against
a reference that decoded the frame's own bytes, 1 refused where the reference
decoded a corrupt frame into bytes the unmutated fixture does not produce
```

## The instance, held at the unit

`tests/zstd_literals_twin.cpp` walks every fixture's literals sections in frame order, carrying the Huffman table a Treeless section needs exactly as the sweep carries it, and moves the first jump-table size of every four-stream Treeless section on a **copy** of that state so a mutant cannot leave a half-built table behind. It asserts the twin refuses at `StreamTruncated` producing nothing, and then reads what the reference does rather than requiring a refusal — the inversion is deliberate and its reason is written at the case:

```
- tables-compressed block 1: first jump-table size moved (0x91 -> 0x11), twin
  refuses at StreamTruncated, the reference does NOT refuse - it returns bytes
  it cannot have read correctly, which is the permissiveness #461 records
- jump-table strictness: 1 instances, 1 of them the reference does not refuse
```

It requires the class to be reached **and** requires at least one instance to be one the reference does not refuse. If the reference ever starts refusing them, the departure has gone and the record needs re-reading rather than this test quietly passing.

`tests/zstd_huf_twin.cpp` gains the neighbouring clause, which no corpus mutation reaches: the description header byte's split at 128, with `0x91` read as the direct spelling of eighteen weights consuming ten bytes, and the same ten bytes under `0x11` refused because that spelling asks for eighteen. Written by hand because the compressor emits only the FSE spelling at these sizes. Its comment states plainly that it is **not** the #461 instance and says where that instance lives, so the misleading mutation name cannot mislead a second reader.

It also records a bound rather than overselling itself: `src/zstd_huf.h` spends `DescriptionTruncated` on the FSE table read, the table build and the bit reader as well, so the rung does not separate the length check from the contents. The consumed length — ten against the eighteen the other spelling asks for — is the evidence, and the comment says so.

## Both guards were proven to bite

Dropping the base-output comparison from the classifier turns the row straight back into a red failure naming the mutant:

```
FAIL tests/zstd_gate_gpu.cu:687: tables-compressed / block1-huffman-description-header-at-22032:
the kernel REFUSED with status 2 a frame the reference decodes to the unmutated
fixture's own bytes, so the mutation was inert and this is a departure to explain
(host twin 2, stage 2, rung 13)
```

Making the twin's flip a no-op reds it for its own reason:

```
FAIL tests/zstd_literals_twin.cpp:1094: instances > 0 | no four-stream Treeless
section in the corpus reaches StreamTruncated on a moved jump table, so the #461
class is unmeasured at this unit
```

Both were restored before the commit.

## The gate

Ubuntu-24.04 WSL, RTX 3080 (sm_86), nvcc 13.3, driver 13.3 — **not** the pinned `nvidia/cuda:12.6.2` container `CLAUDE.md` names as canonical.

```
cmake -B build-af15 -DCUDEC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 \
  -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc && cmake --build build-af15 -j8
ctest --test-dir build-af15 --output-on-failure --no-tests=error
100% tests passed, 0 tests failed out of 72
Label Time Summary:
gpu    =  18.75 sec*proc (14 tests)
```

**The GPU half executed**: 14 gpu-labelled entries ran on the device, they were not skipped. Prettier is clean over `**/*.{md,yml,yaml}`.

## What is not covered

`compute-sanitizer` still cannot attach on this machine, so nothing here is memcheck- or racecheck-clean by measurement; #258 closed with that negative answer and #127 carries the re-measurement. The change adds no device code, so the device binaries it runs are the ones already on `main` plus this test.

## No second reader

This change had no second reader. The evidence above stands in place of one: both new guards were shown to red for the reason they name and were restored, the classifier's counts are unchanged from the run this branch started from, and the correction to the characterisation carries the walker output that produced it.
