### PR TITLE
Give a Zstd frame that overruns its own declaration the corrupt class [#460]

### DIFF
--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1363,6 +1363,24 @@ oversized block and a failed checksum are `CORRUPT_INPUT`. Nothing in the
 subset is refused silently, and no refusal may leave partial output that a
 caller could read as a short decode.
 
+**Where `CUDEC_ERR_OUTPUT_TOO_SMALL` sits, decided (#460).** It fires in
+exactly one place on this path: `Frame_Content_Size` against the caller's
+capacity, at the frame preamble, before anything is written. Every later
+bound - a Raw or RLE block's size, a Compressed block's regenerated size, a
+literals section's regenerated size - is checked against what the
+_declaration_ has left, and passing it is `CORRUPT_INPUT`. That is the
+Snappy mapping under section 10 word for word, and for the same reason: a
+frame whose blocks regenerate past the size its own header declared has
+contradicted itself, no destination of any size repairs that, and a caller
+obeying the header would retry the capacity answer forever. The decision was
+open from the day #203 made the condition observable at the C ABI - the
+kernel answered what the host twin answered, and the twin answered the
+capacity class - and it went the Snappy way rather than the other because
+`OUTPUT_TOO_SMALL` is reserved for the one condition a larger buffer cures.
+It reaches neither LZ4 nor GDeflate: an LZ4 block and a raw GDeflate page
+carry no declared uncompressed length, so their only bound is the caller's
+capacity and their capacity answer is the right one.
+
 ### 12.4 Skippable frames are refused, not stepped over
 
 A skippable frame is refused with `UNSUPPORTED`.

--- a/include/cudec.h
+++ b/include/cudec.h
@@ -231,9 +231,17 @@ cudec_status cudec_gdeflate_decompress_batch(const void* const* d_src_ptrs,
  * can be retried elsewhere.
  *
  * Per frame, and isolated to that frame: those two statuses,
- * CUDEC_ERR_OUTPUT_TOO_SMALL when the decode would pass the supplied
- * capacity, bytes_written == 0 on any of them, and the destination contents
- * then unspecified but never presented as a valid decode.
+ * CUDEC_ERR_OUTPUT_TOO_SMALL when the frame's declared content size exceeds
+ * that chunk's d_dst_capacities entry - decided from the header, before a
+ * byte is written - bytes_written == 0 on any of them, and the destination
+ * contents then unspecified but never presented as a valid decode. The
+ * declared size is the same rule the Snappy entry states: it is checked
+ * against the capacity and never used to size anything, and a block that
+ * regenerates past what the frame itself declared reports
+ * CUDEC_ERR_CORRUPT_INPUT, because a frame contradicting its own header is
+ * malformed rather than short of room, and no larger destination makes it
+ * valid. A caller that retries CUDEC_ERR_OUTPUT_TOO_SMALL with a destination
+ * of the declared size therefore never sees it twice for one frame.
  *
  * A frame is decoded by one BLOCK rather than by one warp, and that is the
  * format rather than a tuning choice: a Zstd frame's entropy decode is

--- a/src/zstd_blocks.h
+++ b/src/zstd_blocks.h
@@ -94,8 +94,14 @@ enum ZstdBlocksReject {
     kZstdBlocksRejectContentPastCapacity,
     /* A Raw or RLE block would regenerate past what the declared content size
      * leaves. The compressed path reaches the same wall inside
-     * ZstdExecuteBlock, which is why only those two are named here. */
-    kZstdBlocksRejectBlockPastCapacity,
+     * ZstdExecuteBlock, which is why only those two are named here. CORRUPT
+     * rather than OUTPUT_TOO_SMALL, by the rule the Snappy entry of the header
+     * states and section 12.3 records for this format: once a frame has
+     * declared its own length, a block that runs past it is inconsistent
+     * rather than short of room, and a larger destination would not make it
+     * valid. The rung above is the one place the Zstd path answers
+     * OUTPUT_TOO_SMALL, and it fires before a byte is written. */
+    kZstdBlocksRejectBlockPastDeclaration,
     /* The frame ended having produced other than its declared content size.
      * Only the short direction reaches this: the long one is refused as it
      * happens, by the rung above and by the execution's own. */
@@ -238,7 +244,10 @@ CUDEC_HOST_DEVICE inline void ZstdBlocksStop(ZstdBlocksReport* report,
  * buffer, which is larger or equal. Handing the smaller of the two down is
  * what makes a block that regenerates past the declaration refuse here rather
  * than at the end of the frame, and the difference matters: at the end, the
- * bytes are already written. */
+ * bytes are already written. It is also what makes the execution's refusal
+ * of that bound a CORRUPT_INPUT answer rather than a capacity one - the
+ * caller's buffer was held against the declaration before the loop began,
+ * so what the execution refuses is the frame contradicting its own header. */
 CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeCompressedBlock(
     const unsigned char* body, uint64_t body_size,
     const ZstdFrameHeader* header, ZstdFrameState* state, uint64_t block_max,
@@ -474,8 +483,8 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdDecodeBlocks(
             const uint64_t regenerated = block.block_size;
             if (regenerated > declared - produced) {
                 ZstdBlocksStop(report, kZstdBlocksStageContentSize, 0);
-                return ZstdBlocksRefuse(kZstdBlocksRejectBlockPastCapacity,
-                                        CUDEC_ERR_OUTPUT_TOO_SMALL, reject);
+                return ZstdBlocksRefuse(kZstdBlocksRejectBlockPastDeclaration,
+                                        CUDEC_ERR_CORRUPT_INPUT, reject);
             }
             const bool raw = block.block_type == kZstdBlockTypeRaw;
             for (uint64_t index = 0; index < regenerated; index++) {

--- a/src/zstd_decode.cuh
+++ b/src/zstd_decode.cuh
@@ -258,32 +258,23 @@ __device__ inline cudec_status ZstdDecodeCompressedBlockDevice(
         return status;
     }
     const uint64_t literals_size = literals_header.regenerated_size;
-    /* THE BLOCK MAXIMUM IS COMPARED HERE AND NOT ONLY INSIDE THE UNIT THAT
-     * OWNS IT, AND THE REASON IS THE ORDER RATHER THAN DOUBT. ZstdDecodeLiterals
-     * makes this same comparison against the same ZstdLiteralsBlockMaximum
-     * value and refuses CORRUPT_INPUT, which is the class the host reports for
-     * such a block - but it cannot be asked until it has an address to decode
-     * into, and the address below only exists once the section fits in what
-     * the frame has left. So the two comparisons run in the host's order:
-     * a section larger than the format allows is malformed, and only a section
-     * the format allows but the declaration does not is the capacity answer
-     * below. The bound is derived once, at block_max, and compared twice. */
-    if (literals_size > block_max) {
-        return CUDEC_ERR_CORRUPT_INPUT;
-    }
     if (literals_size > remaining) {
         /* A block regenerates at least its own literals, so a literals
          * section larger than the frame has left to declare is a block whose
          * size passes the declaration. Refused before the address below is
          * formed, which is what keeps the subtraction from wrapping.
          *
-         * THE STATUS IS THE HOST'S, NOT THE ONE THE CONDITION SUGGESTS. The
-         * host reaches the same bytes through ZstdExecuteBlock's
-         * destination-too-small rung, which answers OUTPUT_TOO_SMALL, and
+         * THE STATUS IS THE HOST'S. The host reaches the same bytes through
+         * ZstdExecuteBlock's block-past-declaration rung, and
          * `plan.block_size >= literals_size` is what makes the two rungs the
-         * same statement. Answering CORRUPT_INPUT here would be the device
-         * and the twin giving different classes for one frame. */
-        return CUDEC_ERR_OUTPUT_TOO_SMALL;
+         * same statement: a frame whose blocks pass its own declaration is
+         * malformed, not short of room (section 12.3, #460). A section past
+         * the block maximum the window implies is refused by
+         * ZstdDecodeLiterals below in the same class, exactly where the host
+         * refuses it, so there is no order between the two bounds for this
+         * function to keep - which is why it no longer compares the block
+         * maximum itself. */
+        return CUDEC_ERR_CORRUPT_INPUT;
     }
     unsigned char* literals = dst + frame->produced + remaining - literals_size;
 
@@ -425,12 +416,14 @@ __device__ inline cudec_status ZstdDecodeCompressedBlockDevice(
              * caller-bug rung, documented as reachable by a wrong scan and
              * never by a stream, and handing the execution `remaining`
              * instead of the block's own size would otherwise let a hostile
-             * frame fire it - answering CORRUPT_INPUT where the host answers
-             * OUTPUT_TOO_SMALL, and mis-filing a stream rejection as a
-             * decoder bug in anything that triages by rung. */
+             * frame fire it - mis-filing a stream rejection as a decoder bug
+             * in anything that triages by rung. The class is the host's
+             * block-past-declaration answer, CORRUPT_INPUT (section 12.3):
+             * the bound being passed is the frame's own declaration, which
+             * no larger destination repairs. */
             if (carry.at > remaining ||
                 literals_size - carry.literals_used > remaining - carry.at) {
-                return CUDEC_ERR_OUTPUT_TOO_SMALL;
+                return CUDEC_ERR_CORRUPT_INPUT;
             }
 
             for (uint32_t index = 0; index < got; index++) {
@@ -467,7 +460,7 @@ __device__ inline cudec_status ZstdDecodeCompressedBlockDevice(
      * is the one for a block with no sequences at all, whose whole size is
      * its literals and which never enters the loop above. */
     if (plan.block_size > remaining) {
-        return CUDEC_ERR_OUTPUT_TOO_SMALL;
+        return CUDEC_ERR_CORRUPT_INPUT;
     }
     frame->copy_count = literals_size - plan.literals_used;
     frame->copy_src = literals + plan.literals_used;
@@ -539,10 +532,13 @@ __device__ inline void ZstdDecodeFrameDevice(ZstdFrameShared* frame,
                     /* Raw and RLE both regenerate their declared size and
                      * differ only in where the bytes come from. Bounded in
                      * the subtraction direction against what the declaration
-                     * leaves, so nothing can wrap. */
+                     * leaves, so nothing can wrap. The class is the host
+                     * loop's: a block past the frame's own declaration is
+                     * CORRUPT_INPUT, and the capacity answer was given once
+                     * above, from the header (section 12.3). */
                     const uint64_t regenerated = block.block_size;
                     if (regenerated > declared - frame->produced) {
-                        frame->status = CUDEC_ERR_OUTPUT_TOO_SMALL;
+                        frame->status = CUDEC_ERR_CORRUPT_INPUT;
                     } else {
                         frame->copy_count = regenerated;
                         frame->copy_is_rle =

--- a/src/zstd_exec.h
+++ b/src/zstd_exec.h
@@ -113,11 +113,16 @@ enum ZstdExecReject {
     kZstdExecRejectOffsetPastWindow,
     /* A match reaching before the first byte the frame has produced. */
     kZstdExecRejectOffsetBeforeOutput,
-    /* The frame's output plus this block does not fit the destination. Its
-     * status is OUTPUT_TOO_SMALL and not CORRUPT_INPUT: the bytes may be
-     * perfectly good and the buffer merely short, and a caller that cannot
-     * tell those apart cannot retry. */
-    kZstdExecRejectDestinationTooSmall,
+    /* The frame's output plus this block passes the bound the caller handed
+     * in. Its status is CORRUPT_INPUT and not OUTPUT_TOO_SMALL, and the reason
+     * is what that bound IS: every caller of this unit hands it the frame's
+     * DECLARED content size, or what that declaration has left, never the
+     * caller's buffer - the buffer was held against the declaration once, at
+     * the frame preamble, and that comparison is the only OUTPUT_TOO_SMALL
+     * the Zstd path answers (section 12.3). So a block that reaches this rung
+     * contradicts its own frame header, and no larger destination repairs
+     * that; a caller told to retry with one would retry forever (#460). */
+    kZstdExecRejectBlockPastDeclaration,
     kZstdExecRejectCount
 };
 
@@ -408,9 +413,13 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdExecuteSequence(
  * here is the finished array, which is what lets every copy below be
  * independent of every other.
  *
- * `dst` is the frame's whole output and `*produced` the bytes of it earlier
- * blocks left, in and out: on success it advances by the block's size, and on
- * any refusal it is left exactly where it was. Bytes may have been written
+ * `dst` is the frame's whole output and `dst_capacity` is what the frame
+ * DECLARED it would regenerate, not the caller's buffer: the block loop hands
+ * the declaration down (src/zstd_blocks.h says why), so the bound refused
+ * below is the frame contradicting itself rather than a short destination.
+ * `*produced` is the bytes of it earlier blocks left, in and out: on success
+ * it advances by the block's size, and on any refusal it is left exactly
+ * where it was. Bytes may have been written
  * past it before a later sequence refused - a partial write is not a partial
  * success, and a caller that presented it as one would be reporting output it
  * has no reason to believe. */
@@ -433,8 +442,8 @@ CUDEC_HOST_DEVICE inline cudec_status ZstdExecuteBlock(
 
     const uint64_t base = *produced;
     if (base > dst_capacity || plan->block_size > dst_capacity - base) {
-        return ZstdExecRefuse(kZstdExecRejectDestinationTooSmall,
-                              CUDEC_ERR_OUTPUT_TOO_SMALL, reject);
+        return ZstdExecRefuse(kZstdExecRejectBlockPastDeclaration,
+                              CUDEC_ERR_CORRUPT_INPUT, reject);
     }
 
     uint64_t literal_at = 0;

--- a/tests/zstd_blocks_twin.cpp
+++ b/tests/zstd_blocks_twin.cpp
@@ -279,14 +279,18 @@ int RunHandBuiltFrames() {
     }
 
     /* Produced more than declared, refused as it happens rather than
-     * afterwards: at "afterwards" the bytes are already written. */
+     * afterwards: at "afterwards" the bytes are already written. THE CLASS IS
+     * CORRUPT_INPUT AND THE CAPACITY IS TWICE THE DECLARATION ON PURPOSE
+     * (#460): the frame has room to spare and is refused anyway, because
+     * what it passed is its own header and not the caller's buffer, and a
+     * caller told OUTPUT_TOO_SMALL here would retry with a larger one
+     * forever. */
     const Bytes half(content.begin(), content.begin() + 32);
     const Bytes long_frame = TwoRawFrame(40, half, half);
     REQUIRE(!ReferenceAccepts(long_frame, &reference));
-    rc = NegativeFrame("a raw block past the declared size", long_frame,
-                       kCapacity,
-                       cudec_detail::kZstdBlocksRejectBlockPastCapacity,
-                       CUDEC_ERR_OUTPUT_TOO_SMALL);
+    rc = NegativeFrame("a raw block past the declared size", long_frame, 80,
+                       cudec_detail::kZstdBlocksRejectBlockPastDeclaration,
+                       CUDEC_ERR_CORRUPT_INPUT);
     if (rc != 0) {
         return rc;
     }
@@ -295,12 +299,58 @@ int RunHandBuiltFrames() {
      * length rather than a body length - the one place those two differ. */
     const Bytes long_rle = TwoRleFrame(400, 0x5A, 250);
     REQUIRE(!ReferenceAccepts(long_rle, &reference));
-    rc = NegativeFrame("an RLE block past the declared size", long_rle,
-                       kCapacity,
-                       cudec_detail::kZstdBlocksRejectBlockPastCapacity,
-                       CUDEC_ERR_OUTPUT_TOO_SMALL);
+    rc = NegativeFrame("an RLE block past the declared size", long_rle, 800,
+                       cudec_detail::kZstdBlocksRejectBlockPastDeclaration,
+                       CUDEC_ERR_CORRUPT_INPUT);
     if (rc != 0) {
         return rc;
+    }
+
+    /* The same wall reached through a Compressed block, which meets it at
+     * the execution's bound rather than in the loop: a Raw block spends most
+     * of the declaration and an RLE literals section then regenerates more
+     * than is left, inside the block maximum the window implies. The loop
+     * reports no rung of its own for a refusal a unit made, so the report's
+     * stage and the unit's rung are what say where it stopped. Twice the
+     * declaration for capacity, as above. */
+    {
+        Bytes frame = FrameHeader(40);
+        const Bytes most(content.begin(), content.begin() + 35);
+        AppendBlockHeader(&frame, 35, 0, false);
+        frame.insert(frame.end(), most.begin(), most.end());
+        AppendBlockHeader(&frame, 3, 2, true);
+        frame.push_back(static_cast<unsigned char>(kZstdLiteralsRle | (30u << 3)));
+        frame.push_back('q');
+        frame.push_back(0x00);
+        REQUIRE(!ReferenceAccepts(frame, &reference));
+
+        Harness harness(kBlockMaximum, static_cast<uint32_t>(kBlockMaximum));
+        cudec_detail::ZstdFrameHeader header;
+        cudec_detail::ZstdFrameReject frame_rung =
+            cudec_detail::kZstdFrameRejectNone;
+        REQUIRE(cudec_detail::ZstdParseFrameHeader(frame.data(), frame.size(),
+                                                   &header,
+                                                   &frame_rung) == CUDEC_OK);
+        Bytes out(81, 0);
+        uint64_t produced = 0;
+        uint64_t consumed = 0;
+        cudec_detail::ZstdBlocksReport report;
+        ZstdBlocksReject rung = cudec_detail::kZstdBlocksRejectNone;
+        const cudec_status status = cudec_detail::ZstdDecodeBlocks(
+            frame.data() + header.header_size,
+            frame.size() - header.header_size, &header, &harness.state,
+            out.data(), 80, &produced, &consumed, &report, &rung);
+        REQUIRE_CTX(status == CUDEC_ERR_CORRUPT_INPUT,
+                    "a compressed block past the declared size: status %d",
+                    static_cast<int>(status));
+        REQUIRE(rung == cudec_detail::kZstdBlocksRejectNone);
+        REQUIRE_CTX(report.stage == cudec_detail::kZstdBlocksStageExecute &&
+                        report.rung ==
+                            cudec_detail::kZstdExecRejectBlockPastDeclaration,
+                    "a compressed block past the declared size: stopped at "
+                    "stage %d rung %d",
+                    static_cast<int>(report.stage), report.rung);
+        REQUIRE(produced == 0);
     }
 
     /* The frame declares more than the caller has room for. Refused before a

--- a/tests/zstd_device.cu
+++ b/tests/zstd_device.cu
@@ -356,16 +356,65 @@ int RunRejectParity() {
         c.capacity = 20 + kCapacitySlack;
         cases.push_back(c);
     }
-    /* A Raw block declaring more than the frame has left. */
+    /* A Raw block larger than the block maximum the window implies. This
+     * case was named "raw block past the declaration" until #460's mutants
+     * showed it never reaches that rung: a single-segment frame's window IS
+     * its content size, so a ten-byte block in a four-byte frame is refused
+     * by the block header, on both residencies, before any bound of the
+     * loop's own is compared. The case stays, under its real name. */
     {
         Case c;
-        c.name = "raw block past the declaration";
+        c.name = "raw block past the block maximum";
         AppendSingleSegmentHeader(&c.frame, 4);
         AppendBlockHeader(&c.frame, 10, kZstdBlockRaw, true);
         for (unsigned i = 0; i < 10; i++) {
             c.frame.push_back(static_cast<unsigned char>('a' + i));
         }
         c.capacity = 64;
+        cases.push_back(c);
+    }
+    /* A Raw block past the declaration and INSIDE the block maximum, which
+     * takes two blocks: the first spends most of the declaration, the second
+     * is legal on its own and only their sum is not. This is the kernel's
+     * own Raw/RLE bound in the block loop, and the only case here that
+     * reaches it. */
+    {
+        Case c;
+        c.name = "raw block past the declaration, room to spare";
+        AppendSingleSegmentHeader(&c.frame, 40);
+        AppendBlockHeader(&c.frame, 35, kZstdBlockRaw, false);
+        for (unsigned i = 0; i < 35; i++) {
+            c.frame.push_back(static_cast<unsigned char>('a' + (i % 26u)));
+        }
+        AppendBlockHeader(&c.frame, 10, kZstdBlockRaw, true);
+        for (unsigned i = 0; i < 10; i++) {
+            c.frame.push_back(static_cast<unsigned char>('A' + i));
+        }
+        c.capacity = 80;
+        cases.push_back(c);
+    }
+    /* The first case again at EXACTLY twice the declaration, which is the
+     * shape #460 names: the destination would hold everything the blocks
+     * regenerate, and the frame is refused anyway because what it passed is
+     * its own header. Held to the host like every other case, and beside it
+     * the class is pinned by name, because this is the one answer on the
+     * list that a caller acts on differently - OUTPUT_TOO_SMALL would send
+     * it back with a larger buffer, and no buffer cures a frame that
+     * contradicts itself. */
+    {
+        Case c;
+        c.name = "compressed block past the declaration, room to spare";
+        AppendSingleSegmentHeader(&c.frame, 40);
+        AppendBlockHeader(&c.frame, 35, kZstdBlockRaw, false);
+        for (unsigned i = 0; i < 35; i++) {
+            c.frame.push_back(static_cast<unsigned char>('a' + (i % 26u)));
+        }
+        AppendBlockHeader(&c.frame, 3, kZstdBlockCompressed, true);
+        c.frame.push_back(
+            static_cast<unsigned char>(kZstdLiteralsRle | (30u << 3)));
+        c.frame.push_back('q');
+        c.frame.push_back(0x00);
+        c.capacity = 80;
         cases.push_back(c);
     }
     /* A frame that declares fewer bytes than its blocks produce is refused;
@@ -468,9 +517,35 @@ int RunRejectParity() {
          * and the contract's promise is bytes_written zero rather than an
          * untouched buffer. */
     }
-    /* The two neighbouring literals cases must not have answered the same,
-     * which is the whole reason they are both here. */
-    REQUIRE(results[0].status != results[1].status);
+    /* The two neighbouring literals cases answer the same class at the ABI
+     * since #460, and the host still tells them apart by where it stopped:
+     * the first at the execution's declaration bound, the second inside the
+     * literals unit at the block maximum. Asserting the host's stages differ
+     * is what keeps the pair meaningful - one field apart, two rungs - now
+     * that the status alone cannot. */
+    {
+        Bytes host_out;
+        int stage_first = -1;
+        int stage_second = -1;
+        int rung_first = -1;
+        int rung_second = -1;
+        cudec_test::HostDecodeFrame(cases[0].frame, cases[0].capacity,
+                                    &host_out, &stage_first, &rung_first);
+        cudec_test::HostDecodeFrame(cases[1].frame, cases[1].capacity,
+                                    &host_out, &stage_second, &rung_second);
+        REQUIRE_CTX(stage_first != stage_second,
+                    "the two literals cases stopped at the same host stage %d",
+                    stage_first);
+    }
+    /* The two room-to-spare cases are the decision itself, pinned by name:
+     * one for the block loop's Raw/RLE bound and one for the execution's. */
+    for (size_t i = 0; i < cases.size(); i++) {
+        if (std::strstr(cases[i].name, "room to spare") != 0) {
+            REQUIRE_CTX(results[i].status == CUDEC_ERR_CORRUPT_INPUT,
+                        "%s: status %d, want CORRUPT_INPUT", cases[i].name,
+                        static_cast<int>(results[i].status));
+        }
+    }
     std::printf(
         "reject parity: %llu refusals, each in the class the host twin gives, "
         "each reporting no bytes\n",

--- a/tests/zstd_exec_twin.cpp
+++ b/tests/zstd_exec_twin.cpp
@@ -43,7 +43,7 @@
 using cudec_detail::kZstdExecRejectBadRequest;
 using cudec_detail::kZstdExecRejectBlockTooLarge;
 using cudec_detail::kZstdExecRejectCount;
-using cudec_detail::kZstdExecRejectDestinationTooSmall;
+using cudec_detail::kZstdExecRejectBlockPastDeclaration;
 using cudec_detail::kZstdExecRejectLiteralsExhausted;
 using cudec_detail::kZstdExecRejectNone;
 using cudec_detail::kZstdExecRejectOffsetBeforeOutput;
@@ -189,8 +189,8 @@ TiledOutcome ExecuteTiled(const std::vector<ZstdSequence>& sequences,
 
     const uint64_t base = produced;
     if (base > dst->size() || out.plan.block_size > dst->size() - base) {
-        out.status = CUDEC_ERR_OUTPUT_TOO_SMALL;
-        out.rung = kZstdExecRejectDestinationTooSmall;
+        out.status = CUDEC_ERR_CORRUPT_INPUT;
+        out.rung = kZstdExecRejectBlockPastDeclaration;
         return out;
     }
     for (uint32_t index = 0; index < count; index++) {
@@ -629,14 +629,16 @@ int Negatives() {
         return 1;
     }
 
-    /* The destination does not hold the frame's output plus this block. Its
-     * status is OUTPUT_TOO_SMALL and not CORRUPT_INPUT: the bytes are good and
-     * the buffer is short, and a caller that cannot tell those apart cannot
-     * retry with a larger one. */
-    if (Refuses("destination-too-small", {Seq(3, 3)}, {3}, literals,
+    /* The frame's output plus this block passes the bound handed in. Its
+     * status is CORRUPT_INPUT and not OUTPUT_TOO_SMALL, because the bound
+     * every caller hands this unit is the frame's own declared content size
+     * and never the caller's buffer (section 12.3, #460): a block past it is
+     * the frame contradicting its header, and no larger destination cures
+     * that. The eight bytes here play the declaration. */
+    if (Refuses("block-past-declaration", {Seq(3, 3)}, {3}, literals,
                 cudec_detail::kZstdBlockSizeCeiling, kWideWindow, 8, 0,
-                kZstdExecRejectDestinationTooSmall,
-                CUDEC_ERR_OUTPUT_TOO_SMALL) != 0) {
+                kZstdExecRejectBlockPastDeclaration,
+                CUDEC_ERR_CORRUPT_INPUT) != 0) {
         return 1;
     }
 


### PR DESCRIPTION
Closes #460.

The decision recorded on #460 on 2026-09-06, executed: a Zstd frame whose blocks
regenerate past the content size its own header declared is
`CUDEC_ERR_CORRUPT_INPUT`, and `CUDEC_ERR_OUTPUT_TOO_SMALL` is reserved on this
path for the one condition a larger destination cures - the declaration against
the caller's capacity, decided from the header before a byte is written. That is
the rule the Snappy entry of `include/cudec.h` already stated twelve lines away,
so the header now says one thing at both entries, and `docs/MASTERPLAN.md` 12.3
records the decision beside the class split it belongs to, including why it
reaches neither LZ4 nor GDeflate (their units carry no declared length).

## What moved

- **Host units.** `src/zstd_blocks.h`'s Raw/RLE rung and `src/zstd_exec.h`'s
  bound take the class and are renamed `...BlockPastDeclaration`: every caller
  hands the execution the frame's declaration and never the caller's buffer, so
  "destination too small" named a condition no caller could produce.
- **Kernel.** The three sites in `src/zstd_decode.cuh` follow the host. The
  block-maximum comparison ahead of the literals address existed only to put
  two classes in the host's order; with one class it decided nothing at the ABI
  and is removed - `ZstdDecodeLiterals` refuses that section where the host
  refuses it, and the device parity case for it still passes.
- **Tests.** `tests/zstd_blocks_twin.cpp` asserts the class on the Raw, RLE and
  a new Compressed overrun, each at twice the declared size; the Compressed one
  is held to the execution's rung through the loop's report.
  `tests/zstd_exec_twin.cpp` follows the rung. `tests/zstd_device.cu` gains the
  Compressed overrun and a two-block Raw overrun at twice the declaration,
  pinned by name beside the host parity, and tells its two literals cases apart
  by the host's stage now that the status cannot.

## The gate, on the device

WSL CUDA route, RTX 3080, `sm_86`, driver 610.88, nvcc `cuda_13.3.r13.3`, g++
13.3.0, at this branch's head:

```
$ ctest --test-dir ~/build-af20 --output-on-failure --no-tests=error
100% tests passed, 0 tests failed out of 73
Label Time Summary:
gpu    =  19.44 sec*proc (15 tests)
```

```
$ ./zstd_device | grep 'reject parity'
reject parity: 10 refusals, each in the class the host twin gives, each reporting no bytes
$ ./zstd_gate_gpu | tail -1
PASS: the Zstd device gate set - determinism across five grids, a three-stream split and a repeat of the shipped entry; two-directional reject parity over 784 mutants with 0 over-strict and 1 refused at a declared departure; and the capacity and window bounds
```

The #399 gate set re-ran green on the patched kernel, as the issue's fourth
done-condition asks, and its capacity section still answers
`OUTPUT_TOO_SMALL` for a capacity below the declaration - that answer did not
move and was never meant to.

## Proven to bite

Four mutants, each reverting one site to the old class, rebuilt and rerun in
the same tree:

| mutant | site reverted | what went red |
| ------ | ------------- | ------------- |
| A | host loop, Raw/RLE past the declaration | `zstd_blocks_twin` (`a raw block past the declared size: status 3, want 2`) |
| B | execution unit's declaration bound | `zstd_blocks_twin`, `zstd_exec_twin`, `zstd_device` parity |
| C | kernel, Raw/RLE past the declaration | `zstd_device` (`raw block past the declaration, room to spare: the device answers 3 and the host twin answers 2`) |
| D | kernel, literals past the declaration | `zstd_device` parity (`the device answers 3`) |

**Mutant C found a case that proved nothing.** `tests/zstd_device.cu` carried a
case named "raw block past the declaration" - a ten-byte Raw block in a
four-byte single-segment frame - and mutant C survived it: a single-segment
frame's window IS its content size, so that block is refused by the block
header on both residencies and never reaches the loop's own bound. The case is
kept under its real name, and the two-block frame that does reach the rung is
what turned C red. The same trap is written at `TwoRawFrame` in the blocks twin
and was walked into anyway; the device file now says so where the case is.

## Not in this landing

- No compute-sanitizer run: the four tools cannot attach on this host (#258,
  #127). **No claim is made that the kernel is clean under memcheck, racecheck,
  initcheck or synccheck.** What stands in its place is the parity above and
  the #399 gate.
- `CHANGELOG.md` is untouched. Its `Unreleased` section carries no Zstd entry
  at all yet - the batch entry that #203 put behind `cudec_zstd_decompress_batch`
  is not recorded there - and a "Changed" line about a status class under a
  format the changelog does not yet say decodes would read as nonsense. The
  class belongs in that entry when it is written, and writing #203's entry is a
  separate topic.

## Second reader

There is no second reader on this board tonight. What stands in place of one:
every site the change touches is held by a test that reddens when that site is
reverted, listed above with the line each one failed on.
